### PR TITLE
Align README tech baseline with 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@
 
 ## 기술 기준
 - Java toolchain / source compatibility: `17`
-- Spring Boot: `2.7.18`
-- Spring Dependency Management Plugin: `1.1.4`
+- Spring Boot: `3.5.9`
+- Spring Dependency Management Plugin: `1.1.7`
 - Build: `Gradle Wrapper`
 
 ## 레포지토리 구성
@@ -181,6 +181,7 @@ studio:
 - 애플리케이션 모듈 가이드: `studio-application-modules/README.md`
 - 사용자 계약: `studio-platform-user/README.md`
 - 사용자 기본 구현: `studio-platform-user-default/README.md`
+- 변경 이력: `CHANGELOG.md` (`2.x` 라인부터 새 기준으로 관리)
 - 보안 운영 규칙: `SECURITY.md`
 - 플랫폼 웹 규칙: `studio-platform/WEB_API_DEVELOPMENT_GUIDE.md`
 - 설정 네임스페이스 가이드: `CONFIGURATION_NAMESPACE_GUIDE.md`


### PR DESCRIPTION
## Why
- The root README still showed the old Spring Boot baseline even though 2.x is already on Boot 3.5.9.
- The changelog handling rule for the 2.x line should also be visible in the root README.

## What
- update README Spring Boot version to 3.5.9
- update README dependency-management version to 1.1.7
- add a short note that CHANGELOG.md is managed from the 2.x line forward

## Related Issues
- Closes #72

## Change Scope
- [ ] API contract
- [ ] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [x] Docs/runbook

## Security Impact
- Risk: none
- Mitigation: docs-only change

## Validation
- Commands:
  - manual verification of README diff
- Result:
  - README now matches merged 2.x technical baseline
- Additional checks:
  - no code changes included

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] validation recorded
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: none
- Rollback plan: revert commit ebe68fc
- Post-deploy checks: verify README tech baseline section renders correctly