### PR TITLE
Remove redundant snakeyaml force override

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,7 +94,6 @@ subprojects {
         resolutionStrategy.force(
             "ch.qos.logback:logback-classic:${property("logbackVersion")}",
             "ch.qos.logback:logback-core:${property("logbackVersion")}",
-            "org.yaml:snakeyaml:${property("snakeyamlVersion")}",
             "com.nimbusds:nimbus-jose-jwt:${property("nimbusJoseJwtVersion")}",
             "net.minidev:json-smart:${property("jsonSmartVersion")}",
             "org.postgresql:postgresql:${property("postgresqlVersion")}"


### PR DESCRIPTION
## Why
- `org.yaml:snakeyaml` force override is redundant under Spring Boot 3.5.9.
- Dependency resolution already selects `2.4` without the explicit force, so keeping it adds maintenance overhead without changing the effective classpath.

## What
- Remove the root `snakeyaml` entry from `resolutionStrategy.force` in `build.gradle.kts`.

## Related Issues
- Closes #74
- Related #76

## Change Scope
- [ ] API contract
- [ ] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [ ] Docs/runbook

## Security Impact
- Risk: Low. The resolved `snakeyaml` version remains unchanged.
- Mitigation: Verified dependency resolution and related module compilation after removing the override.

## Validation
- Commands:
  - `./gradlew -q :starter:studio-platform-starter-objecttype:dependencyInsight --dependency org.yaml:snakeyaml --configuration compileClasspath`
  - `./gradlew -q :starter:studio-platform-starter-objecttype:compileJava`
- Result:
  - `snakeyaml` still resolves to `2.4`
  - related module compile passes
- Additional checks:
  - no unrelated file changes included

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] validation recorded
- [ ] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: none
- Rollback plan: revert commit `2df5fab`
- Post-deploy checks: none
