### PR TITLE
Unify PostgreSQL JDBC version declaration to root policy

### DIFF
--- a/studio-platform-ai/build.gradle.kts
+++ b/studio-platform-ai/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
     implementation("io.github.resilience4j:resilience4j-spring-boot2:${property("resilience4jVersion")}")
     implementation("com.github.spullara.mustache.java:compiler:${property("mustacheVersion")}")
 
-    runtimeOnly("org.postgresql:postgresql:${property("postgresqlVersion")}")    
+    runtimeOnly("org.postgresql:postgresql")    
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.mockito:mockito-core")
     testImplementation("org.testcontainers:postgresql:${property("testcontainersVersion")}")

--- a/studio-platform-security/build.gradle.kts
+++ b/studio-platform-security/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     annotationProcessor ("org.mapstruct:mapstruct-processor:$mapstructVersion")
     annotationProcessor ("org.projectlombok:lombok-mapstruct-binding:0.2.0")
 
-    compileOnly("org.postgresql:postgresql:${project.findProperty("postgresqlVersion")}")    
+    compileOnly("org.postgresql:postgresql")    
     api("io.jsonwebtoken:jjwt-api:$jsonwebtokenVersion")
     api("io.jsonwebtoken:jjwt-impl:$jsonwebtokenVersion")
     api("io.jsonwebtoken:jjwt-jackson:$jsonwebtokenVersion")    


### PR DESCRIPTION
## Why
- PostgreSQL JDBC version selection was duplicated in root resolution rules and module-level dependency declarations.
- Duplicated version declarations increase drift risk during future upgrades.

## What
- Remove explicit PostgreSQL JDBC version from:
  - `studio-platform-ai/build.gradle.kts`
  - `studio-platform-security/build.gradle.kts`
- Keep version control in the root build policy.

## Related Issues
- Closes #80

## Change Scope
- [ ] API contract
- [ ] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [ ] Docs/runbook

## Security Impact
- Risk: Low. No behavior change intended; declaration source is consolidated.
- Mitigation: dependencyInsight and module compile checks completed.

## Validation
- Commands:
  - `./gradlew -q -PnimbusJoseJwtVersion=9.37.4 -PjsonSmartVersion=2.4.10 :studio-platform-ai:dependencyInsight --dependency org.postgresql:postgresql --configuration runtimeClasspath`
  - `./gradlew -q -PnimbusJoseJwtVersion=9.37.4 -PjsonSmartVersion=2.4.10 :studio-platform-ai:compileJava :studio-platform-security:compileJava`
- Result:
  - PostgreSQL dependency resolves and target modules compile successfully
- Additional checks:
  - no unrelated changes included

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] validation recorded
- [ ] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: none
- Rollback plan: revert commit `9bcd0ba`
- Post-deploy checks: none
