### PR TITLE
정책 및 MR/이슈 템플릿에 subagent 워크플로 반영

### DIFF
--- a/.gitlab/issue_templates/default.md
+++ b/.gitlab/issue_templates/default.md
@@ -47,6 +47,13 @@
 - [ ] Refactoring suggestion
 - [ ] Test case / validation checklist
 - [ ] Documentation draft
+- [ ] Subagent delegation
+
+## Subagent Usage
+subagent를 사용한 경우에만 작성합니다.
+- Delegated tasks:
+- Ownership (files/modules/tasks):
+- Main author post-integration validation:
 
 ## Analysis / Findings
 특히 유지보수/버그 작업의 경우, AI 분석 결과 또는 주요 확인 사항을 작성합니다.

--- a/.gitlab/merge_request_templates/default.md
+++ b/.gitlab/merge_request_templates/default.md
@@ -26,10 +26,18 @@
   - 
 - Additional checks:
 
+## Subagent Usage
+아래 항목은 **정확히 하나만** 체크합니다.
+- Used: [ ] No [ ] Yes
+- Delegated tasks:
+- Ownership (files/modules/tasks):
+- Main author post-integration validation:
+
 ## Checklist
 - [ ] policy-compliant commit message
 - [ ] issue template used where applicable
 - [ ] AI-Assisted checked correctly
+- [ ] subagent usage recorded (if used)
 - [ ] validation recorded
 - [ ] CI / repository verification passed
 - [ ] human review completed before merge

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,12 @@ When working in this repository, always follow the project rules in this order:
 2. `CONTRIBUTING.md`
 3. `SKILL.md`
 4. `README.md`
-5. `.gitlab/issue_templates/default.md`
-6. `.gitlab/merge_request_templates/default.md`
-7. `.gitmessage-ai-assisted.txt`
+5. `.codex/config.toml`
+6. `.codex/agents/*.toml`
+7. `docs/agents/*.md`
+8. `.gitlab/issue_templates/default.md`
+9. `.gitlab/merge_request_templates/default.md`
+10. `.gitmessage-ai-assisted.txt`
 
 If rules conflict:
 - Follow the more specific and narrower rule first.
@@ -40,6 +43,37 @@ Issue
 → Human Review
 → CI / validation
 → Merge
+
+When subagents are used, apply this extension:
+
+Issue
+→ Branch
+→ Delegation Plan (task split / ownership)
+→ Develop (Main agent + Subagents)
+→ Integration
+→ Commit
+→ Merge Request
+→ AI Review
+→ Human Review
+→ CI / validation
+→ Merge
+
+## Skill Resolution
+
+All agents must apply instructions in this order:
+
+1. `AI_DEVELOPMENT_POLICY.md`
+2. `CONTRIBUTING.md`
+3. root `SKILL.md`
+4. role-specific agent definition under `.codex/agents/*.toml`
+5. role-specific guidance under `docs/agents/*.md`
+6. `.codex/config.toml` (optional metadata only)
+
+If rules conflict:
+- Follow the narrower role-specific rule first.
+- Policy, security, validation, and commit-format requirements in `AI_DEVELOPMENT_POLICY.md` always win.
+
+If no subagent is specified, use the default main-agent flow with root `SKILL.md` only.
 
 ## Issue Rules
 
@@ -92,6 +126,18 @@ Direct change to `main` is exceptional and must be explicitly justified with str
 - Prefer verifiable goals over vague goals.
 - For multi-step work, briefly state the plan and the verification point for each step.
 
+## Subagent Rules
+
+- Use subagents only for bounded, clearly scoped tasks that can be reviewed independently.
+- Do not delegate immediate critical-path decisions that require main author judgment.
+- Define ownership before delegation (file/module/task boundary) to avoid overlap.
+- Main author is responsible for final integration quality and conflict resolution.
+- Main author must review subagent outputs before merge.
+- Record subagent usage summary in Issue/MR when subagents are used.
+- Each role-specific agent must apply the required repository template for its stage.
+- Prefer Codex-native agent definitions under `.codex/agents/` for reusable subagents.
+- `.codex/config.toml` is optional metadata and does not replace repository policy documents.
+
 ## Validation Rules
 
 Every AI-assisted change must leave at least one executable validation record:
@@ -101,6 +147,7 @@ Every AI-assisted change must leave at least one executable validation record:
 - manual verification if appropriate
 
 Record validation commands and outcomes in the commit body or MR body.
+If subagents are used, include which validation was performed by the main author after integration.
 
 ## Merge Request Rules
 

--- a/AI_DEVELOPMENT_POLICY.md
+++ b/AI_DEVELOPMENT_POLICY.md
@@ -39,6 +39,16 @@
 - `AI-Assisted` 항목은 `Yes/No` 중 정확히 하나만 체크한다.
 - AI를 사용한 작업은 반드시 `Yes`를 체크한다.
 
+6. Subagent 위임 원칙
+- Subagent는 독립 검토가 가능한 명확한 하위 작업에만 사용한다.
+- 위임 전 작업 경계(파일/모듈/책임)를 정의한다.
+- Main author는 subagent 산출물을 통합하고 최종 책임을 가진다.
+- Main author는 merge 전 subagent 결과를 직접 검증한다.
+- Subagent 사용 시 이슈/PR(MR)에 위임 범위와 검증 결과를 기록한다.
+- 역할별 agent를 사용하는 경우에도 공통 `SKILL.md`를 먼저 적용하고, 이후 `.codex/agents/*.toml`과 `docs/agents/*.md`를 적용한다.
+- `.codex/config.toml`은 선택적 메타데이터이며 정책 강제의 기준이 아니다.
+- Subagent를 명시하지 않으면 기존과 동일하게 main agent 기준으로 작업한다.
+
 ## AI 커밋 메시지 규칙
 1. AI 보조 커밋 제목은 반드시 `[ai-assisted]`로 시작한다.
 2. 형식:
@@ -86,6 +96,7 @@ AI로 생성된 변경은 다음 중 하나 이상의 검증을 포함해야 한
 - smoke test 수행
 
 검증 명령은 커밋 또는 PR 본문에 기록한다.
+Subagent를 사용한 경우, 통합 이후 main author의 검증 항목을 포함해 기록한다.
 
 ### 3. PR/MR 검사
 Pull Request(Merge Request) 단계에서 다음을 확인한다.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,8 @@
   - `Large (3)`: 구조 변경 / 복수 모듈
 - Issue 템플릿의 `AI-Assisted`는 `Yes/No` 중 정확히 하나를 체크한다.
   - AI 사용 작업은 반드시 `Yes`를 체크한다.
+- Subagent를 사용한 경우 Issue/MR에 위임 작업, 소유 범위, 통합 후 검증 주체(main author)를 기록한다.
+- Subagent를 명시하지 않으면 기존과 동일하게 main agent 기준으로 진행한다.
 
 ## 브랜치/커밋
 - 기본 브랜치: `main`
@@ -34,6 +36,8 @@
 - AI 보조 커밋은 `AI_DEVELOPMENT_POLICY.md`의 `[ai-assisted]` 규칙을 따른다.
 - AI 보조 커밋 작성 시 `.gitmessage-ai-assisted.txt` 템플릿 사용을 권장한다.
 - AI 보조 변경은 merge 전에 human review를 반드시 거친다.
+- Subagent 산출물은 main author가 통합 후 최종 검토/검증 책임을 가진다.
+- 역할별 agent를 사용할 때는 해당 단계의 템플릿을 함께 완성한다.
 
 ## 코드 변경 규칙
 - 기존 패턴/설계 의도를 우선 존중한다.

--- a/POLICY_VERSION.md
+++ b/POLICY_VERSION.md
@@ -1,8 +1,8 @@
 # Policy Version
 
-- Current Version: `v1.1.0`
+- Current Version: `v1.3.0`
 - Effective Date: `2026-03-18`
-- Last Updated: `2026-03-20`
+- Last Updated: `2026-03-23`
 
 ## Versioning Rules
 - 정책 파일 구조/규칙 변경 시 버전을 갱신한다.
@@ -19,8 +19,11 @@
   - `SKILL.md`
   - `README.md`
   - `.gitmessage-ai-assisted.txt`
+  - `.codex/config.toml`
+  - `.codex/agents/*.toml`
   - `.gitlab/issue_templates/default.md`
   - `.gitlab/merge_request_templates/default.md`
+  - `docs/agents/*.md`
   - `.vscode/java.code-snippets`
   - `docs/dev/vscode-snippets-guide.md`
   - `scripts/install-policy.sh`


### PR DESCRIPTION
## Why
- Issue #84에 따라 subagent 사용 워크플로를 저장소 정책과 이슈/MR 템플릿에 일관되게 반영합니다.
- 문서 규칙, 템플릿, 정책 버전 문서가 서로 같은 책임 모델을 따르도록 정리합니다.

## What
- `AGENTS.md`에 instruction 우선순위, subagent 확장 workflow, skill resolution, subagent rules를 추가했습니다.
- `AI_DEVELOPMENT_POLICY.md`, `CONTRIBUTING.md`에 subagent 사용 원칙과 main author 검증 책임을 반영했습니다.
- issue template에 `Subagent delegation` usage type과 `Subagent Usage` 섹션을 추가했습니다.
- MR template에 `Subagent Usage` 섹션과 checklist 항목을 추가하고, `Used` 항목이 정확히 하나만 선택되도록 명시했습니다.
- `POLICY_VERSION.md`를 `v1.3.0`으로 갱신하고 정책 적용 범위에 `.codex` 및 `docs/agents` 경로를 포함했습니다.

## Related Issues
- Closes #84
- Related #82

## Change Scope
- [ ] API contract
- [x] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [x] Docs/runbook

## Security Impact
- Risk:
  - 직접적인 런타임 보안 동작 변경은 없습니다.
  - 정책과 템플릿 불일치가 남으면 AI-assisted 작업의 추적성과 검증 책임이 약해질 수 있습니다.
- Mitigation:
  - subagent 사용 시 위임 범위와 main author 검증 주체를 issue/MR 템플릿에 기록하도록 정리했습니다.
  - 정책 문서 간 우선순위와 적용 순서를 명시했습니다.

## Validation
- Commands:
  - `git diff -- AGENTS.md AI_DEVELOPMENT_POLICY.md CONTRIBUTING.md POLICY_VERSION.md .gitlab/issue_templates/default.md .gitlab/merge_request_templates/default.md`
- Result:
  - 정책/템플릿 변경 범위와 문서 정합성을 수동 검토했습니다.
- Additional checks:
  - MR template의 `Used: [ ] No [ ] Yes`에 대해 정확히 하나만 선택하도록 안내 문구를 추가해 모호성을 제거했습니다.

## Subagent Usage
- Used: [x] No [ ] Yes
- Delegated tasks:
- Ownership (files/modules/tasks):
  - main author가 정책/템플릿 파일 수정과 최종 검토를 직접 수행했습니다.
- Main author post-integration validation:
  - main author가 변경 문서 간 정합성과 템플릿 필수 항목 포함 여부를 재확인했습니다.

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [ ] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering:
  - 배포 순서는 중요하지 않지만, 후속 `.codex/agents` 및 `docs/agents` PR보다 먼저 머지하는 편이 자연스럽습니다.
- Rollback plan:
  - 본 PR revert 시 subagent 관련 정책/템플릿 규칙이 이전 상태로 복귀합니다.
- Post-deploy checks:
  - 이후 agent 정의/가이드 PR이 본 정책과 템플릿을 기준으로 작성되는지 확인합니다.
