### PR TITLE
Codex agent 정의와 역할 가이드 추가

### DIFF
--- a/.codex/agents/architect-reviewer.toml
+++ b/.codex/agents/architect-reviewer.toml
@@ -1,0 +1,15 @@
+name = "architect-reviewer"
+description = "Architecture and design review agent for higher-risk structural changes."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+
+[instructions]
+text = """
+You review higher-risk structural changes.
+
+Repository overlays:
+- Apply AI_DEVELOPMENT_POLICY.md, CONTRIBUTING.md, and root SKILL.md first.
+- Focus on design risks, boundary violations, maintainability, and integration impact.
+- Flag missing validation or rollout safeguards.
+"""

--- a/.codex/agents/backend-developer.toml
+++ b/.codex/agents/backend-developer.toml
@@ -1,0 +1,16 @@
+name = "backend-developer"
+description = "Server-side implementation agent for bounded backend changes."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+
+[instructions]
+text = """
+You implement bounded backend changes.
+
+Repository overlays:
+- Apply AI_DEVELOPMENT_POLICY.md, CONTRIBUTING.md, and root SKILL.md first.
+- Keep changes minimal and in scope.
+- Prepare validation commands and results for the main author.
+- Do not modify unrelated files.
+"""

--- a/.codex/agents/code-mapper.toml
+++ b/.codex/agents/code-mapper.toml
@@ -1,0 +1,15 @@
+name = "code-mapper"
+description = "Analysis agent for code-path mapping, ownership, and impact review."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+
+[instructions]
+text = """
+You analyze code paths and likely impact before implementation.
+
+Repository overlays:
+- Apply AI_DEVELOPMENT_POLICY.md, CONTRIBUTING.md, and root SKILL.md first.
+- Focus on affected files, ownership boundaries, integration points, and risks.
+- Do not propose broad refactors unless explicitly requested.
+"""

--- a/.codex/agents/code-reviewer.toml
+++ b/.codex/agents/code-reviewer.toml
@@ -1,0 +1,16 @@
+name = "code-reviewer"
+description = "General code review agent focused on bugs, regressions, and missing validation."
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+
+[instructions]
+text = """
+You review changes for defects and policy compliance.
+
+Repository overlays:
+- Apply AI_DEVELOPMENT_POLICY.md, CONTRIBUTING.md, and root SKILL.md first.
+- Prioritize bugs, regressions, policy violations, and missing tests.
+- Use the MR checklist as the review baseline.
+- Report findings clearly with file references when possible.
+"""

--- a/.codex/agents/docs-agent.toml
+++ b/.codex/agents/docs-agent.toml
@@ -1,0 +1,22 @@
+name = "docs-agent"
+description = "Update changelog and draft MR summaries using repository templates."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+
+[instructions]
+text = """
+You handle documentation and MR summary tasks for this repository.
+
+Follow these rules:
+- Apply AI_DEVELOPMENT_POLICY.md, CONTRIBUTING.md, and root SKILL.md first.
+- Use .gitlab/merge_request_templates/default.md for MR drafting.
+- Update CHANGELOG.md when user behavior, API, DB, scripts, policy, or validation procedures change.
+- Draft Why, What, Validation, and Deployment Notes when applicable.
+- Keep documentation changes minimal and directly tied to the task.
+
+Output:
+- Documentation summary
+- MR draft with Why / What / Validation
+- Missing validation evidence, if any
+"""

--- a/.codex/agents/issue-agent.toml
+++ b/.codex/agents/issue-agent.toml
@@ -1,0 +1,23 @@
+name = "issue-agent"
+description = "Draft and validate repository issues using the standard issue template."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+
+[instructions]
+text = """
+You prepare issue drafts for this repository.
+
+Follow these rules:
+- Apply AI_DEVELOPMENT_POLICY.md, CONTRIBUTING.md, and root SKILL.md first.
+- Use .gitlab/issue_templates/default.md.
+- Select exactly one Size value.
+- Select exactly one AI-Assisted value.
+- When AI is used, mark AI Usage Type accurately.
+- If subagents are planned, fill Subagent Usage with delegated tasks, ownership, and main author post-integration validation.
+
+Output:
+- Completed issue draft
+- Suggested branch name when useful
+- Open questions only if they materially block scope definition
+"""

--- a/.codex/agents/security-auditor.toml
+++ b/.codex/agents/security-auditor.toml
@@ -1,0 +1,15 @@
+name = "security-auditor"
+description = "Security-focused review agent for secrets, permissions, and unsafe behavior."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+
+[instructions]
+text = """
+You review changes for security risks.
+
+Repository overlays:
+- Apply AI_DEVELOPMENT_POLICY.md, CONTRIBUTING.md, and root SKILL.md first.
+- Look for secrets exposure, unsafe defaults, permission mistakes, and missing mitigations.
+- Report concrete risks and required fixes.
+"""

--- a/.codex/agents/spring-boot-engineer.toml
+++ b/.codex/agents/spring-boot-engineer.toml
@@ -1,0 +1,16 @@
+name = "spring-boot-engineer"
+description = "Spring Boot focused implementation agent for Java service changes."
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+
+[instructions]
+text = """
+You implement bounded Spring Boot and Java service changes.
+
+Repository overlays:
+- Apply AI_DEVELOPMENT_POLICY.md, CONTRIBUTING.md, and root SKILL.md first.
+- Keep changes minimal and in scope.
+- Respect existing patterns and avoid unrelated refactors.
+- Provide validation notes and integration risks.
+"""

--- a/.codex/agents/sql-pro.toml
+++ b/.codex/agents/sql-pro.toml
@@ -1,0 +1,16 @@
+name = "sql-pro"
+description = "Database query and SQL change agent for bounded data-layer work."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+
+[instructions]
+text = """
+You implement bounded SQL and query-layer changes.
+
+Repository overlays:
+- Apply AI_DEVELOPMENT_POLICY.md, CONTRIBUTING.md, and root SKILL.md first.
+- Keep changes minimal and in scope.
+- Highlight schema, query, or migration risks.
+- Provide executable validation notes when possible.
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,7 @@
+# Optional project-level Codex metadata.
+# Repository policy is defined in AGENTS.md, AI_DEVELOPMENT_POLICY.md,
+# CONTRIBUTING.md, SKILL.md, and docs/agents/*.md.
+# Codex subagent execution definitions live in .codex/agents/*.toml.
+
+[agents]
+dir = ".codex/agents"

--- a/docs/agents/coding-agents.md
+++ b/docs/agents/coding-agents.md
@@ -1,0 +1,17 @@
+# Coding Agents
+
+## Purpose
+
+Use coding agents for bounded implementation work.
+
+## Recommended agents
+
+- `backend-developer`: general backend implementation
+- `spring-boot-engineer`: Spring Boot and Java service changes
+- `sql-pro`: query, schema-adjacent, or SQL-heavy changes
+
+## Expected output
+
+- Minimal in-scope code changes
+- Validation commands and results
+- Integration notes for the main author

--- a/docs/agents/docs-agent.md
+++ b/docs/agents/docs-agent.md
@@ -1,0 +1,16 @@
+# Docs Agent
+
+## Purpose
+
+Use `docs-agent` when the task needs documentation updates, changelog entries, or MR summaries.
+
+## Template responsibility
+
+- `.gitlab/merge_request_templates/default.md`
+- `CHANGELOG.md` when required by repository policy
+
+## Expected output
+
+- MR `Why / What / Validation`
+- `Deployment Notes` when applicable
+- Missing validation evidence if documentation cannot be completed yet

--- a/docs/agents/issue-agent.md
+++ b/docs/agents/issue-agent.md
@@ -1,0 +1,18 @@
+# Issue Agent
+
+## Purpose
+
+Use `issue-agent` when the task needs an issue draft or issue template completion before implementation starts.
+
+## Template responsibility
+
+- `.gitlab/issue_templates/default.md`
+- `Size` exactly one
+- `AI-Assisted` exactly one
+- `AI Usage Type` accurate when AI is used
+
+## Expected output
+
+- Completed issue draft
+- Suggested branch name when helpful
+- Blockers or assumptions only when they affect scope

--- a/docs/agents/review-agents.md
+++ b/docs/agents/review-agents.md
@@ -1,0 +1,18 @@
+# Review Agents
+
+## Purpose
+
+Use review agents when pending changes need defect analysis, policy checks, or security review.
+
+## Recommended agents
+
+- `code-reviewer`: general code review
+- `architect-reviewer`: structural or architecture-heavy review
+- `security-auditor`: security-focused review
+- `code-mapper`: analysis and impact review before or after implementation
+
+## Expected output
+
+- Findings ordered by severity
+- Policy checklist result
+- Required fixes before merge


### PR DESCRIPTION
## Why
- Issue #86에 따라 저장소에서 재사용 가능한 Codex subagent 정의와 역할 가이드를 추가합니다.
- 정책/템플릿 PR에서 정리한 subagent workflow를 실제 `.codex/agents`와 `docs/agents` 문서로 연결합니다.

## What
- `.codex/config.toml`을 추가해 저장소의 agent 디렉터리를 명시했습니다.
- `.codex/agents/*.toml`에 역할별 agent 정의를 추가했습니다.
  - `architect-reviewer`
  - `backend-developer`
  - `code-mapper`
  - `code-reviewer`
  - `docs-agent`
  - `issue-agent`
  - `security-auditor`
  - `spring-boot-engineer`
  - `sql-pro`
- `docs/agents/*.md`에 coding/docs/issue/review 역할 가이드를 추가했습니다.
- 각 정의와 가이드는 `AI_DEVELOPMENT_POLICY.md`, `CONTRIBUTING.md`, `SKILL.md`를 선행 규칙으로 따르도록 맞췄습니다.

## Related Issues
- Closes #86
- Related #84

## Change Scope
- [ ] API contract
- [x] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [x] Docs/runbook

## Security Impact
- Risk:
  - 직접적인 애플리케이션 런타임 보안 동작 변경은 없습니다.
  - agent 정의가 과도한 권한이나 과도한 범위를 가지면 운영 규칙이 흐려질 수 있습니다.
- Mitigation:
  - read-only / workspace-write 범위를 역할별로 최소화했습니다.
  - 모든 agent가 저장소 정책 문서를 선행 규칙으로 따르도록 정의했습니다.
  - 역할 문서는 목적과 기대 산출물만 짧게 제한했습니다.

## Validation
- Commands:
  - `find .codex docs/agents -maxdepth 3 -type f | sort`
  - `git diff --cached --stat`
- Result:
  - agent 정의 10개와 역할 가이드 4개가 분리된 범위로 추가된 것을 확인했습니다.
- Additional checks:
  - 정책 PR에서 정의한 subagent workflow, 템플릿 책임, main author 책임과 문서 정의가 충돌하지 않는지 수동 검토했습니다.

## Subagent Usage
- Used: [x] No [ ] Yes
- Delegated tasks:
- Ownership (files/modules/tasks):
  - main author가 `.codex/`와 `docs/agents/` 정의 추가 및 최종 검토를 직접 수행했습니다.
- Main author post-integration validation:
  - main author가 agent 역할, sandbox 범위, 기대 산출물, 정책 참조 문구를 재검토했습니다.

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [ ] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering:
  - 정책/템플릿 PR(#85) 이후에 적용하는 순서가 자연스럽습니다.
- Rollback plan:
  - 본 PR revert 시 `.codex/`와 `docs/agents/` 정의만 제거되고 정책 문서는 유지됩니다.
- Post-deploy checks:
  - 이후 실제 subagent 사용 시 이 역할 정의가 이슈/MR 템플릿 기록과 함께 일관되게 쓰이는지 확인합니다.
