### PR TITLE
Promote Spring AI alias as the effective default provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `studio.ai.spring-ai.source-provider`와 fail-fast guard를 추가해 Spring AI alias가 명시된 OpenAI provider와 `spring.ai.openai.*` 설정을 사용하도록 고정했다.
 - source provider로 지정된 OpenAI의 LangChain base 경로도 `spring.ai.openai.*`를 사용하도록 바꿔, OpenAI runtime 설정의 단일 소스를 유지한 채 LangChain/Spring AI 비교가 가능하게 했다.
 - `openai-springai` default cutover 검증을 위해 `AiInfoController`, `ChatController`, `EmbeddingController` smoke 테스트를 추가했다.
+- `studio.ai.default-provider`를 비웠을 때 Spring AI alias를 기본 provider로 승격하고, `default-provider=openai`를 명시하면 LangChain base provider로 rollback할 수 있게 정리했다.
 - OpenAI phase 1 운영 설정 원칙을 [spring-ai-openai-phase1.md](/Users/donghyuck.son/git/studio-api/docs/dev/spring-ai-openai-phase1.md)에 문서화했다.
 
 ### 검증

--- a/README.md
+++ b/README.md
@@ -166,12 +166,27 @@ studio:
       audit-enabled: true
   ai:
     enabled: true
-    default-provider: openai
+    default-provider: openai-springai
+    spring-ai:
+      enabled: true
+      source-provider: openai
+      provider-suffix: -springai
     providers:
-      - name: openai
+      openai:
         type: OPENAI
-        api-key: ${OPENAI_API_KEY}
+        chat:
+          enabled: true
         embedding:
+          enabled: true
+spring:
+  ai:
+    openai:
+      api-key: ${OPENAI_API_KEY}
+      chat:
+        options:
+          model: gpt-4o-mini
+      embedding:
+        options:
           model: text-embedding-3-small
 ```
 필요 없는 기능은 `enabled=false` 로 비활성화하고, 경로나 저장소 타입은 `studio.features.<feature>.*` 속성으로 조정한다.

--- a/docs/dev/spring-ai-openai-phase1.md
+++ b/docs/dev/spring-ai-openai-phase1.md
@@ -12,6 +12,7 @@ OpenAI 경로의 런타임 설정 소유권을 `studio.ai.*`에서 `spring.ai.*`
 - `studio.ai.spring-ai.provider-suffix`는 임시 alias suffix이다.
 - `studio.ai.spring-ai.source-provider`는 Spring AI alias의 기준 provider를 지정한다.
 - source provider로 지정된 OpenAI의 LangChain base 경로도 `spring.ai.openai.*`를 읽는다.
+- `studio.ai.default-provider`를 비우면 Spring AI alias(`source-provider + provider-suffix`)가 기본 provider로 승격된다.
 
 ## 현재 권장 설정
 
@@ -82,6 +83,7 @@ source provider로 지정된 OpenAI는 base provider(`openai`)와 alias provider
 - `studio.ai.spring-ai.enabled=true`이면 `spring.ai.openai.api-key`가 반드시 있어야 한다.
 - `studio.ai.spring-ai.source-provider`는 존재하는 `OPENAI` provider를 가리켜야 한다.
 - 기본 provider가 `openai-springai`인데 chat 또는 embedding alias가 없으면 startup이 실패해야 한다.
+- `studio.ai.default-provider`가 비어 있고 Spring AI alias promotion 조건도 없으면 startup이 실패해야 한다.
 
 ## 검증
 

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/AiSecretPresenceGuard.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/AiSecretPresenceGuard.java
@@ -28,6 +28,7 @@ public class AiSecretPresenceGuard {
     @PostConstruct
     void validate() {
         String springAiSourceProvider = properties.getSpringAi().isEnabled() ? resolveSpringAiSourceProvider() : null;
+        validateDefaultProviderSelection();
         for (Map.Entry<String, AiAdapterProperties.Provider> entry : properties.getProviders().entrySet()) {
             String providerId = entry.getKey();
             AiAdapterProperties.Provider provider = entry.getValue();
@@ -50,6 +51,13 @@ public class AiSecretPresenceGuard {
             }
         }
         validateSpringAiAliasSettings();
+    }
+
+    private void validateDefaultProviderSelection() {
+        if (!StringUtils.hasText(properties.effectiveDefaultProvider())) {
+            throw new IllegalStateException(
+                    "studio.ai.default-provider must be configured unless studio.ai.spring-ai.enabled=true with a valid source provider");
+        }
     }
 
     private void validateSpringAiAliasSettings() {

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/AiAdapterProperties.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/AiAdapterProperties.java
@@ -4,6 +4,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -24,6 +25,20 @@ public class AiAdapterProperties {
     private final Map<String, Provider> providers = new LinkedHashMap<>();
     private Endpoints endpoints = new Endpoints();
     private SpringAi springAi = new SpringAi();
+
+    public String effectiveDefaultProvider() {
+        if (StringUtils.hasText(defaultProvider)) {
+            return defaultProvider;
+        }
+        return springAiAliasOrNull();
+    }
+
+    public String springAiAliasOrNull() {
+        if (!springAi.enabled || !StringUtils.hasText(springAi.sourceProvider) || !StringUtils.hasText(springAi.providerSuffix)) {
+            return null;
+        }
+        return springAi.sourceProvider + springAi.providerSuffix;
+    }
 
     @Getter
     @Setter

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/AiProviderRegistryConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/AiProviderRegistryConfiguration.java
@@ -37,7 +37,11 @@ public class AiProviderRegistryConfiguration {
         log.info(LogUtils.format(i18n, I18nKeys.AutoConfig.Feature.Service.DETAILS, FEATURE_NAME,
                 LogUtils.blue(AiProviderRegistry.class, true), LogUtils.red(State.CREATED.toString())));
 
-        return new AiProviderRegistry(properties.getDefaultProvider(), chatPorts, embeddingPorts);
+        String defaultProvider = properties.effectiveDefaultProvider();
+        if (defaultProvider == null || defaultProvider.isBlank()) {
+            throw new IllegalStateException("studio.ai.default-provider must be configured unless Spring AI alias promotion is enabled");
+        }
+        return new AiProviderRegistry(defaultProvider, chatPorts, embeddingPorts);
     }
 
     @Bean

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/web/controller/AiInfoController.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/web/controller/AiInfoController.java
@@ -44,7 +44,7 @@ public class AiInfoController {
         VectorInfo vectorInfo = new VectorInfo(
                 vectorStorePort != null,
                 vectorStorePort == null ? null : vectorStorePort.getClass().getSimpleName());
-        return ResponseEntity.ok(ApiResponse.ok(new AiInfoResponse(providerInfos, properties.getDefaultProvider(), vectorInfo)));
+        return ResponseEntity.ok(ApiResponse.ok(new AiInfoResponse(providerInfos, properties.effectiveDefaultProvider(), vectorInfo)));
     }
 
     private ProviderInfo mapProvider(String name, AiAdapterProperties.Provider provider) {

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/web/controller/AiInfoController.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/web/controller/AiInfoController.java
@@ -1,6 +1,7 @@
 package studio.one.platform.ai.web.controller;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
 import org.springframework.lang.Nullable;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -26,11 +27,13 @@ import java.util.Map;
 public class AiInfoController {
 
     private final AiAdapterProperties properties;
+    private final Environment environment;
     @Nullable
     private final VectorStorePort vectorStorePort;
 
-    public AiInfoController(AiAdapterProperties properties, @Nullable VectorStorePort vectorStorePort) {
+    public AiInfoController(AiAdapterProperties properties, Environment environment, @Nullable VectorStorePort vectorStorePort) {
         this.properties = properties;
+        this.environment = environment;
         this.vectorStorePort = vectorStorePort;
     }
 
@@ -41,10 +44,38 @@ public class AiInfoController {
         for (Map.Entry<String, AiAdapterProperties.Provider> entry : properties.getProviders().entrySet()) {
             providerInfos.add(mapProvider(entry.getKey(), entry.getValue()));
         }
+        addSpringAiAliasProviderInfo(providerInfos);
         VectorInfo vectorInfo = new VectorInfo(
                 vectorStorePort != null,
                 vectorStorePort == null ? null : vectorStorePort.getClass().getSimpleName());
         return ResponseEntity.ok(ApiResponse.ok(new AiInfoResponse(providerInfos, properties.effectiveDefaultProvider(), vectorInfo)));
+    }
+
+    private void addSpringAiAliasProviderInfo(List<ProviderInfo> providerInfos) {
+        String alias = properties.springAiAliasOrNull();
+        if (alias == null || properties.getProviders().containsKey(alias)) {
+            return;
+        }
+        String sourceProviderId = properties.getSpringAi().getSourceProvider();
+        if (sourceProviderId == null) {
+            return;
+        }
+        AiAdapterProperties.Provider sourceProvider = properties.getProviders().get(sourceProviderId);
+        if (sourceProvider == null || sourceProvider.getType() != AiAdapterProperties.ProviderType.OPENAI) {
+            return;
+        }
+        ProviderChannel chat = new ProviderChannel(
+                sourceProvider.getChat().isEnabled(),
+                sourceProvider.getChat().isEnabled() ? environment.getProperty("spring.ai.openai.chat.options.model") : null);
+        ProviderChannel embedding = new ProviderChannel(
+                sourceProvider.getEmbedding().isEnabled(),
+                sourceProvider.getEmbedding().isEnabled() ? environment.getProperty("spring.ai.openai.embedding.options.model") : null);
+        providerInfos.add(new ProviderInfo(
+                alias,
+                sourceProvider.getType(),
+                chat,
+                embedding,
+                environment.getProperty("spring.ai.openai.base-url")));
     }
 
     private ProviderInfo mapProvider(String name, AiAdapterProperties.Provider provider) {

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/AiSecretPresenceGuardTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/AiSecretPresenceGuardTest.java
@@ -34,6 +34,8 @@ class AiSecretPresenceGuardTest {
     @Test
     void validateAllowsConfiguredOllamaBaseUrl() {
         AiAdapterProperties properties = new AiAdapterProperties();
+        properties.setEnabled(true);
+        properties.setDefaultProvider("ollama");
         Provider provider = new Provider();
         provider.setEnabled(true);
         provider.setType(ProviderType.OLLAMA);
@@ -52,6 +54,18 @@ class AiSecretPresenceGuardTest {
         AiAdapterProperties properties = new AiAdapterProperties();
         properties.setEnabled(true);
         properties.getSpringAi().setEnabled(true);
+
+        AiSecretPresenceGuard guard = new AiSecretPresenceGuard(properties, environment(),
+                emptyBeanProvider(org.springframework.ai.chat.model.ChatModel.class),
+                emptyBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class));
+
+        assertThrows(IllegalStateException.class, guard::validate);
+    }
+
+    @Test
+    void validateRejectsMissingDefaultProviderWhenNoSpringAiPromotionExists() {
+        AiAdapterProperties properties = new AiAdapterProperties();
+        properties.setEnabled(true);
 
         AiSecretPresenceGuard guard = new AiSecretPresenceGuard(properties, environment(),
                 emptyBeanProvider(org.springframework.ai.chat.model.ChatModel.class),

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/SpringAiAliasProviderAutoConfigurationTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/SpringAiAliasProviderAutoConfigurationTest.java
@@ -86,6 +86,20 @@ class SpringAiAliasProviderAutoConfigurationTest {
     }
 
     @Test
+    void promotesSpringAiAliasAsEffectiveDefaultProviderWhenDefaultProviderIsOmitted() {
+        contextRunner
+                .withPropertyValues("studio.ai.default-provider=")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    AiProviderRegistry registry = context.getBean(AiProviderRegistry.class);
+
+                    assertThat(registry.defaultProvider()).isEqualTo("openai-springai");
+                    assertThat(context.getBean(ChatPort.class)).isSameAs(registry.chatPort("openai-springai"));
+                    assertThat(context.getBean(EmbeddingPort.class)).isSameAs(registry.embeddingPort("openai-springai"));
+                });
+    }
+
+    @Test
     void routesControllerChatRequestsThroughDefaultSpringAiAlias() {
         contextRunner.run(context -> {
             assertThat(context).hasNotFailed();
@@ -284,8 +298,11 @@ class SpringAiAliasProviderAutoConfigurationTest {
                 .run(context -> {
                     assertThat(context).hasNotFailed();
                     AiProviderRegistry registry = context.getBean(AiProviderRegistry.class);
+                    assertThat(registry.defaultProvider()).isEqualTo("openai");
                     assertThat(registry.availableChatPorts()).containsKeys("openai", "openai-springai");
                     assertThat(registry.availableEmbeddingPorts()).containsKeys("openai", "openai-springai");
+                    assertThat(context.getBean(ChatPort.class)).isSameAs(registry.chatPort("openai"));
+                    assertThat(context.getBean(EmbeddingPort.class)).isSameAs(registry.embeddingPort("openai"));
                 });
     }
 }

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/SpringAiAliasProviderAutoConfigurationTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/SpringAiAliasProviderAutoConfigurationTest.java
@@ -168,6 +168,7 @@ class SpringAiAliasProviderAutoConfigurationTest {
 
             AiInfoController controller = new AiInfoController(
                     context.getBean(AiAdapterProperties.class),
+                    context.getEnvironment(),
                     null);
 
             ResponseEntity<ApiResponse<AiInfoController.AiInfoResponse>> response = controller.providers();
@@ -175,6 +176,9 @@ class SpringAiAliasProviderAutoConfigurationTest {
 
             assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
             assertThat(response.getBody().getData().defaultProvider()).isEqualTo("openai-springai");
+            assertThat(response.getBody().getData().providers())
+                    .extracting(AiInfoController.ProviderInfo::name)
+                    .contains("openai", "openai-springai");
             assertThat(registry.defaultProvider()).isEqualTo("openai-springai");
             assertThat(registry.availableChatPorts()).containsKeys("openai", "openai-springai");
             assertThat(registry.availableEmbeddingPorts()).containsKeys("openai", "openai-springai");


### PR DESCRIPTION
## Why
- `#95`, `#96`, `#98`로 Spring AI OpenAI alias와 cutover validation은 확보됐지만, 기본 provider 승격 규칙은 아직 명시적 설정에만 의존하고 있었습니다.
- 이번 변경은 `default-provider`가 비어 있을 때 Spring AI alias를 기본 provider로 승격하고, `default-provider=openai`를 명시하면 LangChain base provider로 rollback 가능한 규칙을 코드와 문서에 반영합니다.

## What
- `AiAdapterProperties`에 effective default provider 해석을 추가했습니다.
- `AiProviderRegistryConfiguration`와 `AiInfoController`가 runtime 기준 effective default provider를 사용하도록 바꿨습니다.
- `AiSecretPresenceGuard`에 default provider 미설정/미해결 시 fail-fast 검증을 추가했습니다.
- `SpringAiAliasProviderAutoConfigurationTest`, `AiSecretPresenceGuardTest`에 alias promotion/rollback 검증을 추가했습니다.
- `README.md`, `docs/dev/spring-ai-openai-phase1.md`, `CHANGELOG.md`를 현재 기준으로 갱신했습니다.

## Related Issues
- Closes #100
- Follows #95, #96, #98

## Change Scope
- AI starter default provider resolution
- startup fail-fast validation
- Spring AI OpenAI phase 1 운영 문서
- regression tests

## Security Impact
- startup 단계에서 잘못된 default provider 설정을 더 일찍 차단합니다.
- rollback은 `default-provider=openai`를 명시하는 방식으로 유지됩니다.

## Validation
```bash
./gradlew -p /tmp/studio-api-spring-ai -PnimbusJoseJwtVersion=9.37.3 -PjsonSmartVersion=2.5.2 \
  :starter:studio-platform-starter-ai:test \
  --tests 'studio.one.platform.ai.autoconfigure.AiSecretPresenceGuardTest' \
  --tests 'studio.one.platform.ai.autoconfigure.config.SpringAiAliasProviderAutoConfigurationTest'
```
- Result: `BUILD SUCCESSFUL`

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- Used: [x] Yes [ ] No
- Roles:
  - `system-designer`: cutover 이후 기본 provider 규칙과 rollback 기준 정리
  - `code-reviewer`: cutover validation coverage와 residual risk 검토
- Main author integration/validation:
  - main author가 default provider 해석, guard, docs, regression test를 통합 검증함

## Checklist
- [x] 관련 이슈를 연결했다.
- [x] 변경 범위는 이번 작업과 직접 관련된 내용만 포함했다.
- [x] validation 명령과 결과를 기록했다.
- [x] changelog를 갱신했다.
- [x] human review 전 AI review 대상임을 인지했다.

## Deployment Notes
- `studio.ai.default-provider`를 비우면 Spring AI alias(`source-provider + provider-suffix`)가 기본 provider로 승격됩니다.
- LangChain base provider로 rollback하려면 `studio.ai.default-provider=openai`를 명시해야 합니다.
