### PR TITLE
[ai-assisted] refactor(ai): unify core bean ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,4 @@
 # 2026-03-24
 
 - refactor(ai): start splitting AI HTTP endpoints into a dedicated web starter module.
+- refactor(ai): remove remaining core bean stereotypes so AI service ownership stays in starter auto-configuration.

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/adapters/vector/PgVectorStoreAdapterV2.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/adapters/vector/PgVectorStoreAdapterV2.java
@@ -14,7 +14,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.stereotype.Component;
 import studio.one.platform.ai.core.vector.VectorDocument;
 import studio.one.platform.ai.core.vector.VectorSearchRequest;
 import studio.one.platform.ai.core.vector.VectorSearchResult;
@@ -26,7 +25,6 @@ import studio.one.platform.data.sqlquery.annotation.SqlStatement;
  * PgVector {@link VectorStorePort} implementation backed by sqlset-defined
  * statements and {@link SqlStatement} injection.
  */
-@Component
 public class PgVectorStoreAdapterV2 implements VectorStorePort {
 
     private static final RowMapper<VectorSearchResult> ROW_MAPPER = new RowMapper<>() {

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/service/keyword/LlmKeywordExtractor.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/service/keyword/LlmKeywordExtractor.java
@@ -5,8 +5,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import org.springframework.stereotype.Component;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -21,7 +19,6 @@ import studio.one.platform.ai.service.prompt.PromptManager;
 /**
  * LLM 기반 키워드 추출기. 입력 텍스트에서 5~10개의 핵심 키워드를 JSON 배열로 받아 파싱한다.
  */
-@Component
 @RequiredArgsConstructor
 @Slf4j
 public class LlmKeywordExtractor implements KeywordExtractor {

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineService.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineService.java
@@ -7,9 +7,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.stereotype.Service;
-
 import com.github.benmanes.caffeine.cache.Cache;
 
 import io.github.resilience4j.retry.Retry;
@@ -30,8 +27,6 @@ import studio.one.platform.ai.core.vector.VectorStorePort;
 import studio.one.platform.ai.service.keyword.KeywordExtractor;
 import studio.one.platform.constant.ServiceNames;
 
-@Service(RagPipelineService.SERVICE_NAME)
-@ConditionalOnProperty(prefix = "studio.ai", name = "enabled", havingValue = "true", matchIfMissing = false)
 @Slf4j
 public class RagPipelineService {
     public static final String SERVICE_NAME = ServiceNames.Featrues.PREFIX + ":ai:rag-pipelien-service";


### PR DESCRIPTION
## Why
- AI web starter 분리 이후에도 core 모듈에는 일부 service/adapter stereotype이 남아 있어 bean ownership 경계가 흐립니다.
- core starter auto-configuration이 AI service graph를 유일하게 소유하도록 맞출 필요가 있습니다.

## What
- `RagPipelineService`의 `@Service` / `@ConditionalOnProperty`를 제거했습니다.
- `LlmKeywordExtractor`의 `@Component`를 제거했습니다.
- `PgVectorStoreAdapterV2`의 `@Component`를 제거했습니다.
- core starter configuration이 이 bean들의 유일한 생성 경로가 되도록 정리했습니다.

## Validation
- `./gradlew -p /tmp/studio-api-spring-ai -PnimbusJoseJwtVersion=9.37.3 -PjsonSmartVersion=2.5.2 :studio-platform-ai:test --tests 'studio.one.platform.ai.service.pipeline.RagPipelineServiceTest' :starter:studio-platform-starter-ai:compileJava :starter:studio-platform-starter-ai-web:compileJava`

## Checklist
- [x] 범위 외 리팩터링 없음
- [x] validation 수행
- [x] AI-assisted commit 형식 준수
- [x] human review 필요

## Related
- Closes #90
