### PR TITLE
refactor(ai): remove AI starter component scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@
 - refactor(ai): start splitting AI HTTP endpoints into a dedicated web starter module.
 - refactor(ai): remove remaining core bean stereotypes so AI service ownership stays in starter auto-configuration.
 - refactor(ai): narrow AI dependency ownership so web/security concerns stay with the web starter boundary.
+- refactor(ai): replace AI starter component scanning with explicit auto-configuration bean registration.

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
@@ -1,11 +1,19 @@
 package studio.one.platform.ai.autoconfigure;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.lang.Nullable;
 
+import studio.one.platform.ai.autoconfigure.config.AiAdapterProperties;
 import studio.one.platform.ai.core.chat.ChatPort;
+import studio.one.platform.ai.core.embedding.EmbeddingPort;
+import studio.one.platform.ai.core.vector.VectorStorePort;
+import studio.one.platform.ai.service.pipeline.RagPipelineService;
+import studio.one.platform.ai.service.prompt.PromptManager;
 import studio.one.platform.ai.web.controller.AiInfoController;
 import studio.one.platform.ai.web.controller.ChatController;
 import studio.one.platform.ai.web.controller.EmbeddingController;
@@ -18,15 +26,46 @@ import studio.one.platform.constant.PropertyKeys;
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(ChatPort.class)
 @ConditionalOnProperty(prefix = PropertyKeys.AI.PREFIX, name = "enabled", havingValue = "true", matchIfMissing = false)
-@ComponentScan(basePackageClasses = {
-        ChatController.class,
-        EmbeddingController.class,
-        VectorController.class,
-        RagController.class,
-        QueryRewriteController.class,
-        AiInfoController.class,
-        TokenUsageJsonComponent.class
-})
 public class AiWebAutoConfiguration {
 
+    @Bean
+    ChatController chatController(ChatPort chatPort, RagPipelineService ragPipelineService) {
+        return new ChatController(chatPort, ragPipelineService);
+    }
+
+    @Bean
+    EmbeddingController embeddingController(EmbeddingPort embeddingPort) {
+        return new EmbeddingController(embeddingPort);
+    }
+
+    @Bean
+    VectorController vectorController(
+            EmbeddingPort embeddingPort,
+            @Nullable VectorStorePort vectorStorePort,
+            ObjectProvider<PromptManager> promptManagerProvider) {
+        return new VectorController(embeddingPort, vectorStorePort, promptManagerProvider);
+    }
+
+    @Bean
+    RagController ragController(RagPipelineService ragPipelineService) {
+        return new RagController(ragPipelineService);
+    }
+
+    @Bean
+    QueryRewriteController queryRewriteController(PromptManager promptManager, ChatPort chatPort) {
+        return new QueryRewriteController(promptManager, chatPort);
+    }
+
+    @Bean
+    AiInfoController aiInfoController(
+            AiAdapterProperties properties,
+            Environment environment,
+            @Nullable VectorStorePort vectorStorePort) {
+        return new AiInfoController(properties, environment, vectorStorePort);
+    }
+
+    @Bean
+    TokenUsageJsonComponent tokenUsageJsonComponent() {
+        return new TokenUsageJsonComponent();
+    }
 }

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
@@ -57,6 +57,11 @@ public class AiWebAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnProperty(
+            prefix = PropertyKeys.AI.Endpoints.PREFIX,
+            name = "enabled",
+            havingValue = "true",
+            matchIfMissing = false)
     AiInfoController aiInfoController(
             AiAdapterProperties properties,
             Environment environment,

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
@@ -187,4 +187,16 @@ class OpenAiProviderAutoConfigurationTest {
                             .hasRootCauseMessage("Exactly one enabled OPENAI provider is supported");
                 });
     }
+
+    @Test
+    void doesNotRegisterInfoControllerWhenEndpointsAreDisabled() {
+        contextRunner
+                .withPropertyValues("studio.ai.endpoints.enabled=false")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).doesNotHaveBean(AiInfoController.class);
+                    assertThat(context).hasSingleBean(ChatController.class);
+                    assertThat(context).hasSingleBean(EmbeddingController.class);
+                });
+    }
 }

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
@@ -28,6 +28,7 @@ import studio.one.platform.ai.service.pipeline.RagPipelineService;
 import studio.one.platform.ai.web.controller.AiInfoController;
 import studio.one.platform.ai.web.controller.ChatController;
 import studio.one.platform.ai.web.controller.EmbeddingController;
+import studio.one.platform.ai.web.controller.TokenUsageJsonComponent;
 import studio.one.platform.ai.web.dto.ChatMessageDto;
 import studio.one.platform.ai.web.dto.ChatRequestDto;
 import studio.one.platform.ai.web.dto.ChatResponseDto;
@@ -88,6 +89,7 @@ class OpenAiProviderAutoConfigurationTest {
     void routesControllerChatRequestsThroughDefaultOpenAiProvider() {
         contextRunner.run(context -> {
             assertThat(context).hasNotFailed();
+            assertThat(context).hasSingleBean(ChatController.class);
 
             org.springframework.ai.chat.model.ChatModel springAiChatModel =
                     context.getBean(org.springframework.ai.chat.model.ChatModel.class);
@@ -121,6 +123,7 @@ class OpenAiProviderAutoConfigurationTest {
     void routesControllerEmbeddingRequestsThroughDefaultOpenAiProvider() {
         contextRunner.run(context -> {
             assertThat(context).hasNotFailed();
+            assertThat(context).hasSingleBean(EmbeddingController.class);
 
             org.springframework.ai.embedding.EmbeddingModel springAiEmbeddingModel =
                     context.getBean(org.springframework.ai.embedding.EmbeddingModel.class);
@@ -144,6 +147,8 @@ class OpenAiProviderAutoConfigurationTest {
     void exposesOpenAiFromInfoControllerInRuntimeContext() {
         contextRunner.run(context -> {
             assertThat(context).hasNotFailed();
+            assertThat(context).hasSingleBean(AiInfoController.class);
+            assertThat(context).hasSingleBean(TokenUsageJsonComponent.class);
 
             AiInfoController controller = context.getBean(AiInfoController.class);
 


### PR DESCRIPTION
## Why
- `#92`의 목표대로 AI core/web starter에서 `@ComponentScan` 의존을 제거하고 explicit auto-configuration으로 마감해야 합니다.
- 특히 web starter는 controller와 JSON serializer 등록이 scan에 기대고 있어 bean 등록 경계가 코드에서 완전히 드러나지 않았습니다.

## What
- `AiWebAutoConfiguration`의 `@ComponentScan`을 제거했습니다.
- `ChatController`, `EmbeddingController`, `VectorController`, `RagController`, `QueryRewriteController`, `AiInfoController`, `TokenUsageJsonComponent`를 explicit `@Bean`으로 등록하도록 바꿨습니다.
- web starter registration test를 explicit bean wiring 기준으로 보강했습니다.
- changelog를 갱신했습니다.

## Related Issues
- Closes #92
- Related #89

## Change Scope
- [ ] API contract
- [ ] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [x] Docs/runbook

## Security Impact
- Risk:
  - component scan 제거 과정에서 web starter bean 등록 누락이 생길 수 있습니다.
- Mitigation:
  - `OpenAiProviderAutoConfigurationTest`로 runtime context에서 controller와 serializer bean 등록을 직접 검증했습니다.

## Validation
- Commands:
  - `./gradlew -PnimbusJoseJwtVersion=9.37.3 -PjsonSmartVersion=2.5.2 :starter:studio-platform-starter-ai:compileJava :starter:studio-platform-starter-ai-web:compileJava`
  - `./gradlew -PnimbusJoseJwtVersion=9.37.3 -PjsonSmartVersion=2.5.2 :starter:studio-platform-starter-ai-web:test --tests 'studio.one.platform.ai.autoconfigure.config.OpenAiProviderAutoConfigurationTest'`
- Result:
  - both commands passed with `BUILD SUCCESSFUL`
- Additional checks:
  - `rg -n "@ComponentScan" starter/studio-platform-starter-ai starter/studio-platform-starter-ai-web` returned no matches after the change.

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [ ] No
- [x] Yes
- Delegated tasks:
  - `system-designer`: `#92`를 explicit auto-configuration 마감 작업으로 고정
  - `code-mapper`: remaining `@ComponentScan` 위치와 관련 test 범위 식별
- Ownership (files/modules/tasks):
  - main author: `AiWebAutoConfiguration`, test, changelog 수정 및 최종 통합
- Main author post-integration validation:
  - main author가 compile/test와 scan 제거 검색 결과를 직접 검증

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [ ] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering:
  - no deployment ordering needed
- Rollback plan:
  - revert commit `55702c4`
- Post-deploy checks:
  - verify AI web starter endpoints still register in application startup
