### PR TITLE
refactor(ai): prune unused core starter dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,4 @@
 - refactor(ai): remove remaining core bean stereotypes so AI service ownership stays in starter auto-configuration.
 - refactor(ai): narrow AI dependency ownership so web/security concerns stay with the web starter boundary.
 - refactor(ai): replace AI starter component scanning with explicit auto-configuration bean registration.
+- refactor(ai): prune unused compileOnly Spring starter dependencies from `studio-platform-starter-ai`.

--- a/starter/studio-platform-starter-ai/build.gradle.kts
+++ b/starter/studio-platform-starter-ai/build.gradle.kts
@@ -18,11 +18,7 @@ dependencies {
     compileOnly(project(":studio-platform-autoconfigure")) 
     compileOnly(project(":starter:studio-platform-starter")) 
     api(project(":studio-platform-ai")) 
-    compileOnly("org.springframework.boot:spring-boot-starter-web")
-    compileOnly("org.springframework.boot:spring-boot-starter-data-jpa")
-    compileOnly("org.springframework.boot:spring-boot-starter-validation")
-    compileOnly("org.springframework.boot:spring-boot-starter-security")
-    compileOnly("org.springframework.security:spring-security-acl")
+    compileOnly("org.springframework:spring-jdbc")
     
     implementation("com.pgvector:pgvector:${property("pgvectorVersion")}") 
     implementation("org.springframework.ai:spring-ai-starter-model-openai")


### PR DESCRIPTION
## Why
- `starter:studio-platform-starter-ai`는 현재 core AI auto-configuration과 provider wiring만 담당합니다.
- 그런데 build file에는 source set이 직접 사용하지 않는 Spring starter `compileOnly` 의존이 남아 있어 ownership이 과하게 보였습니다.
- 작은 범위로 unused dependency를 줄여 starter 역할을 더 명확히 정리합니다.

## What
- `starter/studio-platform-starter-ai/build.gradle.kts`에서 unused `compileOnly` Spring starter 의존을 제거했습니다.
- `JdbcTemplate`를 직접 쓰는 현재 코드 경계를 반영해 `spring-jdbc`만 `compileOnly`로 유지했습니다.
- changelog를 갱신했습니다.

## Related Issues
- Closes #107
- Related #

## Change Scope
- [ ] API contract
- [ ] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [x] Docs/runbook

## Security Impact
- Risk:
  - 필요한 compile dependency를 과하게 제거하면 starter compile이 깨질 수 있습니다.
- Mitigation:
  - `VectorStoreConfiguration`의 `JdbcTemplate` 사용을 기준으로 `spring-jdbc`는 유지하고 compile validation을 수행했습니다.

## Validation
- Commands:
  - `./gradlew -PnimbusJoseJwtVersion=9.37.3 -PjsonSmartVersion=2.5.2 :starter:studio-platform-starter-ai:compileJava :starter:studio-platform-starter-ai-web:compileJava`
- Result:
  - `BUILD SUCCESSFUL`
- Additional checks:
  - source set import search 기준으로 removed Spring starter APIs의 직접 참조가 없음을 확인했습니다.

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [x] No
- [ ] Yes
- Delegated tasks:
- Ownership (files/modules/tasks):
- Main author post-integration validation:

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [ ] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering:
  - none
- Rollback plan:
  - revert commit `d0d7a97`
- Post-deploy checks:
  - none beyond compile/CI
