### PR TITLE
[ai-assisted] refactor(ai): migrate ollama embedding to spring ai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,4 @@
 - refactor(ai): replace AI starter component scanning with explicit auto-configuration bean registration.
 - refactor(ai): prune unused compileOnly Spring starter dependencies from `studio-platform-starter-ai`.
 - refactor(ai): remove LangChain4j `TokenUsage` coupling from ai-web starter and normalize chat `tokenUsage` metadata shape.
+- refactor(ai): migrate Ollama embedding wiring from LangChain4j to Spring AI and validate `spring.ai.ollama.embedding.options.model` at startup.

--- a/starter/studio-platform-starter-ai/build.gradle.kts
+++ b/starter/studio-platform-starter-ai/build.gradle.kts
@@ -22,8 +22,8 @@ dependencies {
     
     implementation("com.pgvector:pgvector:${property("pgvectorVersion")}") 
     implementation("org.springframework.ai:spring-ai-starter-model-openai")
+    implementation("org.springframework.ai:spring-ai-ollama")
     implementation("dev.langchain4j:langchain4j:${property("langchain4jVersion")}")
-    implementation("dev.langchain4j:langchain4j-ollama:${property("langchain4jVersion")}")
     implementation("dev.langchain4j:langchain4j-google-ai-gemini:${property("langchain4jVersion")}")
     implementation("com.github.ben-manes.caffeine:caffeine:${property("caffeineVersion")}")
     implementation("io.github.resilience4j:resilience4j-spring-boot2:${property("resilience4jVersion")}")

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/AiSecretPresenceGuard.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/AiSecretPresenceGuard.java
@@ -39,8 +39,7 @@ public class AiSecretPresenceGuard {
                 case OPENAI -> validateOpenAiProvider(provider);
                 case GOOGLE_AI_GEMINI -> requireText(provider.getApiKey(),
                         "studio.ai.providers." + providerId + ".api-key must be configured");
-                case OLLAMA -> requireText(provider.getBaseUrl(),
-                        "studio.ai.providers." + providerId + ".base-url must be configured");
+                case OLLAMA -> validateOllamaProvider(provider);
                 default -> {
                 }
             }
@@ -82,6 +81,13 @@ public class AiSecretPresenceGuard {
         }
         if (embeddingEnabled && springAiEmbeddingModelProvider.getIfAvailable() == null) {
             throw new IllegalStateException("Spring AI embedding model bean is required for OPENAI provider");
+        }
+    }
+
+    private void validateOllamaProvider(AiAdapterProperties.Provider provider) {
+        if (provider.getEmbedding().isEnabled()) {
+            requireText(environment.getProperty("spring.ai.ollama.embedding.options.model"),
+                    "spring.ai.ollama.embedding.options.model must be configured for OLLAMA embedding provider");
         }
     }
 

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/LangChainEmbeddingConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/LangChainEmbeddingConfiguration.java
@@ -13,7 +13,6 @@ import org.springframework.core.env.Environment;
 
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.googleai.GoogleAiEmbeddingModel;
-import dev.langchain4j.model.ollama.OllamaEmbeddingModel;
 import lombok.extern.slf4j.Slf4j;
 import studio.one.platform.ai.autoconfigure.adapter.SpringAiEmbeddingAdapter;
 import studio.one.platform.ai.adapters.embedding.LangChainEmbeddingAdapter;
@@ -62,15 +61,15 @@ public class LangChainEmbeddingConfiguration {
         log.debug("Creating Embedding Port by  {}", provider );
         EmbeddingModel embeddingModel = switch (provider.getType()) {
             case OPENAI -> null;
-            case OLLAMA -> OllamaEmbeddingModel.builder()
-                    .baseUrl(resolveBaseUrl(provider, environment))
-                    .modelName(requireModel(provider.getEmbedding().getModel()))
-                    .build();
+            case OLLAMA -> null;
             case GOOGLE_AI_GEMINI -> buildGoogleEmbedding(provider, resolveBaseUrl(provider, environment), requireModel(provider.getEmbedding().getModel()));
             default -> throw new IllegalArgumentException("Unsupported embedding provider: " + provider.getType());
         };
         if (provider.getType() == AiAdapterProperties.ProviderType.OPENAI) {
             return createSpringAiEmbeddingPort(springAiEmbeddingModelProvider);
+        }
+        if (provider.getType() == AiAdapterProperties.ProviderType.OLLAMA) {
+            return createOllamaSpringAiEmbeddingPort(environment);
         }
         log.info(LogUtils.format(i18n, I18nKeys.AutoConfig.Feature.Service.DEPENDS_ON,
                 AiProviderRegistryConfiguration.FEATURE_NAME,
@@ -78,6 +77,23 @@ public class LangChainEmbeddingConfiguration {
                 LogUtils.green(embeddingModel.getClass(), true),
                 LogUtils.red(State.CREATED.toString())));
         return new LangChainEmbeddingAdapter(embeddingModel);
+    }
+
+    private static EmbeddingPort createOllamaSpringAiEmbeddingPort(Environment environment) {
+        String model = requireText(environment.getProperty("spring.ai.ollama.embedding.options.model"),
+                "spring.ai.ollama.embedding.options.model must be configured for OLLAMA embedding provider");
+        String baseUrl = environment.getProperty("spring.ai.ollama.base-url", "http://localhost:11434");
+        org.springframework.ai.ollama.api.OllamaApi ollamaApi = org.springframework.ai.ollama.api.OllamaApi.builder()
+                .baseUrl(baseUrl)
+                .build();
+        org.springframework.ai.ollama.api.OllamaEmbeddingOptions options = org.springframework.ai.ollama.api.OllamaEmbeddingOptions.builder()
+                .model(model)
+                .build();
+        org.springframework.ai.ollama.OllamaEmbeddingModel embeddingModel = org.springframework.ai.ollama.OllamaEmbeddingModel.builder()
+                .ollamaApi(ollamaApi)
+                .defaultOptions(options)
+                .build();
+        return new SpringAiEmbeddingAdapter(embeddingModel);
     }
 
     private static GoogleAiEmbeddingModel buildGoogleEmbedding(AiAdapterProperties.Provider provider, String baseUrl, String model) {
@@ -117,6 +133,13 @@ public class LangChainEmbeddingConfiguration {
             throw new IllegalArgumentException("Model name must be provided for embedding configuration");
         }
         return model;
+    }
+
+    private static String requireText(String value, String message) {
+        if (!StringUtils.isNotBlank(value)) {
+            throw new IllegalStateException(message);
+        }
+        return value;
     }
 
     private static GoogleAiEmbeddingModel.TaskType parseTaskType(String value) {

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/AiSecretPresenceGuardTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/AiSecretPresenceGuardTest.java
@@ -32,21 +32,42 @@ class AiSecretPresenceGuardTest {
     }
 
     @Test
-    void validateAllowsConfiguredOllamaBaseUrl() {
+    void validateAllowsConfiguredSpringAiModelForOllamaEmbedding() {
         AiAdapterProperties properties = new AiAdapterProperties();
         properties.setEnabled(true);
         properties.setDefaultProvider("ollama");
         Provider provider = new Provider();
         provider.setEnabled(true);
         provider.setType(ProviderType.OLLAMA);
-        provider.setBaseUrl("http://localhost:11434");
+        provider.getEmbedding().setEnabled(true);
+        properties.getProviders().put("ollama", provider);
+
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("spring.ai.ollama.embedding.options.model", "nomic-embed-text");
+
+        AiSecretPresenceGuard guard = new AiSecretPresenceGuard(properties, environment,
+                emptyBeanProvider(org.springframework.ai.chat.model.ChatModel.class),
+                emptyBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class));
+
+        assertDoesNotThrow(guard::validate);
+    }
+
+    @Test
+    void validateRejectsMissingSpringAiModelForOllamaEmbedding() {
+        AiAdapterProperties properties = new AiAdapterProperties();
+        properties.setEnabled(true);
+        properties.setDefaultProvider("ollama");
+        Provider provider = new Provider();
+        provider.setEnabled(true);
+        provider.setType(ProviderType.OLLAMA);
+        provider.getEmbedding().setEnabled(true);
         properties.getProviders().put("ollama", provider);
 
         AiSecretPresenceGuard guard = new AiSecretPresenceGuard(properties, environment(),
                 emptyBeanProvider(org.springframework.ai.chat.model.ChatModel.class),
                 emptyBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class));
 
-        assertDoesNotThrow(guard::validate);
+        assertThrows(IllegalStateException.class, guard::validate);
     }
 
     @Test

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/OllamaSpringAiEmbeddingRegistrationTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/OllamaSpringAiEmbeddingRegistrationTest.java
@@ -1,0 +1,50 @@
+package studio.one.platform.ai.autoconfigure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.support.StaticListableBeanFactory;
+import org.springframework.mock.env.MockEnvironment;
+
+import studio.one.platform.ai.autoconfigure.adapter.SpringAiEmbeddingAdapter;
+import studio.one.platform.ai.core.embedding.EmbeddingPort;
+import studio.one.platform.ai.core.registry.AiProviderRegistry;
+import studio.one.platform.service.I18n;
+
+class OllamaSpringAiEmbeddingRegistrationTest {
+
+    @Test
+    void registersOllamaEmbeddingAsSpringAiBackedPath() {
+        AiAdapterProperties properties = new AiAdapterProperties();
+        properties.setDefaultProvider("ollama");
+
+        AiAdapterProperties.Provider provider = new AiAdapterProperties.Provider();
+        provider.setType(AiAdapterProperties.ProviderType.OLLAMA);
+        provider.getEmbedding().setEnabled(true);
+        provider.getEmbedding().setModel("legacy-should-not-be-used");
+        properties.getProviders().put("ollama", provider);
+
+        LangChainEmbeddingConfiguration embeddingConfiguration = new LangChainEmbeddingConfiguration();
+        StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
+        ObjectProvider<I18n> i18nProvider = beanFactory.getBeanProvider(I18n.class);
+        MockEnvironment environment = new MockEnvironment()
+                .withProperty("spring.ai.ollama.base-url", "http://localhost:11434")
+                .withProperty("spring.ai.ollama.embedding.options.model", "nomic-embed-text");
+
+        Map<String, EmbeddingPort> embeddingPorts = embeddingConfiguration.embeddingPorts(
+                properties,
+                i18nProvider,
+                environment,
+                beanFactory.getBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class));
+
+        assertThat(embeddingPorts).containsOnlyKeys("ollama");
+        assertThat(embeddingPorts.get("ollama")).isInstanceOf(SpringAiEmbeddingAdapter.class);
+
+        AiProviderRegistry registry = new AiProviderRegistry("ollama", Map.of(), embeddingPorts);
+        assertThat(registry.defaultProvider()).isEqualTo("ollama");
+        assertThat(registry.embeddingPort(null)).isSameAs(embeddingPorts.get("ollama"));
+    }
+}


### PR DESCRIPTION
## Why
- Continue #109 by addressing #111.
- Remove the remaining LangChain4j dependency from the Ollama embedding path.
- Align Ollama embedding startup validation with Spring AI-owned settings.

## What
- add `spring-ai-ollama` to `starter-ai` and remove `langchain4j-ollama`
- switch the OLLAMA embedding branch in `LangChainEmbeddingConfiguration` to `SpringAiEmbeddingAdapter`
- validate `spring.ai.ollama.embedding.options.model` in `AiSecretPresenceGuard`
- add focused registration and guard tests for Ollama embedding
- update `CHANGELOG.md`

## Validation
- `./gradlew -p /tmp/studio-api-spring-ai -PnimbusJoseJwtVersion=9.37.3 -PjsonSmartVersion=2.5.2 :starter:studio-platform-starter-ai:compileJava :starter:studio-platform-starter-ai:test --tests 'studio.one.platform.ai.autoconfigure.AiSecretPresenceGuardTest' --tests 'studio.one.platform.ai.autoconfigure.config.OllamaSpringAiEmbeddingRegistrationTest'`
