### PR TITLE
[ai-assisted] refactor(ai): migrate google embedding to spring ai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,4 @@
 - refactor(ai): prune unused compileOnly Spring starter dependencies from `studio-platform-starter-ai`.
 - refactor(ai): remove LangChain4j `TokenUsage` coupling from ai-web starter and normalize chat `tokenUsage` metadata shape.
 - refactor(ai): migrate Ollama embedding wiring from LangChain4j to Spring AI and validate `spring.ai.ollama.embedding.options.model` at startup.
+- refactor(ai): migrate Google embedding wiring from LangChain4j to Spring AI and validate `spring.ai.google.genai.embedding.*` at startup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,4 @@
 - refactor(ai): remove LangChain4j `TokenUsage` coupling from ai-web starter and normalize chat `tokenUsage` metadata shape.
 - refactor(ai): migrate Ollama embedding wiring from LangChain4j to Spring AI and validate `spring.ai.ollama.embedding.options.model` at startup.
 - refactor(ai): migrate Google embedding wiring from LangChain4j to Spring AI and validate `spring.ai.google.genai.embedding.*` at startup.
+- refactor(ai): preserve Google embedding `taskType` during the Spring AI migration; `titleMetadataKey` remains inactive because the current embedding request model carries text only.

--- a/starter/studio-platform-starter-ai/build.gradle.kts
+++ b/starter/studio-platform-starter-ai/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     implementation("com.pgvector:pgvector:${property("pgvectorVersion")}") 
     implementation("org.springframework.ai:spring-ai-starter-model-openai")
     implementation("org.springframework.ai:spring-ai-ollama")
+    implementation("org.springframework.ai:spring-ai-google-genai-embedding")
     implementation("dev.langchain4j:langchain4j:${property("langchain4jVersion")}")
     implementation("dev.langchain4j:langchain4j-google-ai-gemini:${property("langchain4jVersion")}")
     implementation("com.github.ben-manes.caffeine:caffeine:${property("caffeineVersion")}")

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/AiSecretPresenceGuard.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/AiSecretPresenceGuard.java
@@ -37,8 +37,7 @@ public class AiSecretPresenceGuard {
             }
             switch (provider.getType()) {
                 case OPENAI -> validateOpenAiProvider(provider);
-                case GOOGLE_AI_GEMINI -> requireText(provider.getApiKey(),
-                        "studio.ai.providers." + providerId + ".api-key must be configured");
+                case GOOGLE_AI_GEMINI -> validateGoogleEmbeddingProvider(providerId, provider);
                 case OLLAMA -> validateOllamaProvider(provider);
                 default -> {
                 }
@@ -88,6 +87,19 @@ public class AiSecretPresenceGuard {
         if (provider.getEmbedding().isEnabled()) {
             requireText(environment.getProperty("spring.ai.ollama.embedding.options.model"),
                     "spring.ai.ollama.embedding.options.model must be configured for OLLAMA embedding provider");
+        }
+    }
+
+    private void validateGoogleEmbeddingProvider(String providerId, AiAdapterProperties.Provider provider) {
+        if (provider.getEmbedding().isEnabled()) {
+            requireText(environment.getProperty("spring.ai.google.genai.embedding.api-key"),
+                    "spring.ai.google.genai.embedding.api-key must be configured for GOOGLE_AI_GEMINI embedding provider");
+            requireText(environment.getProperty("spring.ai.google.genai.embedding.text.options.model"),
+                    "spring.ai.google.genai.embedding.text.options.model must be configured for GOOGLE_AI_GEMINI embedding provider");
+        }
+        if (provider.getChat().isEnabled()) {
+            requireText(provider.getApiKey(),
+                    "studio.ai.providers." + providerId + ".api-key must be configured for GOOGLE_AI_GEMINI chat provider");
         }
     }
 

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/LangChainEmbeddingConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/LangChainEmbeddingConfiguration.java
@@ -72,7 +72,7 @@ public class LangChainEmbeddingConfiguration {
             return createOllamaSpringAiEmbeddingPort(environment);
         }
         if (provider.getType() == AiAdapterProperties.ProviderType.GOOGLE_AI_GEMINI) {
-            return createGoogleSpringAiEmbeddingPort(environment);
+            return createGoogleSpringAiEmbeddingPort(provider, environment);
         }
         log.info(LogUtils.format(i18n, I18nKeys.AutoConfig.Feature.Service.DEPENDS_ON,
                 AiProviderRegistryConfiguration.FEATURE_NAME,
@@ -99,11 +99,12 @@ public class LangChainEmbeddingConfiguration {
         return new SpringAiEmbeddingAdapter(embeddingModel);
     }
 
-    private static EmbeddingPort createGoogleSpringAiEmbeddingPort(Environment environment) {
+    private static EmbeddingPort createGoogleSpringAiEmbeddingPort(AiAdapterProperties.Provider provider, Environment environment) {
         String apiKey = requireText(environment.getProperty("spring.ai.google.genai.embedding.api-key"),
                 "spring.ai.google.genai.embedding.api-key must be configured for GOOGLE_AI_GEMINI embedding provider");
         String model = requireText(environment.getProperty("spring.ai.google.genai.embedding.text.options.model"),
                 "spring.ai.google.genai.embedding.text.options.model must be configured for GOOGLE_AI_GEMINI embedding provider");
+        AiAdapterProperties.GoogleEmbeddingOptions google = provider.getGoogleEmbedding();
         org.springframework.ai.google.genai.GoogleGenAiEmbeddingConnectionDetails connectionDetails =
                 org.springframework.ai.google.genai.GoogleGenAiEmbeddingConnectionDetails.builder()
                         .apiKey(apiKey)
@@ -113,6 +114,7 @@ public class LangChainEmbeddingConfiguration {
         org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingOptions options =
                 org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingOptions.builder()
                         .model(model)
+                        .taskType(parseSpringAiGoogleTaskType(google.getTaskType()))
                         .build();
         org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingModel embeddingModel =
                 new org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingModel(connectionDetails, options);
@@ -170,5 +172,13 @@ public class LangChainEmbeddingConfiguration {
             return null;
         }
         return GoogleAiEmbeddingModel.TaskType.valueOf(value.trim().toUpperCase(Locale.ROOT));
+    }
+
+    private static org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingOptions.TaskType parseSpringAiGoogleTaskType(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingOptions.TaskType.valueOf(
+                value.trim().toUpperCase(Locale.ROOT));
     }
 }

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/LangChainEmbeddingConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/LangChainEmbeddingConfiguration.java
@@ -62,7 +62,7 @@ public class LangChainEmbeddingConfiguration {
         EmbeddingModel embeddingModel = switch (provider.getType()) {
             case OPENAI -> null;
             case OLLAMA -> null;
-            case GOOGLE_AI_GEMINI -> buildGoogleEmbedding(provider, resolveBaseUrl(provider, environment), requireModel(provider.getEmbedding().getModel()));
+            case GOOGLE_AI_GEMINI -> null;
             default -> throw new IllegalArgumentException("Unsupported embedding provider: " + provider.getType());
         };
         if (provider.getType() == AiAdapterProperties.ProviderType.OPENAI) {
@@ -70,6 +70,9 @@ public class LangChainEmbeddingConfiguration {
         }
         if (provider.getType() == AiAdapterProperties.ProviderType.OLLAMA) {
             return createOllamaSpringAiEmbeddingPort(environment);
+        }
+        if (provider.getType() == AiAdapterProperties.ProviderType.GOOGLE_AI_GEMINI) {
+            return createGoogleSpringAiEmbeddingPort(environment);
         }
         log.info(LogUtils.format(i18n, I18nKeys.AutoConfig.Feature.Service.DEPENDS_ON,
                 AiProviderRegistryConfiguration.FEATURE_NAME,
@@ -93,6 +96,26 @@ public class LangChainEmbeddingConfiguration {
                 .ollamaApi(ollamaApi)
                 .defaultOptions(options)
                 .build();
+        return new SpringAiEmbeddingAdapter(embeddingModel);
+    }
+
+    private static EmbeddingPort createGoogleSpringAiEmbeddingPort(Environment environment) {
+        String apiKey = requireText(environment.getProperty("spring.ai.google.genai.embedding.api-key"),
+                "spring.ai.google.genai.embedding.api-key must be configured for GOOGLE_AI_GEMINI embedding provider");
+        String model = requireText(environment.getProperty("spring.ai.google.genai.embedding.text.options.model"),
+                "spring.ai.google.genai.embedding.text.options.model must be configured for GOOGLE_AI_GEMINI embedding provider");
+        org.springframework.ai.google.genai.GoogleGenAiEmbeddingConnectionDetails connectionDetails =
+                org.springframework.ai.google.genai.GoogleGenAiEmbeddingConnectionDetails.builder()
+                        .apiKey(apiKey)
+                        .projectId(environment.getProperty("spring.ai.google.genai.embedding.project-id"))
+                        .location(environment.getProperty("spring.ai.google.genai.embedding.location"))
+                        .build();
+        org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingOptions options =
+                org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingOptions.builder()
+                        .model(model)
+                        .build();
+        org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingModel embeddingModel =
+                new org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingModel(connectionDetails, options);
         return new SpringAiEmbeddingAdapter(embeddingModel);
     }
 

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/AiSecretPresenceGuardTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/AiSecretPresenceGuardTest.java
@@ -71,6 +71,49 @@ class AiSecretPresenceGuardTest {
     }
 
     @Test
+    void validateAllowsConfiguredSpringAiPropertiesForGoogleEmbedding() {
+        AiAdapterProperties properties = new AiAdapterProperties();
+        properties.setEnabled(true);
+        properties.setDefaultProvider("google");
+        Provider provider = new Provider();
+        provider.setEnabled(true);
+        provider.setType(ProviderType.GOOGLE_AI_GEMINI);
+        provider.getEmbedding().setEnabled(true);
+        properties.getProviders().put("google", provider);
+
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("spring.ai.google.genai.embedding.api-key", "test-key");
+        environment.setProperty("spring.ai.google.genai.embedding.text.options.model", "text-embedding-004");
+
+        AiSecretPresenceGuard guard = new AiSecretPresenceGuard(properties, environment,
+                emptyBeanProvider(org.springframework.ai.chat.model.ChatModel.class),
+                emptyBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class));
+
+        assertDoesNotThrow(guard::validate);
+    }
+
+    @Test
+    void validateRejectsMissingSpringAiModelForGoogleEmbedding() {
+        AiAdapterProperties properties = new AiAdapterProperties();
+        properties.setEnabled(true);
+        properties.setDefaultProvider("google");
+        Provider provider = new Provider();
+        provider.setEnabled(true);
+        provider.setType(ProviderType.GOOGLE_AI_GEMINI);
+        provider.getEmbedding().setEnabled(true);
+        properties.getProviders().put("google", provider);
+
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("spring.ai.google.genai.embedding.api-key", "test-key");
+
+        AiSecretPresenceGuard guard = new AiSecretPresenceGuard(properties, environment,
+                emptyBeanProvider(org.springframework.ai.chat.model.ChatModel.class),
+                emptyBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class));
+
+        assertThrows(IllegalStateException.class, guard::validate);
+    }
+
+    @Test
     void validateRequiresDefaultProvider() {
         AiAdapterProperties properties = new AiAdapterProperties();
         properties.setEnabled(true);

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/GoogleSpringAiEmbeddingRegistrationTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/GoogleSpringAiEmbeddingRegistrationTest.java
@@ -1,0 +1,50 @@
+package studio.one.platform.ai.autoconfigure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.support.StaticListableBeanFactory;
+import org.springframework.mock.env.MockEnvironment;
+
+import studio.one.platform.ai.autoconfigure.adapter.SpringAiEmbeddingAdapter;
+import studio.one.platform.ai.core.embedding.EmbeddingPort;
+import studio.one.platform.ai.core.registry.AiProviderRegistry;
+import studio.one.platform.service.I18n;
+
+class GoogleSpringAiEmbeddingRegistrationTest {
+
+    @Test
+    void registersGoogleEmbeddingAsSpringAiBackedPath() {
+        AiAdapterProperties properties = new AiAdapterProperties();
+        properties.setDefaultProvider("google");
+
+        AiAdapterProperties.Provider provider = new AiAdapterProperties.Provider();
+        provider.setType(AiAdapterProperties.ProviderType.GOOGLE_AI_GEMINI);
+        provider.getEmbedding().setEnabled(true);
+        provider.getEmbedding().setModel("legacy-should-not-be-used");
+        properties.getProviders().put("google", provider);
+
+        LangChainEmbeddingConfiguration embeddingConfiguration = new LangChainEmbeddingConfiguration();
+        StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
+        ObjectProvider<I18n> i18nProvider = beanFactory.getBeanProvider(I18n.class);
+        MockEnvironment environment = new MockEnvironment()
+                .withProperty("spring.ai.google.genai.embedding.api-key", "test-key")
+                .withProperty("spring.ai.google.genai.embedding.text.options.model", "text-embedding-004");
+
+        Map<String, EmbeddingPort> embeddingPorts = embeddingConfiguration.embeddingPorts(
+                properties,
+                i18nProvider,
+                environment,
+                beanFactory.getBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class));
+
+        assertThat(embeddingPorts).containsOnlyKeys("google");
+        assertThat(embeddingPorts.get("google")).isInstanceOf(SpringAiEmbeddingAdapter.class);
+
+        AiProviderRegistry registry = new AiProviderRegistry("google", Map.of(), embeddingPorts);
+        assertThat(registry.defaultProvider()).isEqualTo("google");
+        assertThat(registry.embeddingPort(null)).isSameAs(embeddingPorts.get("google"));
+    }
+}

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/GoogleSpringAiEmbeddingRegistrationTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/GoogleSpringAiEmbeddingRegistrationTest.java
@@ -47,4 +47,43 @@ class GoogleSpringAiEmbeddingRegistrationTest {
         assertThat(registry.defaultProvider()).isEqualTo("google");
         assertThat(registry.embeddingPort(null)).isSameAs(embeddingPorts.get("google"));
     }
+
+    @Test
+    void preservesGoogleEmbeddingTaskTypeInSpringAiOptions() throws Exception {
+        AiAdapterProperties properties = new AiAdapterProperties();
+        properties.setDefaultProvider("google");
+
+        AiAdapterProperties.Provider provider = new AiAdapterProperties.Provider();
+        provider.setType(AiAdapterProperties.ProviderType.GOOGLE_AI_GEMINI);
+        provider.getEmbedding().setEnabled(true);
+        provider.getGoogleEmbedding().setTaskType("RETRIEVAL_QUERY");
+        properties.getProviders().put("google", provider);
+
+        LangChainEmbeddingConfiguration embeddingConfiguration = new LangChainEmbeddingConfiguration();
+        StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
+        MockEnvironment environment = new MockEnvironment()
+                .withProperty("spring.ai.google.genai.embedding.api-key", "test-key")
+                .withProperty("spring.ai.google.genai.embedding.text.options.model", "text-embedding-004");
+
+        EmbeddingPort port = embeddingConfiguration.embeddingPorts(
+                properties,
+                beanFactory.getBeanProvider(I18n.class),
+                environment,
+                beanFactory.getBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class)).get("google");
+
+        assertThat(port).isInstanceOf(SpringAiEmbeddingAdapter.class);
+
+        java.lang.reflect.Field modelField = SpringAiEmbeddingAdapter.class.getDeclaredField("embeddingModel");
+        modelField.setAccessible(true);
+        Object model = modelField.get(port);
+
+        java.lang.reflect.Field optionsField = model.getClass().getDeclaredField("defaultOptions");
+        optionsField.setAccessible(true);
+        Object options = optionsField.get(model);
+
+        java.lang.reflect.Method taskTypeMethod = options.getClass().getMethod("getTaskType");
+        Object taskType = taskTypeMethod.invoke(options);
+
+        assertThat(String.valueOf(taskType)).isEqualTo("RETRIEVAL_QUERY");
+    }
 }


### PR DESCRIPTION
## Why
- Continue #109 by addressing #112.
- Remove the remaining LangChain4j dependency from the Google embedding path.
- Align Google embedding startup validation with Spring AI-owned settings while leaving chat on the existing LangChain4j path.

## What
- add `spring-ai-google-genai-embedding` to `starter-ai`
- switch the GOOGLE_AI_GEMINI embedding branch in `LangChainEmbeddingConfiguration` to `SpringAiEmbeddingAdapter`
- validate `spring.ai.google.genai.embedding.api-key` and `spring.ai.google.genai.embedding.text.options.model` in `AiSecretPresenceGuard`
- keep Google chat on the existing LangChain4j path
- add focused registration and guard tests for Google embedding
- update `CHANGELOG.md`

## Validation
- `./gradlew -p /tmp/studio-api-spring-ai -PnimbusJoseJwtVersion=9.37.3 -PjsonSmartVersion=2.5.2 :starter:studio-platform-starter-ai:compileJava :starter:studio-platform-starter-ai:test --tests 'studio.one.platform.ai.autoconfigure.AiSecretPresenceGuardTest' --tests 'studio.one.platform.ai.autoconfigure.config.GoogleSpringAiEmbeddingRegistrationTest'`
