### PR TITLE
[ai-assisted] refactor(ai): remove langchain4j naming remnants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,4 @@
 - refactor(ai): remove the remaining LangChain4j embedding adapter and dead embedding wiring, keeping LangChain4j only for the Google chat path.
 - refactor(ai): migrate Google chat wiring from LangChain4j to Spring AI and remove the remaining LangChain4j chat adapter path.
 - fix(ai): preserve custom Google chat base URL when building the Spring AI Google GenAI client.
+- refactor(ai): rename provider wiring configurations to neutral names after removing LangChain4j runtime paths.

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
@@ -43,8 +43,8 @@ class OpenAiProviderAutoConfigurationTest {
             .withUserConfiguration(
                     AiSecretPresenceGuard.class,
                     AiWebAutoConfiguration.class,
-                    LangChainChatConfiguration.class,
-                    LangChainEmbeddingConfiguration.class,
+                    ProviderChatConfiguration.class,
+                    ProviderEmbeddingConfiguration.class,
                     AiProviderRegistryConfiguration.class)
             .withBean(I18n.class, () -> (code, args, locale) -> code)
             .withBean(RagPipelineService.class, () -> org.mockito.Mockito.mock(RagPipelineService.class))

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/AiAutoConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/AiAutoConfiguration.java
@@ -7,8 +7,8 @@ import org.springframework.context.annotation.Import;
 
 import studio.one.platform.ai.autoconfigure.config.AiProviderRegistryConfiguration;
 import studio.one.platform.ai.autoconfigure.config.RagPipelineConfiguration;
-import studio.one.platform.ai.autoconfigure.config.LangChainChatConfiguration;
-import studio.one.platform.ai.autoconfigure.config.LangChainEmbeddingConfiguration;
+import studio.one.platform.ai.autoconfigure.config.ProviderChatConfiguration;
+import studio.one.platform.ai.autoconfigure.config.ProviderEmbeddingConfiguration;
 import studio.one.platform.ai.autoconfigure.config.PromptConfiguration;
 import studio.one.platform.ai.autoconfigure.config.VectorStoreConfiguration;
 import studio.one.platform.ai.autoconfigure.config.KeywordExtractorConfiguration;
@@ -20,8 +20,8 @@ import studio.one.platform.constant.PropertyKeys;
 @ConditionalOnProperty(prefix = PropertyKeys.AI.PREFIX, name = "enabled", havingValue = "true", matchIfMissing = false)
 @Import({
                 
-                LangChainEmbeddingConfiguration.class,
-                LangChainChatConfiguration.class, 
+                ProviderEmbeddingConfiguration.class,
+                ProviderChatConfiguration.class, 
                 AiProviderRegistryConfiguration.class,
                 RagPipelineConfiguration.class,
                 VectorStoreConfiguration.class,

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/ProviderChatConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/ProviderChatConfiguration.java
@@ -20,7 +20,7 @@ import studio.one.platform.util.I18nUtils;
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(AiAdapterProperties.class)
 @Slf4j
-public class LangChainChatConfiguration {
+public class ProviderChatConfiguration {
 
     @Bean(name = "providerChatPorts")
     public Map<String, ChatPort> chatPorts(AiAdapterProperties properties,
@@ -91,23 +91,6 @@ public class LangChainChatConfiguration {
         }
         return value;
     }
-    private static String resolveBaseUrl(AiAdapterProperties.Provider provider, Environment environment) {
-        if (provider.getType() == AiAdapterProperties.ProviderType.OPENAI) {
-            String configured = environment.getProperty("spring.ai.openai.base-url");
-            if (StringUtils.isNotBlank(configured)) {
-                return configured;
-            }
-        }
-        if (StringUtils.isNotBlank(provider.getBaseUrl())) {
-            return provider.getBaseUrl();
-        } 
-        return switch (provider.getType()) {
-            case OPENAI -> "https://api.openai.com/v1";
-            //case GOOGLE_AI_GEMINI -> "https://generativelanguage.googleapis.com/v1";
-            default -> null;
-        };
-    }
-
     private static String requireModel(String model) {
         if (model == null || model.isBlank()) {
             throw new IllegalArgumentException("Model name must be provided for provider chat configuration");

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/ProviderEmbeddingConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/ProviderEmbeddingConfiguration.java
@@ -20,7 +20,7 @@ import studio.one.platform.util.I18nUtils;
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(AiAdapterProperties.class)
 @Slf4j
-public class LangChainEmbeddingConfiguration {
+public class ProviderEmbeddingConfiguration {
 
     @Bean(name = "providerEmbeddingPorts")
     public Map<String, EmbeddingPort> embeddingPorts(AiAdapterProperties properties,
@@ -98,24 +98,6 @@ public class LangChainEmbeddingConfiguration {
         org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingModel embeddingModel =
                 new org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingModel(connectionDetails, options);
         return new SpringAiEmbeddingAdapter(embeddingModel);
-    }
-
-    private static String resolveBaseUrl(AiAdapterProperties.Provider provider, Environment environment) {
-        if (provider.getType() == AiAdapterProperties.ProviderType.OPENAI) {
-            String configured = environment.getProperty("spring.ai.openai.base-url");
-            if (StringUtils.isNotBlank(configured)) {
-                return configured;
-            }
-        }
-        if (StringUtils.isNotBlank(provider.getBaseUrl())) {
-            return provider.getBaseUrl();
-        }
-        return switch (provider.getType()) {
-            case OPENAI -> "https://api.openai.com/v1";
-            case OLLAMA -> "http://localhost:11434";
-            case GOOGLE_AI_GEMINI -> "https://generativelanguage.googleapis.com/v1";
-            default -> null;
-        };
     }
 
     private static String requireText(String value, String message) {

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/GoogleSpringAiChatRegistrationTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/GoogleSpringAiChatRegistrationTest.java
@@ -30,7 +30,7 @@ class GoogleSpringAiChatRegistrationTest {
         provider.setApiKey("test-key");
         properties.getProviders().put("google", provider);
 
-        LangChainChatConfiguration chatConfiguration = new LangChainChatConfiguration();
+        ProviderChatConfiguration chatConfiguration = new ProviderChatConfiguration();
         StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
         ObjectProvider<I18n> i18nProvider = beanFactory.getBeanProvider(I18n.class);
         MockEnvironment environment = new MockEnvironment();
@@ -62,7 +62,7 @@ class GoogleSpringAiChatRegistrationTest {
         provider.setBaseUrl("https://proxy.example.test/v1beta");
         properties.getProviders().put("google", provider);
 
-        LangChainChatConfiguration chatConfiguration = new LangChainChatConfiguration();
+        ProviderChatConfiguration chatConfiguration = new ProviderChatConfiguration();
         StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
         ObjectProvider<I18n> i18nProvider = beanFactory.getBeanProvider(I18n.class);
         MockEnvironment environment = new MockEnvironment();

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/GoogleSpringAiEmbeddingRegistrationTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/GoogleSpringAiEmbeddingRegistrationTest.java
@@ -27,7 +27,7 @@ class GoogleSpringAiEmbeddingRegistrationTest {
         provider.getEmbedding().setModel("legacy-should-not-be-used");
         properties.getProviders().put("google", provider);
 
-        LangChainEmbeddingConfiguration embeddingConfiguration = new LangChainEmbeddingConfiguration();
+        ProviderEmbeddingConfiguration embeddingConfiguration = new ProviderEmbeddingConfiguration();
         StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
         ObjectProvider<I18n> i18nProvider = beanFactory.getBeanProvider(I18n.class);
         MockEnvironment environment = new MockEnvironment()
@@ -59,7 +59,7 @@ class GoogleSpringAiEmbeddingRegistrationTest {
         provider.getGoogleEmbedding().setTaskType("RETRIEVAL_QUERY");
         properties.getProviders().put("google", provider);
 
-        LangChainEmbeddingConfiguration embeddingConfiguration = new LangChainEmbeddingConfiguration();
+        ProviderEmbeddingConfiguration embeddingConfiguration = new ProviderEmbeddingConfiguration();
         StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
         MockEnvironment environment = new MockEnvironment()
                 .withProperty("spring.ai.google.genai.embedding.api-key", "test-key")

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/OllamaSpringAiEmbeddingRegistrationTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/OllamaSpringAiEmbeddingRegistrationTest.java
@@ -27,7 +27,7 @@ class OllamaSpringAiEmbeddingRegistrationTest {
         provider.getEmbedding().setModel("legacy-should-not-be-used");
         properties.getProviders().put("ollama", provider);
 
-        LangChainEmbeddingConfiguration embeddingConfiguration = new LangChainEmbeddingConfiguration();
+        ProviderEmbeddingConfiguration embeddingConfiguration = new ProviderEmbeddingConfiguration();
         StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
         ObjectProvider<I18n> i18nProvider = beanFactory.getBeanProvider(I18n.class);
         MockEnvironment environment = new MockEnvironment()

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiSpringAiProviderRegistrationTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiSpringAiProviderRegistrationTest.java
@@ -27,8 +27,8 @@ class OpenAiSpringAiProviderRegistrationTest {
         provider.getEmbedding().setEnabled(true);
         properties.getProviders().put("openai", provider);
 
-        LangChainChatConfiguration chatConfiguration = new LangChainChatConfiguration();
-        LangChainEmbeddingConfiguration embeddingConfiguration = new LangChainEmbeddingConfiguration();
+        ProviderChatConfiguration chatConfiguration = new ProviderChatConfiguration();
+        ProviderEmbeddingConfiguration embeddingConfiguration = new ProviderEmbeddingConfiguration();
         StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
         beanFactory.addBean("springAiChatModel", org.mockito.Mockito.mock(org.springframework.ai.chat.model.ChatModel.class));
         beanFactory.addBean("springAiEmbeddingModel", org.mockito.Mockito.mock(org.springframework.ai.embedding.EmbeddingModel.class));
@@ -78,7 +78,7 @@ class OpenAiSpringAiProviderRegistrationTest {
                 .withProperty("spring.ai.openai.api-key", "test-key")
                 .withProperty("spring.ai.openai.chat.options.model", "gpt-4o-mini");
 
-        Map<String, ChatPort> chatPorts = new LangChainChatConfiguration().chatPorts(
+        Map<String, ChatPort> chatPorts = new ProviderChatConfiguration().chatPorts(
                 properties,
                 i18nProvider,
                 environment,

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/AiProvider.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/AiProvider.java
@@ -1,7 +1,7 @@
 package studio.one.platform.ai.core;
 
 /**
- * Supported AI providers for LangChain4j adapters.
+ * Supported AI providers for the platform AI adapters.
  */
 public enum AiProvider {
     OPENAI,


### PR DESCRIPTION
## Why
- #109의 후속 작업으로 #114를 반영합니다.
- 런타임 의존성 제거 이후에도 남아 있는 LangChain4j 전용 네이밍과 주석을 정리합니다.
- 현재 Spring AI 기반 provider 중립 구조에 맞도록 설정 명칭을 일관되게 맞춥니다.

## What
- `LangChainChatConfiguration`를 `ProviderChatConfiguration`으로 변경합니다.
- `LangChainEmbeddingConfiguration`를 `ProviderEmbeddingConfiguration`으로 변경합니다.
- 관련 auto-configuration 및 registration 테스트를 중립 명칭 기준으로 정리합니다.
- `AiProvider`에 남아 있는 LangChain4j 전용 주석을 제거합니다.

## Related Issues
- Closes #121
- Related #109
- Related #114

## Change Scope
- [ ] API contract
- [x] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [ ] Docs/runbook

## Security Impact
- Risk:
  - 낮음. 내부 설정 타입 명칭과 주석만 정리하는 변경이며, 새로운 권한, 비밀정보, 외부 연동을 추가하지 않습니다.
- Mitigation:
  - rename 영향이 있는 auto-configuration 및 provider registration 테스트를 실행해 회귀를 확인합니다.

## Validation
- Commands:
  - `./gradlew -p /tmp/studio-api-spring-ai -PnimbusJoseJwtVersion=9.37.3 -PjsonSmartVersion=2.5.2 :studio-platform-ai:compileJava :starter:studio-platform-starter-ai:compileJava :starter:studio-platform-starter-ai-web:compileJava :starter:studio-platform-starter-ai:test --tests studio.one.platform.ai.autoconfigure.config.OpenAiSpringAiProviderRegistrationTest --tests studio.one.platform.ai.autoconfigure.config.OllamaSpringAiEmbeddingRegistrationTest --tests studio.one.platform.ai.autoconfigure.config.GoogleSpringAiEmbeddingRegistrationTest --tests studio.one.platform.ai.autoconfigure.config.GoogleSpringAiChatRegistrationTest :starter:studio-platform-starter-ai-web:test --tests studio.one.platform.ai.autoconfigure.config.OpenAiProviderAutoConfigurationTest`
- Result:
  - 변경된 provider 중립 클래스명을 기준으로 대상 compile 및 registration/auto-configuration 테스트가 통과했습니다.
- Additional checks:
  - `AiProvider`의 잔여 LangChain4j 전용 주석이 제거되었는지 확인했습니다.
  - 런타임 의존성 복구나 범위 밖 리팩터링이 포함되지 않았는지 확인했습니다.

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- Used: [x] No [ ] Yes
- Delegated tasks:
- Ownership (files/modules/tasks):
- Main author post-integration validation:

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [ ] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering:
  - 별도 마이그레이션이나 배포 순서는 필요하지 않습니다.
- Rollback plan:
  - 설정 연결 또는 테스트 기대값에 회귀가 있으면 rename 커밋을 되돌립니다.
- Post-deploy checks:
  - 관련 starter 및 auto-configuration 테스트 범위의 CI가 정상인지 확인합니다.
