### PR TITLE
[ai-assisted] refactor(ai): improve rag search fallback quality

### DIFF
--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineService.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineService.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import com.github.benmanes.caffeine.cache.Cache;
@@ -33,6 +34,7 @@ public class RagPipelineService {
 
     private static final double HYBRID_VECTOR_WEIGHT = 0.7;
     private static final double HYBRID_LEXICAL_WEIGHT = 0.3;
+    private static final double MIN_RELEVANCE_SCORE = 0.15;
 
     private final EmbeddingPort embeddingPort;
     private final VectorStorePort vectorStorePort;
@@ -85,37 +87,29 @@ public class RagPipelineService {
     public List<RagSearchResult> search(RagSearchRequest request) {
         List<Double> queryEmbedding = embedWithCache(request.query());
         VectorSearchRequest searchRequest = new VectorSearchRequest(queryEmbedding, request.topK());
-        List<VectorSearchResult> results = vectorStorePort.hybridSearch(
+        List<VectorSearchResult> results = searchWithFallback(
                 request.query(),
                 searchRequest,
-                HYBRID_VECTOR_WEIGHT,
-                HYBRID_LEXICAL_WEIGHT);
-        return results.stream()
-                .map(result -> new RagSearchResult(
-                        result.document().id(),
-                        result.document().content(),
-                        result.document().metadata(),
-                        result.score()))
-                .toList();
+                query -> vectorStorePort.hybridSearch(query, searchRequest, HYBRID_VECTOR_WEIGHT, HYBRID_LEXICAL_WEIGHT),
+                () -> vectorStorePort.search(searchRequest));
+        return toRagSearchResults(results);
     }
 
     public List<RagSearchResult> searchByObject(RagSearchRequest request, String objectType, String objectId) {
         List<Double> queryEmbedding = embedWithCache(request.query());
         VectorSearchRequest searchRequest = new VectorSearchRequest(queryEmbedding, request.topK());
-        List<VectorSearchResult> results = vectorStorePort.hybridSearchByObject(
+        List<VectorSearchResult> results = searchWithFallback(
                 request.query(),
-                objectType,
-                objectId,
                 searchRequest,
-                HYBRID_VECTOR_WEIGHT,
-                HYBRID_LEXICAL_WEIGHT);
-        return results.stream()
-                .map(result -> new RagSearchResult(
-                        result.document().id(),
-                        result.document().content(),
-                        result.document().metadata(),
-                        result.score()))
-                .toList();
+                query -> vectorStorePort.hybridSearchByObject(
+                        query,
+                        objectType,
+                        objectId,
+                        searchRequest,
+                        HYBRID_VECTOR_WEIGHT,
+                        HYBRID_LEXICAL_WEIGHT),
+                () -> vectorStorePort.searchByObject(objectType, objectId, searchRequest));
+        return toRagSearchResults(results);
     }
 
     public List<RagSearchResult> listByObject(String objectType, String objectId, Integer limit) {
@@ -159,5 +153,74 @@ public class RagPipelineService {
         } catch (Exception ignored) {
             return List.of();
         }
+    }
+
+    private List<VectorSearchResult> searchWithFallback(
+            String query,
+            VectorSearchRequest searchRequest,
+            Function<String, List<VectorSearchResult>> hybridSearch,
+            Supplier<List<VectorSearchResult>> semanticSearch) {
+        List<VectorSearchResult> results = hybridSearch.apply(query);
+        if (hasRelevantResults(results)) {
+            return results;
+        }
+
+        String enrichedQuery = enrichQuery(query);
+        if (!enrichedQuery.equals(query)) {
+            List<VectorSearchResult> enrichedResults = hybridSearch.apply(enrichedQuery);
+            if (hasRelevantResults(enrichedResults)) {
+                return enrichedResults;
+            }
+        }
+
+        List<VectorSearchResult> semanticResults = semanticSearch.get();
+        if (hasRelevantResults(semanticResults)) {
+            return semanticResults;
+        }
+        return List.of();
+    }
+
+    private String enrichQuery(String query) {
+        if (keywordExtractor == null) {
+            return query;
+        }
+        try {
+            List<String> extracted = keywordExtractor.extract(query);
+            if (extracted == null || extracted.isEmpty()) {
+                return query;
+            }
+            List<String> uniqueTerms = new ArrayList<>();
+            uniqueTerms.add(query.trim());
+            for (String keyword : extracted) {
+                if (keyword == null || keyword.isBlank()) {
+                    continue;
+                }
+                String normalized = keyword.trim();
+                if (uniqueTerms.stream().noneMatch(normalized::equalsIgnoreCase)) {
+                    uniqueTerms.add(normalized);
+                }
+            }
+            return String.join(" ", uniqueTerms);
+        } catch (Exception ex) {
+            log.debug("Failed to extract keywords for RAG search fallback. query={}", query, ex);
+            return query;
+        }
+    }
+
+    private boolean hasRelevantResults(List<VectorSearchResult> results) {
+        if (results == null || results.isEmpty()) {
+            return false;
+        }
+        return results.stream().anyMatch(result -> result.score() >= MIN_RELEVANCE_SCORE);
+    }
+
+    private List<RagSearchResult> toRagSearchResults(List<VectorSearchResult> results) {
+        return results.stream()
+                .map(result -> new RagSearchResult(
+                        result.document().id(),
+                        result.document().content(),
+                        result.document().metadata(),
+                        result.score()))
+                .toList();
     }
 }

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
@@ -34,6 +34,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -119,5 +121,127 @@ class RagPipelineServiceTest {
         assertThat(result.documentId()).isEqualTo("doc-1");
         assertThat(result.metadata()).containsEntry("author", "test");
         assertThat(result.score()).isEqualTo(0.9);
+    }
+
+    @Test
+    void shouldFallbackToKeywordEnrichedHybridSearchWhenInitialResultsAreLowRelevance() {
+        RagSearchRequest request = new RagSearchRequest("hello", 2);
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("hello", List.of(0.5, 0.6)))));
+        when(keywordExtractor.extract("hello")).thenReturn(List.of("greeting", "salutation"));
+        when(vectorStorePort.hybridSearch(eq("hello"), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-low", "weak", Map.of(), List.of(0.5, 0.6)), 0.05)));
+        when(vectorStorePort.hybridSearch(eq("hello greeting salutation"), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-strong", "better", Map.of("source", "keyword-fallback"), List.of(0.5, 0.6)), 0.9)));
+
+        List<RagSearchResult> results = ragPipelineService.search(request);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).documentId()).isEqualTo("doc-strong");
+        assertThat(results.get(0).metadata()).containsEntry("source", "keyword-fallback");
+        verify(vectorStorePort).hybridSearch(eq("hello"), any(VectorSearchRequest.class), anyDouble(), anyDouble());
+        verify(vectorStorePort).hybridSearch(eq("hello greeting salutation"), any(VectorSearchRequest.class), anyDouble(), anyDouble());
+    }
+
+    @Test
+    void shouldFallbackToSemanticSearchWhenKeywordExtractionFailsAndHybridReturnsNoHits() {
+        RagSearchRequest request = new RagSearchRequest("hello", 2);
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("hello", List.of(0.5, 0.6)))));
+        when(vectorStorePort.hybridSearch(anyString(), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of());
+        when(keywordExtractor.extract("hello")).thenThrow(new RuntimeException("keyword failure"));
+        when(vectorStorePort.search(any(VectorSearchRequest.class)))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-semantic", "semantic hit", Map.of("source", "semantic-fallback"), List.of(0.5, 0.6)), 0.7)));
+
+        List<RagSearchResult> results = ragPipelineService.search(request);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).documentId()).isEqualTo("doc-semantic");
+        assertThat(results.get(0).metadata()).containsEntry("source", "semantic-fallback");
+        verify(vectorStorePort, times(1)).hybridSearch(eq("hello"), any(VectorSearchRequest.class), anyDouble(), anyDouble());
+        verify(vectorStorePort).search(any(VectorSearchRequest.class));
+    }
+
+    @Test
+    void shouldReturnEmptyWhenNoRelevantHitsRemainAfterFallbacks() {
+        RagSearchRequest request = new RagSearchRequest("hello", 2);
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("hello", List.of(0.5, 0.6)))));
+        when(keywordExtractor.extract("hello")).thenReturn(List.of());
+        when(vectorStorePort.hybridSearch(anyString(), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-low", "weak", Map.of(), List.of(0.5, 0.6)), 0.01)));
+        when(vectorStorePort.search(any(VectorSearchRequest.class)))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-low-semantic", "weak semantic", Map.of(), List.of(0.5, 0.6)), 0.02)));
+
+        List<RagSearchResult> results = ragPipelineService.search(request);
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    void shouldFallbackToKeywordEnrichedHybridSearchWithinObjectScope() {
+        RagSearchRequest request = new RagSearchRequest("hello", 2);
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("hello", List.of(0.5, 0.6)))));
+        when(keywordExtractor.extract("hello")).thenReturn(List.of("greeting", "salutation"));
+        when(vectorStorePort.hybridSearchByObject(eq("hello"), eq("attachment"), eq("42"), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-low", "weak", Map.of(), List.of(0.5, 0.6)), 0.05)));
+        when(vectorStorePort.hybridSearchByObject(eq("hello greeting salutation"), eq("attachment"), eq("42"), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-strong", "better", Map.of("source", "object-keyword-fallback"), List.of(0.5, 0.6)), 0.9)));
+
+        List<RagSearchResult> results = ragPipelineService.searchByObject(request, "attachment", "42");
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).documentId()).isEqualTo("doc-strong");
+        assertThat(results.get(0).metadata()).containsEntry("source", "object-keyword-fallback");
+        verify(vectorStorePort).hybridSearchByObject(eq("hello"), eq("attachment"), eq("42"), any(VectorSearchRequest.class), anyDouble(), anyDouble());
+        verify(vectorStorePort).hybridSearchByObject(eq("hello greeting salutation"), eq("attachment"), eq("42"), any(VectorSearchRequest.class), anyDouble(), anyDouble());
+    }
+
+    @Test
+    void shouldFallbackToSemanticSearchWithinObjectScopeWhenKeywordExtractionFails() {
+        RagSearchRequest request = new RagSearchRequest("hello", 2);
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("hello", List.of(0.5, 0.6)))));
+        when(vectorStorePort.hybridSearchByObject(anyString(), eq("attachment"), eq("42"), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of());
+        when(keywordExtractor.extract("hello")).thenThrow(new RuntimeException("keyword failure"));
+        when(vectorStorePort.searchByObject(eq("attachment"), eq("42"), any(VectorSearchRequest.class)))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-semantic", "semantic hit", Map.of("source", "object-semantic-fallback"), List.of(0.5, 0.6)), 0.7)));
+
+        List<RagSearchResult> results = ragPipelineService.searchByObject(request, "attachment", "42");
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).documentId()).isEqualTo("doc-semantic");
+        assertThat(results.get(0).metadata()).containsEntry("source", "object-semantic-fallback");
+        verify(vectorStorePort, times(1)).hybridSearchByObject(eq("hello"), eq("attachment"), eq("42"), any(VectorSearchRequest.class), anyDouble(), anyDouble());
+        verify(vectorStorePort).searchByObject(eq("attachment"), eq("42"), any(VectorSearchRequest.class));
+    }
+
+    @Test
+    void shouldReturnEmptyWhenObjectScopedFallbacksRemainLowRelevance() {
+        RagSearchRequest request = new RagSearchRequest("hello", 2);
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("hello", List.of(0.5, 0.6)))));
+        when(keywordExtractor.extract("hello")).thenReturn(List.of());
+        when(vectorStorePort.hybridSearchByObject(anyString(), eq("attachment"), eq("42"), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-low", "weak", Map.of(), List.of(0.5, 0.6)), 0.01)));
+        when(vectorStorePort.searchByObject(eq("attachment"), eq("42"), any(VectorSearchRequest.class)))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-low-semantic", "weak semantic", Map.of(), List.of(0.5, 0.6)), 0.02)));
+
+        List<RagSearchResult> results = ragPipelineService.searchByObject(request, "attachment", "42");
+
+        assertThat(results).isEmpty();
     }
 }


### PR DESCRIPTION
## Why
- #132 후속으로 RAG 검색 경로의 fallback, relevance, no-hit 처리를 보강해 검색 품질을 개선합니다.
- keyword extraction 실패나 낮은 relevance 결과에서 검색 품질이 쉽게 흔들리는 문제를 완화합니다.

## What
- `RagPipelineService`에 `hybrid -> keyword-enriched hybrid -> semantic` fallback 흐름을 추가합니다.
- relevance가 낮거나 no-hit인 경우에만 다음 fallback으로 넘어가도록 정리합니다.
- `searchByObject(...)`를 포함한 object-scoped fallback/relevance 동작을 테스트로 고정합니다.

## Related Issues
- Closes #132

## Change Scope
- [ ] API contract
- [x] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [ ] Docs/runbook

## Security Impact
- Risk:
  - 낮음. 검색 fallback 정책과 테스트 보강 중심의 변경입니다.
- Mitigation:
  - core compile/test로 fallback 경로와 object-scoped 검색 동작을 검증했습니다.

## Validation
- Commands:
  - `./gradlew -p /Users/donghyuck.son/git/studio-api -PnimbusJoseJwtVersion=9.37.3 -PjsonSmartVersion=2.5.2 :studio-platform-ai:compileJava`
  - `./gradlew -p /Users/donghyuck.son/git/studio-api -PnimbusJoseJwtVersion=9.37.3 -PjsonSmartVersion=2.5.2 :studio-platform-ai:compileTestJava`
  - `./gradlew -p /Users/donghyuck.son/git/studio-api -PnimbusJoseJwtVersion=9.37.3 -PjsonSmartVersion=2.5.2 :studio-platform-ai:test --tests studio.one.platform.ai.service.pipeline.RagPipelineServiceTest`
- Result:
  - 대상 compile 및 test가 통과했습니다.
- Additional checks:
  - `spring-boot-engineer`가 구현과 검증을 수행했습니다.
  - `code-reviewer`가 `searchByObject(...)` fallback 공백 보강 후 재리뷰했고 findings 없음으로 확인했습니다.

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- Used: [ ] No [x] Yes
- Delegated tasks:
  - `spring-boot-engineer`: `#132` 구현 및 검증
  - `code-reviewer`: 구현 리뷰 및 follow-up 확인
- Ownership (files/modules/tasks):
  - main author: 작업 순서 결정, 리뷰 반영 판단, 커밋/브랜치/PR 정리
  - spring-boot-engineer: 구현 및 테스트
  - code-reviewer: findings 검토
- Main author post-integration validation:
  - main author가 최종 diff 범위와 워크트리 상태를 확인했습니다.

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering:
  - 별도 마이그레이션은 필요하지 않습니다.
- Rollback plan:
  - 회귀가 있으면 `fd22eeb` 커밋을 되돌립니다.
- Post-deploy checks:
  - RAG 검색 관련 CI와 `RagPipelineServiceTest`가 정상인지 확인합니다.
