### PR TITLE
[ai-assisted] refactor(ai): stabilize query rewrite normalization

### DIFF
--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/QueryRewriteController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/QueryRewriteController.java
@@ -1,5 +1,11 @@
 package studio.one.platform.ai.web.controller;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
 import jakarta.validation.Valid;
 
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -111,13 +117,21 @@ public class QueryRewriteController {
         String cleaned = sanitize(raw);
         try {
             JsonNode node = objectMapper.readTree(cleaned);
-            String expanded = textValue(node.get("expanded_query"), raw);
-            java.util.List<String> keywords = toList(node.get("keywords"));
-            String orig = textValue(node.get("original_query"), originalQuery);
+            List<String> keywords = normalizeKeywords(toList(node.get("keywords")));
+            String expanded = normalizeExpandedQuery(textValue(node.get("expanded_query"), ""), keywords, cleaned, originalQuery);
+            if (keywords.isEmpty()) {
+                keywords = normalizeKeywords(splitTerms(expanded));
+            }
+            if (expanded.isBlank() && !keywords.isEmpty()) {
+                expanded = String.join(", ", keywords);
+            }
+            String orig = normalizeText(textValue(node.get("original_query"), originalQuery), originalQuery);
             return new QueryRewriteResponseDto(orig, expanded, keywords, prompt, raw);
         } catch (Exception e) {
             log.warn("Failed to parse query rewrite response as JSON. Using raw text. cause={}", e.toString());
-            return new QueryRewriteResponseDto(originalQuery, cleaned, java.util.List.of(), prompt, raw);
+            List<String> keywords = normalizeKeywords(splitTerms(cleaned));
+            String expanded = normalizeExpandedQuery(cleaned, keywords, cleaned, originalQuery);
+            return new QueryRewriteResponseDto(originalQuery, expanded, keywords, prompt, raw);
         }
     }
 
@@ -165,5 +179,57 @@ public class QueryRewriteController {
             }
         });
         return list;
+    }
+
+    private String normalizeExpandedQuery(String expanded, List<String> keywords, String cleaned, String originalQuery) {
+        List<String> expandedTerms = normalizeKeywords(splitTerms(expanded));
+        if (!expandedTerms.isEmpty()) {
+            return String.join(", ", expandedTerms);
+        }
+        if (!keywords.isEmpty()) {
+            return String.join(", ", keywords);
+        }
+        String normalized = normalizeText(cleaned, originalQuery);
+        return normalized.equals(originalQuery) ? originalQuery : normalized;
+    }
+
+    private List<String> splitTerms(String value) {
+        if (value == null || value.isBlank()) {
+            return List.of();
+        }
+        String[] parts = value.split("[,;\\n]+");
+        List<String> terms = new ArrayList<>();
+        for (String part : parts) {
+            String normalized = normalizeText(part, "");
+            if (!normalized.isBlank()) {
+                terms.add(normalized);
+            }
+        }
+        return terms;
+    }
+
+    private List<String> normalizeKeywords(List<String> keywords) {
+        if (keywords == null || keywords.isEmpty()) {
+            return List.of();
+        }
+        List<String> normalized = new ArrayList<>();
+        Set<String> seen = new LinkedHashSet<>();
+        for (String keyword : keywords) {
+            for (String term : splitTerms(keyword)) {
+                String dedupeKey = term.toLowerCase(Locale.ROOT);
+                if (seen.add(dedupeKey)) {
+                    normalized.add(term);
+                }
+            }
+        }
+        return normalized;
+    }
+
+    private String normalizeText(String value, String fallback) {
+        if (value == null) {
+            return fallback;
+        }
+        String normalized = value.trim().replaceAll("\\s+", " ");
+        return normalized.isBlank() ? fallback : normalized;
     }
 }

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/QueryRewriteControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/QueryRewriteControllerTest.java
@@ -1,0 +1,87 @@
+package studio.one.platform.ai.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.ai.core.chat.ChatMessage;
+import studio.one.platform.ai.core.chat.ChatPort;
+import studio.one.platform.ai.core.chat.ChatResponse;
+import studio.one.platform.ai.service.prompt.PromptRenderer;
+import studio.one.platform.ai.web.dto.QueryRewriteRequestDto;
+import studio.one.platform.ai.web.dto.QueryRewriteResponseDto;
+import studio.one.platform.web.dto.ApiResponse;
+
+class QueryRewriteControllerTest {
+
+    private PromptRenderer promptRenderer;
+    private ChatPort chatPort;
+    private QueryRewriteController controller;
+
+    @BeforeEach
+    void setUp() {
+        promptRenderer = mock(PromptRenderer.class);
+        chatPort = mock(ChatPort.class);
+        controller = new QueryRewriteController(promptRenderer, chatPort);
+        when(promptRenderer.render(any(), any())).thenReturn("prompt");
+    }
+
+    @Test
+    void normalizesExpandedQueryAndDeduplicatesKeywordsFromParsedJson() {
+        when(chatPort.chat(any())).thenReturn(response("""
+                {
+                  "original_query": "  hello  ",
+                  "expanded_query": "hello, greeting,\\n salutation , hello",
+                  "keywords": ["hello", "Greeting", "salutation", "hello"]
+                }
+                """));
+
+        ApiResponse<QueryRewriteResponseDto> response = controller.rewrite(new QueryRewriteRequestDto("hello"));
+
+        assertThat(response.getData().originalQuery()).isEqualTo("hello");
+        assertThat(response.getData().expandedQuery()).isEqualTo("hello, greeting, salutation");
+        assertThat(response.getData().keywords()).containsExactly("hello", "Greeting", "salutation");
+    }
+
+    @Test
+    void derivesKeywordsFromExpandedQueryWhenKeywordsFieldIsMissing() {
+        when(chatPort.chat(any())).thenReturn(response("""
+                {
+                  "original_query": "hello",
+                  "expanded_query": "hello, greeting, salutation"
+                }
+                """));
+
+        ApiResponse<QueryRewriteResponseDto> response = controller.rewrite(new QueryRewriteRequestDto("hello"));
+
+        assertThat(response.getData().expandedQuery()).isEqualTo("hello, greeting, salutation");
+        assertThat(response.getData().keywords()).containsExactly("hello", "greeting", "salutation");
+    }
+
+    @Test
+    void fallsBackToNormalizedRawTermsWhenJsonParsingFails() {
+        when(chatPort.chat(any())).thenReturn(response("""
+                ```json
+                hello, greeting,
+                salutation, hello
+                ```
+                """));
+
+        ApiResponse<QueryRewriteResponseDto> response = controller.rewrite(new QueryRewriteRequestDto("hello"));
+
+        assertThat(response.getData().expandedQuery()).isEqualTo("hello, greeting, salutation");
+        assertThat(response.getData().keywords()).containsExactly("hello", "greeting", "salutation");
+        assertThat(response.getData().rawResponse()).contains("hello, greeting");
+    }
+
+    private ChatResponse response(String content) {
+        return new ChatResponse(List.of(ChatMessage.assistant(content)), "test-model", Map.of());
+    }
+}


### PR DESCRIPTION
## Why
- #130 후속으로 query rewrite 응답의 schema, normalization, fallback 품질을 안정화합니다.
- 응답 편차와 parse fallback 품질 문제로 downstream 검색 입력이 흔들릴 수 있었습니다.

## What
- `QueryRewriteController`에 keywords deduplication, expanded query normalization, parse fallback 복원 로직을 추가합니다.
- `keywords` 누락, malformed JSON, raw text 응답에 대한 fallback 품질을 보강합니다.
- controller 테스트를 추가해 normalization, request binding, fallback 동작을 고정합니다.

## Related Issues
- Closes #130

## Change Scope
- [ ] API contract
- [x] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [ ] Docs/runbook

## Security Impact
- Risk:
  - 낮음. query rewrite 응답 정규화와 테스트 보강 중심의 변경입니다.
- Mitigation:
  - web starter compile/test로 normalization과 fallback 동작을 검증했습니다.

## Validation
- Commands:
  - `./gradlew -p /Users/donghyuck.son/git/studio-api -PnimbusJoseJwtVersion=9.37.3 -PjsonSmartVersion=2.5.2 :starter:studio-platform-starter-ai-web:compileTestJava`
  - `./gradlew -p /Users/donghyuck.son/git/studio-api -PnimbusJoseJwtVersion=9.37.3 -PjsonSmartVersion=2.5.2 :starter:studio-platform-starter-ai-web:test --tests studio.one.platform.ai.web.controller.QueryRewriteControllerTest`
- Result:
  - 대상 compile 및 test가 통과했습니다.
- Additional checks:
  - `spring-boot-engineer`가 구현과 검증을 수행했습니다.
  - `code-reviewer` 리뷰 결과 findings 없음으로 확인했습니다.

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- Used: [ ] No [x] Yes
- Delegated tasks:
  - `spring-boot-engineer`: `#130` 구현 및 검증
  - `code-reviewer`: 구현 리뷰
- Ownership (files/modules/tasks):
  - main author: 작업 순서 결정, 리뷰 반영 판단, 커밋/브랜치/PR 정리
  - spring-boot-engineer: 구현 및 테스트
  - code-reviewer: findings 검토
- Main author post-integration validation:
  - main author가 최종 diff 범위와 워크트리 상태를 확인했습니다.

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [ ] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering:
  - 별도 마이그레이션은 필요하지 않습니다.
- Rollback plan:
  - 회귀가 있으면 `7a988db` 커밋을 되돌립니다.
- Post-deploy checks:
  - query rewrite endpoint 관련 CI와 controller test가 정상인지 확인합니다.
