### PR TITLE
[ai-assisted] feat(ai): expand vector search filtering options

### DIFF
--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/VectorController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/VectorController.java
@@ -164,13 +164,27 @@ public class VectorController {
     private List<VectorSearchResult> executeSearch(VectorStorePort store, VectorSearchRequestDto request,
             VectorSearchRequest searchRequest) {
         boolean useHybrid = Boolean.TRUE.equals(request.hybrid());
+        boolean hasObjectFilter = hasText(request.objectType()) || hasText(request.objectId());
+        List<VectorSearchResult> results;
         if (!useHybrid) {
-            return store.search(searchRequest);
+            results = hasObjectFilter
+                    ? store.searchByObject(request.objectType(), request.objectId(), searchRequest)
+                    : store.search(searchRequest);
+            return applyMinScore(results, request.minScore());
         }
         if (request.query() == null || request.query().isBlank()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "hybrid search requires a query string");
         }
-        return store.hybridSearch(request.query(), searchRequest, HYBRID_VECTOR_WEIGHT, HYBRID_LEXICAL_WEIGHT);
+        results = hasObjectFilter
+                ? store.hybridSearchByObject(
+                        request.query(),
+                        request.objectType(),
+                        request.objectId(),
+                        searchRequest,
+                        HYBRID_VECTOR_WEIGHT,
+                        HYBRID_LEXICAL_WEIGHT)
+                : store.hybridSearch(request.query(), searchRequest, HYBRID_VECTOR_WEIGHT, HYBRID_LEXICAL_WEIGHT);
+        return applyMinScore(results, request.minScore());
     }
 
     private List<Double> normalizeEmbedding(List<Double> embedding, int expectedDim) {
@@ -205,6 +219,19 @@ public class VectorController {
                 document.content(),
                 metadata == null ? Collections.emptyMap() : Map.copyOf(metadata),
                 result.score());
+    }
+
+    private List<VectorSearchResult> applyMinScore(List<VectorSearchResult> results, Double minScore) {
+        if (minScore == null) {
+            return results;
+        }
+        return results.stream()
+                .filter(result -> result.score() >= minScore)
+                .toList();
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
     }
 
     private VectorStorePort requireVectorStore() {

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/VectorSearchRequestDto.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/VectorSearchRequestDto.java
@@ -1,5 +1,7 @@
 package studio.one.platform.ai.web.dto;
 
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Min;
 import java.util.List;
 
@@ -10,7 +12,12 @@ public record VectorSearchRequestDto(
         String query,
         List<Double> embedding,
         @Min(value = 1, message = "topK must be at least 1") Integer topK,
-        Boolean hybrid
+        Boolean hybrid,
+        String objectType,
+        String objectId,
+        @DecimalMin(value = "0.0", message = "minScore must be at least 0.0")
+        @DecimalMax(value = "1.0", message = "minScore must be at most 1.0")
+        Double minScore
 ) {
     public VectorSearchRequestDto {
         if (topK == null) {

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/VectorControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/VectorControllerTest.java
@@ -1,0 +1,153 @@
+package studio.one.platform.ai.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
+
+import studio.one.platform.ai.core.embedding.EmbeddingPort;
+import studio.one.platform.ai.core.embedding.EmbeddingResponse;
+import studio.one.platform.ai.core.embedding.EmbeddingVector;
+import studio.one.platform.ai.core.vector.VectorDocument;
+import studio.one.platform.ai.core.vector.VectorSearchRequest;
+import studio.one.platform.ai.core.vector.VectorSearchResult;
+import studio.one.platform.ai.core.vector.VectorStorePort;
+import studio.one.platform.ai.web.dto.VectorSearchRequestDto;
+import studio.one.platform.ai.web.dto.VectorSearchResultDto;
+import studio.one.platform.web.dto.ApiResponse;
+
+class VectorControllerTest {
+
+    private EmbeddingPort embeddingPort;
+    private VectorStorePort vectorStorePort;
+    private VectorController controller;
+
+    @BeforeEach
+    void setUp() {
+        embeddingPort = mock(EmbeddingPort.class);
+        vectorStorePort = mock(VectorStorePort.class);
+        controller = new VectorController(embeddingPort, vectorStorePort);
+    }
+
+    @Test
+    void searchesWithinObjectScopeWhenObjectFilterIsProvided() {
+        when(embeddingPort.embed(any()))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("query", List.of(1.0, 0.0)))));
+        when(vectorStorePort.searchByObject(eq("attachment"), eq("42"), any(VectorSearchRequest.class)))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-1", "chunk", Map.of("objectType", "attachment", "objectId", "42"), List.of()),
+                        0.8d)));
+
+        ResponseEntity<ApiResponse<List<VectorSearchResultDto>>> response = controller.search(
+                new VectorSearchRequestDto("hello", null, 3, false, "attachment", "42", null));
+
+        assertThat(response.getBody().getData()).hasSize(1);
+        assertThat(response.getBody().getData().get(0).documentId()).isEqualTo("doc-1");
+        verify(vectorStorePort).searchByObject(eq("attachment"), eq("42"), any(VectorSearchRequest.class));
+    }
+
+    @Test
+    void usesHybridSearchWithinObjectScopeWhenRequested() {
+        when(embeddingPort.embed(any()))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("query", List.of(1.0, 0.0)))));
+        when(vectorStorePort.hybridSearchByObject(eq("hello"), eq("attachment"), eq("42"), any(VectorSearchRequest.class), eq(0.7d), eq(0.3d)))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-2", "hybrid", Map.of("objectType", "attachment", "objectId", "42"), List.of()),
+                        0.9d)));
+
+        ResponseEntity<ApiResponse<List<VectorSearchResultDto>>> response = controller.search(
+                new VectorSearchRequestDto("hello", null, 3, true, "attachment", "42", null));
+
+        assertThat(response.getBody().getData()).hasSize(1);
+        assertThat(response.getBody().getData().get(0).documentId()).isEqualTo("doc-2");
+        verify(vectorStorePort).hybridSearchByObject(eq("hello"), eq("attachment"), eq("42"), any(VectorSearchRequest.class), eq(0.7d), eq(0.3d));
+    }
+
+    @Test
+    void filtersResultsByMinScore() {
+        when(embeddingPort.embed(any()))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("query", List.of(1.0, 0.0)))));
+        when(vectorStorePort.search(any(VectorSearchRequest.class)))
+                .thenReturn(List.of(
+                        new VectorSearchResult(new VectorDocument("doc-low", "low", Map.of(), List.of()), 0.39d),
+                        new VectorSearchResult(new VectorDocument("doc-high", "high", Map.of(), List.of()), 0.61d)));
+
+        ResponseEntity<ApiResponse<List<VectorSearchResultDto>>> response = controller.search(
+                new VectorSearchRequestDto("hello", null, 3, false, null, null, 0.4d));
+
+        assertThat(response.getBody().getData())
+                .extracting(VectorSearchResultDto::documentId)
+                .containsExactly("doc-high");
+    }
+
+    @Test
+    void searchesWithinObjectScopeWhenOnlyObjectTypeIsProvided() {
+        when(embeddingPort.embed(any()))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("query", List.of(1.0, 0.0)))));
+        when(vectorStorePort.searchByObject(eq("attachment"), eq(null), any(VectorSearchRequest.class)))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-type-only", "chunk", Map.of("objectType", "attachment"), List.of()),
+                        0.75d)));
+
+        ResponseEntity<ApiResponse<List<VectorSearchResultDto>>> response = controller.search(
+                new VectorSearchRequestDto("hello", null, 3, false, "attachment", null, null));
+
+        assertThat(response.getBody().getData())
+                .extracting(VectorSearchResultDto::documentId)
+                .containsExactly("doc-type-only");
+        verify(vectorStorePort).searchByObject(eq("attachment"), eq(null), any(VectorSearchRequest.class));
+    }
+
+    @Test
+    void searchesWithinObjectScopeWhenOnlyObjectIdIsProvided() {
+        when(embeddingPort.embed(any()))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("query", List.of(1.0, 0.0)))));
+        when(vectorStorePort.searchByObject(eq(null), eq("42"), any(VectorSearchRequest.class)))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-id-only", "chunk", Map.of("objectId", "42"), List.of()),
+                        0.76d)));
+
+        ResponseEntity<ApiResponse<List<VectorSearchResultDto>>> response = controller.search(
+                new VectorSearchRequestDto("hello", null, 3, false, null, "42", null));
+
+        assertThat(response.getBody().getData())
+                .extracting(VectorSearchResultDto::documentId)
+                .containsExactly("doc-id-only");
+        verify(vectorStorePort).searchByObject(eq(null), eq("42"), any(VectorSearchRequest.class));
+    }
+
+    @Test
+    void treatsBlankObjectFiltersAsAbsent() {
+        when(embeddingPort.embed(any()))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("query", List.of(1.0, 0.0)))));
+        when(vectorStorePort.search(any(VectorSearchRequest.class)))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-global", "chunk", Map.of(), List.of()),
+                        0.7d)));
+
+        ResponseEntity<ApiResponse<List<VectorSearchResultDto>>> response = controller.search(
+                new VectorSearchRequestDto("hello", null, 3, false, "   ", "", null));
+
+        assertThat(response.getBody().getData())
+                .extracting(VectorSearchResultDto::documentId)
+                .containsExactly("doc-global");
+        verify(vectorStorePort).search(any(VectorSearchRequest.class));
+    }
+
+    @Test
+    void rejectsHybridObjectSearchWithoutQueryText() {
+        assertThrows(ResponseStatusException.class, () -> controller.search(
+                new VectorSearchRequestDto(null, List.of(1.0, 0.0), 3, true, "attachment", "42", null)));
+    }
+}


### PR DESCRIPTION
## Why
- #131 후속으로 vector 검색 경로에 실사용 제어 옵션을 확장합니다.
- 기본 search 경로만으로는 object-scoped 검색과 결과 threshold 제어가 제한적이었습니다.

## What
- `VectorSearchRequestDto`에 `objectType`, `objectId`, `minScore` 옵션을 추가합니다.
- `VectorController`에서 object filter가 있으면 `searchByObject(...)` / `hybridSearchByObject(...)` 경로를 사용하도록 정리합니다.
- `minScore` 후처리 필터를 추가하고 partial object filter 계약을 포함한 controller 테스트를 보강합니다.

## Related Issues
- Closes #131

## Change Scope
- [ ] API contract
- [x] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [ ] Docs/runbook

## Security Impact
- Risk:
  - 낮음. controller 옵션 확장과 결과 후처리 중심의 변경입니다.
- Mitigation:
  - web starter compile/test로 object-scoped 검색 경로와 threshold 필터 동작을 검증했습니다.

## Validation
- Commands:
  - `./gradlew -p /Users/donghyuck.son/git/studio-api -PnimbusJoseJwtVersion=9.37.3 -PjsonSmartVersion=2.5.2 :starter:studio-platform-starter-ai-web:compileTestJava`
  - `./gradlew -p /Users/donghyuck.son/git/studio-api -PnimbusJoseJwtVersion=9.37.3 -PjsonSmartVersion=2.5.2 :starter:studio-platform-starter-ai-web:test --tests studio.one.platform.ai.web.controller.VectorControllerTest`
- Result:
  - 대상 compile 및 test가 통과했습니다.
- Additional checks:
  - `spring-boot-engineer`가 구현과 검증을 수행했습니다.
  - `code-reviewer`가 partial object filter 공백 보강 후 재리뷰했고 findings 없음으로 확인했습니다.

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- Used: [ ] No [x] Yes
- Delegated tasks:
  - `spring-boot-engineer`: `#131` 구현 및 검증
  - `code-reviewer`: 구현 리뷰 및 follow-up 확인
- Ownership (files/modules/tasks):
  - main author: 작업 순서 결정, 리뷰 반영 판단, 커밋/브랜치/PR 정리
  - spring-boot-engineer: 구현 및 테스트
  - code-reviewer: findings 검토
- Main author post-integration validation:
  - main author가 최종 diff 범위와 워크트리 상태를 확인했습니다.

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering:
  - 별도 마이그레이션은 필요하지 않습니다.
- Rollback plan:
  - 회귀가 있으면 `6680565` 커밋을 되돌립니다.
- Post-deploy checks:
  - vector search endpoint 관련 CI와 controller test가 정상인지 확인합니다.
