### PR TITLE
refactor(ai-starter): provider optional activation via ProviderPortFactory pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 2026-03-26
+
+### 변경됨
+- `studio-platform-starter-ai`의 provider 의존성(OpenAI, Google GenAI, Ollama)을 `implementation`에서 `compileOnly`로 전환했다. 소비 애플리케이션이 필요한 provider 라이브러리를 직접 선언해야 한다.
+- Spring AI BOM을 `api(platform(...))`으로 노출하여 소비 앱이 별도 BOM 선언 없이 Spring AI 버전을 일관되게 관리할 수 있도록 했다.
+- `ProviderChatPortFactory` / `ProviderEmbeddingPortFactory` 인터페이스와 provider별 `@Configuration` 구현체를 도입했다. 각 구현체는 `@ConditionalOnClass`로 보호되어, provider 라이브러리가 classpath에 있을 때만 해당 factory가 등록된다.
+- `ProviderChatConfiguration` / `ProviderEmbeddingConfiguration`의 switch 기반 직접 참조를 제거하고, 등록된 factory를 수집하는 방식으로 교체했다. factory가 없는 provider는 조용히 제외된다.
+- `AiSecretPresenceGuard`에서 `ChatModel` / `EmbeddingModel` bean 주입을 제거했다. property 기반 검증만 유지한다.
+- `AiProviderRegistryConfiguration`에 fail-fast guard를 추가했다. `studio.ai.default-provider`에 지정된 provider가 chat port와 embedding port 모두에 없으면 시작 시점에 명확한 오류로 실패한다.
+
+### 사용 방법 (OpenAI 예시)
+```kotlin
+// build.gradle.kts
+implementation("studio-platform-starter-ai")
+implementation("org.springframework.ai:spring-ai-starter-model-openai")
+```
+```yaml
+# application.yml
+studio:
+  ai:
+    enabled: true
+    default-provider: openai
+    providers:
+      openai:
+        type: OPENAI
+        chat:
+          enabled: true
+        embedding:
+          enabled: true
+spring:
+  ai:
+    openai:
+      api-key: ${OPENAI_API_KEY}
+      chat.options.model: gpt-4o-mini
+      embedding.options.model: text-embedding-3-small
+```
+
+### 검증
+- `./gradlew :starter:studio-platform-starter-ai:build`
+
 ## 2026-03-23
 
 ### 변경됨

--- a/starter/README.md
+++ b/starter/README.md
@@ -34,6 +34,121 @@ dependencies {
 - `studio-platform-starter-objectstorage`, `-aws`, `-oci`: 오브젝트 스토리지 공통 및 provider별 구성
 - `studio-application-starter-attachment`, `-avatar`, `-template`, `-mail`: 애플리케이션 기능 모듈 자동 구성
 
+## studio-platform-starter-ai 사용법
+
+AI 기능을 사용하려면 스타터와 함께 **필요한 provider 라이브러리를 직접 선언**해야 한다. 스타터는 provider 라이브러리를 transitive하게 제공하지 않는다.
+
+### OpenAI
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    implementation(project(":starter:studio-platform-starter-ai"))
+    implementation("org.springframework.ai:spring-ai-starter-model-openai")
+}
+```
+
+```yaml
+# application.yml
+studio:
+  ai:
+    enabled: true
+    default-provider: openai
+    providers:
+      openai:
+        type: OPENAI
+        chat:
+          enabled: true
+        embedding:
+          enabled: true
+spring:
+  ai:
+    openai:
+      api-key: ${OPENAI_API_KEY}
+      chat.options.model: gpt-4o-mini
+      embedding.options.model: text-embedding-3-small
+```
+
+### Google GenAI (Chat)
+
+```kotlin
+dependencies {
+    implementation(project(":starter:studio-platform-starter-ai"))
+    implementation("org.springframework.ai:spring-ai-google-genai")
+}
+```
+
+```yaml
+studio:
+  ai:
+    enabled: true
+    default-provider: google
+    providers:
+      google:
+        type: GOOGLE_AI_GEMINI
+        api-key: ${GOOGLE_API_KEY}
+        chat:
+          enabled: true
+          model: gemini-2.5-flash
+```
+
+### Google GenAI (Embedding)
+
+```kotlin
+dependencies {
+    implementation(project(":starter:studio-platform-starter-ai"))
+    implementation("org.springframework.ai:spring-ai-google-genai-embedding")
+}
+```
+
+```yaml
+studio:
+  ai:
+    enabled: true
+    default-provider: google
+    providers:
+      google:
+        type: GOOGLE_AI_GEMINI
+        embedding:
+          enabled: true
+spring:
+  ai:
+    google.genai.embedding:
+      api-key: ${GOOGLE_API_KEY}
+      text.options.model: text-embedding-004
+```
+
+### Ollama (Embedding)
+
+```kotlin
+dependencies {
+    implementation(project(":starter:studio-platform-starter-ai"))
+    implementation("org.springframework.ai:spring-ai-ollama")
+}
+```
+
+```yaml
+studio:
+  ai:
+    enabled: true
+    default-provider: ollama
+    providers:
+      ollama:
+        type: OLLAMA
+        embedding:
+          enabled: true
+spring:
+  ai:
+    ollama:
+      base-url: http://localhost:11434
+      embedding.options.model: nomic-embed-text
+```
+
+### 동작 원리
+- provider 라이브러리가 classpath에 있을 때만 해당 provider auto-configuration이 활성화된다.
+- `studio.ai.default-provider`에 지정된 provider가 활성화되지 않으면 애플리케이션 시작 시 오류로 실패한다.
+- Spring AI BOM이 `api`로 노출되므로 provider 라이브러리의 버전은 별도로 지정하지 않아도 된다.
+
 ## 문서 바로가기
 - 루트 개요: `../README.md`
 - 애플리케이션 모듈 가이드: `../studio-application-modules/README.md`

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
@@ -43,6 +43,7 @@ class OpenAiProviderAutoConfigurationTest {
             .withUserConfiguration(
                     AiSecretPresenceGuard.class,
                     AiWebAutoConfiguration.class,
+                    OpenAiPortFactoryConfiguration.class,
                     ProviderChatConfiguration.class,
                     ProviderEmbeddingConfiguration.class,
                     AiProviderRegistryConfiguration.class)

--- a/starter/studio-platform-starter-ai/build.gradle.kts
+++ b/starter/studio-platform-starter-ai/build.gradle.kts
@@ -13,22 +13,31 @@ tasks.named<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {
     enabled = false
 }
 
-dependencies {  
-    implementation(platform("org.springframework.ai:spring-ai-bom:1.1.2"))
-    compileOnly(project(":studio-platform-autoconfigure")) 
-    compileOnly(project(":starter:studio-platform-starter")) 
-    api(project(":studio-platform-ai")) 
+dependencies {
+    // BOM as api: consumers inherit Spring AI version management without declaring it separately
+    api(platform("org.springframework.ai:spring-ai-bom:1.1.2"))
+    compileOnly(project(":studio-platform-autoconfigure"))
+    compileOnly(project(":starter:studio-platform-starter"))
+    api(project(":studio-platform-ai"))
     compileOnly("org.springframework:spring-jdbc")
-    
-    implementation("com.pgvector:pgvector:${property("pgvectorVersion")}") 
-    implementation("org.springframework.ai:spring-ai-starter-model-openai")
-    implementation("org.springframework.ai:spring-ai-google-genai")
-    implementation("org.springframework.ai:spring-ai-ollama")
-    implementation("org.springframework.ai:spring-ai-google-genai-embedding")
+
+    // Provider libraries: compileOnly so they do NOT become transitive dependencies.
+    // Consumers must declare the provider library they need explicitly.
+    compileOnly("org.springframework.ai:spring-ai-starter-model-openai")
+    compileOnly("org.springframework.ai:spring-ai-google-genai")
+    compileOnly("org.springframework.ai:spring-ai-ollama")
+    compileOnly("org.springframework.ai:spring-ai-google-genai-embedding")
+
+    implementation("com.pgvector:pgvector:${property("pgvectorVersion")}")
     implementation("com.github.ben-manes.caffeine:caffeine:${property("caffeineVersion")}")
     implementation("io.github.resilience4j:resilience4j-retry:${property("resilience4jVersion")}")
     implementation("com.github.spullara.mustache.java:compiler:${property("mustacheVersion")}")
 
+    // Tests need the provider libraries at runtime to exercise the factory implementations
+    testImplementation("org.springframework.ai:spring-ai-starter-model-openai")
+    testImplementation("org.springframework.ai:spring-ai-google-genai")
+    testImplementation("org.springframework.ai:spring-ai-ollama")
+    testImplementation("org.springframework.ai:spring-ai-google-genai-embedding")
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("org.mockito:mockito-core")
     testImplementation(project(":studio-platform"))

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/AiAutoConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/AiAutoConfiguration.java
@@ -6,12 +6,16 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 import studio.one.platform.ai.autoconfigure.config.AiProviderRegistryConfiguration;
-import studio.one.platform.ai.autoconfigure.config.RagPipelineConfiguration;
+import studio.one.platform.ai.autoconfigure.config.GoogleGenAiChatPortFactoryConfiguration;
+import studio.one.platform.ai.autoconfigure.config.GoogleGenAiEmbeddingPortFactoryConfiguration;
+import studio.one.platform.ai.autoconfigure.config.KeywordExtractorConfiguration;
+import studio.one.platform.ai.autoconfigure.config.OllamaPortFactoryConfiguration;
+import studio.one.platform.ai.autoconfigure.config.OpenAiPortFactoryConfiguration;
+import studio.one.platform.ai.autoconfigure.config.PromptConfiguration;
 import studio.one.platform.ai.autoconfigure.config.ProviderChatConfiguration;
 import studio.one.platform.ai.autoconfigure.config.ProviderEmbeddingConfiguration;
-import studio.one.platform.ai.autoconfigure.config.PromptConfiguration;
+import studio.one.platform.ai.autoconfigure.config.RagPipelineConfiguration;
 import studio.one.platform.ai.autoconfigure.config.VectorStoreConfiguration;
-import studio.one.platform.ai.autoconfigure.config.KeywordExtractorConfiguration;
 import studio.one.platform.ai.core.chat.ChatPort;
 import studio.one.platform.constant.PropertyKeys;
 
@@ -19,9 +23,12 @@ import studio.one.platform.constant.PropertyKeys;
 @ConditionalOnClass(ChatPort.class)
 @ConditionalOnProperty(prefix = PropertyKeys.AI.PREFIX, name = "enabled", havingValue = "true", matchIfMissing = false)
 @Import({
-                
+                OpenAiPortFactoryConfiguration.class,
+                GoogleGenAiChatPortFactoryConfiguration.class,
+                GoogleGenAiEmbeddingPortFactoryConfiguration.class,
+                OllamaPortFactoryConfiguration.class,
                 ProviderEmbeddingConfiguration.class,
-                ProviderChatConfiguration.class, 
+                ProviderChatConfiguration.class,
                 AiProviderRegistryConfiguration.class,
                 RagPipelineConfiguration.class,
                 VectorStoreConfiguration.class,

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/AiSecretPresenceGuard.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/AiSecretPresenceGuard.java
@@ -4,7 +4,6 @@ import java.util.Map;
 
 import jakarta.annotation.PostConstruct;
 
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -22,8 +21,6 @@ public class AiSecretPresenceGuard {
 
     private final AiAdapterProperties properties;
     private final Environment environment;
-    private final ObjectProvider<org.springframework.ai.chat.model.ChatModel> springAiChatModelProvider;
-    private final ObjectProvider<org.springframework.ai.embedding.EmbeddingModel> springAiEmbeddingModelProvider;
 
     @PostConstruct
     void validate() {
@@ -37,7 +34,7 @@ public class AiSecretPresenceGuard {
             }
             switch (provider.getType()) {
                 case OPENAI -> validateOpenAiProvider(provider);
-                case GOOGLE_AI_GEMINI -> validateGoogleEmbeddingProvider(providerId, provider);
+                case GOOGLE_AI_GEMINI -> validateGoogleProvider(providerId, provider);
                 case OLLAMA -> validateOllamaProvider(provider);
                 default -> {
                 }
@@ -65,21 +62,13 @@ public class AiSecretPresenceGuard {
     private void validateOpenAiProvider(AiAdapterProperties.Provider provider) {
         requireText(environment.getProperty("spring.ai.openai.api-key"),
                 "spring.ai.openai.api-key must be configured for OPENAI provider");
-        boolean chatEnabled = provider.getChat().isEnabled();
-        boolean embeddingEnabled = provider.getEmbedding().isEnabled();
-        if (chatEnabled) {
+        if (provider.getChat().isEnabled()) {
             requireText(environment.getProperty("spring.ai.openai.chat.options.model"),
                     "spring.ai.openai.chat.options.model must be configured for OPENAI provider");
         }
-        if (embeddingEnabled) {
+        if (provider.getEmbedding().isEnabled()) {
             requireText(environment.getProperty("spring.ai.openai.embedding.options.model"),
                     "spring.ai.openai.embedding.options.model must be configured for OPENAI provider");
-        }
-        if (chatEnabled && springAiChatModelProvider.getIfAvailable() == null) {
-            throw new IllegalStateException("Spring AI chat model bean is required for OPENAI provider");
-        }
-        if (embeddingEnabled && springAiEmbeddingModelProvider.getIfAvailable() == null) {
-            throw new IllegalStateException("Spring AI embedding model bean is required for OPENAI provider");
         }
     }
 
@@ -90,7 +79,7 @@ public class AiSecretPresenceGuard {
         }
     }
 
-    private void validateGoogleEmbeddingProvider(String providerId, AiAdapterProperties.Provider provider) {
+    private void validateGoogleProvider(String providerId, AiAdapterProperties.Provider provider) {
         if (provider.getEmbedding().isEnabled()) {
             requireText(environment.getProperty("spring.ai.google.genai.embedding.api-key"),
                     "spring.ai.google.genai.embedding.api-key must be configured for GOOGLE_AI_GEMINI embedding provider");

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/AiProviderRegistryConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/AiProviderRegistryConfiguration.java
@@ -41,6 +41,12 @@ public class AiProviderRegistryConfiguration {
         if (defaultProvider == null || defaultProvider.isBlank()) {
             throw new IllegalStateException("studio.ai.default-provider must be configured");
         }
+        String normalizedDefault = defaultProvider.toLowerCase(java.util.Locale.ROOT);
+        if (!chatPorts.containsKey(normalizedDefault) && !embeddingPorts.containsKey(normalizedDefault)) {
+            throw new IllegalStateException(
+                    "studio.ai.default-provider '" + defaultProvider + "' has no registered chat or embedding port. " +
+                    "Ensure the provider library is on the classpath and the provider is enabled in studio.ai.providers.");
+        }
         return new AiProviderRegistry(defaultProvider, chatPorts, embeddingPorts);
     }
 

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/GoogleGenAiChatPortFactoryConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/GoogleGenAiChatPortFactoryConfiguration.java
@@ -1,0 +1,69 @@
+package studio.one.platform.ai.autoconfigure.config;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import studio.one.platform.ai.autoconfigure.adapter.GoogleSpringAiChatAdapter;
+import studio.one.platform.ai.core.chat.ChatPort;
+
+/**
+ * Registers a {@link ProviderChatPortFactory} bean for the Google GenAI provider.
+ * Active only when {@code spring-ai-google-genai} is on the classpath.
+ * Builds the {@code GoogleGenAiChatModel} directly using {@code studio.ai.*} configuration.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(name = "org.springframework.ai.google.genai.GoogleGenAiChatModel")
+public class GoogleGenAiChatPortFactoryConfiguration {
+
+    @Bean
+    public ProviderChatPortFactory googleGenAiChatPortFactory() {
+        return new GoogleGenAiChatPortFactory();
+    }
+
+    static final class GoogleGenAiChatPortFactory implements ProviderChatPortFactory {
+
+        @Override
+        public AiAdapterProperties.ProviderType supportedType() {
+            return AiAdapterProperties.ProviderType.GOOGLE_AI_GEMINI;
+        }
+
+        @Override
+        public ChatPort create(AiAdapterProperties.Provider provider,
+                               Environment env,
+                               ObjectProvider<org.springframework.ai.chat.model.ChatModel> chatModelProvider) {
+            String apiKey = requireText(provider.getApiKey(),
+                    "studio.ai.providers.<id>.api-key must be configured for GOOGLE_AI_GEMINI chat provider");
+            String model = requireText(provider.getChat().getModel(),
+                    "studio.ai.providers.<id>.chat.model must be configured for GOOGLE_AI_GEMINI chat provider");
+
+            com.google.genai.Client.Builder clientBuilder = com.google.genai.Client.builder().apiKey(apiKey);
+            if (StringUtils.isNotBlank(provider.getBaseUrl())) {
+                clientBuilder.httpOptions(com.google.genai.types.HttpOptions.builder()
+                        .baseUrl(provider.getBaseUrl())
+                        .build());
+            }
+            com.google.genai.Client client = clientBuilder.build();
+
+            org.springframework.ai.google.genai.GoogleGenAiChatOptions defaultOptions =
+                    org.springframework.ai.google.genai.GoogleGenAiChatOptions.builder()
+                            .model(model)
+                            .build();
+            org.springframework.ai.google.genai.GoogleGenAiChatModel chatModel =
+                    org.springframework.ai.google.genai.GoogleGenAiChatModel.builder()
+                            .genAiClient(client)
+                            .defaultOptions(defaultOptions)
+                            .build();
+            return new GoogleSpringAiChatAdapter(chatModel);
+        }
+
+        private static String requireText(String value, String message) {
+            if (!StringUtils.isNotBlank(value)) {
+                throw new IllegalStateException(message);
+            }
+            return value;
+        }
+    }
+}

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/GoogleGenAiEmbeddingPortFactoryConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/GoogleGenAiEmbeddingPortFactoryConfiguration.java
@@ -1,0 +1,79 @@
+package studio.one.platform.ai.autoconfigure.config;
+
+import java.util.Locale;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import studio.one.platform.ai.autoconfigure.adapter.SpringAiEmbeddingAdapter;
+import studio.one.platform.ai.core.embedding.EmbeddingPort;
+
+/**
+ * Registers a {@link ProviderEmbeddingPortFactory} bean for the Google GenAI embedding provider.
+ * Active only when {@code spring-ai-google-genai-embedding} is on the classpath.
+ * Builds the {@code GoogleGenAiTextEmbeddingModel} using {@code spring.ai.google.genai.embedding.*}
+ * configuration properties.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(name = "org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingModel")
+public class GoogleGenAiEmbeddingPortFactoryConfiguration {
+
+    @Bean
+    public ProviderEmbeddingPortFactory googleGenAiEmbeddingPortFactory() {
+        return new GoogleGenAiEmbeddingPortFactory();
+    }
+
+    static final class GoogleGenAiEmbeddingPortFactory implements ProviderEmbeddingPortFactory {
+
+        @Override
+        public AiAdapterProperties.ProviderType supportedType() {
+            return AiAdapterProperties.ProviderType.GOOGLE_AI_GEMINI;
+        }
+
+        @Override
+        public EmbeddingPort create(AiAdapterProperties.Provider provider,
+                                    Environment env,
+                                    ObjectProvider<org.springframework.ai.embedding.EmbeddingModel> embeddingModelProvider) {
+            String apiKey = requireText(env.getProperty("spring.ai.google.genai.embedding.api-key"),
+                    "spring.ai.google.genai.embedding.api-key must be configured for GOOGLE_AI_GEMINI embedding provider");
+            String model = requireText(env.getProperty("spring.ai.google.genai.embedding.text.options.model"),
+                    "spring.ai.google.genai.embedding.text.options.model must be configured for GOOGLE_AI_GEMINI embedding provider");
+
+            org.springframework.ai.google.genai.GoogleGenAiEmbeddingConnectionDetails connectionDetails =
+                    org.springframework.ai.google.genai.GoogleGenAiEmbeddingConnectionDetails.builder()
+                            .apiKey(apiKey)
+                            .projectId(env.getProperty("spring.ai.google.genai.embedding.project-id"))
+                            .location(env.getProperty("spring.ai.google.genai.embedding.location"))
+                            .build();
+
+            AiAdapterProperties.GoogleEmbeddingOptions googleOptions = provider.getGoogleEmbedding();
+            org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingOptions options =
+                    org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingOptions.builder()
+                            .model(model)
+                            .taskType(parseTaskType(googleOptions.getTaskType()))
+                            .build();
+
+            org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingModel embeddingModel =
+                    new org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingModel(connectionDetails, options);
+            return new SpringAiEmbeddingAdapter(embeddingModel);
+        }
+
+        private static String requireText(String value, String message) {
+            if (!StringUtils.isNotBlank(value)) {
+                throw new IllegalStateException(message);
+            }
+            return value;
+        }
+
+        private static org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingOptions.TaskType parseTaskType(String value) {
+            if (value == null || value.isBlank()) {
+                return null;
+            }
+            return org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingOptions.TaskType.valueOf(
+                    value.trim().toUpperCase(Locale.ROOT));
+        }
+    }
+}

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/OllamaPortFactoryConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/OllamaPortFactoryConfiguration.java
@@ -1,0 +1,65 @@
+package studio.one.platform.ai.autoconfigure.config;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import studio.one.platform.ai.autoconfigure.adapter.SpringAiEmbeddingAdapter;
+import studio.one.platform.ai.core.embedding.EmbeddingPort;
+
+/**
+ * Registers a {@link ProviderEmbeddingPortFactory} bean for the Ollama provider.
+ * Active only when {@code spring-ai-ollama} is on the classpath.
+ * Builds the {@code OllamaEmbeddingModel} directly using {@code spring.ai.ollama.*}
+ * configuration properties.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(name = "org.springframework.ai.ollama.OllamaEmbeddingModel")
+public class OllamaPortFactoryConfiguration {
+
+    @Bean
+    public ProviderEmbeddingPortFactory ollamaEmbeddingPortFactory() {
+        return new OllamaEmbeddingPortFactory();
+    }
+
+    static final class OllamaEmbeddingPortFactory implements ProviderEmbeddingPortFactory {
+
+        @Override
+        public AiAdapterProperties.ProviderType supportedType() {
+            return AiAdapterProperties.ProviderType.OLLAMA;
+        }
+
+        @Override
+        public EmbeddingPort create(AiAdapterProperties.Provider provider,
+                                    Environment env,
+                                    ObjectProvider<org.springframework.ai.embedding.EmbeddingModel> embeddingModelProvider) {
+            String model = requireText(env.getProperty("spring.ai.ollama.embedding.options.model"),
+                    "spring.ai.ollama.embedding.options.model must be configured for OLLAMA embedding provider");
+            String baseUrl = env.getProperty("spring.ai.ollama.base-url", "http://localhost:11434");
+
+            org.springframework.ai.ollama.api.OllamaApi ollamaApi =
+                    org.springframework.ai.ollama.api.OllamaApi.builder()
+                            .baseUrl(baseUrl)
+                            .build();
+            org.springframework.ai.ollama.api.OllamaEmbeddingOptions options =
+                    org.springframework.ai.ollama.api.OllamaEmbeddingOptions.builder()
+                            .model(model)
+                            .build();
+            org.springframework.ai.ollama.OllamaEmbeddingModel embeddingModel =
+                    org.springframework.ai.ollama.OllamaEmbeddingModel.builder()
+                            .ollamaApi(ollamaApi)
+                            .defaultOptions(options)
+                            .build();
+            return new SpringAiEmbeddingAdapter(embeddingModel);
+        }
+
+        private static String requireText(String value, String message) {
+            if (!StringUtils.isNotBlank(value)) {
+                throw new IllegalStateException(message);
+            }
+            return value;
+        }
+    }
+}

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/OpenAiPortFactoryConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/OpenAiPortFactoryConfiguration.java
@@ -1,0 +1,74 @@
+package studio.one.platform.ai.autoconfigure.config;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import studio.one.platform.ai.autoconfigure.adapter.SpringAiChatAdapter;
+import studio.one.platform.ai.autoconfigure.adapter.SpringAiEmbeddingAdapter;
+import studio.one.platform.ai.core.chat.ChatPort;
+import studio.one.platform.ai.core.embedding.EmbeddingPort;
+
+/**
+ * Registers {@link ProviderChatPortFactory} and {@link ProviderEmbeddingPortFactory} beans
+ * for the OpenAI provider. Active only when {@code spring-ai-starter-model-openai} is on
+ * the classpath. The factory delegates to the {@code ChatModel} / {@code EmbeddingModel}
+ * beans created by Spring AI's own OpenAI auto-configuration.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(name = "org.springframework.ai.openai.OpenAiChatModel")
+public class OpenAiPortFactoryConfiguration {
+
+    @Bean
+    public ProviderChatPortFactory openAiChatPortFactory() {
+        return new OpenAiChatPortFactory();
+    }
+
+    @Bean
+    public ProviderEmbeddingPortFactory openAiEmbeddingPortFactory() {
+        return new OpenAiEmbeddingPortFactory();
+    }
+
+    static final class OpenAiChatPortFactory implements ProviderChatPortFactory {
+
+        @Override
+        public AiAdapterProperties.ProviderType supportedType() {
+            return AiAdapterProperties.ProviderType.OPENAI;
+        }
+
+        @Override
+        public ChatPort create(AiAdapterProperties.Provider provider,
+                               Environment env,
+                               ObjectProvider<org.springframework.ai.chat.model.ChatModel> chatModelProvider) {
+            org.springframework.ai.chat.model.ChatModel chatModel = chatModelProvider.getIfAvailable();
+            if (chatModel == null) {
+                throw new IllegalStateException(
+                        "Spring AI ChatModel bean is required for OPENAI provider. " +
+                        "Ensure spring-ai-starter-model-openai is on the classpath and spring.ai.openai.api-key is configured.");
+            }
+            return new SpringAiChatAdapter(chatModel);
+        }
+    }
+
+    static final class OpenAiEmbeddingPortFactory implements ProviderEmbeddingPortFactory {
+
+        @Override
+        public AiAdapterProperties.ProviderType supportedType() {
+            return AiAdapterProperties.ProviderType.OPENAI;
+        }
+
+        @Override
+        public EmbeddingPort create(AiAdapterProperties.Provider provider,
+                                    Environment env,
+                                    ObjectProvider<org.springframework.ai.embedding.EmbeddingModel> embeddingModelProvider) {
+            org.springframework.ai.embedding.EmbeddingModel embeddingModel = embeddingModelProvider.getIfAvailable();
+            if (embeddingModel == null) {
+                throw new IllegalStateException(
+                        "Spring AI EmbeddingModel bean is required for OPENAI provider. " +
+                        "Ensure spring-ai-starter-model-openai is on the classpath and spring.ai.openai.api-key is configured.");
+            }
+            return new SpringAiEmbeddingAdapter(embeddingModel);
+        }
+    }
+}

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/ProviderChatConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/ProviderChatConfiguration.java
@@ -1,9 +1,10 @@
 package studio.one.platform.ai.autoconfigure.config;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -11,11 +12,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 
 import lombok.extern.slf4j.Slf4j;
-import studio.one.platform.ai.autoconfigure.adapter.GoogleSpringAiChatAdapter;
-import studio.one.platform.ai.autoconfigure.adapter.SpringAiChatAdapter;
 import studio.one.platform.ai.core.chat.ChatPort;
-import studio.one.platform.service.I18n;
-import studio.one.platform.util.I18nUtils;
 
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(AiAdapterProperties.class)
@@ -23,78 +20,32 @@ import studio.one.platform.util.I18nUtils;
 public class ProviderChatConfiguration {
 
     @Bean(name = "providerChatPorts")
-    public Map<String, ChatPort> chatPorts(AiAdapterProperties properties,
-            ObjectProvider<I18n> i18nProvider,
+    public Map<String, ChatPort> chatPorts(
+            AiAdapterProperties properties,
             Environment environment,
-            ObjectProvider<org.springframework.ai.chat.model.ChatModel> springAiChatModelProvider) {
-        I18n i18n = I18nUtils.resolve(i18nProvider);
+            ObjectProvider<org.springframework.ai.chat.model.ChatModel> springAiChatModelProvider,
+            List<ProviderChatPortFactory> factories) {
+
+        Map<AiAdapterProperties.ProviderType, ProviderChatPortFactory> factoryMap = factories.stream()
+                .collect(Collectors.toMap(ProviderChatPortFactory::supportedType, f -> f));
+
         Map<String, ChatPort> ports = new LinkedHashMap<>();
         for (Map.Entry<String, AiAdapterProperties.Provider> entry : properties.getProviders().entrySet()) {
             AiAdapterProperties.Provider provider = entry.getValue();
-            log.debug("checking <{}> : provider - {}, chat - {}", entry.getKey(), provider.isEnabled(), provider.getChat().isEnabled());
-           
+            log.debug("checking <{}> : provider - {}, chat - {}",
+                    entry.getKey(), provider.isEnabled(), provider.getChat().isEnabled());
+
             if (!provider.isEnabled() || !provider.getChat().isEnabled()) {
                 continue;
             }
-            ports.put(entry.getKey(), createChatPort(entry.getKey(), provider, environment, i18n, springAiChatModelProvider));
+            ProviderChatPortFactory factory = factoryMap.get(provider.getType());
+            if (factory == null) {
+                log.debug("No chat port factory available for provider type {}, skipping <{}>",
+                        provider.getType(), entry.getKey());
+                continue;
+            }
+            ports.put(entry.getKey(), factory.create(provider, environment, springAiChatModelProvider));
         }
         return ports;
-    }
-
-    private static ChatPort createSpringAiChatPort(
-            ObjectProvider<org.springframework.ai.chat.model.ChatModel> springAiChatModelProvider) {
-        org.springframework.ai.chat.model.ChatModel chatModel = springAiChatModelProvider.getIfAvailable();
-        if (chatModel == null) {
-            throw new IllegalStateException("Spring AI chat model bean is required for OPENAI provider");
-        }
-        return new SpringAiChatAdapter(chatModel);
-    }
-
-    private static ChatPort createChatPort(String providerName, AiAdapterProperties.Provider provider,
-            Environment environment, I18n i18n,
-            ObjectProvider<org.springframework.ai.chat.model.ChatModel> springAiChatModelProvider) {
-        log.debug("Creating Chat Port by  {}", provider );
-        return switch (provider.getType()) {
-            case OPENAI -> createSpringAiChatPort(springAiChatModelProvider);
-            case GOOGLE_AI_GEMINI -> createGoogleSpringAiChatPort(provider, environment);
-            default -> throw new IllegalArgumentException("Unsupported chat provider type: " + provider.getType());
-        };
-    }
-
-    private static ChatPort createGoogleSpringAiChatPort(AiAdapterProperties.Provider provider, Environment environment) {
-        String apiKey = requireText(provider.getApiKey(),
-                "studio.ai.providers.google.api-key must be configured for GOOGLE_AI_GEMINI chat provider");
-        String model = requireModel(provider.getChat().getModel());
-        com.google.genai.Client.Builder clientBuilder = com.google.genai.Client.builder()
-                .apiKey(apiKey);
-        if (StringUtils.isNotBlank(provider.getBaseUrl())) {
-            clientBuilder.httpOptions(com.google.genai.types.HttpOptions.builder()
-                    .baseUrl(provider.getBaseUrl())
-                    .build());
-        }
-        com.google.genai.Client client = clientBuilder.build();
-        org.springframework.ai.google.genai.GoogleGenAiChatOptions defaultOptions =
-                org.springframework.ai.google.genai.GoogleGenAiChatOptions.builder()
-                        .model(model)
-                        .build();
-        org.springframework.ai.google.genai.GoogleGenAiChatModel chatModel =
-                org.springframework.ai.google.genai.GoogleGenAiChatModel.builder()
-                        .genAiClient(client)
-                        .defaultOptions(defaultOptions)
-                        .build();
-        return new GoogleSpringAiChatAdapter(chatModel);
-    }
-
-    private static String requireText(String value, String message) {
-        if (value == null || value.isBlank()) {
-            throw new IllegalStateException(message);
-        }
-        return value;
-    }
-    private static String requireModel(String model) {
-        if (model == null || model.isBlank()) {
-            throw new IllegalArgumentException("Model name must be provided for provider chat configuration");
-        }
-        return model;
     }
 }

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/ProviderChatPortFactory.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/ProviderChatPortFactory.java
@@ -1,0 +1,19 @@
+package studio.one.platform.ai.autoconfigure.config;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.core.env.Environment;
+import studio.one.platform.ai.core.chat.ChatPort;
+
+/**
+ * Strategy interface for creating a {@link ChatPort} for a specific provider type.
+ * Implementations are registered conditionally based on provider library presence
+ * ({@code @ConditionalOnClass}) and collected at runtime to assemble the provider port map.
+ */
+public interface ProviderChatPortFactory {
+
+    AiAdapterProperties.ProviderType supportedType();
+
+    ChatPort create(AiAdapterProperties.Provider provider,
+                    Environment env,
+                    ObjectProvider<org.springframework.ai.chat.model.ChatModel> chatModelProvider);
+}

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/ProviderEmbeddingConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/ProviderEmbeddingConfiguration.java
@@ -1,10 +1,10 @@
 package studio.one.platform.ai.autoconfigure.config;
 
 import java.util.LinkedHashMap;
-import java.util.Locale;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -12,10 +12,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 
 import lombok.extern.slf4j.Slf4j;
-import studio.one.platform.ai.autoconfigure.adapter.SpringAiEmbeddingAdapter;
 import studio.one.platform.ai.core.embedding.EmbeddingPort;
-import studio.one.platform.service.I18n;
-import studio.one.platform.util.I18nUtils;
 
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(AiAdapterProperties.class)
@@ -23,95 +20,32 @@ import studio.one.platform.util.I18nUtils;
 public class ProviderEmbeddingConfiguration {
 
     @Bean(name = "providerEmbeddingPorts")
-    public Map<String, EmbeddingPort> embeddingPorts(AiAdapterProperties properties,
-                                                    ObjectProvider<I18n> i18nProvider,
-                                                    Environment environment,
-                                                    ObjectProvider<org.springframework.ai.embedding.EmbeddingModel> springAiEmbeddingModelProvider) {
-        I18n i18n = I18nUtils.resolve(i18nProvider);
+    public Map<String, EmbeddingPort> embeddingPorts(
+            AiAdapterProperties properties,
+            Environment environment,
+            ObjectProvider<org.springframework.ai.embedding.EmbeddingModel> springAiEmbeddingModelProvider,
+            List<ProviderEmbeddingPortFactory> factories) {
+
+        Map<AiAdapterProperties.ProviderType, ProviderEmbeddingPortFactory> factoryMap = factories.stream()
+                .collect(Collectors.toMap(ProviderEmbeddingPortFactory::supportedType, f -> f));
+
         Map<String, EmbeddingPort> ports = new LinkedHashMap<>();
         for (Map.Entry<String, AiAdapterProperties.Provider> entry : properties.getProviders().entrySet()) {
             AiAdapterProperties.Provider provider = entry.getValue();
-            log.debug("checking <{}> : provider - {}, embedding - {}", entry.getKey(), provider.isEnabled(), provider.getEmbedding().isEnabled());
+            log.debug("checking <{}> : provider - {}, embedding - {}",
+                    entry.getKey(), provider.isEnabled(), provider.getEmbedding().isEnabled());
+
             if (!provider.isEnabled() || !provider.getEmbedding().isEnabled()) {
                 continue;
             }
-            ports.put(entry.getKey(), createEmbedding(provider, environment, i18n, springAiEmbeddingModelProvider));
+            ProviderEmbeddingPortFactory factory = factoryMap.get(provider.getType());
+            if (factory == null) {
+                log.debug("No embedding port factory available for provider type {}, skipping <{}>",
+                        provider.getType(), entry.getKey());
+                continue;
+            }
+            ports.put(entry.getKey(), factory.create(provider, environment, springAiEmbeddingModelProvider));
         }
         return ports;
-    }
-
-    private static EmbeddingPort createSpringAiEmbeddingPort(
-            ObjectProvider<org.springframework.ai.embedding.EmbeddingModel> springAiEmbeddingModelProvider) {
-        org.springframework.ai.embedding.EmbeddingModel embeddingModel = springAiEmbeddingModelProvider.getIfAvailable();
-        if (embeddingModel == null) {
-            throw new IllegalStateException("Spring AI embedding model bean is required for OPENAI provider");
-        }
-        return new SpringAiEmbeddingAdapter(embeddingModel);
-    }
-
-    private static EmbeddingPort createEmbedding(AiAdapterProperties.Provider provider,
-            Environment environment, I18n i18n,
-            ObjectProvider<org.springframework.ai.embedding.EmbeddingModel> springAiEmbeddingModelProvider) {
-        log.debug("Creating Embedding Port by  {}", provider );
-        return switch (provider.getType()) {
-            case OPENAI -> createSpringAiEmbeddingPort(springAiEmbeddingModelProvider);
-            case OLLAMA -> createOllamaSpringAiEmbeddingPort(environment);
-            case GOOGLE_AI_GEMINI -> createGoogleSpringAiEmbeddingPort(provider, environment);
-            default -> throw new IllegalArgumentException("Unsupported embedding provider: " + provider.getType());
-        };
-    }
-
-    private static EmbeddingPort createOllamaSpringAiEmbeddingPort(Environment environment) {
-        String model = requireText(environment.getProperty("spring.ai.ollama.embedding.options.model"),
-                "spring.ai.ollama.embedding.options.model must be configured for OLLAMA embedding provider");
-        String baseUrl = environment.getProperty("spring.ai.ollama.base-url", "http://localhost:11434");
-        org.springframework.ai.ollama.api.OllamaApi ollamaApi = org.springframework.ai.ollama.api.OllamaApi.builder()
-                .baseUrl(baseUrl)
-                .build();
-        org.springframework.ai.ollama.api.OllamaEmbeddingOptions options = org.springframework.ai.ollama.api.OllamaEmbeddingOptions.builder()
-                .model(model)
-                .build();
-        org.springframework.ai.ollama.OllamaEmbeddingModel embeddingModel = org.springframework.ai.ollama.OllamaEmbeddingModel.builder()
-                .ollamaApi(ollamaApi)
-                .defaultOptions(options)
-                .build();
-        return new SpringAiEmbeddingAdapter(embeddingModel);
-    }
-
-    private static EmbeddingPort createGoogleSpringAiEmbeddingPort(AiAdapterProperties.Provider provider, Environment environment) {
-        String apiKey = requireText(environment.getProperty("spring.ai.google.genai.embedding.api-key"),
-                "spring.ai.google.genai.embedding.api-key must be configured for GOOGLE_AI_GEMINI embedding provider");
-        String model = requireText(environment.getProperty("spring.ai.google.genai.embedding.text.options.model"),
-                "spring.ai.google.genai.embedding.text.options.model must be configured for GOOGLE_AI_GEMINI embedding provider");
-        AiAdapterProperties.GoogleEmbeddingOptions google = provider.getGoogleEmbedding();
-        org.springframework.ai.google.genai.GoogleGenAiEmbeddingConnectionDetails connectionDetails =
-                org.springframework.ai.google.genai.GoogleGenAiEmbeddingConnectionDetails.builder()
-                        .apiKey(apiKey)
-                        .projectId(environment.getProperty("spring.ai.google.genai.embedding.project-id"))
-                        .location(environment.getProperty("spring.ai.google.genai.embedding.location"))
-                        .build();
-        org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingOptions options =
-                org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingOptions.builder()
-                        .model(model)
-                        .taskType(parseSpringAiGoogleTaskType(google.getTaskType()))
-                        .build();
-        org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingModel embeddingModel =
-                new org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingModel(connectionDetails, options);
-        return new SpringAiEmbeddingAdapter(embeddingModel);
-    }
-
-    private static String requireText(String value, String message) {
-        if (!StringUtils.isNotBlank(value)) {
-            throw new IllegalStateException(message);
-        }
-        return value;
-    }
-
-    private static org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingOptions.TaskType parseSpringAiGoogleTaskType(String value) {
-        if (value == null || value.isBlank()) {
-            return null;
-        }
-        return org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingOptions.TaskType.valueOf(
-                value.trim().toUpperCase(Locale.ROOT));
     }
 }

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/ProviderEmbeddingPortFactory.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/ProviderEmbeddingPortFactory.java
@@ -1,0 +1,19 @@
+package studio.one.platform.ai.autoconfigure.config;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.core.env.Environment;
+import studio.one.platform.ai.core.embedding.EmbeddingPort;
+
+/**
+ * Strategy interface for creating an {@link EmbeddingPort} for a specific provider type.
+ * Implementations are registered conditionally based on provider library presence
+ * ({@code @ConditionalOnClass}) and collected at runtime to assemble the provider port map.
+ */
+public interface ProviderEmbeddingPortFactory {
+
+    AiAdapterProperties.ProviderType supportedType();
+
+    EmbeddingPort create(AiAdapterProperties.Provider provider,
+                         Environment env,
+                         ObjectProvider<org.springframework.ai.embedding.EmbeddingModel> embeddingModelProvider);
+}

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/AiSecretPresenceGuardTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/AiSecretPresenceGuardTest.java
@@ -4,8 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.beans.factory.support.StaticListableBeanFactory;
 import org.springframework.core.env.Environment;
 import org.springframework.mock.env.MockEnvironment;
 
@@ -16,23 +14,78 @@ import studio.one.platform.ai.autoconfigure.config.AiAdapterProperties.ProviderT
 class AiSecretPresenceGuardTest {
 
     @Test
-    void validateRejectsMissingApiKeyForOpenAiProvider() {
+    void validateRequiresDefaultProvider() {
         AiAdapterProperties properties = new AiAdapterProperties();
-        Provider provider = new Provider();
-        provider.setEnabled(true);
-        provider.setType(ProviderType.OPENAI);
-        provider.setApiKey(" ");
-        properties.getProviders().put("openai", provider);
+        properties.setEnabled(true);
 
-        AiSecretPresenceGuard guard = new AiSecretPresenceGuard(properties, environment(),
-                emptyBeanProvider(org.springframework.ai.chat.model.ChatModel.class),
-                emptyBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class));
+        AiSecretPresenceGuard guard = new AiSecretPresenceGuard(properties, environment());
 
         assertThrows(IllegalStateException.class, guard::validate);
     }
 
     @Test
-    void validateAllowsConfiguredSpringAiModelForOllamaEmbedding() {
+    void validateRequiresSpringAiApiKeyForOpenAiProvider() {
+        AiAdapterProperties properties = new AiAdapterProperties();
+        properties.setEnabled(true);
+        properties.setDefaultProvider("openai");
+
+        Provider provider = new Provider();
+        provider.setEnabled(true);
+        provider.setType(ProviderType.OPENAI);
+        provider.getChat().setEnabled(true);
+        properties.getProviders().put("openai", provider);
+
+        AiSecretPresenceGuard guard = new AiSecretPresenceGuard(properties, environment());
+
+        assertThrows(IllegalStateException.class, guard::validate);
+    }
+
+    @Test
+    void validateRequiresSpringAiChatModelPropertyForEnabledOpenAiChat() {
+        AiAdapterProperties properties = new AiAdapterProperties();
+        properties.setEnabled(true);
+        properties.setDefaultProvider("openai");
+
+        Provider provider = new Provider();
+        provider.setEnabled(true);
+        provider.setType(ProviderType.OPENAI);
+        provider.getChat().setEnabled(true);
+        properties.getProviders().put("openai", provider);
+
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("spring.ai.openai.api-key", "test-key");
+        // intentionally omit spring.ai.openai.chat.options.model
+
+        AiSecretPresenceGuard guard = new AiSecretPresenceGuard(properties, environment);
+
+        assertThrows(IllegalStateException.class, guard::validate);
+    }
+
+    @Test
+    void validateAllowsOpenAiProviderWithFullSpringAiProperties() {
+        AiAdapterProperties properties = new AiAdapterProperties();
+        properties.setEnabled(true);
+        properties.setDefaultProvider("openai");
+
+        Provider provider = new Provider();
+        provider.setEnabled(true);
+        provider.setType(ProviderType.OPENAI);
+        provider.getChat().setEnabled(true);
+        provider.getEmbedding().setEnabled(true);
+        properties.getProviders().put("openai", provider);
+
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("spring.ai.openai.api-key", "test-key");
+        environment.setProperty("spring.ai.openai.chat.options.model", "gpt-4o-mini");
+        environment.setProperty("spring.ai.openai.embedding.options.model", "text-embedding-3-small");
+
+        AiSecretPresenceGuard guard = new AiSecretPresenceGuard(properties, environment);
+
+        assertDoesNotThrow(guard::validate);
+    }
+
+    @Test
+    void validateAllowsConfiguredSpringAiPropertiesForOllamaEmbedding() {
         AiAdapterProperties properties = new AiAdapterProperties();
         properties.setEnabled(true);
         properties.setDefaultProvider("ollama");
@@ -45,15 +98,13 @@ class AiSecretPresenceGuardTest {
         MockEnvironment environment = new MockEnvironment();
         environment.setProperty("spring.ai.ollama.embedding.options.model", "nomic-embed-text");
 
-        AiSecretPresenceGuard guard = new AiSecretPresenceGuard(properties, environment,
-                emptyBeanProvider(org.springframework.ai.chat.model.ChatModel.class),
-                emptyBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class));
+        AiSecretPresenceGuard guard = new AiSecretPresenceGuard(properties, environment);
 
         assertDoesNotThrow(guard::validate);
     }
 
     @Test
-    void validateRejectsMissingSpringAiModelForOllamaEmbedding() {
+    void validateRejectsMissingModelPropertyForOllamaEmbedding() {
         AiAdapterProperties properties = new AiAdapterProperties();
         properties.setEnabled(true);
         properties.setDefaultProvider("ollama");
@@ -63,9 +114,7 @@ class AiSecretPresenceGuardTest {
         provider.getEmbedding().setEnabled(true);
         properties.getProviders().put("ollama", provider);
 
-        AiSecretPresenceGuard guard = new AiSecretPresenceGuard(properties, environment(),
-                emptyBeanProvider(org.springframework.ai.chat.model.ChatModel.class),
-                emptyBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class));
+        AiSecretPresenceGuard guard = new AiSecretPresenceGuard(properties, environment());
 
         assertThrows(IllegalStateException.class, guard::validate);
     }
@@ -85,15 +134,13 @@ class AiSecretPresenceGuardTest {
         environment.setProperty("spring.ai.google.genai.embedding.api-key", "test-key");
         environment.setProperty("spring.ai.google.genai.embedding.text.options.model", "text-embedding-004");
 
-        AiSecretPresenceGuard guard = new AiSecretPresenceGuard(properties, environment,
-                emptyBeanProvider(org.springframework.ai.chat.model.ChatModel.class),
-                emptyBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class));
+        AiSecretPresenceGuard guard = new AiSecretPresenceGuard(properties, environment);
 
         assertDoesNotThrow(guard::validate);
     }
 
     @Test
-    void validateRejectsMissingSpringAiModelForGoogleEmbedding() {
+    void validateRejectsMissingModelPropertyForGoogleEmbedding() {
         AiAdapterProperties properties = new AiAdapterProperties();
         properties.setEnabled(true);
         properties.setDefaultProvider("google");
@@ -105,10 +152,9 @@ class AiSecretPresenceGuardTest {
 
         MockEnvironment environment = new MockEnvironment();
         environment.setProperty("spring.ai.google.genai.embedding.api-key", "test-key");
+        // intentionally omit text.options.model
 
-        AiSecretPresenceGuard guard = new AiSecretPresenceGuard(properties, environment,
-                emptyBeanProvider(org.springframework.ai.chat.model.ChatModel.class),
-                emptyBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class));
+        AiSecretPresenceGuard guard = new AiSecretPresenceGuard(properties, environment);
 
         assertThrows(IllegalStateException.class, guard::validate);
     }
@@ -123,103 +169,15 @@ class AiSecretPresenceGuardTest {
         provider.setType(ProviderType.GOOGLE_AI_GEMINI);
         provider.getChat().setEnabled(true);
         provider.setApiKey("test-key");
+        // intentionally omit provider.getChat().setModel(...)
         properties.getProviders().put("google", provider);
 
-        AiSecretPresenceGuard guard = new AiSecretPresenceGuard(properties, environment(),
-                emptyBeanProvider(org.springframework.ai.chat.model.ChatModel.class),
-                emptyBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class));
-
-        assertThrows(IllegalStateException.class, guard::validate);
-    }
-
-    @Test
-    void validateRequiresDefaultProvider() {
-        AiAdapterProperties properties = new AiAdapterProperties();
-        properties.setEnabled(true);
-
-        AiSecretPresenceGuard guard = new AiSecretPresenceGuard(properties, environment(),
-                emptyBeanProvider(org.springframework.ai.chat.model.ChatModel.class),
-                emptyBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class));
-
-        assertThrows(IllegalStateException.class, guard::validate);
-    }
-
-    @Test
-    void validateRequiresSpringAiApiKeyForOpenAiProvider() {
-        AiAdapterProperties properties = new AiAdapterProperties();
-        properties.setEnabled(true);
-        properties.setDefaultProvider("openai");
-
-        Provider provider = new Provider();
-        provider.setEnabled(true);
-        provider.setType(ProviderType.OPENAI);
-        provider.getChat().setEnabled(true);
-        properties.getProviders().put("openai", provider);
-
-        AiSecretPresenceGuard guard = new AiSecretPresenceGuard(properties, environment(),
-                emptyBeanProvider(org.springframework.ai.chat.model.ChatModel.class),
-                emptyBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class));
-
-        assertThrows(IllegalStateException.class, guard::validate);
-    }
-
-    @Test
-    void validateAllowsOpenAiProviderWithoutLegacyStudioApiKey() {
-        AiAdapterProperties properties = new AiAdapterProperties();
-        properties.setEnabled(true);
-        properties.setDefaultProvider("openai");
-
-        Provider provider = new Provider();
-        provider.setEnabled(true);
-        provider.setType(ProviderType.OPENAI);
-        provider.getChat().setEnabled(true);
-        provider.getEmbedding().setEnabled(true);
-        properties.getProviders().put("openai", provider);
-
-        MockEnvironment environment = new MockEnvironment();
-        environment.setProperty("spring.ai.openai.api-key", "test-key");
-        environment.setProperty("spring.ai.openai.chat.options.model", "gpt-4o-mini");
-        environment.setProperty("spring.ai.openai.embedding.options.model", "text-embedding-3-small");
-        StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
-        beanFactory.addBean("chatModel", org.mockito.Mockito.mock(org.springframework.ai.chat.model.ChatModel.class));
-        beanFactory.addBean("embeddingModel", org.mockito.Mockito.mock(org.springframework.ai.embedding.EmbeddingModel.class));
-
-        AiSecretPresenceGuard guard = new AiSecretPresenceGuard(properties, environment,
-                beanFactory.getBeanProvider(org.springframework.ai.chat.model.ChatModel.class),
-                beanFactory.getBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class));
-
-        assertDoesNotThrow(guard::validate);
-    }
-
-    @Test
-    void validateRequiresSpringAiChatModelPropertyForEnabledOpenAiChat() {
-        AiAdapterProperties properties = new AiAdapterProperties();
-        properties.setEnabled(true);
-        properties.setDefaultProvider("openai");
-
-        Provider provider = new Provider();
-        provider.setEnabled(true);
-        provider.setType(ProviderType.OPENAI);
-        provider.getChat().setEnabled(true);
-        properties.getProviders().put("openai", provider);
-
-        MockEnvironment environment = new MockEnvironment();
-        environment.setProperty("spring.ai.openai.api-key", "test-key");
-        StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
-        beanFactory.addBean("chatModel", org.mockito.Mockito.mock(org.springframework.ai.chat.model.ChatModel.class));
-
-        AiSecretPresenceGuard guard = new AiSecretPresenceGuard(properties, environment,
-                beanFactory.getBeanProvider(org.springframework.ai.chat.model.ChatModel.class),
-                beanFactory.getBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class));
+        AiSecretPresenceGuard guard = new AiSecretPresenceGuard(properties, environment());
 
         assertThrows(IllegalStateException.class, guard::validate);
     }
 
     private static Environment environment() {
         return new MockEnvironment();
-    }
-
-    private static <T> ObjectProvider<T> emptyBeanProvider(Class<T> type) {
-        return new StaticListableBeanFactory().getBeanProvider(type);
     }
 }

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/AiProviderRegistryConfigurationTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/AiProviderRegistryConfigurationTest.java
@@ -1,0 +1,80 @@
+package studio.one.platform.ai.autoconfigure.config;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.support.StaticListableBeanFactory;
+
+import studio.one.platform.ai.core.chat.ChatPort;
+import studio.one.platform.ai.core.embedding.EmbeddingPort;
+import studio.one.platform.ai.core.registry.AiProviderRegistry;
+
+/**
+ * Verifies that AiProviderRegistryConfiguration fails fast when the configured
+ * default-provider has no registered port (library missing or provider disabled).
+ */
+class AiProviderRegistryConfigurationTest {
+
+    @Test
+    void registryCreationFailsWhenDefaultProviderHasNoChatOrEmbeddingPort() {
+        AiAdapterProperties properties = new AiAdapterProperties();
+        properties.setDefaultProvider("openai");
+
+        AiProviderRegistryConfiguration configuration =
+                new AiProviderRegistryConfiguration(new StaticListableBeanFactory().getBeanProvider(
+                        studio.one.platform.service.I18n.class));
+
+        assertThatThrownBy(() -> configuration.aiProviderRegistry(
+                properties,
+                Map.of(),        // no chat ports — factory was not registered
+                Map.of()))       // no embedding ports
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("openai")
+                .hasMessageContaining("studio.ai.default-provider");
+    }
+
+    @Test
+    void registryCreationSucceedsWhenDefaultProviderHasChatPort() {
+        AiAdapterProperties properties = new AiAdapterProperties();
+        properties.setDefaultProvider("openai");
+
+        StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
+        AiProviderRegistryConfiguration configuration =
+                new AiProviderRegistryConfiguration(beanFactory.getBeanProvider(
+                        studio.one.platform.service.I18n.class));
+
+        ChatPort mockChatPort = org.mockito.Mockito.mock(ChatPort.class);
+
+        AiProviderRegistry registry = configuration.aiProviderRegistry(
+                properties,
+                Map.of("openai", mockChatPort),
+                Map.of());
+
+        assertThat(registry.defaultProvider()).isEqualTo("openai");
+        assertThat(registry.chatPort(null)).isSameAs(mockChatPort);
+    }
+
+    @Test
+    void registryCreationSucceedsWhenDefaultProviderHasEmbeddingPortOnly() {
+        AiAdapterProperties properties = new AiAdapterProperties();
+        properties.setDefaultProvider("ollama");
+
+        StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
+        AiProviderRegistryConfiguration configuration =
+                new AiProviderRegistryConfiguration(beanFactory.getBeanProvider(
+                        studio.one.platform.service.I18n.class));
+
+        EmbeddingPort mockEmbeddingPort = org.mockito.Mockito.mock(EmbeddingPort.class);
+
+        AiProviderRegistry registry = configuration.aiProviderRegistry(
+                properties,
+                Map.of(),
+                Map.of("ollama", mockEmbeddingPort));
+
+        assertThat(registry.defaultProvider()).isEqualTo("ollama");
+        assertThat(registry.embeddingPort(null)).isSameAs(mockEmbeddingPort);
+    }
+}

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/GoogleSpringAiChatRegistrationTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/GoogleSpringAiChatRegistrationTest.java
@@ -4,17 +4,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.support.StaticListableBeanFactory;
 import org.springframework.mock.env.MockEnvironment;
 
 import studio.one.platform.ai.autoconfigure.adapter.GoogleSpringAiChatAdapter;
 import studio.one.platform.ai.core.chat.ChatPort;
 import studio.one.platform.ai.core.registry.AiProviderRegistry;
-import studio.one.platform.service.I18n;
 
 class GoogleSpringAiChatRegistrationTest {
 
@@ -30,16 +29,14 @@ class GoogleSpringAiChatRegistrationTest {
         provider.setApiKey("test-key");
         properties.getProviders().put("google", provider);
 
-        ProviderChatConfiguration chatConfiguration = new ProviderChatConfiguration();
         StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
-        ObjectProvider<I18n> i18nProvider = beanFactory.getBeanProvider(I18n.class);
         MockEnvironment environment = new MockEnvironment();
 
-        Map<String, ChatPort> chatPorts = chatConfiguration.chatPorts(
+        Map<String, ChatPort> chatPorts = new ProviderChatConfiguration().chatPorts(
                 properties,
-                i18nProvider,
                 environment,
-                beanFactory.getBeanProvider(org.springframework.ai.chat.model.ChatModel.class));
+                beanFactory.getBeanProvider(org.springframework.ai.chat.model.ChatModel.class),
+                List.of(new GoogleGenAiChatPortFactoryConfiguration().googleGenAiChatPortFactory()));
 
         assertThat(chatPorts).containsOnlyKeys("google");
         assertThat(chatPorts.get("google")).isInstanceOf(GoogleSpringAiChatAdapter.class);
@@ -62,16 +59,14 @@ class GoogleSpringAiChatRegistrationTest {
         provider.setBaseUrl("https://proxy.example.test/v1beta");
         properties.getProviders().put("google", provider);
 
-        ProviderChatConfiguration chatConfiguration = new ProviderChatConfiguration();
         StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
-        ObjectProvider<I18n> i18nProvider = beanFactory.getBeanProvider(I18n.class);
         MockEnvironment environment = new MockEnvironment();
 
-        Map<String, ChatPort> chatPorts = chatConfiguration.chatPorts(
+        Map<String, ChatPort> chatPorts = new ProviderChatConfiguration().chatPorts(
                 properties,
-                i18nProvider,
                 environment,
-                beanFactory.getBeanProvider(org.springframework.ai.chat.model.ChatModel.class));
+                beanFactory.getBeanProvider(org.springframework.ai.chat.model.ChatModel.class),
+                List.of(new GoogleGenAiChatPortFactoryConfiguration().googleGenAiChatPortFactory()));
 
         GoogleSpringAiChatAdapter adapter = (GoogleSpringAiChatAdapter) chatPorts.get("google");
         Field chatModelField = studio.one.platform.ai.autoconfigure.adapter.SpringAiChatAdapter.class

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/GoogleSpringAiEmbeddingRegistrationTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/GoogleSpringAiEmbeddingRegistrationTest.java
@@ -2,17 +2,16 @@ package studio.one.platform.ai.autoconfigure.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.support.StaticListableBeanFactory;
 import org.springframework.mock.env.MockEnvironment;
 
 import studio.one.platform.ai.autoconfigure.adapter.SpringAiEmbeddingAdapter;
 import studio.one.platform.ai.core.embedding.EmbeddingPort;
 import studio.one.platform.ai.core.registry.AiProviderRegistry;
-import studio.one.platform.service.I18n;
 
 class GoogleSpringAiEmbeddingRegistrationTest {
 
@@ -27,18 +26,16 @@ class GoogleSpringAiEmbeddingRegistrationTest {
         provider.getEmbedding().setModel("legacy-should-not-be-used");
         properties.getProviders().put("google", provider);
 
-        ProviderEmbeddingConfiguration embeddingConfiguration = new ProviderEmbeddingConfiguration();
         StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
-        ObjectProvider<I18n> i18nProvider = beanFactory.getBeanProvider(I18n.class);
         MockEnvironment environment = new MockEnvironment()
                 .withProperty("spring.ai.google.genai.embedding.api-key", "test-key")
                 .withProperty("spring.ai.google.genai.embedding.text.options.model", "text-embedding-004");
 
-        Map<String, EmbeddingPort> embeddingPorts = embeddingConfiguration.embeddingPorts(
+        Map<String, EmbeddingPort> embeddingPorts = new ProviderEmbeddingConfiguration().embeddingPorts(
                 properties,
-                i18nProvider,
                 environment,
-                beanFactory.getBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class));
+                beanFactory.getBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class),
+                List.of(new GoogleGenAiEmbeddingPortFactoryConfiguration().googleGenAiEmbeddingPortFactory()));
 
         assertThat(embeddingPorts).containsOnlyKeys("google");
         assertThat(embeddingPorts.get("google")).isInstanceOf(SpringAiEmbeddingAdapter.class);
@@ -59,17 +56,17 @@ class GoogleSpringAiEmbeddingRegistrationTest {
         provider.getGoogleEmbedding().setTaskType("RETRIEVAL_QUERY");
         properties.getProviders().put("google", provider);
 
-        ProviderEmbeddingConfiguration embeddingConfiguration = new ProviderEmbeddingConfiguration();
         StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
         MockEnvironment environment = new MockEnvironment()
                 .withProperty("spring.ai.google.genai.embedding.api-key", "test-key")
                 .withProperty("spring.ai.google.genai.embedding.text.options.model", "text-embedding-004");
 
-        EmbeddingPort port = embeddingConfiguration.embeddingPorts(
+        EmbeddingPort port = new ProviderEmbeddingConfiguration().embeddingPorts(
                 properties,
-                beanFactory.getBeanProvider(I18n.class),
                 environment,
-                beanFactory.getBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class)).get("google");
+                beanFactory.getBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class),
+                List.of(new GoogleGenAiEmbeddingPortFactoryConfiguration().googleGenAiEmbeddingPortFactory()))
+                .get("google");
 
         assertThat(port).isInstanceOf(SpringAiEmbeddingAdapter.class);
 

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/OllamaSpringAiEmbeddingRegistrationTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/OllamaSpringAiEmbeddingRegistrationTest.java
@@ -2,17 +2,16 @@ package studio.one.platform.ai.autoconfigure.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.support.StaticListableBeanFactory;
 import org.springframework.mock.env.MockEnvironment;
 
 import studio.one.platform.ai.autoconfigure.adapter.SpringAiEmbeddingAdapter;
 import studio.one.platform.ai.core.embedding.EmbeddingPort;
 import studio.one.platform.ai.core.registry.AiProviderRegistry;
-import studio.one.platform.service.I18n;
 
 class OllamaSpringAiEmbeddingRegistrationTest {
 
@@ -27,18 +26,16 @@ class OllamaSpringAiEmbeddingRegistrationTest {
         provider.getEmbedding().setModel("legacy-should-not-be-used");
         properties.getProviders().put("ollama", provider);
 
-        ProviderEmbeddingConfiguration embeddingConfiguration = new ProviderEmbeddingConfiguration();
         StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
-        ObjectProvider<I18n> i18nProvider = beanFactory.getBeanProvider(I18n.class);
         MockEnvironment environment = new MockEnvironment()
                 .withProperty("spring.ai.ollama.base-url", "http://localhost:11434")
                 .withProperty("spring.ai.ollama.embedding.options.model", "nomic-embed-text");
 
-        Map<String, EmbeddingPort> embeddingPorts = embeddingConfiguration.embeddingPorts(
+        Map<String, EmbeddingPort> embeddingPorts = new ProviderEmbeddingConfiguration().embeddingPorts(
                 properties,
-                i18nProvider,
                 environment,
-                beanFactory.getBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class));
+                beanFactory.getBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class),
+                List.of(new OllamaPortFactoryConfiguration().ollamaEmbeddingPortFactory()));
 
         assertThat(embeddingPorts).containsOnlyKeys("ollama");
         assertThat(embeddingPorts.get("ollama")).isInstanceOf(SpringAiEmbeddingAdapter.class);

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiSpringAiProviderRegistrationTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiSpringAiProviderRegistrationTest.java
@@ -2,17 +2,16 @@ package studio.one.platform.ai.autoconfigure.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.support.StaticListableBeanFactory;
 import org.springframework.mock.env.MockEnvironment;
 
 import studio.one.platform.ai.core.chat.ChatPort;
 import studio.one.platform.ai.core.embedding.EmbeddingPort;
 import studio.one.platform.ai.core.registry.AiProviderRegistry;
-import studio.one.platform.service.I18n;
 
 class OpenAiSpringAiProviderRegistrationTest {
 
@@ -27,23 +26,27 @@ class OpenAiSpringAiProviderRegistrationTest {
         provider.getEmbedding().setEnabled(true);
         properties.getProviders().put("openai", provider);
 
-        ProviderChatConfiguration chatConfiguration = new ProviderChatConfiguration();
-        ProviderEmbeddingConfiguration embeddingConfiguration = new ProviderEmbeddingConfiguration();
         StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
         beanFactory.addBean("springAiChatModel", org.mockito.Mockito.mock(org.springframework.ai.chat.model.ChatModel.class));
         beanFactory.addBean("springAiEmbeddingModel", org.mockito.Mockito.mock(org.springframework.ai.embedding.EmbeddingModel.class));
-        ObjectProvider<I18n> i18nProvider = beanFactory.getBeanProvider(I18n.class);
         MockEnvironment environment = new MockEnvironment()
                 .withProperty("spring.ai.openai.api-key", "test-key")
                 .withProperty("spring.ai.openai.chat.options.model", "gpt-4o-mini")
                 .withProperty("spring.ai.openai.embedding.options.model", "text-embedding-3-small");
 
-        Map<String, ChatPort> chatPorts = chatConfiguration.chatPorts(properties, i18nProvider,
+        ProviderChatPortFactory chatFactory = new OpenAiPortFactoryConfiguration().openAiChatPortFactory();
+        ProviderEmbeddingPortFactory embeddingFactory = new OpenAiPortFactoryConfiguration().openAiEmbeddingPortFactory();
+
+        Map<String, ChatPort> chatPorts = new ProviderChatConfiguration().chatPorts(
+                properties,
                 environment,
-                beanFactory.getBeanProvider(org.springframework.ai.chat.model.ChatModel.class));
-        Map<String, EmbeddingPort> embeddingPorts = embeddingConfiguration.embeddingPorts(properties, i18nProvider,
+                beanFactory.getBeanProvider(org.springframework.ai.chat.model.ChatModel.class),
+                List.of(chatFactory));
+        Map<String, EmbeddingPort> embeddingPorts = new ProviderEmbeddingConfiguration().embeddingPorts(
+                properties,
                 environment,
-                beanFactory.getBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class));
+                beanFactory.getBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class),
+                List.of(embeddingFactory));
 
         assertThat(chatPorts).containsOnlyKeys("openai");
         assertThat(embeddingPorts).containsOnlyKeys("openai");
@@ -73,16 +76,19 @@ class OpenAiSpringAiProviderRegistrationTest {
 
         StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
         beanFactory.addBean("springAiChatModel", org.mockito.Mockito.mock(org.springframework.ai.chat.model.ChatModel.class));
-        ObjectProvider<I18n> i18nProvider = beanFactory.getBeanProvider(I18n.class);
         MockEnvironment environment = new MockEnvironment()
                 .withProperty("spring.ai.openai.api-key", "test-key")
                 .withProperty("spring.ai.openai.chat.options.model", "gpt-4o-mini");
 
+        List<ProviderChatPortFactory> factories = List.of(
+                new OpenAiPortFactoryConfiguration().openAiChatPortFactory(),
+                new GoogleGenAiChatPortFactoryConfiguration().googleGenAiChatPortFactory());
+
         Map<String, ChatPort> chatPorts = new ProviderChatConfiguration().chatPorts(
                 properties,
-                i18nProvider,
                 environment,
-                beanFactory.getBeanProvider(org.springframework.ai.chat.model.ChatModel.class));
+                beanFactory.getBeanProvider(org.springframework.ai.chat.model.ChatModel.class),
+                factories);
 
         assertThat(chatPorts).containsOnlyKeys("openai", "google");
     }

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/ProviderPortFactoryCollectionTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/ProviderPortFactoryCollectionTest.java
@@ -1,0 +1,134 @@
+package studio.one.platform.ai.autoconfigure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.support.StaticListableBeanFactory;
+import org.springframework.mock.env.MockEnvironment;
+
+import studio.one.platform.ai.core.chat.ChatPort;
+import studio.one.platform.ai.core.embedding.EmbeddingPort;
+
+/**
+ * Verifies that ProviderChatConfiguration / ProviderEmbeddingConfiguration
+ * correctly exclude providers whose factory is not registered (simulating a missing
+ * provider library on the classpath) and include only the providers whose factory
+ * is present.
+ */
+class ProviderPortFactoryCollectionTest {
+
+    @Test
+    void chatPortsIsEmptyWhenNoFactoryRegistered() {
+        AiAdapterProperties properties = new AiAdapterProperties();
+        AiAdapterProperties.Provider provider = new AiAdapterProperties.Provider();
+        provider.setType(AiAdapterProperties.ProviderType.OPENAI);
+        provider.getChat().setEnabled(true);
+        properties.getProviders().put("openai", provider);
+
+        Map<String, ChatPort> ports = new ProviderChatConfiguration().chatPorts(
+                properties,
+                new MockEnvironment(),
+                new StaticListableBeanFactory().getBeanProvider(org.springframework.ai.chat.model.ChatModel.class),
+                List.of()); // no factory registered — simulates library not on classpath
+
+        assertThat(ports).isEmpty();
+    }
+
+    @Test
+    void embeddingPortsIsEmptyWhenNoFactoryRegistered() {
+        AiAdapterProperties properties = new AiAdapterProperties();
+        AiAdapterProperties.Provider provider = new AiAdapterProperties.Provider();
+        provider.setType(AiAdapterProperties.ProviderType.OLLAMA);
+        provider.getEmbedding().setEnabled(true);
+        properties.getProviders().put("ollama", provider);
+
+        Map<String, EmbeddingPort> ports = new ProviderEmbeddingConfiguration().embeddingPorts(
+                properties,
+                new MockEnvironment(),
+                new StaticListableBeanFactory().getBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class),
+                List.of()); // no factory registered
+
+        assertThat(ports).isEmpty();
+    }
+
+    @Test
+    void onlyProvidersWithRegisteredFactoryAreIncludedInChatPorts() {
+        AiAdapterProperties properties = new AiAdapterProperties();
+
+        AiAdapterProperties.Provider openAi = new AiAdapterProperties.Provider();
+        openAi.setType(AiAdapterProperties.ProviderType.OPENAI);
+        openAi.getChat().setEnabled(true);
+        properties.getProviders().put("openai", openAi);
+
+        AiAdapterProperties.Provider google = new AiAdapterProperties.Provider();
+        google.setType(AiAdapterProperties.ProviderType.GOOGLE_AI_GEMINI);
+        google.getChat().setEnabled(true);
+        google.setApiKey("test-key");
+        google.getChat().setModel("gemini-2.5-flash");
+        properties.getProviders().put("google", google);
+
+        StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
+        beanFactory.addBean("chatModel", org.mockito.Mockito.mock(org.springframework.ai.chat.model.ChatModel.class));
+
+        // Only Google factory registered — OpenAI is absent (simulates missing library)
+        Map<String, ChatPort> ports = new ProviderChatConfiguration().chatPorts(
+                properties,
+                new MockEnvironment(),
+                beanFactory.getBeanProvider(org.springframework.ai.chat.model.ChatModel.class),
+                List.of(new GoogleGenAiChatPortFactoryConfiguration().googleGenAiChatPortFactory()));
+
+        assertThat(ports).containsOnlyKeys("google");
+    }
+
+    @Test
+    void onlyProvidersWithRegisteredFactoryAreIncludedInEmbeddingPorts() {
+        AiAdapterProperties properties = new AiAdapterProperties();
+
+        AiAdapterProperties.Provider openAi = new AiAdapterProperties.Provider();
+        openAi.setType(AiAdapterProperties.ProviderType.OPENAI);
+        openAi.getEmbedding().setEnabled(true);
+        properties.getProviders().put("openai", openAi);
+
+        AiAdapterProperties.Provider ollama = new AiAdapterProperties.Provider();
+        ollama.setType(AiAdapterProperties.ProviderType.OLLAMA);
+        ollama.getEmbedding().setEnabled(true);
+        properties.getProviders().put("ollama", ollama);
+
+        MockEnvironment environment = new MockEnvironment()
+                .withProperty("spring.ai.ollama.embedding.options.model", "nomic-embed-text");
+
+        // Only Ollama factory registered — OpenAI is absent
+        Map<String, EmbeddingPort> ports = new ProviderEmbeddingConfiguration().embeddingPorts(
+                properties,
+                environment,
+                new StaticListableBeanFactory().getBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class),
+                List.of(new OllamaPortFactoryConfiguration().ollamaEmbeddingPortFactory()));
+
+        assertThat(ports).containsOnlyKeys("ollama");
+    }
+
+    @Test
+    void disabledProviderIsExcludedEvenWhenFactoryIsRegistered() {
+        AiAdapterProperties properties = new AiAdapterProperties();
+        AiAdapterProperties.Provider provider = new AiAdapterProperties.Provider();
+        provider.setType(AiAdapterProperties.ProviderType.OLLAMA);
+        provider.setEnabled(false); // explicitly disabled
+        provider.getEmbedding().setEnabled(true);
+        properties.getProviders().put("ollama", provider);
+
+        MockEnvironment environment = new MockEnvironment()
+                .withProperty("spring.ai.ollama.embedding.options.model", "nomic-embed-text");
+
+        Map<String, EmbeddingPort> ports = new ProviderEmbeddingConfiguration().embeddingPorts(
+                properties,
+                environment,
+                new StaticListableBeanFactory().getBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class),
+                List.of(new OllamaPortFactoryConfiguration().ollamaEmbeddingPortFactory()));
+
+        assertThat(ports).isEmpty();
+    }
+}


### PR DESCRIPTION
## Why
- `studio-platform-starter-ai`가 OpenAI/Google/Ollama provider 라이브러리를 `implementation`으로 전이 의존성으로 포함하고 있어, 소비 애플리케이션이 불필요한 provider 라이브러리를 모두 받게 되었다.
- classpath에 없는 provider도 항상 wire되어 시작 실패 원인이 불명확했다.

## What
- `ProviderChatPortFactory` / `ProviderEmbeddingPortFactory` 인터페이스 도입 및 provider별 `@ConditionalOnClass` 구현체 추가 (OpenAI, Google GenAI Chat, Google GenAI Embedding, Ollama)
- provider 라이브러리를 `implementation` → `compileOnly` 전환; Spring AI BOM을 `api(platform(...))` 으로 노출
- `AiSecretPresenceGuard`에서 `ChatModel`/`EmbeddingModel` bean 주입 제거 — property 검증 전담으로 좁힘
- `AiProviderRegistryConfiguration`에 fail-fast guard 추가: `default-provider`에 chat/embedding port가 하나도 없으면 시작 시점에 `IllegalStateException`
- 시나리오 테스트 추가 및 `starter/README.md`, `CHANGELOG.md` 업데이트

## Related Issues
- Closes #137
- Closes #138
- Closes #139
- Closes #136

## Change Scope
- [ ] API contract
- [x] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [x] Docs/runbook

## Security Impact
- Risk: None
- Mitigation: N/A

## Validation
- Commands:
  - `./gradlew :starter:studio-platform-starter-ai:build`
- Result:
  - BUILD SUCCESSFUL
- Additional checks:
  - `ProviderPortFactoryCollectionTest` — factory 미등록 시 port 제외 검증
  - `AiProviderRegistryConfigurationTest` — default-provider fail-fast 검증
  - `AiSecretPresenceGuardTest` — property 검증 시나리오 전체 통과

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- Used: [ ] No [x] Yes
- Delegated tasks: ProviderPortFactory 패턴 설계·구현, 테스트 작성, 문서 업데이트
- Ownership (files/modules/tasks): `starter/studio-platform-starter-ai/**`, `starter/README.md`, `CHANGELOG.md`
- Main author post-integration validation: 빌드 및 테스트 결과 확인 완료

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: 없음
- Rollback plan: 소비 애플리케이션에서 provider 라이브러리를 직접 선언하지 않은 경우 컴파일 오류 발생 → 의존성 추가 필요
- Post-deploy checks: provider 라이브러리가 classpath에 있는지, `studio.ai.default-provider` 및 관련 Spring AI 설정이 yml에 있는지 확인