### PR TITLE
[studio-platform-core] 보안/안정성 즉시 조치 반영

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2026-03-30
+
+### 변경됨
+- `PropertyValidator`가 점(`.`)과 하이픈(`-`)이 포함된 민감 프로퍼티 키도 감지하도록 수정했다.
+- `RepositoryImpl`에 경로 탐색 방어를 추가하고, startup refresh 이벤트가 즉시 `UnsupportedOperationException`으로 실패하지 않도록 정리했다.
+- `GlobalExceptionHandler`가 unsupported method/media type 예외를 각각 405/415로 응답하도록 수정했다.
+- `JasyptHttpController`의 토큰 검증을 상수 시간 비교로 바꾸고, `JasyptProperties`에 암호화 비밀번호 최소 길이 검증을 추가했다.
+- `studio-platform`과 `starter-jasypt`에 회귀 테스트를 추가하고, 테스트용 웹 의존성을 보강했다.
+
+### 검증
+- `./gradlew :studio-platform:test --tests 'studio.one.platform.component.PropertyValidatorTest' --tests 'studio.one.platform.component.RepositoryImplTest' --tests 'studio.one.platform.web.advice.GlobalExceptionHandlerTest'`
+- `./gradlew :starter:studio-platform-starter-jasypt:test --tests 'studio.one.platform.autoconfigure.jasypt.JasyptHttpControllerTest' --tests 'studio.one.platform.autoconfigure.jasypt.JasyptPropertiesTest'`
+
 ## 2026-03-26
 
 ### 변경됨

--- a/starter/studio-platform-starter-jasypt/build.gradle.kts
+++ b/starter/studio-platform-starter-jasypt/build.gradle.kts
@@ -18,6 +18,8 @@ dependencies {
     compileOnly("org.springframework.boot:spring-boot-starter-web")
     compileOnly("org.springframework.boot:spring-boot-starter-data-jpa")
     compileOnly("org.springframework.boot:spring-boot-starter-validation")
+    testImplementation(project(":starter:studio-platform-starter"))
+    testImplementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.jasypt:jasypt:1.9.3")
     implementation("org.bouncycastle:bcprov-jdk15to18:${project.findProperty("bouncycastleVersion")}")
 }

--- a/starter/studio-platform-starter-jasypt/src/main/java/studio/one/platform/autoconfigure/jasypt/JasyptHttpController.java
+++ b/starter/studio-platform-starter-jasypt/src/main/java/studio/one/platform/autoconfigure/jasypt/JasyptHttpController.java
@@ -23,6 +23,7 @@ package studio.one.platform.autoconfigure.jasypt;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.net.InetAddress;
+import java.security.MessageDigest;
 import java.util.regex.Pattern;
 
 import jakarta.annotation.PostConstruct;
@@ -159,6 +160,7 @@ class JasyptHttpController {
         if (expected == null || expected.isEmpty()) {
             expected = System.getenv(props.getTokenEnv());
         }
-        return expected != null && expected.equals(provided);
+        return expected != null
+                && MessageDigest.isEqual(expected.getBytes(UTF_8), provided.getBytes(UTF_8));
     }
 }

--- a/starter/studio-platform-starter-jasypt/src/main/java/studio/one/platform/autoconfigure/jasypt/JasyptProperties.java
+++ b/starter/studio-platform-starter-jasypt/src/main/java/studio/one/platform/autoconfigure/jasypt/JasyptProperties.java
@@ -27,6 +27,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
@@ -74,6 +75,7 @@ public class JasyptProperties extends FeatureToggle {
         private String bean;
 
         @NotBlank
+        @Size(min = 16, message = "password must be at least 16 characters long")
         private String password ; // 디폴트 암호화 비밀번호
 
         @NotBlank

--- a/starter/studio-platform-starter-jasypt/src/test/java/studio/one/platform/autoconfigure/jasypt/JasyptHttpControllerTest.java
+++ b/starter/studio-platform-starter-jasypt/src/test/java/studio/one/platform/autoconfigure/jasypt/JasyptHttpControllerTest.java
@@ -1,0 +1,97 @@
+package studio.one.platform.autoconfigure.jasypt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jasypt.encryption.StringEncryptor;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import studio.one.platform.service.I18n;
+
+class JasyptHttpControllerTest {
+
+    private final StringEncryptor encryptor = new StubEncryptor();
+    private final JasyptProperties properties = new JasyptProperties();
+    private final I18n i18n = (code, args, locale) -> code;
+
+    @Test
+    void encryptReturnsUnauthorizedForInvalidToken() {
+        JasyptHttpController controller = new JasyptHttpController(encryptor, httpProps("expected-token"), i18n);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("127.0.0.1");
+        request.addHeader("X-JASYPT-TOKEN", "wrong-token");
+
+        JasyptHttpController.CryptoRequest body = new JasyptHttpController.CryptoRequest();
+        body.setValue("plain");
+
+        var response = controller.encrypt(body, request);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(401);
+    }
+
+    @Test
+    void encryptSucceedsForValidToken() {
+        JasyptHttpController controller = new JasyptHttpController(encryptor, httpProps("expected-token"), i18n);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("127.0.0.1");
+        request.addHeader("X-JASYPT-TOKEN", "expected-token");
+
+        JasyptHttpController.CryptoRequest body = new JasyptHttpController.CryptoRequest();
+        body.setValue("plain");
+
+        var response = controller.encrypt(body, request);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).isEqualTo("ENC(cipher)");
+    }
+
+    @Test
+    void encryptReturnsForbiddenForNonLocalRequest() {
+        JasyptHttpController controller = new JasyptHttpController(encryptor, httpProps("expected-token"), i18n);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("203.0.113.1");
+        request.addHeader("X-JASYPT-TOKEN", "expected-token");
+
+        JasyptHttpController.CryptoRequest body = new JasyptHttpController.CryptoRequest();
+        body.setValue("plain");
+
+        var response = controller.encrypt(body, request);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(403);
+    }
+
+    @Test
+    void encryptReturnsUnauthorizedWhenTokenHeaderMissing() {
+        JasyptHttpController controller = new JasyptHttpController(encryptor, httpProps("expected-token"), i18n);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("127.0.0.1");
+
+        JasyptHttpController.CryptoRequest body = new JasyptHttpController.CryptoRequest();
+        body.setValue("plain");
+
+        var response = controller.encrypt(body, request);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(401);
+    }
+
+    private JasyptProperties.JasyptHttpEndpointProperties httpProps(String tokenValue) {
+        JasyptProperties.JasyptHttpEndpointProperties http = properties.new JasyptHttpEndpointProperties();
+        http.setEnabled(true);
+        http.setRequireToken(true);
+        http.setTokenValue(tokenValue);
+        return http;
+    }
+
+    private static class StubEncryptor implements StringEncryptor {
+
+        @Override
+        public String encrypt(String message) {
+            return "cipher";
+        }
+
+        @Override
+        public String decrypt(String encryptedMessage) {
+            return "plain";
+        }
+    }
+}

--- a/starter/studio-platform-starter-jasypt/src/test/java/studio/one/platform/autoconfigure/jasypt/JasyptPropertiesTest.java
+++ b/starter/studio-platform-starter-jasypt/src/test/java/studio/one/platform/autoconfigure/jasypt/JasyptPropertiesTest.java
@@ -1,0 +1,49 @@
+package studio.one.platform.autoconfigure.jasypt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jasypt.encryption.StringEncryptor;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class JasyptPropertiesTest {
+
+    private static final String VALID_TEST_PASSWORD = String.join("-",
+            "not", "a", "real", "test", "password", "123456");
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    ValidationAutoConfiguration.class,
+                    JasyptAutoConfiguration.class));
+
+    @Test
+    void rejectsShortEncryptorPasswordAtBindingTime() {
+        contextRunner
+                .withPropertyValues(
+                        "studio.features.jasypt.enabled=true",
+                        "studio.features.jasypt.encryptor.password=short")
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure())
+                            .hasMessageContaining("Could not bind properties to 'JasyptProperties'")
+                            .rootCause()
+                            .hasMessageContaining("password")
+                            .hasMessageContaining("16");
+                });
+    }
+
+    @Test
+    void createsEncryptorForValidPassword() {
+        contextRunner
+                .withPropertyValues(
+                        "studio.features.jasypt.enabled=true",
+                        "studio.features.jasypt.encryptor.password=" + VALID_TEST_PASSWORD)
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).hasSingleBean(JasyptProperties.class);
+                    assertThat(context).hasSingleBean(StringEncryptor.class);
+                });
+    }
+}

--- a/studio-platform/build.gradle.kts
+++ b/studio-platform/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     compileOnly("org.springframework.security:spring-security-acl")
     compileOnly("org.springframework.boot:spring-boot-starter-validation")
     compileOnly("org.springframework.boot:spring-boot-starter-data-jpa")
+    testImplementation("org.springframework.boot:spring-boot-starter-web")
     api("commons-io:commons-io:${project.findProperty("apacheCommonsIoVersion")}") 
     api("org.apache.commons:commons-lang3:${project.findProperty("apacheCommonsLang3Version")}")
 }

--- a/studio-platform/src/main/java/studio/one/platform/component/PropertyValidator.java
+++ b/studio-platform/src/main/java/studio/one/platform/component/PropertyValidator.java
@@ -56,6 +56,6 @@ public class PropertyValidator {
         if (!StringUtils.hasText(name)) {
             return false;
         }
-        return SENSITIVE_PATTERN.matcher(name).matches();
+        return SENSITIVE_PATTERN.matcher(name).find();
     }
 }

--- a/studio-platform/src/main/java/studio/one/platform/component/RepositoryImpl.java
+++ b/studio-platform/src/main/java/studio/one/platform/component/RepositoryImpl.java
@@ -239,11 +239,22 @@ public class RepositoryImpl implements Repository, DomainEvents, ServletContextA
 	 * @throws IOException if the file cannot be accessed.
 	 */
 	public File getFile(String name) throws IOException {
+		File root;
+		File target;
 		try {
-			return new File(getRootResource().getFile(), name);
+			root = getRootResource().getFile().getCanonicalFile();
+			target = new File(root, name).getCanonicalFile();
+		} catch (IllegalStateException e) {
+			throw e;
 		} catch (IOException e) {
 			throw new IOException(LogUtils.format(i18n, MessageCodes.Error.FILE_ACCESS, name), e);
 		}
+		String rootPath = root.getPath();
+		String targetPath = target.getPath();
+		if (!targetPath.equals(rootPath) && !targetPath.startsWith(rootPath + File.separator)) {
+			throw new IOException(LogUtils.format(i18n, MessageCodes.Error.FILE_ACCESS, name));
+		}
+		return target;
 	}
 
 	private Resource getRootResource() {
@@ -259,7 +270,11 @@ public class RepositoryImpl implements Repository, DomainEvents, ServletContextA
 	 * @throws UnsupportedOperationException currently not implemented.
 	 */
 	public void refresh() {
-		throw new UnsupportedOperationException();
+		if (!initialized.get()) {
+			throw new IllegalStateException(i18n.get(MessageCodes.Error.CONFIG_ROOT_NOT_INITIALIZED));
+		}
+		// TODO: implement dynamic configuration reload when a runtime refresh flow exists.
+		// The startup event only verifies that the repository is already initialized.
 	}
 
 	/**

--- a/studio-platform/src/main/java/studio/one/platform/web/advice/GlobalExceptionHandler.java
+++ b/studio-platform/src/main/java/studio/one/platform/web/advice/GlobalExceptionHandler.java
@@ -252,7 +252,14 @@ public class GlobalExceptionHandler extends AbstractExceptionHandler {
             HttpMediaTypeNotSupportedException.class
     })
     public ResponseEntity<ProblemDetails> handleHttp4xx(Exception ex, HttpServletRequest req) {
-        HttpStatus status = HttpStatus.BAD_REQUEST;
+        HttpStatus status;
+        if (ex instanceof HttpRequestMethodNotSupportedException) {
+            status = HttpStatus.METHOD_NOT_ALLOWED;
+        } else if (ex instanceof HttpMediaTypeNotSupportedException) {
+            status = HttpStatus.UNSUPPORTED_MEDIA_TYPE;
+        } else {
+            status = HttpStatus.BAD_REQUEST;
+        }
         ProblemDetails body = baseProblem(status, req)
                 .type("urn:error:http")
                 .detail(ex.getMessage())

--- a/studio-platform/src/test/java/studio/one/platform/component/PropertyValidatorTest.java
+++ b/studio-platform/src/test/java/studio/one/platform/component/PropertyValidatorTest.java
@@ -1,0 +1,24 @@
+package studio.one.platform.component;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class PropertyValidatorTest {
+
+    @Test
+    void detectsNestedSensitivePropertyNames() {
+        assertThat(PropertyValidator.isSensitiveProperty("spring.datasource.password")).isTrue();
+        assertThat(PropertyValidator.isSensitiveProperty("server.ssl.key-store-password")).isTrue();
+        assertThat(PropertyValidator.isSensitiveProperty("jasypt.encryptor.password")).isTrue();
+        assertThat(PropertyValidator.isSensitiveProperty("spring.security.oauth2.client.registration.app.client-secret"))
+                .isTrue();
+    }
+
+    @Test
+    void ignoresNonSensitivePropertyNames() {
+        assertThat(PropertyValidator.isSensitiveProperty("studio.features.text.enabled")).isFalse();
+        assertThat(PropertyValidator.isSensitiveProperty("")).isFalse();
+        assertThat(PropertyValidator.isSensitiveProperty(null)).isFalse();
+    }
+}

--- a/studio-platform/src/test/java/studio/one/platform/component/RepositoryImplTest.java
+++ b/studio-platform/src/test/java/studio/one/platform/component/RepositoryImplTest.java
@@ -1,0 +1,118 @@
+package studio.one.platform.component;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import studio.one.platform.component.event.PropertiesRefreshedEvent;
+import studio.one.platform.service.ApplicationProperties;
+import studio.one.platform.service.I18n;
+
+class RepositoryImplTest {
+
+    @TempDir
+    File tempDir;
+
+    @Test
+    void getFileRejectsPathTraversal() {
+        RepositoryImpl repository = createRepository();
+
+        assertThatThrownBy(() -> repository.getFile("../outside.txt"))
+                .isInstanceOf(IOException.class);
+    }
+
+    @Test
+    void getFileAllowsRootDirectory() throws IOException {
+        RepositoryImpl repository = createRepository();
+
+        File result = repository.getFile(".");
+
+        assertThat(result.getCanonicalFile()).isEqualTo(tempDir.getCanonicalFile());
+    }
+
+    @Test
+    void getFileReturnsCanonicalFileInsideRoot() throws IOException {
+        RepositoryImpl repository = createRepository();
+        File nested = new File(tempDir, "config/app.yml");
+        Files.createDirectories(nested.getParentFile().toPath());
+        Files.writeString(nested.toPath(), "ok");
+
+        File result = repository.getFile("config/../config/app.yml");
+
+        assertThat(result.getCanonicalFile()).isEqualTo(nested.getCanonicalFile());
+    }
+
+    @Test
+    void startupRefreshEventDoesNotThrowWhenInitialized() {
+        RepositoryImpl repository = createRepository();
+
+        assertThatNoException()
+                .isThrownBy(() -> repository.handlePropertiesRefreshedEvent(
+                        new PropertiesRefreshedEvent(this, "startup")));
+    }
+
+    private RepositoryImpl createRepository() {
+        I18n i18n = (code, args, locale) -> code + ":" + Locale.ROOT;
+        RepositoryImpl repository = new RepositoryImpl(
+                new StubApplicationProperties(),
+                i18n,
+                new MockEnvironment(),
+                event -> {
+                });
+        ReflectionTestUtils.setField(repository, "rootResource", new FileSystemResource(tempDir));
+        ReflectionTestUtils.setField(repository, "initialized", new AtomicBoolean(true));
+        return repository;
+    }
+
+    private static class StubApplicationProperties extends java.util.HashMap<String, String>
+            implements ApplicationProperties {
+
+        @Override
+        public boolean getBooleanProperty(String name) {
+            return Boolean.parseBoolean(get(name));
+        }
+
+        @Override
+        public boolean getBooleanProperty(String name, boolean defaultValue) {
+            return containsKey(name) ? Boolean.parseBoolean(get(name)) : defaultValue;
+        }
+
+        @Override
+        public java.util.Collection<String> getChildrenNames(String name) {
+            return java.util.List.of();
+        }
+
+        @Override
+        public int getIntProperty(String name, int defaultValue) {
+            return containsKey(name) ? Integer.parseInt(get(name)) : defaultValue;
+        }
+
+        @Override
+        public long getLongProperty(String name, long defaultValue) {
+            return containsKey(name) ? Long.parseLong(get(name)) : defaultValue;
+        }
+
+        @Override
+        public java.util.Collection<String> getPropertyNames() {
+            return keySet();
+        }
+
+        @Override
+        public String getStringProperty(String name, String defaultValue) {
+            return getOrDefault(name, defaultValue);
+        }
+    }
+}

--- a/studio-platform/src/test/java/studio/one/platform/web/advice/GlobalExceptionHandlerTest.java
+++ b/studio-platform/src/test/java/studio/one/platform/web/advice/GlobalExceptionHandlerTest.java
@@ -1,0 +1,43 @@
+package studio.one.platform.web.advice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+
+import studio.one.platform.service.I18n;
+
+class GlobalExceptionHandlerTest {
+
+    private final I18n i18n = (code, args, locale) -> code;
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler(i18n);
+
+    @Test
+    void returnsMethodNotAllowedForUnsupportedHttpMethod() {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/test");
+
+        var response = handler.handleHttp4xx(new HttpRequestMethodNotSupportedException("POST"), request);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(405);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(405);
+    }
+
+    @Test
+    void returnsUnsupportedMediaTypeForUnsupportedContentType() {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/test");
+
+        var response = handler.handleHttp4xx(
+                new HttpMediaTypeNotSupportedException(MediaType.APPLICATION_XML, List.of(MediaType.APPLICATION_JSON)),
+                request);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(415);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(415);
+    }
+}


### PR DESCRIPTION
## Why
- `docs/dev/code-review-studio-platform-core.md`에서 식별된 코어 보안/안정성 이슈 중 즉시 조치 범위를 반영한다.
- 민감 프로퍼티 로그 노출, Jasypt 토큰 비교, 경로 탐색, 잘못된 HTTP 상태 코드, startup refresh 실패 경로를 우선 정리한다.

## What
- `PropertyValidator`가 중첩 프로퍼티 키에서도 민감 키를 감지하도록 수정
- `RepositoryImpl`에 path traversal 방어 추가 및 startup refresh 실패 경로 제거
- `GlobalExceptionHandler`의 405/415 상태 코드 분리
- `JasyptHttpController`의 상수 시간 토큰 비교 적용
- `JasyptProperties`의 암호화 비밀번호 최소 길이 검증 추가
- 관련 회귀 테스트 추가 및 `CHANGELOG.md` 갱신

## Related Issues
- Closes #142
- Closes #143
- Closes #144
- Closes #145
- Closes #146
- Closes #147
- Related #141

## Change Scope
- [ ] API contract
- [x] Business logic
- [ ] DB schema/query
- [x] Security/permission
- [x] Docs/runbook

## Security Impact
- Risk:
  - 민감 프로퍼티 마스킹 누락, Jasypt 토큰 비교 타이밍 차이, 경로 탐색 가능성
- Mitigation:
  - 민감 키 탐지 보강, 상수 시간 비교 적용, canonical path 검증, 설정 검증 강화

## Validation
- Commands:
  - `./gradlew :studio-platform:test --tests 'studio.one.platform.component.PropertyValidatorTest' --tests 'studio.one.platform.component.RepositoryImplTest' --tests 'studio.one.platform.web.advice.GlobalExceptionHandlerTest'`
  - `./gradlew :starter:studio-platform-starter-jasypt:test --tests 'studio.one.platform.autoconfigure.jasypt.JasyptHttpControllerTest' --tests 'studio.one.platform.autoconfigure.jasypt.JasyptPropertiesTest'`
- Result:
  - 두 검증 명령 모두 성공
- Additional checks:
  - `CHANGELOG.md` 반영

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- Used: [x] No [ ] Yes
- Delegated tasks:
- Ownership (files/modules/tasks):
- Main author post-integration validation:

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering:
  - 없음
- Rollback plan:
  - 브랜치 revert 또는 개별 커밋 revert
- Post-deploy checks:
  - 민감 프로퍼티 마스킹, 405/415 응답, Jasypt 토큰 인증 동작 확인
