### PR TITLE
[ai-assisted] [studio-platform-core] 후속 리뷰 항목(#148, #149, #151) 반영

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
 - `GlobalExceptionHandler`가 unsupported method/media type 예외를 각각 405/415로 응답하도록 수정했다.
 - `JasyptHttpController`의 토큰 검증을 상수 시간 비교로 바꾸고, `JasyptProperties`에 암호화 비밀번호 최소 길이 검증을 추가했다.
 - `studio-platform`과 `starter-jasypt`에 회귀 테스트를 추가하고, 테스트용 웹 의존성을 보강했다.
+
+### 검증
+- `./gradlew :studio-platform:test --tests 'studio.one.platform.component.PropertyValidatorTest' --tests 'studio.one.platform.component.RepositoryImplTest' --tests 'studio.one.platform.web.advice.GlobalExceptionHandlerTest'`
+- `./gradlew :starter:studio-platform-starter-jasypt:test --tests 'studio.one.platform.autoconfigure.jasypt.JasyptHttpControllerTest' --tests 'studio.one.platform.autoconfigure.jasypt.JasyptPropertiesTest'`
+
+## 2026-03-30 (follow-up)
+
+### 변경됨
 - `studio-platform-autoconfigure`의 `CompositeAuditorAware`가 외부에서 주입한 `AuditorAware`를 우선 처리할 수 있도록 확장했다.
 - `CompositeAuditorAware`의 기존 security/header/fixed 기본 합성 동작은 유지했다.
 - `studio-platform-autoconfigure`에 `CompositeAuditorAware` 회귀 테스트와 테스트용 `spring-data-commons` 의존성을 추가했다.
@@ -16,8 +24,6 @@
 - `studio-platform`에 `DomainPolicyRegistryImpl` 병합/정규화 회귀 테스트를 추가하고, contributor 병합 시 불변 맵을 다시 수정하던 경로를 안전하게 고쳤다.
 
 ### 검증
-- `./gradlew :studio-platform:test --tests 'studio.one.platform.component.PropertyValidatorTest' --tests 'studio.one.platform.component.RepositoryImplTest' --tests 'studio.one.platform.web.advice.GlobalExceptionHandlerTest'`
-- `./gradlew :starter:studio-platform-starter-jasypt:test --tests 'studio.one.platform.autoconfigure.jasypt.JasyptHttpControllerTest' --tests 'studio.one.platform.autoconfigure.jasypt.JasyptPropertiesTest'`
 - `./gradlew :studio-platform-autoconfigure:test --tests 'studio.one.platform.autoconfigure.perisistence.jpa.auditor.CompositeAuditorAwareTest'`
 - `./gradlew :studio-platform:test --tests 'studio.one.platform.security.authz.DomainPolicyRegistryImplTest'`
 - `./gradlew :studio-platform-data:test --tests 'studio.one.platform.data.jdbc.pagination.PaginationDialectTest'`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,19 @@
 - `GlobalExceptionHandler`가 unsupported method/media type 예외를 각각 405/415로 응답하도록 수정했다.
 - `JasyptHttpController`의 토큰 검증을 상수 시간 비교로 바꾸고, `JasyptProperties`에 암호화 비밀번호 최소 길이 검증을 추가했다.
 - `studio-platform`과 `starter-jasypt`에 회귀 테스트를 추가하고, 테스트용 웹 의존성을 보강했다.
+- `studio-platform-autoconfigure`의 `CompositeAuditorAware`가 외부에서 주입한 `AuditorAware`를 우선 처리할 수 있도록 확장했다.
+- `CompositeAuditorAware`의 기존 security/header/fixed 기본 합성 동작은 유지했다.
+- `studio-platform-autoconfigure`에 `CompositeAuditorAware` 회귀 테스트와 테스트용 `spring-data-commons` 의존성을 추가했다.
+- 루트 OWASP dependency-check의 `failBuildOnCVSS`를 `7.0F`로 낮춰 High 이상 취약점에서 빌드가 실패하도록 조정했다.
+- `studio-platform-data`에 `PaginationDialect` 회귀 테스트를 추가했다.
+- `studio-platform`에 `DomainPolicyRegistryImpl` 병합/정규화 회귀 테스트를 추가하고, contributor 병합 시 불변 맵을 다시 수정하던 경로를 안전하게 고쳤다.
 
 ### 검증
 - `./gradlew :studio-platform:test --tests 'studio.one.platform.component.PropertyValidatorTest' --tests 'studio.one.platform.component.RepositoryImplTest' --tests 'studio.one.platform.web.advice.GlobalExceptionHandlerTest'`
 - `./gradlew :starter:studio-platform-starter-jasypt:test --tests 'studio.one.platform.autoconfigure.jasypt.JasyptHttpControllerTest' --tests 'studio.one.platform.autoconfigure.jasypt.JasyptPropertiesTest'`
+- `./gradlew :studio-platform-autoconfigure:test --tests 'studio.one.platform.autoconfigure.perisistence.jpa.auditor.CompositeAuditorAwareTest'`
+- `./gradlew :studio-platform:test --tests 'studio.one.platform.security.authz.DomainPolicyRegistryImplTest'`
+- `./gradlew :studio-platform-data:test --tests 'studio.one.platform.data.jdbc.pagination.PaginationDialectTest'`
 
 ## 2026-03-26
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ subprojects {
 	afterEvaluate{
 		the<org.owasp.dependencycheck.gradle.extension.DependencyCheckExtension>().apply {
 			autoUpdate = false  // 폐쇄망이므로 false
-			failBuildOnCVSS = 10.0F // 7.0f // CVSS 점수가 7.0 이상인 경우 빌드 실패
+			failBuildOnCVSS = 7.0F // High 이상 취약점에서 빌드 실패
 			suppressionFile = "${rootDir}/dependency-check-suppressions.xml"
 			val scanRoots = listOf("src/main/java", "src/main/kotlin")
 				.map { file(it) }

--- a/studio-platform-autoconfigure/build.gradle.kts
+++ b/studio-platform-autoconfigure/build.gradle.kts
@@ -17,4 +17,5 @@ dependencies {
     compileOnly("org.springframework.boot:spring-boot-starter-data-jpa")
     compileOnly("org.springframework.boot:spring-boot-starter-security")
     compileOnly("org.springframework.boot:spring-boot-starter-validation") 
+    testImplementation("org.springframework.data:spring-data-commons")
 }

--- a/studio-platform-autoconfigure/src/main/java/studio/one/platform/autoconfigure/perisistence/jpa/auditor/CompositeAuditorAware.java
+++ b/studio-platform-autoconfigure/src/main/java/studio/one/platform/autoconfigure/perisistence/jpa/auditor/CompositeAuditorAware.java
@@ -1,35 +1,67 @@
 package studio.one.platform.autoconfigure.perisistence.jpa.auditor;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
 import studio.one.platform.autoconfigure.JpaAuditingProperties;
 
 public class CompositeAuditorAware implements org.springframework.data.domain.AuditorAware<String> {
-    private final java.util.List<org.springframework.data.domain.AuditorAware<String>> delegates;
+    private final List<org.springframework.data.domain.AuditorAware<String>> delegates;
 
     public CompositeAuditorAware(JpaAuditingProperties props) {
-        var list = new java.util.ArrayList<org.springframework.data.domain.AuditorAware<String>>();
+        this(buildDefaultDelegates(props));
+    }
+
+    public CompositeAuditorAware(List<org.springframework.data.domain.AuditorAware<String>> delegates,
+            JpaAuditingProperties props) {
+        this(mergeDelegates(delegates, buildDefaultDelegates(props)));
+    }
+
+    private CompositeAuditorAware(List<org.springframework.data.domain.AuditorAware<String>> delegates) {
+        this.delegates = Collections.unmodifiableList(new ArrayList<>(delegates));
+    }
+
+    private static List<org.springframework.data.domain.AuditorAware<String>> mergeDelegates(
+            List<org.springframework.data.domain.AuditorAware<String>> delegates,
+            List<org.springframework.data.domain.AuditorAware<String>> defaults) {
+        var merged = new ArrayList<org.springframework.data.domain.AuditorAware<String>>();
+        if (delegates != null) {
+            merged.addAll(delegates);
+        }
+        merged.addAll(defaults);
+        return merged;
+    }
+
+    private static List<org.springframework.data.domain.AuditorAware<String>> buildDefaultDelegates(
+            JpaAuditingProperties props) {
+        var list = new ArrayList<org.springframework.data.domain.AuditorAware<String>>();
         for (String s : props.getAuditor().getComposite()) {
             switch (s.toLowerCase()) {
-                case "security":
-                    list.add(new SecurityAuditorAware());
-                    break;
-                case "header":
-                    list.add(new HeaderAuditorAware(props.getAuditor().getHeader()));
-                    break;
-                case "fixed":
-                    list.add(new FixedAuditorAware(props.getAuditor().getFixed()));
-                    break;
+            case "security":
+                list.add(new SecurityAuditorAware());
+                break;
+            case "header":
+                list.add(new HeaderAuditorAware(props.getAuditor().getHeader()));
+                break;
+            case "fixed":
+                list.add(new FixedAuditorAware(props.getAuditor().getFixed()));
+                break;
+            default:
+                break;
             }
         }
-        this.delegates = java.util.Collections.unmodifiableList(list);
+        return list;
     }
 
     @Override
-    public java.util.Optional<String> getCurrentAuditor() {
+    public Optional<String> getCurrentAuditor() {
         for (var d : delegates) {
             var v = d.getCurrentAuditor();
             if (v.isPresent())
                 return v;
         }
-        return java.util.Optional.of("system");
+        return Optional.of("system");
     }
 }

--- a/studio-platform-autoconfigure/src/test/java/studio/one/platform/autoconfigure/perisistence/jpa/auditor/CompositeAuditorAwareTest.java
+++ b/studio-platform-autoconfigure/src/test/java/studio/one/platform/autoconfigure/perisistence/jpa/auditor/CompositeAuditorAwareTest.java
@@ -1,0 +1,50 @@
+package studio.one.platform.autoconfigure.perisistence.jpa.auditor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.autoconfigure.JpaAuditingProperties;
+import org.springframework.data.domain.AuditorAware;
+
+class CompositeAuditorAwareTest {
+
+    @Test
+    void returnsFirstCustomAuditorBeforeDefaultDelegates() {
+        JpaAuditingProperties props = new JpaAuditingProperties();
+        props.getAuditor().setComposite(List.of("fixed"));
+        props.getAuditor().setFixed("default-user");
+
+        CompositeAuditorAware aware = new CompositeAuditorAware(
+                List.<AuditorAware<String>>of(() -> Optional.of("custom-user")),
+                props);
+
+        assertThat(aware.getCurrentAuditor()).contains("custom-user");
+    }
+
+    @Test
+    void preservesDefaultFallbackWhenCustomDelegatesAreEmpty() {
+        JpaAuditingProperties props = new JpaAuditingProperties();
+        props.getAuditor().setComposite(List.of("fixed"));
+        props.getAuditor().setFixed("default-user");
+
+        CompositeAuditorAware aware = new CompositeAuditorAware(
+                List.<AuditorAware<String>>of(() -> Optional.empty()),
+                props);
+
+        assertThat(aware.getCurrentAuditor()).contains("default-user");
+    }
+
+    @Test
+    void fallsBackToSystemWhenNoDelegateProvidesAuditor() {
+        JpaAuditingProperties props = new JpaAuditingProperties();
+        props.getAuditor().setComposite(List.of());
+
+        CompositeAuditorAware aware = new CompositeAuditorAware(props);
+
+        assertThat(aware.getCurrentAuditor()).contains("system");
+    }
+}

--- a/studio-platform-data/src/test/java/studio/one/platform/data/jdbc/pagination/PaginationDialectTest.java
+++ b/studio-platform-data/src/test/java/studio/one/platform/data/jdbc/pagination/PaginationDialectTest.java
@@ -16,6 +16,14 @@ class PaginationDialectTest {
     }
 
     @Test
+    void mysqlDialectSupportsZeroOffset() {
+        PaginationDialect dialect = new MySqlPaginationDialect();
+
+        assertThat(dialect.applyPagination("select * from sample", 0, 10))
+                .isEqualTo("select * from sample LIMIT 0, 10");
+    }
+
+    @Test
     void postgresDialectAppendsLimitThenOffset() {
         PaginationDialect dialect = new PostgresPaginationDialect();
 

--- a/studio-platform-data/src/test/java/studio/one/platform/data/jdbc/pagination/PaginationDialectTest.java
+++ b/studio-platform-data/src/test/java/studio/one/platform/data/jdbc/pagination/PaginationDialectTest.java
@@ -1,0 +1,53 @@
+package studio.one.platform.data.jdbc.pagination;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class PaginationDialectTest {
+
+    @Test
+    void mysqlDialectAppendsLimitOffsetClause() {
+        PaginationDialect dialect = new MySqlPaginationDialect();
+
+        assertThat(dialect.applyPagination("select * from sample", 5, 10))
+                .isEqualTo("select * from sample LIMIT 5, 10");
+    }
+
+    @Test
+    void postgresDialectAppendsLimitThenOffset() {
+        PaginationDialect dialect = new PostgresPaginationDialect();
+
+        assertThat(dialect.applyPagination("select * from sample", 5, 10))
+                .isEqualTo("select * from sample LIMIT 10 OFFSET 5");
+    }
+
+    @Test
+    void oracleDialectWrapsQueryWithRownumBounds() {
+        PaginationDialect dialect = new OraclePaginationDialect();
+
+        assertThat(dialect.applyPagination("select * from sample order by id", 5, 10))
+                .contains("ROWNUM <=")
+                .contains("WHERE rnum > 5");
+    }
+
+    @Test
+    void sqlServerDialectAddsFallbackOrderByWhenMissing() {
+        PaginationDialect dialect = new SqlServerPaginationDialect();
+
+        assertThat(dialect.applyPagination("select * from sample", 5, 10))
+                .contains("ORDER BY (SELECT 1)")
+                .endsWith("OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY");
+    }
+
+    @Test
+    void defaultDialectReportsUnsupportedPagination() {
+        PaginationDialect dialect = new DefaultPaginationDialect();
+
+        assertThat(dialect.supportsPagination()).isFalse();
+        assertThatThrownBy(() -> dialect.applyPagination("select 1", 0, 10))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("Pagination is not supported");
+    }
+}

--- a/studio-platform/src/main/java/studio/one/platform/security/authz/DomainPolicyRegistryImpl.java
+++ b/studio-platform/src/main/java/studio/one/platform/security/authz/DomainPolicyRegistryImpl.java
@@ -93,21 +93,22 @@ public class DomainPolicyRegistryImpl implements DomainPolicyRegistry {
     // ===== 병합/정규화 =====
 
     private AclProperties.DomainPolicy deepMerge(AclProperties.DomainPolicy a, AclProperties.DomainPolicy b) {
+        AclProperties.DomainPolicy merged = copyDomain(a);
         if (b.getRoles() != null)
-            a.setRoles(mergeRoles(a.getRoles(), b.getRoles()));
+            merged.setRoles(mergeRoles(merged.getRoles(), b.getRoles()));
         if (b.getComponents() != null) {
-            if (a.getComponents() == null)
-                a.setComponents(new HashMap<>());
+            if (merged.getComponents() == null)
+                merged.setComponents(new HashMap<>());
             b.getComponents().forEach((ck, cv) -> {
                 String nck = norm(ck);
-                var existing = a.getComponents().get(nck);
+                var existing = merged.getComponents().get(nck);
                 if (existing == null)
-                    a.getComponents().put(nck, freezeComponent(copyComponent(cv)));
+                    merged.getComponents().put(nck, freezeComponent(copyComponent(cv)));
                 else if (cv.getRoles() != null)
                     existing.setRoles(mergeRoles(existing.getRoles(), cv.getRoles()));
             });
         }
-        return freezeDomain(a);
+        return freezeDomain(merged);
     }
 
     private AclProperties.DomainPolicy copyDomain(AclProperties.DomainPolicy src) {

--- a/studio-platform/src/test/java/studio/one/platform/security/authz/DomainPolicyRegistryImplTest.java
+++ b/studio-platform/src/test/java/studio/one/platform/security/authz/DomainPolicyRegistryImplTest.java
@@ -1,0 +1,124 @@
+package studio.one.platform.security.authz;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+import studio.one.platform.security.acl.AclProperties;
+
+class DomainPolicyRegistryImplTest {
+
+    @Test
+    void mergesContributorPoliciesWithNormalizationAndComponentOverride() {
+        AclProperties.DomainPolicy first = domain(
+                listOf("ROLE_admin"),
+                listOf("manager"),
+                null,
+                mapOf(" Dashboard ", component(listOf("viewer"), listOf("editor"), null)));
+        AclProperties.DomainPolicy second = domain(
+                null,
+                null,
+                null,
+                mapOf("dashboard", component(listOf("auditor"), null, null)));
+
+        DomainPolicyRegistryImpl registry = new DomainPolicyRegistryImpl(provider(
+                contributor(mapOf(" Sales ", first)),
+                contributor(mapOf("sales", second))));
+
+        assertThat(registry.requiredRoles("sales", "read")).containsExactly("ADMIN");
+        assertThat(registry.requiredRoles("sales", "write")).containsExactly("MANAGER");
+        assertThat(registry.requiredRoles("sales:dashboard", "read")).containsExactly("AUDITOR");
+        assertThat(registry.requiredRoles("sales:dashboard", "write")).containsExactly("EDITOR");
+    }
+
+    @Test
+    void fallsBackAdminToWriteAndReturnsEmptyForUnknownResource() {
+        DomainPolicyRegistryImpl registry = new DomainPolicyRegistryImpl(provider(
+                contributor(mapOf("sales", domain(null, listOf("writer"), null, new HashMap<>())))));
+
+        assertThat(registry.requiredRoles("sales", "admin")).containsExactly("WRITER");
+        assertThat(registry.requiredRoles("unknown", "read")).isEmpty();
+    }
+
+    private static DomainPolicyContributor contributor(Map<String, AclProperties.DomainPolicy> policies) {
+        return () -> policies;
+    }
+
+    @SafeVarargs
+    private static ObjectProvider<List<DomainPolicyContributor>> provider(DomainPolicyContributor... contributors) {
+        List<DomainPolicyContributor> list = List.of(contributors);
+        return new ObjectProvider<>() {
+            @Override
+            public List<DomainPolicyContributor> getObject(Object... args) {
+                return list;
+            }
+
+            @Override
+            public List<DomainPolicyContributor> getIfAvailable() {
+                return list;
+            }
+
+            @Override
+            public List<DomainPolicyContributor> getIfUnique() {
+                return list;
+            }
+
+            @Override
+            public List<DomainPolicyContributor> getObject() {
+                return list;
+            }
+
+            @Override
+            public Stream<List<DomainPolicyContributor>> stream() {
+                return Stream.of(list);
+            }
+
+            @Override
+            public Stream<List<DomainPolicyContributor>> orderedStream() {
+                return stream();
+            }
+        };
+    }
+
+    private static AclProperties.DomainPolicy domain(
+            List<String> read,
+            List<String> write,
+            List<String> admin,
+            Map<String, AclProperties.ComponentPolicy> components) {
+        AclProperties.DomainPolicy policy = new AclProperties.DomainPolicy();
+        policy.setRoles(roles(read, write, admin));
+        policy.setComponents(components);
+        return policy;
+    }
+
+    private static AclProperties.ComponentPolicy component(List<String> read, List<String> write, List<String> admin) {
+        AclProperties.ComponentPolicy policy = new AclProperties.ComponentPolicy();
+        policy.setRoles(roles(read, write, admin));
+        return policy;
+    }
+
+    private static AclProperties.Roles roles(List<String> read, List<String> write, List<String> admin) {
+        AclProperties.Roles roles = new AclProperties.Roles();
+        roles.setRead(read);
+        roles.setWrite(write);
+        roles.setAdmin(admin);
+        return roles;
+    }
+
+    private static List<String> listOf(String... values) {
+        return new ArrayList<>(List.of(values));
+    }
+
+    private static <K, V> Map<K, V> mapOf(K key, V value) {
+        Map<K, V> map = new HashMap<>();
+        map.put(key, value);
+        return map;
+    }
+}

--- a/studio-platform/src/test/java/studio/one/platform/security/authz/DomainPolicyRegistryImplTest.java
+++ b/studio-platform/src/test/java/studio/one/platform/security/authz/DomainPolicyRegistryImplTest.java
@@ -53,38 +53,7 @@ class DomainPolicyRegistryImplTest {
 
     @SafeVarargs
     private static ObjectProvider<List<DomainPolicyContributor>> provider(DomainPolicyContributor... contributors) {
-        List<DomainPolicyContributor> list = List.of(contributors);
-        return new ObjectProvider<>() {
-            @Override
-            public List<DomainPolicyContributor> getObject(Object... args) {
-                return list;
-            }
-
-            @Override
-            public List<DomainPolicyContributor> getIfAvailable() {
-                return list;
-            }
-
-            @Override
-            public List<DomainPolicyContributor> getIfUnique() {
-                return list;
-            }
-
-            @Override
-            public List<DomainPolicyContributor> getObject() {
-                return list;
-            }
-
-            @Override
-            public Stream<List<DomainPolicyContributor>> stream() {
-                return Stream.of(list);
-            }
-
-            @Override
-            public Stream<List<DomainPolicyContributor>> orderedStream() {
-                return stream();
-            }
-        };
+        return new FixedObjectProvider<>(List.of(contributors));
     }
 
     private static AclProperties.DomainPolicy domain(
@@ -120,5 +89,44 @@ class DomainPolicyRegistryImplTest {
         Map<K, V> map = new HashMap<>();
         map.put(key, value);
         return map;
+    }
+
+    private static final class FixedObjectProvider<T> implements ObjectProvider<T> {
+
+        private final T value;
+
+        private FixedObjectProvider(T value) {
+            this.value = value;
+        }
+
+        @Override
+        public T getObject(Object... args) {
+            return value;
+        }
+
+        @Override
+        public T getIfAvailable() {
+            return value;
+        }
+
+        @Override
+        public T getIfUnique() {
+            return value;
+        }
+
+        @Override
+        public T getObject() {
+            return value;
+        }
+
+        @Override
+        public Stream<T> stream() {
+            return Stream.of(value);
+        }
+
+        @Override
+        public Stream<T> orderedStream() {
+            return stream();
+        }
     }
 }


### PR DESCRIPTION
## Why
- `docs/dev/code-review-studio-platform-core.md`의 후속 조치 항목 중 구현 가능한 범위를 `2.x`에 반영한다.
- `CompositeAuditorAware` 확장성, dependency-check 임계값, 코어 회귀 테스트 보강을 우선 처리한다.

## What
- `CompositeAuditorAware`가 외부 `AuditorAware<String>` delegate를 우선 처리할 수 있도록 확장
- `CompositeAuditorAware` 회귀 테스트 및 테스트용 `spring-data-commons` 의존성 추가
- OWASP dependency-check `failBuildOnCVSS`를 `7.0F`로 조정
- `PaginationDialectTest` 추가
- `DomainPolicyRegistryImplTest` 추가 및 contributor 병합 시 불변 스냅샷을 다시 수정하던 버그 수정
- `CHANGELOG.md` 갱신

## Related Issues
- Closes #148
- Closes #149
- Closes #151
- Related #150

## Change Scope
- [ ] API contract
- [x] Business logic
- [ ] DB schema/query
- [x] Security/permission
- [x] Docs/runbook

## Security Impact
- Risk:
  - 외부 감사자 확장 경로 부족, dependency-check 임계값 과소, 회귀 테스트 부족
- Mitigation:
  - delegate 확장, High 이상 취약점 fail gate, pagination/ACL 병합 회귀 테스트 추가

## Validation
- Commands:
  - `./gradlew :studio-platform-autoconfigure:test --tests 'studio.one.platform.autoconfigure.perisistence.jpa.auditor.CompositeAuditorAwareTest'`
  - `./gradlew :studio-platform:test --tests 'studio.one.platform.security.authz.DomainPolicyRegistryImplTest'`
  - `./gradlew :studio-platform-data:test --tests 'studio.one.platform.data.jdbc.pagination.PaginationDialectTest'`
- Result:
  - 세 검증 명령 모두 성공
- Additional checks:
  - `#150` 패키지명 변경은 호환성 영향 때문에 이번 PR에서 제외

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- Used: [ ] No [x] Yes
- Delegated tasks:
  - `CompositeAuditorAware` 확장성 개선안 구현 및 테스트 추가
- Ownership (files/modules/tasks):
  - Subagent: `studio-platform-autoconfigure/**`
  - Main author: `build.gradle.kts`, `studio-platform/**`, `studio-platform-data/**`, 통합 검증
- Main author post-integration validation:
  - 위 3개 Gradle 테스트 명령 실행 완료

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering:
  - 없음
- Rollback plan:
  - 브랜치 revert 또는 개별 커밋 revert
- Post-deploy checks:
  - custom `AuditorAware` 우선 적용, dependency-check gate, pagination/ACL 테스트 상태 확인
