### PR TITLE
[ai-assisted] [studio-platform-identity] 계약 명확화 및 테스트 보강

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 - `studio-platform`에 `DomainPolicyRegistryImpl` 병합/정규화 회귀 테스트를 추가하고, contributor 병합 시 불변 맵을 다시 수정하던 경로를 안전하게 고쳤다.
 - `starter`의 `perisitence`와 `studio-platform-autoconfigure`의 `perisistence` 오타 패키지에 대응해 정상 패키지명 `persistence` 경로를 추가하고, 기존 경로는 deprecated 호환 브리지로 유지했다.
 - Spring Boot auto-configuration 등록 경로를 `persistence` 패키지로 전환했다.
+- `studio-platform-identity` 계약에 principal/resolver 규약과 `UserDto` 용도를 문서화하고, identity service bean 이름 상수를 별도 상수 클래스로 분리했다.
+- `studio-platform-identity`를 순수 계약 모듈로 유지하도록 Spring Boot 플러그인을 제거했다.
 
 ### 검증
 - `./gradlew :studio-platform-autoconfigure:test --tests 'studio.one.platform.autoconfigure.perisistence.jpa.auditor.CompositeAuditorAwareTest'`
@@ -31,6 +33,8 @@
 - `./gradlew :studio-platform-data:test --tests 'studio.one.platform.data.jdbc.pagination.PaginationDialectTest'`
 - `./gradlew :studio-platform-autoconfigure:test --tests 'studio.one.platform.autoconfigure.persistence.jpa.auditor.CompositeAuditorAwareTest'`
 - `./gradlew :starter:studio-platform-starter:compileJava`
+- `./gradlew :studio-platform-identity:test`
+- `./gradlew :studio-platform-identity:build`
 
 ## 2026-03-26
 

--- a/starter/studio-platform-starter-user/src/main/java/studio/one/platform/user/autoconfigure/UserServicesAutoConfiguration.java
+++ b/starter/studio-platform-starter-user/src/main/java/studio/one/platform/user/autoconfigure/UserServicesAutoConfiguration.java
@@ -47,6 +47,7 @@ import studio.one.platform.component.State;
 import studio.one.platform.constant.PropertyKeys;
 import studio.one.platform.constant.ServiceNames;
 import studio.one.platform.identity.IdentityService;
+import studio.one.platform.identity.IdentityConstants;
 import studio.one.platform.service.DomainEvents;
 import studio.one.platform.service.I18n;
 import studio.one.platform.util.I18nUtils;
@@ -70,7 +71,7 @@ public class UserServicesAutoConfiguration {
         }
 
         @Bean
-        @ConditionalOnMissingBean(name = IdentityService.SERVICE_NAME)
+        @ConditionalOnMissingBean(name = IdentityConstants.SERVICE_NAME)
         @ConditionalOnExpression("${" + PropertyKeys.Features.User.ENABLED + ":true} && ${" + PropertyKeys.Features.User.USE_DEFAULT + ":true}")
         public ApplicationRunner identityServiceWarning(ObjectProvider<IdentityService> identityServiceProvider) {
                 return args -> {

--- a/studio-platform-identity/build.gradle.kts
+++ b/studio-platform-identity/build.gradle.kts
@@ -2,9 +2,14 @@ description = "Studio One Platform Identity"
 
 plugins {
     id("java-library")
-    id("org.springframework.boot")
     id("io.spring.dependency-management")
     id("maven-publish")
+}
+
+the<io.spring.gradle.dependencymanagement.dsl.DependencyManagementExtension>().apply {
+    imports {
+        mavenBom("org.springframework.boot:spring-boot-dependencies:${property("springBootVersion")}")
+    }
 }
 
 tasks.named<Jar>("jar") {
@@ -12,6 +17,6 @@ tasks.named<Jar>("jar") {
     archiveClassifier.set("")
 }
 
-tasks.named<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {
-    enabled = false
+dependencies {
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/studio-platform-identity/src/main/java/studio/one/platform/identity/ApplicationPrincipal.java
+++ b/studio-platform-identity/src/main/java/studio/one/platform/identity/ApplicationPrincipal.java
@@ -1,15 +1,42 @@
 package studio.one.platform.identity;
 
-import java.util.Set;
+import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
 
+/**
+ * Application-level authenticated principal contract.
+ *
+ * <p>This contract intentionally avoids direct dependency on Spring Security or a
+ * specific user domain model. Implementations may represent a fully identified
+ * application user, a service account, or an adapter-backed principal.</p>
+ */
 public interface ApplicationPrincipal {
 
-    Long getUserId(); // nullable 허용 가능(익명/외부계정 등)
+    /**
+     * Returns the application user id when available.
+     *
+     * <p>Implementations may return {@code null} for anonymous, external, or
+     * service-account principals that do not map to a local user id.</p>
+     */
+    Long getUserId();
 
-    String getUsername(); // nullable 허용 가능(서비스계정 등)
+    /**
+     * Returns the username when available.
+     *
+     * <p>Implementations may return {@code null} when the principal has no stable
+     * username representation.</p>
+     */
+    String getUsername();
 
-    Set<String> getRoles(); // "ADMIN", "MODERATOR", "USER" 같은 roleName 권장
+    /**
+     * Returns the principal's roles.
+     *
+     * <p>Implementations should return an empty set when no roles are available and
+     * should not return {@code null}. {@link #roles()} keeps backward compatibility
+     * for legacy implementations that still do.</p>
+     */
+    Set<String> getRoles();
 
     default Optional<Long> userId() {
         return Optional.ofNullable(getUserId());
@@ -19,7 +46,12 @@ public interface ApplicationPrincipal {
         return Optional.ofNullable(getUsername());
     }
 
+    default Set<String> roles() {
+        Set<String> roles = getRoles();
+        return roles == null ? Collections.emptySet() : roles;
+    }
+
     default boolean hasRole(String role) {
-        return getRoles() != null && getRoles().contains(role);
+        return roles().contains(role);
     }
 }

--- a/studio-platform-identity/src/main/java/studio/one/platform/identity/IdentityConstants.java
+++ b/studio-platform-identity/src/main/java/studio/one/platform/identity/IdentityConstants.java
@@ -1,0 +1,12 @@
+package studio.one.platform.identity;
+
+/**
+ * Shared bean names and constants for the identity contract module.
+ */
+public final class IdentityConstants {
+
+    public static final String SERVICE_NAME = "features:identity:identity-service";
+
+    private IdentityConstants() {
+    }
+}

--- a/studio-platform-identity/src/main/java/studio/one/platform/identity/IdentityService.java
+++ b/studio-platform-identity/src/main/java/studio/one/platform/identity/IdentityService.java
@@ -4,7 +4,11 @@ import java.util.Optional;
 
 public interface IdentityService {
 
-    public static final String SERVICE_NAME = "features:identity:identity-service";
+    /**
+     * @deprecated Use {@link IdentityConstants#SERVICE_NAME} instead.
+     */
+    @Deprecated(forRemoval = false)
+    String SERVICE_NAME = IdentityConstants.SERVICE_NAME;
 
     Optional<UserRef> findById(Long userId);
 

--- a/studio-platform-identity/src/main/java/studio/one/platform/identity/IdentityService.java
+++ b/studio-platform-identity/src/main/java/studio/one/platform/identity/IdentityService.java
@@ -7,7 +7,7 @@ public interface IdentityService {
     /**
      * @deprecated Use {@link IdentityConstants#SERVICE_NAME} instead.
      */
-    @Deprecated(forRemoval = false)
+    @Deprecated
     String SERVICE_NAME = IdentityConstants.SERVICE_NAME;
 
     Optional<UserRef> findById(Long userId);

--- a/studio-platform-identity/src/main/java/studio/one/platform/identity/PrincipalResolver.java
+++ b/studio-platform-identity/src/main/java/studio/one/platform/identity/PrincipalResolver.java
@@ -1,8 +1,29 @@
 package studio.one.platform.identity;
 
+/**
+ * Resolves the current application principal from the active execution context.
+ */
 public interface PrincipalResolver {
-    
-    ApplicationPrincipal current(); // 인증 없으면 예외 또는 anonymous principal 반환
 
-    ApplicationPrincipal currentOrNull(); // 인증 없으면 null
+    /**
+     * Returns the current principal or throws when no authenticated principal is available.
+     *
+     * @throws IllegalStateException when no principal can be resolved
+     */
+    default ApplicationPrincipal current() {
+        ApplicationPrincipal principal = currentOrNull();
+        if (principal == null) {
+            throw new IllegalStateException("No authentication principal available");
+        }
+        return principal;
+    }
+
+    /**
+     * Returns the current principal when available.
+     *
+     * <p>Implementations should return {@code null} when no principal can be resolved.
+     * They should not return an anonymous placeholder unless that placeholder is an
+     * intentional application principal.</p>
+     */
+    ApplicationPrincipal currentOrNull();
 }

--- a/studio-platform-identity/src/main/java/studio/one/platform/identity/UserDto.java
+++ b/studio-platform-identity/src/main/java/studio/one/platform/identity/UserDto.java
@@ -1,3 +1,8 @@
 package studio.one.platform.identity;
 
+/**
+ * Lightweight user projection for response payloads that only need id and username.
+ *
+ * <p>Unlike {@link UserRef}, this type intentionally omits roles.</p>
+ */
 public record UserDto(Long userId, String username) {}

--- a/studio-platform-identity/src/test/java/studio/one/platform/identity/IdentityContractsTest.java
+++ b/studio-platform-identity/src/test/java/studio/one/platform/identity/IdentityContractsTest.java
@@ -2,6 +2,7 @@ package studio.one.platform.identity;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -21,7 +22,7 @@ class IdentityContractsTest {
         assertTrue(resolved.isPresent());
         assertEquals(new UserRef(7L, "id-user", Set.of("ADMIN")), resolved.get());
         assertEquals(7L, service.lastResolvedId);
-        assertEquals(null, service.lastResolvedUsername);
+        assertNull(service.lastResolvedUsername);
     }
 
     @Test
@@ -32,7 +33,7 @@ class IdentityContractsTest {
 
         assertTrue(resolved.isPresent());
         assertEquals(new UserRef(8L, "alice", Set.of("USER")), resolved.get());
-        assertEquals(null, service.lastResolvedId);
+        assertNull(service.lastResolvedId);
         assertEquals("alice", service.lastResolvedUsername);
     }
 

--- a/studio-platform-identity/src/test/java/studio/one/platform/identity/IdentityContractsTest.java
+++ b/studio-platform-identity/src/test/java/studio/one/platform/identity/IdentityContractsTest.java
@@ -1,0 +1,98 @@
+package studio.one.platform.identity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+class IdentityContractsTest {
+
+    @Test
+    void resolveDispatchesUserIdKeyToFindById() {
+        RecordingIdentityService service = new RecordingIdentityService();
+
+        Optional<UserRef> resolved = service.resolve(new UserIdKey(7L));
+
+        assertTrue(resolved.isPresent());
+        assertEquals(new UserRef(7L, "id-user", Set.of("ADMIN")), resolved.get());
+        assertEquals(7L, service.lastResolvedId);
+        assertEquals(null, service.lastResolvedUsername);
+    }
+
+    @Test
+    void resolveDispatchesUsernameKeyToFindByUsername() {
+        RecordingIdentityService service = new RecordingIdentityService();
+
+        Optional<UserRef> resolved = service.resolve(new UsernameKey("alice"));
+
+        assertTrue(resolved.isPresent());
+        assertEquals(new UserRef(8L, "alice", Set.of("USER")), resolved.get());
+        assertEquals(null, service.lastResolvedId);
+        assertEquals("alice", service.lastResolvedUsername);
+    }
+
+    @Test
+    void applicationPrincipalConvenienceMethodsHandleNulls() {
+        ApplicationPrincipal principal = new TestPrincipal(null, "alice", null);
+
+        assertTrue(principal.userId().isEmpty());
+        assertEquals(Optional.of("alice"), principal.username());
+        assertTrue(principal.roles().isEmpty());
+        assertFalse(principal.hasRole("ADMIN"));
+    }
+
+    @Test
+    void principalResolverCurrentDelegatesToCurrentOrNull() {
+        PrincipalResolver resolver = () -> new TestPrincipal(1L, "alice", Set.of("ADMIN"));
+
+        assertEquals("alice", resolver.current().getUsername());
+    }
+
+    @Test
+    void principalResolverCurrentThrowsWhenPrincipalMissing() {
+        PrincipalResolver resolver = () -> null;
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, resolver::current);
+        assertTrue(exception.getMessage().contains("No authentication principal available"));
+    }
+
+    private static final class RecordingIdentityService implements IdentityService {
+        private Long lastResolvedId;
+        private String lastResolvedUsername;
+
+        @Override
+        public Optional<UserRef> findById(Long userId) {
+            lastResolvedId = userId;
+            return Optional.of(new UserRef(userId, "id-user", Set.of("ADMIN")));
+        }
+
+        @Override
+        public Optional<UserRef> findByUsername(String username) {
+            lastResolvedUsername = username;
+            return Optional.of(new UserRef(8L, username, Set.of("USER")));
+        }
+    }
+
+    private record TestPrincipal(Long principalUserId, String principalUsername, Set<String> principalRoles)
+            implements ApplicationPrincipal {
+        @Override
+        public Long getUserId() {
+            return principalUserId;
+        }
+
+        @Override
+        public String getUsername() {
+            return principalUsername;
+        }
+
+        @Override
+        public Set<String> getRoles() {
+            return principalRoles;
+        }
+    }
+}

--- a/studio-platform-identity/src/test/java/studio/one/platform/identity/UserKeyTest.java
+++ b/studio-platform-identity/src/test/java/studio/one/platform/identity/UserKeyTest.java
@@ -1,0 +1,38 @@
+package studio.one.platform.identity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class UserKeyTest {
+
+    @Test
+    void userIdKeyAcceptsPositiveValue() {
+        UserIdKey key = new UserIdKey(1L);
+
+        assertEquals(1L, key.userId());
+    }
+
+    @Test
+    void userIdKeyRejectsNonPositiveValue() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> new UserIdKey(0L));
+
+        assertTrue(exception.getMessage().contains("positive"));
+    }
+
+    @Test
+    void usernameKeyAcceptsNonBlankValue() {
+        UsernameKey key = new UsernameKey("alice");
+
+        assertEquals("alice", key.username());
+    }
+
+    @Test
+    void usernameKeyRejectsBlankValue() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> new UsernameKey(" "));
+
+        assertTrue(exception.getMessage().contains("required"));
+    }
+}

--- a/studio-platform-identity/src/test/java/studio/one/platform/identity/UserRefTest.java
+++ b/studio-platform-identity/src/test/java/studio/one/platform/identity/UserRefTest.java
@@ -1,7 +1,6 @@
 package studio.one.platform.identity;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.LinkedHashSet;
@@ -20,13 +19,6 @@ class UserRefTest {
         roles.add("USER");
 
         assertEquals(Set.of("ADMIN"), userRef.roles());
-    }
-
-    @Test
-    void exposesImmutableRoleSet() {
-        UserRef userRef = new UserRef(1L, "alice", Set.of("ADMIN"));
-
-        assertThrows(UnsupportedOperationException.class, () -> userRef.roles().add("USER"));
     }
 
     @Test

--- a/studio-platform-identity/src/test/java/studio/one/platform/identity/UserRefTest.java
+++ b/studio-platform-identity/src/test/java/studio/one/platform/identity/UserRefTest.java
@@ -1,0 +1,38 @@
+package studio.one.platform.identity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+class UserRefTest {
+
+    @Test
+    void copiesRolesDefensively() {
+        Set<String> roles = new LinkedHashSet<>();
+        roles.add("ADMIN");
+
+        UserRef userRef = new UserRef(1L, "alice", roles);
+        roles.add("USER");
+
+        assertEquals(Set.of("ADMIN"), userRef.roles());
+    }
+
+    @Test
+    void exposesImmutableRoleSet() {
+        UserRef userRef = new UserRef(1L, "alice", Set.of("ADMIN"));
+
+        assertThrows(UnsupportedOperationException.class, () -> userRef.roles().add("USER"));
+    }
+
+    @Test
+    void replacesNullRolesWithEmptySet() {
+        UserRef userRef = new UserRef(1L, "alice", null);
+
+        assertTrue(userRef.roles().isEmpty());
+    }
+}

--- a/studio-platform-user-default/src/main/java/studio/one/base/user/service/impl/ApplicationIdentityService.java
+++ b/studio-platform-user-default/src/main/java/studio/one/base/user/service/impl/ApplicationIdentityService.java
@@ -14,10 +14,11 @@ import studio.one.base.user.domain.entity.ApplicationRole;
 import studio.one.base.user.domain.entity.ApplicationUser;
 import studio.one.base.user.persistence.ApplicationUserRepository;
 import studio.one.base.user.persistence.ApplicationUserRoleRepository;
+import studio.one.platform.identity.IdentityConstants;
 import studio.one.platform.identity.IdentityService;
 import studio.one.platform.identity.UserRef;
 
-@Service(IdentityService.SERVICE_NAME)
+@Service(IdentityConstants.SERVICE_NAME)
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ApplicationIdentityService implements IdentityService {


### PR DESCRIPTION
## Why
- `studio-platform-identity`는 구현 분리 의도는 좋지만 principal/resolver 계약, bean-name 상수 위치, 계약 테스트가 느슨해 소비자와 유지보수자가 해석 규칙을 추측해야 했다.
- 코드 작업 시점에는 GitHub API 접근 문제로 이슈를 선등록하지 못했고, 네트워크 복구 후 `#155`-`#157`로 후등록했다.

## What
- `PrincipalResolver.current()`를 `currentOrNull()` 기반 기본 동작으로 정리하고 Javadoc으로 계약을 명확히 했다.
- `ApplicationPrincipal`에 null-safe `roles()`를 추가하고 role/nullability 계약을 문서화했다.
- `IdentityConstants`로 bean-name 상수를 분리하고 `IdentityService.SERVICE_NAME`은 deprecated alias로 유지했다.
- `UserDto`의 용도를 Javadoc으로 명시했다.
- `studio-platform-identity`에서 Spring Boot plugin을 제거하고 BOM 기반 순수 계약 모듈 구성을 유지했다.
- `UserKeyTest`, `UserRefTest`, `IdentityContractsTest`를 추가했다.
- `CHANGELOG.md`에 계약/빌드/검증 변경을 기록했다.

## Related Issues
- Closes #155
- Closes #156
- Closes #157

## Change Scope
- [x] API contract
- [ ] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [x] Docs/runbook

## Security Impact
- Risk: 인증/식별 계약 해석이 모호하면 호출부가 null/예외 처리를 잘못할 수 있다.
- Mitigation: principal/resolver 계약을 코드와 Javadoc으로 고정하고 회귀 테스트를 추가했다.

## Validation
- Commands:
  - `./gradlew :studio-platform-identity:test`
  - `./gradlew :studio-platform-identity:build`
- Result:
  - 두 명령 모두 성공
- Additional checks:
  - 메인 작성자가 subagent 통합 후 전체 identity 모듈 테스트/빌드를 재실행했다.

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- Used: [ ] No [x] Yes
- Delegated tasks: identity 계약 테스트 초안 작성
- Ownership (files/modules/tasks): `studio-platform-identity/src/test/**`
- Main author post-integration validation: `./gradlew :studio-platform-identity:test`, `./gradlew :studio-platform-identity:build`

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: 별도 마이그레이션 없음
- Rollback plan: PR revert 또는 커밋 `480c0a2` revert
- Post-deploy checks: identity 모듈 소비자가 `PrincipalResolver`와 `IdentityService`를 정상 주입받는지 CI로 확인
