### PR TITLE
[ai-assisted] [objecttype-attachment] 회귀 테스트 보강

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,18 @@
 - `./gradlew :studio-application-modules:attachment-service:test --tests 'studio.one.application.attachment.service.AttachmentServiceImplTest' --tests 'studio.one.application.web.controller.AttachmentMgmtControllerAuthorizationTest'`
 - `./gradlew :studio-application-modules:attachment-service:compileJava :starter:studio-platform-starter-objecttype:compileJava`
 
+## 2026-03-30 (objecttype-attachment tests)
+
+### 변경됨
+- `studio-platform-objecttype`에 `CachedObjectRebindService` 회귀 테스트를 추가해 YAML delegate 사용 시에도 cache invalidation 동작이 유지되는지 고정했다.
+- `attachment-service`에 `AttachmentServiceImpl` 테스트를 추가해 objecttype 업로드 정책 검증 요청과 storage failure 전파 순서를 고정했다.
+- `AttachmentMgmtControllerAuthorizationTest`에 `ROLE_ADMIN` 권한이 현재는 관리자 경로로 처리되지 않는 분기 테스트를 추가했다.
+- `attachment-service` 테스트 소스셋에 `studio-platform-objecttype` 테스트 의존성을 보강했다.
+
+### 검증
+- `./gradlew :studio-platform-objecttype:test --tests 'studio.one.platform.objecttype.CachedObjectRebindServiceTest' --tests 'studio.one.platform.objecttype.ObjectTypeRuntimeServiceTest'`
+- `./gradlew :studio-application-modules:attachment-service:test --tests 'studio.one.application.attachment.service.AttachmentServiceImplTest' --tests 'studio.one.application.web.controller.AttachmentMgmtControllerAuthorizationTest'`
+
 ## 2026-03-26
 
 ### 변경됨

--- a/studio-application-modules/attachment-service/build.gradle.kts
+++ b/studio-application-modules/attachment-service/build.gradle.kts
@@ -32,4 +32,5 @@ dependencies {
     testImplementation(project(":studio-platform"))
     testImplementation(project(":studio-platform-data"))
     testImplementation(project(":studio-platform-identity"))
+    testImplementation(project(":studio-platform-objecttype"))
 }

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/service/AttachmentServiceImplTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/service/AttachmentServiceImplTest.java
@@ -1,0 +1,203 @@
+package studio.one.application.attachment.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+
+import studio.one.application.attachment.domain.entity.ApplicationAttachment;
+import studio.one.application.attachment.storage.FileStorage;
+import studio.one.application.attachment.thumbnail.ThumbnailService;
+import studio.one.platform.identity.ApplicationPrincipal;
+import studio.one.platform.identity.PrincipalResolver;
+import studio.one.platform.objecttype.service.ObjectTypeRuntimeService;
+import studio.one.platform.objecttype.service.ValidateUploadCommand;
+import studio.one.platform.objecttype.service.ValidateUploadResult;
+import studio.one.platform.exception.PlatformRuntimeException;
+import studio.one.platform.objecttype.error.ObjectTypeErrorCodes;
+
+@ExtendWith(MockitoExtension.class)
+class AttachmentServiceImplTest {
+
+    @Mock
+    private studio.one.application.attachment.persistence.AttachmentRepository attachmentRepository;
+
+    @Mock
+    private FileStorage fileStorage;
+
+    @Mock
+    private ObjectProvider<PrincipalResolver> principalResolverProvider;
+
+    @Mock
+    private ObjectProvider<ObjectTypeRuntimeService> objectTypeRuntimeServiceProvider;
+
+    @Mock
+    private ObjectProvider<ThumbnailService> thumbnailServiceProvider;
+
+    @Mock
+    private PrincipalResolver principalResolver;
+
+    @Mock
+    private ObjectTypeRuntimeService objectTypeRuntimeService;
+
+    @Test
+    void createAttachmentValidatesUploadPolicyAndPersistsCreator() {
+        AttachmentServiceImpl service = service();
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4 });
+
+        when(objectTypeRuntimeServiceProvider.getIfAvailable()).thenReturn(objectTypeRuntimeService);
+        when(objectTypeRuntimeService.validateUpload(eq(1200), any(ValidateUploadCommand.class)))
+                .thenReturn(new ValidateUploadResult(true, null));
+        when(principalResolverProvider.getIfAvailable()).thenReturn(principalResolver);
+        when(principalResolver.currentOrNull()).thenReturn(principal(7L, "USER"));
+        when(attachmentRepository.save(any(ApplicationAttachment.class))).thenAnswer(invocation -> {
+            ApplicationAttachment attachment = invocation.getArgument(0);
+            attachment.setAttachmentId(99L);
+            attachment.setCreatedAt(Instant.parse("2026-03-30T00:00:00Z"));
+            return attachment;
+        });
+
+        ApplicationAttachment created = (ApplicationAttachment) service.createAttachment(
+                1200,
+                3400L,
+                "contract.pdf",
+                "application/pdf",
+                inputStream,
+                4);
+
+        ArgumentCaptor<ValidateUploadCommand> requestCaptor = ArgumentCaptor.forClass(ValidateUploadCommand.class);
+        verify(objectTypeRuntimeService).validateUpload(eq(1200), requestCaptor.capture());
+        ValidateUploadCommand request = requestCaptor.getValue();
+        assertEquals("contract.pdf", request.fileName());
+        assertEquals("application/pdf", request.contentType());
+        assertEquals(4L, request.sizeBytes());
+
+        ArgumentCaptor<ApplicationAttachment> attachmentCaptor = ArgumentCaptor.forClass(ApplicationAttachment.class);
+        verify(attachmentRepository).save(attachmentCaptor.capture());
+        ApplicationAttachment saved = attachmentCaptor.getValue();
+        assertEquals(1200, saved.getObjectType());
+        assertEquals(3400L, saved.getObjectId());
+        assertEquals("contract.pdf", saved.getName());
+        assertEquals("application/pdf", saved.getContentType());
+        assertEquals(4L, saved.getSize());
+        assertEquals(7L, saved.getCreatedBy());
+
+        verify(fileStorage).save(created, inputStream);
+        assertEquals(99L, created.getAttachmentId());
+    }
+
+    @Test
+    void createAttachmentSkipsValidationWhenObjectTypeServiceAbsent() {
+        AttachmentServiceImpl service = service();
+        InputStream inputStream = new ByteArrayInputStream(new byte[0]);
+
+        when(objectTypeRuntimeServiceProvider.getIfAvailable()).thenReturn(null);
+        when(attachmentRepository.save(any(ApplicationAttachment.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.createAttachment(1200, 3400L, "file.pdf", "application/pdf", inputStream, 0);
+
+        verify(attachmentRepository).save(any(ApplicationAttachment.class));
+        verify(fileStorage).save(any(ApplicationAttachment.class), eq(inputStream));
+    }
+
+    @Test
+    void createAttachmentPropagatesObjectTypeValidationFailureBeforeSaving() {
+        AttachmentServiceImpl service = service();
+        InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3 });
+        PlatformRuntimeException validationFailure = PlatformRuntimeException.of(
+                ObjectTypeErrorCodes.POLICY_VIOLATION,
+                "allowedExt");
+
+        when(objectTypeRuntimeServiceProvider.getIfAvailable()).thenReturn(objectTypeRuntimeService);
+        doThrow(validationFailure).when(objectTypeRuntimeService)
+                .validateUpload(eq(1200), any(ValidateUploadCommand.class));
+
+        PlatformRuntimeException thrown = assertThrows(PlatformRuntimeException.class, () -> service.createAttachment(
+                1200,
+                3400L,
+                "blocked.pdf",
+                "application/pdf",
+                inputStream,
+                3));
+
+        assertSame(validationFailure, thrown);
+        verify(attachmentRepository, never()).save(any(ApplicationAttachment.class));
+        verify(fileStorage, never()).save(any(ApplicationAttachment.class), any(InputStream.class));
+    }
+
+    /**
+     * Current implementation does not compensate for a previously saved DB row when file storage fails.
+     * Update this test together with the production code once a compensation strategy is introduced.
+     * Related: #162
+     */
+    @Test
+    void createAttachmentPropagatesStorageFailureWithoutCompensation() {
+        AttachmentServiceImpl service = service();
+        RuntimeException storageFailure = new RuntimeException("storage failure");
+        InputStream inputStream = new ByteArrayInputStream(new byte[] { 9, 8, 7 });
+
+        when(attachmentRepository.save(any(ApplicationAttachment.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(fileStorage.save(any(ApplicationAttachment.class), any(InputStream.class))).thenThrow(storageFailure);
+
+        RuntimeException thrown = assertThrows(RuntimeException.class, () -> service.createAttachment(
+                2000,
+                1L,
+                "error.txt",
+                "text/plain",
+                inputStream,
+                3));
+
+        assertSame(storageFailure, thrown);
+        InOrder inOrder = inOrder(attachmentRepository, fileStorage);
+        inOrder.verify(attachmentRepository).save(any(ApplicationAttachment.class));
+        inOrder.verify(fileStorage).save(any(ApplicationAttachment.class), eq(inputStream));
+        verify(attachmentRepository, never()).delete(any(ApplicationAttachment.class));
+    }
+
+    private AttachmentServiceImpl service() {
+        return new AttachmentServiceImpl(
+                attachmentRepository,
+                fileStorage,
+                principalResolverProvider,
+                objectTypeRuntimeServiceProvider,
+                thumbnailServiceProvider);
+    }
+
+    private ApplicationPrincipal principal(Long userId, String role) {
+        return new ApplicationPrincipal() {
+            @Override
+            public Long getUserId() {
+                return userId;
+            }
+
+            @Override
+            public String getUsername() {
+                return "user-" + userId;
+            }
+
+            @Override
+            public Set<String> getRoles() {
+                return Set.of(role);
+            }
+        };
+    }
+}

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/web/controller/AttachmentMgmtControllerAuthorizationTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/web/controller/AttachmentMgmtControllerAuthorizationTest.java
@@ -86,6 +86,19 @@ class AttachmentMgmtControllerAuthorizationTest {
     }
 
     @Test
+    void listByObjectTreatsRolePrefixedAdminAsNonAdmin() {
+        AttachmentMgmtController controller = controller();
+
+        when(principalResolverProvider.getIfAvailable()).thenReturn(principalResolver);
+        when(principalResolver.currentOrNull()).thenReturn(principal(1L, "ROLE_ADMIN"));
+        when(attachmentService.getAttachmentsByObjectAndCreator(12, 34L, 1L)).thenReturn(Collections.emptyList());
+
+        controller.listByObject(12, 34L);
+
+        verify(attachmentService).getAttachmentsByObjectAndCreator(12, 34L, 1L);
+    }
+
+    @Test
     void extractTextPropagatesLimitFailure() throws Exception {
         AttachmentMgmtController controller = controller();
         Attachment attachment = mock(Attachment.class);

--- a/studio-platform-objecttype/src/test/java/studio/one/platform/objecttype/CachedObjectRebindServiceTest.java
+++ b/studio-platform-objecttype/src/test/java/studio/one/platform/objecttype/CachedObjectRebindServiceTest.java
@@ -1,0 +1,103 @@
+package studio.one.platform.objecttype;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.objecttype.cache.CacheInvalidatable;
+import studio.one.platform.objecttype.cache.CachedObjectRebindService;
+import studio.one.platform.objecttype.lifecycle.ObjectRebindService;
+import studio.one.platform.objecttype.yaml.YamlObjectRebindService;
+
+class CachedObjectRebindServiceTest {
+
+    @Test
+    void rebindInvalidatesAllCachesAfterDelegateRebind() {
+        RecordingRebindService delegate = new RecordingRebindService();
+        RecordingCache registryCache = new RecordingCache();
+        RecordingCache policyCache = new RecordingCache();
+        CachedObjectRebindService service = new CachedObjectRebindService(delegate, registryCache, policyCache);
+
+        service.rebind();
+
+        assertEquals(1, delegate.rebindCalls);
+        assertEquals(1, registryCache.invalidateAllCalls);
+        assertEquals(1, policyCache.invalidateAllCalls);
+        assertEquals(0, registryCache.invalidateTypeCalls);
+        assertEquals(0, policyCache.invalidateTypeCalls);
+    }
+
+    @Test
+    void rebindByTypeInvalidatesMatchingCacheEntries() {
+        RecordingRebindService delegate = new RecordingRebindService();
+        RecordingCache registryCache = new RecordingCache();
+        RecordingCache policyCache = new RecordingCache();
+        CachedObjectRebindService service = new CachedObjectRebindService(delegate, registryCache, policyCache);
+
+        service.rebind(1200);
+
+        assertEquals(1, delegate.rebindByTypeCalls);
+        assertEquals(1200, delegate.lastObjectType);
+        assertEquals(0, registryCache.invalidateAllCalls);
+        assertEquals(0, policyCache.invalidateAllCalls);
+        assertEquals(1, registryCache.invalidateTypeCalls);
+        assertEquals(1, policyCache.invalidateTypeCalls);
+        assertEquals(1200, registryCache.lastInvalidatedType);
+        assertEquals(1200, policyCache.lastInvalidatedType);
+    }
+
+    @Test
+    void cleanupStillInvalidatesCachesForYamlDelegate() {
+        RecordingCache registryCache = new RecordingCache();
+        RecordingCache policyCache = new RecordingCache();
+        CachedObjectRebindService service = new CachedObjectRebindService(
+                new YamlObjectRebindService(),
+                registryCache,
+                policyCache);
+
+        service.cleanup();
+
+        assertEquals(1, registryCache.invalidateAllCalls);
+        assertEquals(1, policyCache.invalidateAllCalls);
+    }
+
+    private static final class RecordingRebindService implements ObjectRebindService {
+
+        private int rebindCalls;
+        private int rebindByTypeCalls;
+        private int lastObjectType = -1;
+
+        @Override
+        public void rebind() {
+            rebindCalls++;
+        }
+
+        @Override
+        public void rebind(int objectType) {
+            rebindByTypeCalls++;
+            lastObjectType = objectType;
+        }
+
+        @Override
+        public void cleanup() {
+        }
+    }
+
+    private static final class RecordingCache implements CacheInvalidatable {
+
+        private int invalidateAllCalls;
+        private int invalidateTypeCalls;
+        private int lastInvalidatedType = -1;
+
+        @Override
+        public void invalidateAll() {
+            invalidateAllCalls++;
+        }
+
+        @Override
+        public void invalidateType(int objectType) {
+            invalidateTypeCalls++;
+            lastInvalidatedType = objectType;
+        }
+    }
+}


### PR DESCRIPTION
## Why
- `objecttype`와 `attachment` 리팩터링 전에 현재 동작을 고정할 회귀 테스트가 부족했습니다.
- 특히 YAML rebind cache invalidation, attachment 업로드 정책 검증 경로, 관리자 role 분기 동작을 먼저 테스트로 고정할 필요가 있었습니다.

## What
- `CachedObjectRebindService` 테스트를 추가해 YAML delegate 사용 시에도 cache invalidation이 유지되는지 검증했습니다.
- `AttachmentServiceImpl` 테스트를 추가해 objecttype 업로드 정책 검증 요청과 storage failure 전파 순서를 고정했습니다.
- `AttachmentMgmtControllerAuthorizationTest`에 `ROLE_ADMIN` authority가 현재는 관리자 경로로 처리되지 않는 분기를 추가했습니다.
- `attachment-service` 테스트에서 `studio-platform-objecttype`를 참조할 수 있도록 테스트 의존성을 추가했습니다.
- `CHANGELOG.md`에 이번 회귀 테스트 작업과 검증 명령을 기록했습니다.

## Related Issues
- Closes #159
- Related #160
- Related #161
- Related #162
- Related #163

## Change Scope
- [ ] API contract
- [x] Business logic
- [ ] DB schema/query
- [x] Security/permission
- [x] Docs/runbook

## Security Impact
- Risk: low. 테스트와 테스트 의존성만 추가했고 운영 동작은 변경하지 않았습니다.
- Mitigation: 현재 권한 분기와 업로드 정책 검증 흐름을 테스트로 고정해 후속 리팩터링 회귀를 줄입니다.

## Validation
- Commands:
  - `./gradlew :studio-platform-objecttype:test --tests 'studio.one.platform.objecttype.CachedObjectRebindServiceTest' --tests 'studio.one.platform.objecttype.ObjectTypeRuntimeServiceTest'`\n  - `./gradlew :studio-application-modules:attachment-service:test --tests 'studio.one.application.attachment.service.AttachmentServiceImplTest' --tests 'studio.one.application.web.controller.AttachmentMgmtControllerAuthorizationTest'`\n- Result:\n  - 두 명령 모두 성공했습니다.\n- Additional checks:\n  - `CHANGELOG.md` 업데이트 포함\n\n## Subagent Usage\n아래 항목은 **정확히 하나만** 체크합니다.\n- Used: [x] No [ ] Yes\n- Delegated tasks:\n- Ownership (files/modules/tasks): main author handled test additions in `studio-platform-objecttype` and `attachment-service`.\n- Main author post-integration validation: 위 validation 명령을 main author가 직접 실행했습니다.\n\n## Checklist\n- [x] policy-compliant commit message\n- [x] issue template used where applicable\n- [x] AI-Assisted checked correctly\n- [x] subagent usage recorded (if used)\n- [x] validation recorded\n- [ ] CI / repository verification passed\n- [ ] human review completed before merge\n- [x] no unrelated changes included\n\n## Deployment Notes\n- Migration/ordering: 없음\n- Rollback plan: PR revert 또는 커밋 revert\n- Post-deploy checks: 없음 (test-only change)\n