### PR TITLE
[ai-assisted] [attachment] 컨트롤러 공통 정책 및 권한 판별 정리

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,14 @@
 ## 2026-03-31
 
 ### 변경됨
-- `attachment-service`의 웹 컨트롤러 공통 로직을 `AttachmentWebSupport`로 묶어 파일명 정제, 미디어 타입 해석, 다운로드 헤더, bad request 응답 생성을 정리했다.
-- `AttachmentMgmtController`의 관리자 판별이 `ADMIN`과 `ROLE_ADMIN` 모두를 허용하도록 정리했다.
-- `attachment-service`에 웹 컨트롤러 회귀 테스트와 공통 support 테스트를 추가했다.
+- `attachment-service`의 `AttachmentController`, `AttachmentMgmtController`, `MeAttachmentController`가 파일명 정제, MIME 정규화, 다운로드 헤더 구성을 공통 `AttachmentWebSupport`로 공유하도록 정리했다.
+- `AttachmentMgmtController`의 관리자 판별이 `ADMIN`과 `ROLE_ADMIN`을 모두 허용하도록 보강해 Spring Security authority 표현 차이로 인한 owner 우회 오판정을 줄였다.
+- `attachment-service`에 attachment 웹 helper 회귀 테스트를 추가하고, mgmt 권한 테스트가 `ROLE_ADMIN` 경로를 검증하도록 보강했다.
+- `attachment-service`의 접근 제어 helper를 `AttachmentAccessSupport`로 분리해 principal 조회, 관리자 판별, owner 접근 검사를 컨트롤러에서 공통으로 사용하도록 정리했다.
 
 ### 검증
-- `./gradlew -p /tmp/studio-api-issue-161 :studio-application-modules:attachment-service:test --tests 'studio.one.application.web.controller.AttachmentMgmtControllerAuthorizationTest' --tests 'studio.one.application.web.controller.AttachmentWebSupportTest'`
+- `./gradlew :studio-application-modules:attachment-service:test --tests 'studio.one.application.web.controller.AttachmentMgmtControllerAuthorizationTest' --tests 'studio.one.application.web.controller.AttachmentWebSupportTest'`
+- `./gradlew :studio-application-modules:attachment-service:compileJava`
 
 ## 2026-03-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 - `attachment-service`의 접근 제어 helper를 `AttachmentAccessSupport`로 분리해 principal 조회, 관리자 판별, owner 접근 검사를 컨트롤러에서 공통으로 사용하도록 정리했다.
 
 ### 검증
-- `./gradlew -p /tmp/studio-api-issue-161 :studio-application-modules:attachment-service:test --tests 'studio.one.application.web.controller.AttachmentControllerTest' --tests 'studio.one.application.web.controller.AttachmentMgmtControllerAuthorizationTest' --tests 'studio.one.application.web.controller.AttachmentWebSupportTest' --tests 'studio.one.application.web.controller.MeAttachmentControllerTest'`
-- `./gradlew -p /tmp/studio-api-issue-161 :studio-application-modules:attachment-service:compileJava`
+- `./gradlew :studio-application-modules:attachment-service:test --tests 'studio.one.application.web.controller.AttachmentAccessSupportTest' --tests 'studio.one.application.web.controller.AttachmentControllerTest' --tests 'studio.one.application.web.controller.AttachmentMgmtControllerAuthorizationTest' --tests 'studio.one.application.web.controller.AttachmentWebSupportTest' --tests 'studio.one.application.web.controller.MeAttachmentControllerTest'`
+- `./gradlew :studio-application-modules:attachment-service:compileJava`
 
 ## 2026-03-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-03-31
+
+### 변경됨
+- `attachment-service`의 웹 컨트롤러 공통 로직을 `AttachmentWebSupport`로 묶어 파일명 정제, 미디어 타입 해석, 다운로드 헤더, bad request 응답 생성을 정리했다.
+- `AttachmentMgmtController`의 관리자 판별이 `ADMIN`과 `ROLE_ADMIN` 모두를 허용하도록 정리했다.
+- `attachment-service`에 웹 컨트롤러 회귀 테스트와 공통 support 테스트를 추가했다.
+
+### 검증
+- `./gradlew -p /tmp/studio-api-issue-161 :studio-application-modules:attachment-service:test --tests 'studio.one.application.web.controller.AttachmentMgmtControllerAuthorizationTest' --tests 'studio.one.application.web.controller.AttachmentWebSupportTest'`
+
 ## 2026-03-30
 
 ### 변경됨

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 - `attachment-service`의 접근 제어 helper를 `AttachmentAccessSupport`로 분리해 principal 조회, 관리자 판별, owner 접근 검사를 컨트롤러에서 공통으로 사용하도록 정리했다.
 
 ### 검증
-- `./gradlew :studio-application-modules:attachment-service:test --tests 'studio.one.application.web.controller.AttachmentMgmtControllerAuthorizationTest' --tests 'studio.one.application.web.controller.AttachmentWebSupportTest'`
-- `./gradlew :studio-application-modules:attachment-service:compileJava`
+- `./gradlew -p /tmp/studio-api-issue-161 :studio-application-modules:attachment-service:test --tests 'studio.one.application.web.controller.AttachmentControllerTest' --tests 'studio.one.application.web.controller.AttachmentMgmtControllerAuthorizationTest' --tests 'studio.one.application.web.controller.AttachmentWebSupportTest' --tests 'studio.one.application.web.controller.MeAttachmentControllerTest'`
+- `./gradlew -p /tmp/studio-api-issue-161 :studio-application-modules:attachment-service:compileJava`
 
 ## 2026-03-30
 

--- a/studio-application-modules/attachment-service/README.md
+++ b/studio-application-modules/attachment-service/README.md
@@ -55,6 +55,7 @@ studio:
 - `DELETE /{attachmentId}`: 메타데이터 및 바이너리 삭제. 권한 `features:attachment/delete`.
 
 보안은 `@endpointAuthz.can('features:attachment','<action>')` 스코프를 사용하며, 업로드/다운로드/삭제 등 주요 API에 적용되어 있다.
+관리자 범위 판별은 소유자 우회가 필요한 mgmt 엔드포인트에서 `ADMIN`과 `ROLE_ADMIN`을 모두 허용한다.
 
 ### 업로드 예시 (multipart)
 ```bash
@@ -153,6 +154,7 @@ objecttypes:
 - 삭제는 메타데이터와 바이너리 모두 제거하며, 캐시 스토리지도 비운다.
 - 텍스트 추출은 선택 기능이므로, 빈이 없을 때 501(NOT_IMPLEMENTED)을 반환한다.
 - 업로드 시 파일명은 sanitize 처리되며, 최대 업로드 크기는 50MB로 제한한다(컨트롤러 수준).
+- `AttachmentMgmtController`, `AttachmentController`, `MeAttachmentController`는 공통 웹 helper를 통해 파일명 정제, MIME 정규화, 다운로드 헤더 구성을 공유한다.
 - objecttype 정책 검증이 활성화되면 용량/확장자/MIME 정책 위반 시 `POLICY_VIOLATION` 에러가 발생한다.
 - 기본 캐시 이름은 `attachments.byId`이며, 캐시 설정이 필요하면 전역 CacheManager에 매핑을 추가한다.
 

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/AttachmentAccessSupport.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/AttachmentAccessSupport.java
@@ -1,0 +1,60 @@
+package studio.one.application.web.controller;
+
+import java.util.Objects;
+import java.util.Set;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+
+import studio.one.application.attachment.domain.model.Attachment;
+import studio.one.platform.identity.ApplicationPrincipal;
+import studio.one.platform.identity.PrincipalResolver;
+
+final class AttachmentAccessSupport {
+
+    private static final Set<String> ADMIN_ROLES = Set.of("ADMIN", "ROLE_ADMIN");
+
+    private AttachmentAccessSupport() {
+    }
+
+    static ApplicationPrincipal requirePrincipal(ObjectProvider<PrincipalResolver> principalResolverProvider) {
+        PrincipalResolver resolver = principalResolverProvider.getIfAvailable();
+        if (resolver == null) {
+            throw new AuthenticationCredentialsNotFoundException("No principal resolver configured");
+        }
+        ApplicationPrincipal principal = resolver.currentOrNull();
+        if (principal == null) {
+            throw new AuthenticationCredentialsNotFoundException("No authenticated user");
+        }
+        return principal;
+    }
+
+    static boolean isAdmin(ApplicationPrincipal principal) {
+        return principal != null && principal.roles().stream().anyMatch(ADMIN_ROLES::contains);
+    }
+
+    static long requireUserId(ApplicationPrincipal principal) {
+        if (principal != null && principal.getUserId() != null && principal.getUserId() > 0) {
+            return principal.getUserId();
+        }
+        throw new AuthenticationCredentialsNotFoundException("No authenticated user");
+    }
+
+    static long requireUserId(Long userId) {
+        if (userId != null && userId > 0) {
+            return userId;
+        }
+        throw new AuthenticationCredentialsNotFoundException("No authenticated user");
+    }
+
+    static void requireAttachmentAccess(Attachment attachment, ApplicationPrincipal principal) {
+        if (isAdmin(principal)) {
+            return;
+        }
+        long userId = requireUserId(principal);
+        if (!Objects.equals(attachment.getCreatedBy(), userId)) {
+            throw new AccessDeniedException("Forbidden attachment access");
+        }
+    }
+}

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/AttachmentController.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/AttachmentController.java
@@ -3,7 +3,10 @@ package studio.one.application.web.controller;
 import java.io.IOException;
 import java.util.List;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -22,7 +25,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import studio.one.application.attachment.domain.model.Attachment;
 import studio.one.application.attachment.service.AttachmentService;
-import org.springframework.beans.factory.ObjectProvider;
 import studio.one.application.attachment.thumbnail.ThumbnailData;
 import studio.one.application.attachment.thumbnail.ThumbnailService;
 import studio.one.application.web.dto.AttachmentDto;
@@ -37,8 +39,6 @@ import studio.one.platform.web.dto.ApiResponse;
 @Validated
 public class AttachmentController {
 
-    private static final long MAX_UPLOAD_SIZE_BYTES = 50 * 1024 * 1024; // 50MB 상한으로 자원 고갈 방지
-
     private final AttachmentService attachmentService;
     private final ObjectProvider<ThumbnailService> thumbnailServiceProvider;
 
@@ -48,29 +48,20 @@ public class AttachmentController {
             @RequestParam("objectType") int objectType,
             @RequestParam("objectId") long objectId,
             @RequestParam("file") MultipartFile file) throws IOException {
-
-        if (file == null || file.isEmpty()) {
-            return AttachmentWebSupport.badRequest("File is empty");
+        AttachmentWebSupport.PreparedUpload upload;
+        try {
+            upload = AttachmentWebSupport.prepareUpload(file);
+        } catch (IllegalArgumentException e) {
+            return AttachmentWebSupport.badRequest(e.getMessage());
         }
-        if (file.getSize() > MAX_UPLOAD_SIZE_BYTES) {
-            return AttachmentWebSupport.badRequest("File too large");
-        }
-        if (file.getSize() > Integer.MAX_VALUE) {
-            return AttachmentWebSupport.badRequest("File size exceeds supported limit");
-        }
-        String sanitizedName = AttachmentWebSupport.sanitizeFilename(file.getOriginalFilename());
-        if (sanitizedName == null) {
-            return AttachmentWebSupport.badRequest("Invalid file name");
-        }
-        String contentType = AttachmentWebSupport.resolveMediaTypeString(file.getContentType());
 
         Attachment saved = attachmentService.createAttachment(
                 objectType,
                 objectId,
-                sanitizedName,
-                contentType,
+                upload.name(),
+                upload.contentType(),
                 file.getInputStream(),
-                (int) file.getSize());
+                upload.sizeBytes());
         AttachmentDto dto = AttachmentDto.of(saved, null);
         return ResponseEntity.ok(ApiResponse.ok(dto));
     }
@@ -88,15 +79,10 @@ public class AttachmentController {
     public ResponseEntity<StreamingResponseBody> download(@PathVariable("attachmentId") long attachmentId)
             throws IOException, NotFoundException {
         Attachment attachment = attachmentService.getAttachmentById(attachmentId);
-        StreamingResponseBody body = out -> {
-            try (var in = attachmentService.getInputStream(attachment)) {
-                in.transferTo(out);
-            }
-        };
-        var headers = AttachmentWebSupport.downloadHeaders(attachment.getContentType(), attachment.getSize(), attachment.getName());
-        return ResponseEntity.ok()
-                .headers(headers)
-                .body(body);
+        return AttachmentWebSupport.downloadResponse(
+                attachment,
+                attachmentService.getInputStream(attachment),
+                CacheControl.noCache());
     }
 
     @GetMapping("/{attachmentId:[\\p{Digit}]+}/thumbnail")
@@ -116,10 +102,11 @@ public class AttachmentController {
             return ResponseEntity.noContent().build();
         }
         ThumbnailData data = result.get();
-        StreamingResponseBody body = out -> {
-            out.write(data.getBytes());
-        };
-        var headers = AttachmentWebSupport.thumbnailHeaders(data.getContentType(), data.getBytes().length);
+        StreamingResponseBody body = out -> out.write(data.getBytes());
+        HttpHeaders headers = new HttpHeaders();
+        headers.setCacheControl(CacheControl.maxAge(3600, java.util.concurrent.TimeUnit.SECONDS).getHeaderValue());
+        headers.setContentType(AttachmentWebSupport.resolveMediaType(data.getContentType()));
+        headers.setContentLength(data.getBytes().length);
         return ResponseEntity.ok()
                 .headers(headers)
                 .body(body);

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/AttachmentController.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/AttachmentController.java
@@ -4,13 +4,9 @@ import java.io.IOException;
 import java.util.List;
 
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.CacheControl;
-import org.springframework.http.ContentDisposition;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -54,19 +50,19 @@ public class AttachmentController {
             @RequestParam("file") MultipartFile file) throws IOException {
 
         if (file == null || file.isEmpty()) {
-            return badRequest("File is empty");
+            return AttachmentWebSupport.badRequest("File is empty");
         }
         if (file.getSize() > MAX_UPLOAD_SIZE_BYTES) {
-            return badRequest("File too large");
+            return AttachmentWebSupport.badRequest("File too large");
         }
         if (file.getSize() > Integer.MAX_VALUE) {
-            return badRequest("File size exceeds supported limit");
+            return AttachmentWebSupport.badRequest("File size exceeds supported limit");
         }
-        String sanitizedName = sanitizeFilename(file.getOriginalFilename());
-        if (!StringUtils.hasText(sanitizedName)) {
-            return badRequest("Invalid file name");
+        String sanitizedName = AttachmentWebSupport.sanitizeFilename(file.getOriginalFilename());
+        if (sanitizedName == null) {
+            return AttachmentWebSupport.badRequest("Invalid file name");
         }
-        String contentType = resolveMediaTypeString(file.getContentType());
+        String contentType = AttachmentWebSupport.resolveMediaTypeString(file.getContentType());
 
         Attachment saved = attachmentService.createAttachment(
                 objectType,
@@ -97,16 +93,7 @@ public class AttachmentController {
                 in.transferTo(out);
             }
         };
-        HttpHeaders headers = new HttpHeaders();
-        headers.setCacheControl(CacheControl.noCache().getHeaderValue());
-        headers.setContentType(resolveMediaType(attachment.getContentType()));
-        headers.setContentLength(attachment.getSize());
-        if (StringUtils.hasText(attachment.getName())) {
-            ContentDisposition cd = ContentDisposition.attachment()
-                    .filename(attachment.getName())
-                    .build();
-            headers.setContentDisposition(cd);
-        }
+        var headers = AttachmentWebSupport.downloadHeaders(attachment.getContentType(), attachment.getSize(), attachment.getName());
         return ResponseEntity.ok()
                 .headers(headers)
                 .body(body);
@@ -132,10 +119,7 @@ public class AttachmentController {
         StreamingResponseBody body = out -> {
             out.write(data.getBytes());
         };
-        HttpHeaders headers = new HttpHeaders();
-        headers.setCacheControl(CacheControl.maxAge(3600, java.util.concurrent.TimeUnit.SECONDS).getHeaderValue());
-        headers.setContentType(resolveMediaType(data.getContentType()));
-        headers.setContentLength(data.getBytes().length);
+        var headers = AttachmentWebSupport.thumbnailHeaders(data.getContentType(), data.getBytes().length);
         return ResponseEntity.ok()
                 .headers(headers)
                 .body(body);
@@ -167,41 +151,5 @@ public class AttachmentController {
         Attachment attachment = attachmentService.getAttachmentById(attachmentId);
         attachmentService.removeAttachment(attachment);
         return ResponseEntity.ok(ApiResponse.ok());
-    }
-
-    private MediaType resolveMediaType(String contentType) {
-        if (!StringUtils.hasText(contentType)) {
-            return MediaType.APPLICATION_OCTET_STREAM;
-        }
-        try {
-            return MediaType.parseMediaType(contentType);
-        } catch (Exception ignored) {
-            return MediaType.APPLICATION_OCTET_STREAM;
-        }
-    }
-
-    private String resolveMediaTypeString(String contentType) {
-        if (!StringUtils.hasText(contentType)) {
-            return MediaType.APPLICATION_OCTET_STREAM_VALUE;
-        }
-        try {
-            return MediaType.parseMediaType(contentType).toString();
-        } catch (Exception ignored) {
-            return MediaType.APPLICATION_OCTET_STREAM_VALUE;
-        }
-    }
-
-    private String sanitizeFilename(String original) {
-        if (!StringUtils.hasText(original)) {
-            return null;
-        }
-        return original.replace("\\", "/").replaceAll(".*/", "");
-    }
-
-    private <T> ResponseEntity<ApiResponse<T>> badRequest(String message) {
-        ApiResponse<T> body = ApiResponse.<T>builder()
-                .message(message)
-                .build();
-        return ResponseEntity.badRequest().body(body);
     }
 }

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/AttachmentMgmtController.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/AttachmentMgmtController.java
@@ -3,18 +3,16 @@ package studio.one.application.web.controller;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
-import java.util.Objects;
 
-import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -36,8 +34,6 @@ import studio.one.platform.exception.NotFoundException;
 import studio.one.platform.identity.ApplicationPrincipal;
 import studio.one.platform.identity.IdentityService;
 import studio.one.platform.identity.PrincipalResolver;
-import studio.one.platform.identity.UserDto;
-import studio.one.platform.identity.UserRef;
 import studio.one.platform.text.service.FileContentExtractionService;
 import studio.one.platform.web.dto.ApiResponse;
 
@@ -48,7 +44,6 @@ import studio.one.platform.web.dto.ApiResponse;
 @Validated
 public class AttachmentMgmtController {
 
-    private static final long MAX_UPLOAD_SIZE_BYTES = 50 * 1024 * 1024; // 50MB 상한으로 자원 고갈 방지
     private final AttachmentService attachmentService;
     private final ObjectProvider<IdentityService> identityServiceProvider;
     private final ObjectProvider<PrincipalResolver> principalResolverProvider;
@@ -60,31 +55,21 @@ public class AttachmentMgmtController {
             @RequestParam("objectType") int objectType,
             @RequestParam("objectId") long objectId,
             @RequestParam("file") MultipartFile file) throws IOException {
-
-        if (file == null || file.isEmpty()) {
-            return AttachmentWebSupport.badRequest("File is empty");
+        AttachmentWebSupport.PreparedUpload upload;
+        try {
+            upload = AttachmentWebSupport.prepareUpload(file);
+        } catch (IllegalArgumentException e) {
+            return AttachmentWebSupport.badRequest(e.getMessage());
         }
-        if (file.getSize() > MAX_UPLOAD_SIZE_BYTES) {
-            return AttachmentWebSupport.badRequest("File too large");
-        }
-        if (file.getSize() > Integer.MAX_VALUE) {
-            return AttachmentWebSupport.badRequest("File size exceeds supported limit");
-        }
-        String sanitizedName = AttachmentWebSupport.sanitizeFilename(file.getOriginalFilename());
-        if (sanitizedName == null) {
-            return AttachmentWebSupport.badRequest("Invalid file name");
-        }
-        String contentType = AttachmentWebSupport.resolveMediaTypeString(file.getContentType());
 
         Attachment saved = attachmentService.createAttachment(
                 objectType,
                 objectId,
-                sanitizedName,
-                contentType,
+                upload.name(),
+                upload.contentType(),
                 file.getInputStream(),
-                (int) file.getSize());
-        AttachmentDto dto = toDto(saved);
-        return ResponseEntity.ok(ApiResponse.ok(dto));
+                upload.sizeBytes());
+        return ResponseEntity.ok(ApiResponse.ok(toDto(saved)));
     }
 
     @GetMapping("/{attachmentId:[\\p{Digit}]+}")
@@ -92,7 +77,7 @@ public class AttachmentMgmtController {
     public ResponseEntity<ApiResponse<AttachmentDto>> get(@PathVariable("attachmentId") long attachmentId)
             throws NotFoundException {
         Attachment attachment = attachmentService.getAttachmentById(attachmentId);
-        requireAttachmentAccess(attachment);
+        AttachmentAccessSupport.requireAttachmentAccess(attachment, requirePrincipal());
         return ResponseEntity.ok(ApiResponse.ok(toDto(attachment)));
     }
 
@@ -108,7 +93,7 @@ public class AttachmentMgmtController {
             return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(body);
         }
         Attachment attachment = attachmentService.getAttachmentById(attachmentId);
-        requireAttachmentAccess(attachment);
+        AttachmentAccessSupport.requireAttachmentAccess(attachment, requirePrincipal());
         try (InputStream in = attachmentService.getInputStream(attachment)) {
             String text = extractor.extractText(attachment.getContentType(), attachment.getName(), in);
             return ResponseEntity.ok(ApiResponse.ok(text));
@@ -120,17 +105,11 @@ public class AttachmentMgmtController {
     public ResponseEntity<StreamingResponseBody> download(@PathVariable("attachmentId") long attachmentId)
             throws IOException, NotFoundException {
         Attachment attachment = attachmentService.getAttachmentById(attachmentId);
-        requireAttachmentAccess(attachment);
-        InputStream in = attachmentService.getInputStream(attachment);
-        StreamingResponseBody body = out -> {
-            try (in) {
-                IOUtils.copy(in, out);
-            }
-        };
-        var headers = AttachmentWebSupport.downloadHeaders(attachment.getContentType(), attachment.getSize(), attachment.getName());
-        return ResponseEntity.ok()
-                .headers(headers)
-                .body(body);
+        AttachmentAccessSupport.requireAttachmentAccess(attachment, requirePrincipal());
+        return AttachmentWebSupport.downloadResponse(
+                attachment,
+                attachmentService.getInputStream(attachment),
+                CacheControl.noCache());
     }
 
     @GetMapping
@@ -141,7 +120,7 @@ public class AttachmentMgmtController {
             @RequestParam(value = "keyword", required = false) String keyword,
             @PageableDefault Pageable pageable) {
         ApplicationPrincipal principal = requirePrincipal();
-        boolean admin = AttachmentWebSupport.isAdmin(principal);
+        boolean admin = AttachmentAccessSupport.isAdmin(principal);
         Page<Attachment> page;
         if (objectType != null && objectId != null) {
             if (admin) {
@@ -151,31 +130,29 @@ public class AttachmentMgmtController {
                     page = attachmentService.findAttachments(objectType, objectId, keyword, pageable);
                 }
             } else {
-                long userId = AttachmentWebSupport.requireUserId(principal);
+                long userId = AttachmentAccessSupport.requireUserId(principal);
                 if (keyword == null || keyword.isBlank()) {
                     page = attachmentService.findAttachmentsByObjectAndCreator(objectType, objectId, userId, pageable);
                 } else {
-                    page = attachmentService.findAttachmentsByObjectAndCreator(objectType, objectId, userId, keyword, pageable);
+                    page = attachmentService.findAttachmentsByObjectAndCreator(objectType, objectId, userId, keyword,
+                            pageable);
                 }
+            }
+        } else if (admin) {
+            if (keyword == null || keyword.isBlank()) {
+                page = attachmentService.findAttachments(pageable);
+            } else {
+                page = attachmentService.findAttachments(keyword, pageable);
             }
         } else {
-            if (admin) {
-                if (keyword == null || keyword.isBlank()) {
-                    page = attachmentService.findAttachments(pageable);
-                } else {
-                    page = attachmentService.findAttachments(keyword, pageable);
-                }
+            long userId = AttachmentAccessSupport.requireUserId(principal);
+            if (keyword == null || keyword.isBlank()) {
+                page = attachmentService.findAttachmentsByCreator(userId, pageable);
             } else {
-                long userId = AttachmentWebSupport.requireUserId(principal);
-                if (keyword == null || keyword.isBlank()) {
-                    page = attachmentService.findAttachmentsByCreator(userId, pageable);
-                } else {
-                    page = attachmentService.findAttachmentsByCreator(userId, keyword, pageable);
-                }
+                page = attachmentService.findAttachmentsByCreator(userId, keyword, pageable);
             }
         }
-        Page<AttachmentDto> dtoPage = page.map(this::toDto);
-        return ResponseEntity.ok(ApiResponse.ok(dtoPage));
+        return ResponseEntity.ok(ApiResponse.ok(page.map(this::toDto)));
     }
 
     @GetMapping("/objects/{objectType:[\\p{Digit}]+}/{objectId:[\\p{Digit}]+}")
@@ -184,13 +161,13 @@ public class AttachmentMgmtController {
             @PathVariable int objectType,
             @PathVariable long objectId) {
         ApplicationPrincipal principal = requirePrincipal();
-        List<Attachment> attachments = AttachmentWebSupport.isAdmin(principal)
+        List<Attachment> attachments = AttachmentAccessSupport.isAdmin(principal)
                 ? attachmentService.getAttachments(objectType, objectId)
-                : attachmentService.getAttachmentsByObjectAndCreator(objectType, objectId, AttachmentWebSupport.requireUserId(principal));
-        List<AttachmentDto> dto = attachments.stream()
-                .map(this::toDto)
-                .toList();
-        return ResponseEntity.ok(ApiResponse.ok(dto));
+                : attachmentService.getAttachmentsByObjectAndCreator(
+                        objectType,
+                        objectId,
+                        AttachmentAccessSupport.requireUserId(principal));
+        return ResponseEntity.ok(ApiResponse.ok(attachments.stream().map(this::toDto).toList()));
     }
 
     @DeleteMapping("/{attachmentId:[\\p{Digit}]+}")
@@ -198,57 +175,16 @@ public class AttachmentMgmtController {
     public ResponseEntity<ApiResponse<Void>> delete(@PathVariable("attachmentId") long attachmentId)
             throws NotFoundException, IOException {
         Attachment attachment = attachmentService.getAttachmentById(attachmentId);
-        requireAttachmentAccess(attachment);
+        AttachmentAccessSupport.requireAttachmentAccess(attachment, requirePrincipal());
         attachmentService.removeAttachment(attachment);
         return ResponseEntity.ok(ApiResponse.ok());
     }
 
-    private void requireAttachmentAccess(Attachment attachment) {
-        ApplicationPrincipal principal = requirePrincipal();
-        if (AttachmentWebSupport.isAdmin(principal)) {
-            return;
-        }
-        long userId = AttachmentWebSupport.requireUserId(principal);
-        if (!Objects.equals(attachment.getCreatedBy(), userId)) {
-            throw new org.springframework.security.access.AccessDeniedException("Forbidden attachment access");
-        }
-    }
-
     private ApplicationPrincipal requirePrincipal() {
-        PrincipalResolver resolver = principalResolverProvider.getIfAvailable();
-        if (resolver == null) {
-            throw new AuthenticationCredentialsNotFoundException("No principal resolver configured");
-        }
-        ApplicationPrincipal principal = resolver.currentOrNull();
-        if (principal == null) {
-            throw new AuthenticationCredentialsNotFoundException("No authenticated user");
-        }
-        return principal;
+        return AttachmentAccessSupport.requirePrincipal(principalResolverProvider);
     }
 
     private AttachmentDto toDto(Attachment attachment) {
-        UserDto creator = findUserDto(attachment.getCreatedBy(), attachment.getAttachmentId());
-        return AttachmentDto.of(attachment, creator);
+        return AttachmentWebSupport.toDto(attachment, identityServiceProvider, log);
     }
-
-    private UserDto findUserDto(long userId, long attachmentId) {
-        if (userId <= 0) {
-            return null;
-        }
-        IdentityService identityService = identityServiceProvider.getIfAvailable();
-        if (identityService == null) {
-            return null;
-        }
-        return identityService.findById(userId)
-                .map(this::toUserDto)
-                .orElseGet(() -> {
-                    log.warn("User {} not found for attachment {}", userId, attachmentId);
-                    return null;
-                });
-    }
-
-    private UserDto toUserDto(UserRef userRef) {
-        return new UserDto(userRef.userId(), userRef.username());
-    }
-
 }

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/AttachmentMgmtController.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/AttachmentMgmtController.java
@@ -185,6 +185,6 @@ public class AttachmentMgmtController {
     }
 
     private AttachmentDto toDto(Attachment attachment) {
-        return AttachmentWebSupport.toDto(attachment, identityServiceProvider, log);
+        return AttachmentWebSupport.toDto(attachment, identityServiceProvider);
     }
 }

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/AttachmentMgmtController.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/AttachmentMgmtController.java
@@ -10,15 +10,11 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.CacheControl;
-import org.springframework.http.ContentDisposition;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
-import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -66,19 +62,19 @@ public class AttachmentMgmtController {
             @RequestParam("file") MultipartFile file) throws IOException {
 
         if (file == null || file.isEmpty()) {
-            return badRequest("File is empty");
+            return AttachmentWebSupport.badRequest("File is empty");
         }
         if (file.getSize() > MAX_UPLOAD_SIZE_BYTES) {
-            return badRequest("File too large");
+            return AttachmentWebSupport.badRequest("File too large");
         }
         if (file.getSize() > Integer.MAX_VALUE) {
-            return badRequest("File size exceeds supported limit");
+            return AttachmentWebSupport.badRequest("File size exceeds supported limit");
         }
-        String sanitizedName = sanitizeFilename(file.getOriginalFilename());
-        if (!StringUtils.hasText(sanitizedName)) {
-            return badRequest("Invalid file name");
+        String sanitizedName = AttachmentWebSupport.sanitizeFilename(file.getOriginalFilename());
+        if (sanitizedName == null) {
+            return AttachmentWebSupport.badRequest("Invalid file name");
         }
-        String contentType = resolveMediaTypeString(file.getContentType());
+        String contentType = AttachmentWebSupport.resolveMediaTypeString(file.getContentType());
 
         Attachment saved = attachmentService.createAttachment(
                 objectType,
@@ -131,16 +127,7 @@ public class AttachmentMgmtController {
                 IOUtils.copy(in, out);
             }
         };
-        HttpHeaders headers = new HttpHeaders();
-        headers.setCacheControl(CacheControl.noCache().getHeaderValue());
-        headers.setContentType(resolveMediaType(attachment.getContentType()));
-        headers.setContentLength(attachment.getSize());
-        if (StringUtils.hasText(attachment.getName())) {
-            ContentDisposition cd = ContentDisposition.attachment()
-                    .filename(attachment.getName())
-                    .build();
-            headers.setContentDisposition(cd);
-        }
+        var headers = AttachmentWebSupport.downloadHeaders(attachment.getContentType(), attachment.getSize(), attachment.getName());
         return ResponseEntity.ok()
                 .headers(headers)
                 .body(body);
@@ -154,7 +141,7 @@ public class AttachmentMgmtController {
             @RequestParam(value = "keyword", required = false) String keyword,
             @PageableDefault Pageable pageable) {
         ApplicationPrincipal principal = requirePrincipal();
-        boolean admin = isAdmin(principal);
+        boolean admin = AttachmentWebSupport.isAdmin(principal);
         Page<Attachment> page;
         if (objectType != null && objectId != null) {
             if (admin) {
@@ -164,7 +151,7 @@ public class AttachmentMgmtController {
                     page = attachmentService.findAttachments(objectType, objectId, keyword, pageable);
                 }
             } else {
-                long userId = requireUserId(principal);
+                long userId = AttachmentWebSupport.requireUserId(principal);
                 if (keyword == null || keyword.isBlank()) {
                     page = attachmentService.findAttachmentsByObjectAndCreator(objectType, objectId, userId, pageable);
                 } else {
@@ -179,7 +166,7 @@ public class AttachmentMgmtController {
                     page = attachmentService.findAttachments(keyword, pageable);
                 }
             } else {
-                long userId = requireUserId(principal);
+                long userId = AttachmentWebSupport.requireUserId(principal);
                 if (keyword == null || keyword.isBlank()) {
                     page = attachmentService.findAttachmentsByCreator(userId, pageable);
                 } else {
@@ -197,9 +184,9 @@ public class AttachmentMgmtController {
             @PathVariable int objectType,
             @PathVariable long objectId) {
         ApplicationPrincipal principal = requirePrincipal();
-        List<Attachment> attachments = isAdmin(principal)
+        List<Attachment> attachments = AttachmentWebSupport.isAdmin(principal)
                 ? attachmentService.getAttachments(objectType, objectId)
-                : attachmentService.getAttachmentsByObjectAndCreator(objectType, objectId, requireUserId(principal));
+                : attachmentService.getAttachmentsByObjectAndCreator(objectType, objectId, AttachmentWebSupport.requireUserId(principal));
         List<AttachmentDto> dto = attachments.stream()
                 .map(this::toDto)
                 .toList();
@@ -218,10 +205,10 @@ public class AttachmentMgmtController {
 
     private void requireAttachmentAccess(Attachment attachment) {
         ApplicationPrincipal principal = requirePrincipal();
-        if (isAdmin(principal)) {
+        if (AttachmentWebSupport.isAdmin(principal)) {
             return;
         }
-        long userId = requireUserId(principal);
+        long userId = AttachmentWebSupport.requireUserId(principal);
         if (!Objects.equals(attachment.getCreatedBy(), userId)) {
             throw new org.springframework.security.access.AccessDeniedException("Forbidden attachment access");
         }
@@ -237,17 +224,6 @@ public class AttachmentMgmtController {
             throw new AuthenticationCredentialsNotFoundException("No authenticated user");
         }
         return principal;
-    }
-
-    private boolean isAdmin(ApplicationPrincipal principal) {
-        return principal != null && principal.hasRole("ADMIN");
-    }
-
-    private long requireUserId(ApplicationPrincipal principal) {
-        if (principal != null && principal.getUserId() != null && principal.getUserId() > 0) {
-            return principal.getUserId();
-        }
-        throw new AuthenticationCredentialsNotFoundException("No authenticated user");
     }
 
     private AttachmentDto toDto(Attachment attachment) {
@@ -275,36 +251,4 @@ public class AttachmentMgmtController {
         return new UserDto(userRef.userId(), userRef.username());
     }
 
-    private MediaType resolveMediaType(String contentType) {
-        if (!StringUtils.hasText(contentType)) {
-            return MediaType.APPLICATION_OCTET_STREAM;
-        }
-        try {
-            return MediaType.parseMediaType(contentType);
-        } catch (Exception ignored) {
-            return MediaType.APPLICATION_OCTET_STREAM;
-        }
-    }
-
-    private String resolveMediaTypeString(String contentType) {
-        return resolveMediaType(contentType).toString();
-    }
-
-    private String sanitizeFilename(String original) {
-        if (!StringUtils.hasText(original)) {
-            return null;
-        }
-        String cleaned = org.springframework.util.StringUtils.getFilename(original);
-        if (!StringUtils.hasText(cleaned)) {
-            return null;
-        }
-        return cleaned.replace("\\", "").replace("/", "");
-    }
-
-    private <T> ResponseEntity<ApiResponse<T>> badRequest(String message) {
-        ApiResponse<T> body = ApiResponse.<T>builder()
-                .message(message)
-                .build();
-        return ResponseEntity.badRequest().body(body);
-    }
 }

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/AttachmentWebSupport.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/AttachmentWebSupport.java
@@ -1,31 +1,76 @@
 package studio.one.application.web.controller;
 
-import java.util.concurrent.TimeUnit;
+import java.io.InputStream;
 
+import org.slf4j.Logger;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.http.CacheControl;
 import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
-import studio.one.platform.identity.ApplicationPrincipal;
+import studio.one.application.attachment.domain.model.Attachment;
+import studio.one.application.web.dto.AttachmentDto;
+import studio.one.platform.identity.IdentityService;
+import studio.one.platform.identity.UserDto;
+import studio.one.platform.identity.UserRef;
 import studio.one.platform.web.dto.ApiResponse;
 
 final class AttachmentWebSupport {
 
+    static final long MAX_UPLOAD_SIZE_BYTES = 50 * 1024 * 1024;
+
     private AttachmentWebSupport() {
     }
 
-    static String sanitizeFilename(String original) {
-        if (!StringUtils.hasText(original)) {
-            return null;
+    static PreparedUpload prepareUpload(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("File is empty");
         }
-        String cleaned = StringUtils.getFilename(original);
-        if (!StringUtils.hasText(cleaned)) {
-            return null;
+        if (file.getSize() > MAX_UPLOAD_SIZE_BYTES) {
+            throw new IllegalArgumentException("File too large");
         }
-        return cleaned.replace("\\", "").replace("/", "");
+        if (file.getSize() > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("File size exceeds supported limit");
+        }
+        String sanitizedName = sanitizeFilename(file.getOriginalFilename());
+        if (!StringUtils.hasText(sanitizedName)) {
+            throw new IllegalArgumentException("Invalid file name");
+        }
+        return new PreparedUpload(sanitizedName, resolveMediaTypeString(file.getContentType()), (int) file.getSize());
+    }
+
+    static ResponseEntity<StreamingResponseBody> downloadResponse(
+            Attachment attachment,
+            InputStream in,
+            CacheControl cacheControl) {
+        StreamingResponseBody body = out -> {
+            try (in) {
+                in.transferTo(out);
+            }
+        };
+        HttpHeaders headers = new HttpHeaders();
+        headers.setCacheControl(cacheControl.getHeaderValue());
+        headers.setContentType(resolveMediaType(attachment.getContentType()));
+        headers.setContentLength(attachment.getSize());
+        if (StringUtils.hasText(attachment.getName())) {
+            headers.setContentDisposition(ContentDisposition.attachment()
+                    .filename(attachment.getName())
+                    .build());
+        }
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(body);
+    }
+
+    static AttachmentDto toDto(Attachment attachment, ObjectProvider<IdentityService> identityServiceProvider, Logger log) {
+        return AttachmentDto.of(
+                attachment,
+                findUserDto(identityServiceProvider, attachment.getCreatedBy(), attachment.getAttachmentId(), log));
     }
 
     static MediaType resolveMediaType(String contentType) {
@@ -43,23 +88,15 @@ final class AttachmentWebSupport {
         return resolveMediaType(contentType).toString();
     }
 
-    static HttpHeaders downloadHeaders(String contentType, long size, String filename) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setCacheControl(CacheControl.noCache().getHeaderValue());
-        headers.setContentType(resolveMediaType(contentType));
-        headers.setContentLength(size);
-        if (StringUtils.hasText(filename)) {
-            headers.setContentDisposition(ContentDisposition.attachment().filename(filename).build());
+    static String sanitizeFilename(String original) {
+        if (!StringUtils.hasText(original)) {
+            return null;
         }
-        return headers;
-    }
-
-    static HttpHeaders thumbnailHeaders(String contentType, long size) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setCacheControl(CacheControl.maxAge(3600, TimeUnit.SECONDS).getHeaderValue());
-        headers.setContentType(resolveMediaType(contentType));
-        headers.setContentLength(size);
-        return headers;
+        String cleaned = org.springframework.util.StringUtils.getFilename(original.replace("\\", "/"));
+        if (!StringUtils.hasText(cleaned)) {
+            return null;
+        }
+        return cleaned.replace("\\", "").replace("/", "");
     }
 
     static <T> ResponseEntity<ApiResponse<T>> badRequest(String message) {
@@ -69,23 +106,30 @@ final class AttachmentWebSupport {
         return ResponseEntity.badRequest().body(body);
     }
 
-    static boolean isAdmin(ApplicationPrincipal principal) {
-        return principal != null && (principal.hasRole("ADMIN") || principal.hasRole("ROLE_ADMIN"));
+    private static UserDto findUserDto(
+            ObjectProvider<IdentityService> identityServiceProvider,
+            long userId,
+            long attachmentId,
+            Logger log) {
+        if (userId <= 0) {
+            return null;
+        }
+        IdentityService identityService = identityServiceProvider.getIfAvailable();
+        if (identityService == null) {
+            return null;
+        }
+        return identityService.findById(userId)
+                .map(AttachmentWebSupport::toUserDto)
+                .orElseGet(() -> {
+                    log.warn("User {} not found for attachment {}", userId, attachmentId);
+                    return null;
+                });
     }
 
-    static long requireUserId(ApplicationPrincipal principal) {
-        if (principal != null && principal.getUserId() != null && principal.getUserId() > 0) {
-            return principal.getUserId();
-        }
-        throw new org.springframework.security.authentication.AuthenticationCredentialsNotFoundException(
-                "No authenticated user");
+    private static UserDto toUserDto(UserRef userRef) {
+        return new UserDto(userRef.userId(), userRef.username());
     }
 
-    static long requireUserId(Long userId) {
-        if (userId != null && userId > 0) {
-            return userId;
-        }
-        throw new org.springframework.security.authentication.AuthenticationCredentialsNotFoundException(
-                "No authenticated user");
+    record PreparedUpload(String name, String contentType, int sizeBytes) {
     }
 }

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/AttachmentWebSupport.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/AttachmentWebSupport.java
@@ -1,0 +1,91 @@
+package studio.one.application.web.controller;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.http.CacheControl;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+
+import studio.one.platform.identity.ApplicationPrincipal;
+import studio.one.platform.web.dto.ApiResponse;
+
+final class AttachmentWebSupport {
+
+    private AttachmentWebSupport() {
+    }
+
+    static String sanitizeFilename(String original) {
+        if (!StringUtils.hasText(original)) {
+            return null;
+        }
+        String cleaned = StringUtils.getFilename(original);
+        if (!StringUtils.hasText(cleaned)) {
+            return null;
+        }
+        return cleaned.replace("\\", "").replace("/", "");
+    }
+
+    static MediaType resolveMediaType(String contentType) {
+        if (!StringUtils.hasText(contentType)) {
+            return MediaType.APPLICATION_OCTET_STREAM;
+        }
+        try {
+            return MediaType.parseMediaType(contentType);
+        } catch (Exception ignored) {
+            return MediaType.APPLICATION_OCTET_STREAM;
+        }
+    }
+
+    static String resolveMediaTypeString(String contentType) {
+        return resolveMediaType(contentType).toString();
+    }
+
+    static HttpHeaders downloadHeaders(String contentType, long size, String filename) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setCacheControl(CacheControl.noCache().getHeaderValue());
+        headers.setContentType(resolveMediaType(contentType));
+        headers.setContentLength(size);
+        if (StringUtils.hasText(filename)) {
+            headers.setContentDisposition(ContentDisposition.attachment().filename(filename).build());
+        }
+        return headers;
+    }
+
+    static HttpHeaders thumbnailHeaders(String contentType, long size) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setCacheControl(CacheControl.maxAge(3600, TimeUnit.SECONDS).getHeaderValue());
+        headers.setContentType(resolveMediaType(contentType));
+        headers.setContentLength(size);
+        return headers;
+    }
+
+    static <T> ResponseEntity<ApiResponse<T>> badRequest(String message) {
+        ApiResponse<T> body = ApiResponse.<T>builder()
+                .message(message)
+                .build();
+        return ResponseEntity.badRequest().body(body);
+    }
+
+    static boolean isAdmin(ApplicationPrincipal principal) {
+        return principal != null && (principal.hasRole("ADMIN") || principal.hasRole("ROLE_ADMIN"));
+    }
+
+    static long requireUserId(ApplicationPrincipal principal) {
+        if (principal != null && principal.getUserId() != null && principal.getUserId() > 0) {
+            return principal.getUserId();
+        }
+        throw new org.springframework.security.authentication.AuthenticationCredentialsNotFoundException(
+                "No authenticated user");
+    }
+
+    static long requireUserId(Long userId) {
+        if (userId != null && userId > 0) {
+            return userId;
+        }
+        throw new org.springframework.security.authentication.AuthenticationCredentialsNotFoundException(
+                "No authenticated user");
+    }
+}

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/AttachmentWebSupport.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/AttachmentWebSupport.java
@@ -3,6 +3,7 @@ package studio.one.application.web.controller;
 import java.io.InputStream;
 
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.http.CacheControl;
 import org.springframework.http.ContentDisposition;
@@ -22,6 +23,7 @@ import studio.one.platform.web.dto.ApiResponse;
 
 final class AttachmentWebSupport {
 
+    private static final Logger log = LoggerFactory.getLogger(AttachmentWebSupport.class);
     static final long MAX_UPLOAD_SIZE_BYTES = 50 * 1024 * 1024;
 
     private AttachmentWebSupport() {
@@ -67,7 +69,7 @@ final class AttachmentWebSupport {
                 .body(body);
     }
 
-    static AttachmentDto toDto(Attachment attachment, ObjectProvider<IdentityService> identityServiceProvider, Logger log) {
+    static AttachmentDto toDto(Attachment attachment, ObjectProvider<IdentityService> identityServiceProvider) {
         return AttachmentDto.of(
                 attachment,
                 findUserDto(identityServiceProvider, attachment.getCreatedBy(), attachment.getAttachmentId(), log));

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/MeAttachmentController.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/MeAttachmentController.java
@@ -169,6 +169,6 @@ public class MeAttachmentController {
     }
 
     private AttachmentDto toDto(Attachment attachment) {
-        return AttachmentWebSupport.toDto(attachment, identityServiceProvider, log);
+        return AttachmentWebSupport.toDto(attachment, identityServiceProvider);
     }
 }

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/MeAttachmentController.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/MeAttachmentController.java
@@ -9,16 +9,11 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.CacheControl;
-import org.springframework.http.ContentDisposition;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -64,21 +59,21 @@ public class MeAttachmentController {
             @RequestParam("file") MultipartFile file,
             @AuthenticationPrincipal(expression = "userId") Long userId) throws IOException {
 
-        requireUserId(userId);
+        AttachmentWebSupport.requireUserId(userId);
         if (file == null || file.isEmpty()) {
-            return badRequest("File is empty");
+            return AttachmentWebSupport.badRequest("File is empty");
         }
         if (file.getSize() > MAX_UPLOAD_SIZE_BYTES) {
-            return badRequest("File too large");
+            return AttachmentWebSupport.badRequest("File too large");
         }
         if (file.getSize() > Integer.MAX_VALUE) {
-            return badRequest("File size exceeds supported limit");
+            return AttachmentWebSupport.badRequest("File size exceeds supported limit");
         }
-        String sanitizedName = sanitizeFilename(file.getOriginalFilename());
-        if (!StringUtils.hasText(sanitizedName)) {
-            return badRequest("Invalid file name");
+        String sanitizedName = AttachmentWebSupport.sanitizeFilename(file.getOriginalFilename());
+        if (sanitizedName == null) {
+            return AttachmentWebSupport.badRequest("Invalid file name");
         }
-        String contentType = resolveMediaTypeString(file.getContentType());
+        String contentType = AttachmentWebSupport.resolveMediaTypeString(file.getContentType());
 
         Attachment saved = attachmentService.createAttachment(
                 objectType,
@@ -95,7 +90,7 @@ public class MeAttachmentController {
     public ResponseEntity<ApiResponse<AttachmentDto>> get(
             @PathVariable("attachmentId") long attachmentId,
             @AuthenticationPrincipal(expression = "userId") Long userId) throws NotFoundException {
-        long resolvedUserId = requireUserId(userId);
+        long resolvedUserId = AttachmentWebSupport.requireUserId(userId);
         Attachment attachment = attachmentService.getAttachmentById(attachmentId);
         if (attachment.getCreatedBy() != resolvedUserId) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
@@ -107,7 +102,7 @@ public class MeAttachmentController {
     public ResponseEntity<ApiResponse<String>> extractText(
             @PathVariable("attachmentId") long attachmentId,
             @AuthenticationPrincipal(expression = "userId") Long userId) throws NotFoundException, IOException {
-        long resolvedUserId = requireUserId(userId);
+        long resolvedUserId = AttachmentWebSupport.requireUserId(userId);
         FileContentExtractionService extractor = textExtractionProvider.getIfAvailable();
         if (extractor == null) {
             ApiResponse<String> body = ApiResponse.<String>builder()
@@ -129,7 +124,7 @@ public class MeAttachmentController {
     public ResponseEntity<StreamingResponseBody> download(
             @PathVariable("attachmentId") long attachmentId,
             @AuthenticationPrincipal(expression = "userId") Long userId) throws IOException, NotFoundException {
-        long resolvedUserId = requireUserId(userId);
+        long resolvedUserId = AttachmentWebSupport.requireUserId(userId);
         Attachment attachment = attachmentService.getAttachmentById(attachmentId);
         if (attachment.getCreatedBy() != resolvedUserId) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
@@ -140,16 +135,7 @@ public class MeAttachmentController {
                 IOUtils.copy(in, out);
             }
         };
-        HttpHeaders headers = new HttpHeaders();
-        headers.setCacheControl(CacheControl.noCache().getHeaderValue());
-        headers.setContentType(resolveMediaType(attachment.getContentType()));
-        headers.setContentLength(attachment.getSize());
-        if (StringUtils.hasText(attachment.getName())) {
-            ContentDisposition cd = ContentDisposition.attachment()
-                    .filename(attachment.getName())
-                    .build();
-            headers.setContentDisposition(cd);
-        }
+        var headers = AttachmentWebSupport.downloadHeaders(attachment.getContentType(), attachment.getSize(), attachment.getName());
         return ResponseEntity.ok()
                 .headers(headers)
                 .body(body);
@@ -162,7 +148,7 @@ public class MeAttachmentController {
             @RequestParam(value = "keyword", required = false) String keyword,
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PageableDefault Pageable pageable) {
-        long resolvedUserId = requireUserId(userId);
+        long resolvedUserId = AttachmentWebSupport.requireUserId(userId);
         Page<Attachment> page;
         if (objectType != null && objectId != null) {
             if (keyword == null || keyword.isBlank()) {
@@ -187,7 +173,7 @@ public class MeAttachmentController {
             @PathVariable int objectType,
             @PathVariable long objectId,
             @AuthenticationPrincipal(expression = "userId") Long userId) {
-        long resolvedUserId = requireUserId(userId);
+        long resolvedUserId = AttachmentWebSupport.requireUserId(userId);
         List<Attachment> attachments = attachmentService.getAttachmentsByObjectAndCreator(objectType, objectId, resolvedUserId);
         List<AttachmentDto> dto = attachments.stream()
                 .map(this::toDto)
@@ -199,20 +185,13 @@ public class MeAttachmentController {
     public ResponseEntity<ApiResponse<Void>> delete(
             @PathVariable("attachmentId") long attachmentId,
             @AuthenticationPrincipal(expression = "userId") Long userId) throws NotFoundException, IOException {
-        long resolvedUserId = requireUserId(userId);
+        long resolvedUserId = AttachmentWebSupport.requireUserId(userId);
         Attachment attachment = attachmentService.getAttachmentById(attachmentId);
         if (attachment.getCreatedBy() != resolvedUserId) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
         attachmentService.removeAttachment(attachment);
         return ResponseEntity.ok(ApiResponse.ok());
-    }
-
-    private long requireUserId(Long userId) {
-        if (userId != null && userId > 0) {
-            return userId;
-        }
-        throw new AuthenticationCredentialsNotFoundException("No authenticated user");
     }
 
     private AttachmentDto toDto(Attachment attachment) {
@@ -240,36 +219,4 @@ public class MeAttachmentController {
         return new UserDto(userRef.userId(), userRef.username());
     }
 
-    private MediaType resolveMediaType(String contentType) {
-        if (!StringUtils.hasText(contentType)) {
-            return MediaType.APPLICATION_OCTET_STREAM;
-        }
-        try {
-            return MediaType.parseMediaType(contentType);
-        } catch (Exception ignored) {
-            return MediaType.APPLICATION_OCTET_STREAM;
-        }
-    }
-
-    private String resolveMediaTypeString(String contentType) {
-        return resolveMediaType(contentType).toString();
-    }
-
-    private String sanitizeFilename(String original) {
-        if (!StringUtils.hasText(original)) {
-            return null;
-        }
-        String cleaned = org.springframework.util.StringUtils.getFilename(original);
-        if (!StringUtils.hasText(cleaned)) {
-            return null;
-        }
-        return cleaned.replace("\\", "").replace("/", "");
-    }
-
-    private <T> ResponseEntity<ApiResponse<T>> badRequest(String message) {
-        ApiResponse<T> body = ApiResponse.<T>builder()
-                .message(message)
-                .build();
-        return ResponseEntity.badRequest().body(body);
-    }
 }

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/MeAttachmentController.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/MeAttachmentController.java
@@ -4,11 +4,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
-import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -33,8 +33,6 @@ import studio.one.application.web.dto.AttachmentDto;
 import studio.one.platform.constant.PropertyKeys;
 import studio.one.platform.exception.NotFoundException;
 import studio.one.platform.identity.IdentityService;
-import studio.one.platform.identity.UserDto;
-import studio.one.platform.identity.UserRef;
 import studio.one.platform.text.service.FileContentExtractionService;
 import studio.one.platform.web.dto.ApiResponse;
 
@@ -46,8 +44,6 @@ import studio.one.platform.web.dto.ApiResponse;
 @PreAuthorize("isAuthenticated()")
 public class MeAttachmentController {
 
-    private static final long MAX_UPLOAD_SIZE_BYTES = 50 * 1024 * 1024; // 50MB 상한으로 자원 고갈 방지
-
     private final AttachmentService attachmentService;
     private final ObjectProvider<IdentityService> identityServiceProvider;
     private final ObjectProvider<FileContentExtractionService> textExtractionProvider;
@@ -58,39 +54,29 @@ public class MeAttachmentController {
             @RequestParam("objectId") long objectId,
             @RequestParam("file") MultipartFile file,
             @AuthenticationPrincipal(expression = "userId") Long userId) throws IOException {
-
-        AttachmentWebSupport.requireUserId(userId);
-        if (file == null || file.isEmpty()) {
-            return AttachmentWebSupport.badRequest("File is empty");
+        AttachmentAccessSupport.requireUserId(userId);
+        AttachmentWebSupport.PreparedUpload upload;
+        try {
+            upload = AttachmentWebSupport.prepareUpload(file);
+        } catch (IllegalArgumentException e) {
+            return AttachmentWebSupport.badRequest(e.getMessage());
         }
-        if (file.getSize() > MAX_UPLOAD_SIZE_BYTES) {
-            return AttachmentWebSupport.badRequest("File too large");
-        }
-        if (file.getSize() > Integer.MAX_VALUE) {
-            return AttachmentWebSupport.badRequest("File size exceeds supported limit");
-        }
-        String sanitizedName = AttachmentWebSupport.sanitizeFilename(file.getOriginalFilename());
-        if (sanitizedName == null) {
-            return AttachmentWebSupport.badRequest("Invalid file name");
-        }
-        String contentType = AttachmentWebSupport.resolveMediaTypeString(file.getContentType());
 
         Attachment saved = attachmentService.createAttachment(
                 objectType,
                 objectId,
-                sanitizedName,
-                contentType,
+                upload.name(),
+                upload.contentType(),
                 file.getInputStream(),
-                (int) file.getSize());
-        AttachmentDto dto = toDto(saved);
-        return ResponseEntity.ok(ApiResponse.ok(dto));
+                upload.sizeBytes());
+        return ResponseEntity.ok(ApiResponse.ok(toDto(saved)));
     }
 
     @GetMapping("/{attachmentId:[\\p{Digit}]+}")
     public ResponseEntity<ApiResponse<AttachmentDto>> get(
             @PathVariable("attachmentId") long attachmentId,
             @AuthenticationPrincipal(expression = "userId") Long userId) throws NotFoundException {
-        long resolvedUserId = AttachmentWebSupport.requireUserId(userId);
+        long resolvedUserId = AttachmentAccessSupport.requireUserId(userId);
         Attachment attachment = attachmentService.getAttachmentById(attachmentId);
         if (attachment.getCreatedBy() != resolvedUserId) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
@@ -102,7 +88,7 @@ public class MeAttachmentController {
     public ResponseEntity<ApiResponse<String>> extractText(
             @PathVariable("attachmentId") long attachmentId,
             @AuthenticationPrincipal(expression = "userId") Long userId) throws NotFoundException, IOException {
-        long resolvedUserId = AttachmentWebSupport.requireUserId(userId);
+        long resolvedUserId = AttachmentAccessSupport.requireUserId(userId);
         FileContentExtractionService extractor = textExtractionProvider.getIfAvailable();
         if (extractor == null) {
             ApiResponse<String> body = ApiResponse.<String>builder()
@@ -124,21 +110,15 @@ public class MeAttachmentController {
     public ResponseEntity<StreamingResponseBody> download(
             @PathVariable("attachmentId") long attachmentId,
             @AuthenticationPrincipal(expression = "userId") Long userId) throws IOException, NotFoundException {
-        long resolvedUserId = AttachmentWebSupport.requireUserId(userId);
+        long resolvedUserId = AttachmentAccessSupport.requireUserId(userId);
         Attachment attachment = attachmentService.getAttachmentById(attachmentId);
         if (attachment.getCreatedBy() != resolvedUserId) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
-        InputStream in = attachmentService.getInputStream(attachment);
-        StreamingResponseBody body = out -> {
-            try (in) {
-                IOUtils.copy(in, out);
-            }
-        };
-        var headers = AttachmentWebSupport.downloadHeaders(attachment.getContentType(), attachment.getSize(), attachment.getName());
-        return ResponseEntity.ok()
-                .headers(headers)
-                .body(body);
+        return AttachmentWebSupport.downloadResponse(
+                attachment,
+                attachmentService.getInputStream(attachment),
+                CacheControl.noCache());
     }
 
     @GetMapping
@@ -148,7 +128,7 @@ public class MeAttachmentController {
             @RequestParam(value = "keyword", required = false) String keyword,
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PageableDefault Pageable pageable) {
-        long resolvedUserId = AttachmentWebSupport.requireUserId(userId);
+        long resolvedUserId = AttachmentAccessSupport.requireUserId(userId);
         Page<Attachment> page;
         if (objectType != null && objectId != null) {
             if (keyword == null || keyword.isBlank()) {
@@ -157,15 +137,12 @@ public class MeAttachmentController {
                 page = attachmentService.findAttachmentsByObjectAndCreator(objectType, objectId, resolvedUserId, keyword,
                         pageable);
             }
+        } else if (keyword == null || keyword.isBlank()) {
+            page = attachmentService.findAttachmentsByCreator(resolvedUserId, pageable);
         } else {
-            if (keyword == null || keyword.isBlank()) {
-                page = attachmentService.findAttachmentsByCreator(resolvedUserId, pageable);
-            } else {
-                page = attachmentService.findAttachmentsByCreator(resolvedUserId, keyword, pageable);
-            }
+            page = attachmentService.findAttachmentsByCreator(resolvedUserId, keyword, pageable);
         }
-        Page<AttachmentDto> dtoPage = page.map(this::toDto);
-        return ResponseEntity.ok(ApiResponse.ok(dtoPage));
+        return ResponseEntity.ok(ApiResponse.ok(page.map(this::toDto)));
     }
 
     @GetMapping("/objects/{objectType:[\\p{Digit}]+}/{objectId:[\\p{Digit}]+}")
@@ -173,19 +150,16 @@ public class MeAttachmentController {
             @PathVariable int objectType,
             @PathVariable long objectId,
             @AuthenticationPrincipal(expression = "userId") Long userId) {
-        long resolvedUserId = AttachmentWebSupport.requireUserId(userId);
+        long resolvedUserId = AttachmentAccessSupport.requireUserId(userId);
         List<Attachment> attachments = attachmentService.getAttachmentsByObjectAndCreator(objectType, objectId, resolvedUserId);
-        List<AttachmentDto> dto = attachments.stream()
-                .map(this::toDto)
-                .toList();
-        return ResponseEntity.ok(ApiResponse.ok(dto));
+        return ResponseEntity.ok(ApiResponse.ok(attachments.stream().map(this::toDto).toList()));
     }
 
     @DeleteMapping("/{attachmentId:[\\p{Digit}]+}")
     public ResponseEntity<ApiResponse<Void>> delete(
             @PathVariable("attachmentId") long attachmentId,
             @AuthenticationPrincipal(expression = "userId") Long userId) throws NotFoundException, IOException {
-        long resolvedUserId = AttachmentWebSupport.requireUserId(userId);
+        long resolvedUserId = AttachmentAccessSupport.requireUserId(userId);
         Attachment attachment = attachmentService.getAttachmentById(attachmentId);
         if (attachment.getCreatedBy() != resolvedUserId) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
@@ -195,28 +169,6 @@ public class MeAttachmentController {
     }
 
     private AttachmentDto toDto(Attachment attachment) {
-        UserDto creator = findUserDto(attachment.getCreatedBy(), attachment.getAttachmentId());
-        return AttachmentDto.of(attachment, creator);
+        return AttachmentWebSupport.toDto(attachment, identityServiceProvider, log);
     }
-
-    private UserDto findUserDto(long userId, long attachmentId) {
-        if (userId <= 0) {
-            return null;
-        }
-        IdentityService identityService = identityServiceProvider.getIfAvailable();
-        if (identityService == null) {
-            return null;
-        }
-        return identityService.findById(userId)
-                .map(this::toUserDto)
-                .orElseGet(() -> {
-                    log.warn("User {} not found for attachment {}", userId, attachmentId);
-                    return null;
-                });
-    }
-
-    private UserDto toUserDto(UserRef userRef) {
-        return new UserDto(userRef.userId(), userRef.username());
-    }
-
 }

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/web/controller/AttachmentAccessSupportTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/web/controller/AttachmentAccessSupportTest.java
@@ -1,0 +1,37 @@
+package studio.one.application.web.controller;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.identity.ApplicationPrincipal;
+
+class AttachmentAccessSupportTest {
+
+    @Test
+    void isAdminAcceptsLegacyAndSpringSecurityRoleNames() {
+        assertTrue(AttachmentAccessSupport.isAdmin(principal("ADMIN")));
+        assertTrue(AttachmentAccessSupport.isAdmin(principal("ROLE_ADMIN")));
+    }
+
+    private ApplicationPrincipal principal(String role) {
+        return new ApplicationPrincipal() {
+            @Override
+            public Long getUserId() {
+                return 1L;
+            }
+
+            @Override
+            public String getUsername() {
+                return "admin";
+            }
+
+            @Override
+            public Set<String> getRoles() {
+                return Set.of(role);
+            }
+        };
+    }
+}

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/web/controller/AttachmentControllerTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/web/controller/AttachmentControllerTest.java
@@ -1,0 +1,84 @@
+package studio.one.application.web.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+
+import studio.one.application.attachment.domain.model.Attachment;
+import studio.one.application.attachment.service.AttachmentService;
+import studio.one.application.attachment.thumbnail.ThumbnailService;
+import studio.one.application.web.dto.AttachmentDto;
+import studio.one.platform.web.dto.ApiResponse;
+
+@ExtendWith(MockitoExtension.class)
+class AttachmentControllerTest {
+
+    @Mock
+    private AttachmentService attachmentService;
+
+    @Mock
+    private ObjectProvider<ThumbnailService> thumbnailServiceProvider;
+
+    @Test
+    void uploadSanitizesFilenameAndNormalizesContentType() throws Exception {
+        AttachmentController controller = new AttachmentController(attachmentService, thumbnailServiceProvider);
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "C:\\temp\\contract.pdf",
+                "invalid content type",
+                new byte[] { 1, 2, 3 });
+        Attachment saved = mock(Attachment.class);
+
+        when(attachmentService.createAttachment(
+                eq(12),
+                eq(34L),
+                eq("contract.pdf"),
+                eq("application/octet-stream"),
+                any(InputStream.class),
+                eq(3))).thenReturn(saved);
+
+        ResponseEntity<ApiResponse<AttachmentDto>> response = controller.upload(12, 34L, file);
+
+        assertEquals(200, response.getStatusCode().value());
+        verify(attachmentService).createAttachment(
+                eq(12),
+                eq(34L),
+                eq("contract.pdf"),
+                eq("application/octet-stream"),
+                any(InputStream.class),
+                eq(3));
+    }
+
+    @Test
+    void downloadBuildsAttachmentHeaders() throws Exception {
+        AttachmentController controller = new AttachmentController(attachmentService, thumbnailServiceProvider);
+        Attachment attachment = mock(Attachment.class);
+
+        when(attachmentService.getAttachmentById(88L)).thenReturn(attachment);
+        when(attachmentService.getInputStream(attachment)).thenReturn(new ByteArrayInputStream(new byte[] { 1, 2 }));
+        when(attachment.getContentType()).thenReturn("application/pdf");
+        when(attachment.getSize()).thenReturn(2L);
+        when(attachment.getName()).thenReturn("report.pdf");
+
+        ResponseEntity<?> response = controller.download(88L);
+
+        assertEquals("application/pdf", response.getHeaders().getContentType().toString());
+        assertEquals(2L, response.getHeaders().getContentLength());
+        assertEquals("attachment; filename=\"report.pdf\"",
+                response.getHeaders().getFirst("Content-Disposition"));
+    }
+}

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/web/controller/AttachmentMgmtControllerAuthorizationTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/web/controller/AttachmentMgmtControllerAuthorizationTest.java
@@ -86,6 +86,19 @@ class AttachmentMgmtControllerAuthorizationTest {
     }
 
     @Test
+    void listByObjectUsesGlobalQueryForRoleAdmin() {
+        AttachmentMgmtController controller = controller();
+
+        when(principalResolverProvider.getIfAvailable()).thenReturn(principalResolver);
+        when(principalResolver.currentOrNull()).thenReturn(principal(1L, "ROLE_ADMIN"));
+        when(attachmentService.getAttachments(12, 34L)).thenReturn(Collections.emptyList());
+
+        controller.listByObject(12, 34L);
+
+        verify(attachmentService).getAttachments(12, 34L);
+    }
+
+    @Test
     void extractTextPropagatesLimitFailure() throws Exception {
         AttachmentMgmtController controller = controller();
         Attachment attachment = mock(Attachment.class);

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/web/controller/AttachmentMgmtControllerAuthorizationTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/web/controller/AttachmentMgmtControllerAuthorizationTest.java
@@ -77,7 +77,7 @@ class AttachmentMgmtControllerAuthorizationTest {
         AttachmentMgmtController controller = controller();
 
         when(principalResolverProvider.getIfAvailable()).thenReturn(principalResolver);
-        when(principalResolver.currentOrNull()).thenReturn(principal(1L, "ADMIN"));
+        when(principalResolver.currentOrNull()).thenReturn(principal(1L, "ROLE_ADMIN"));
         when(attachmentService.getAttachments(12, 34L)).thenReturn(Collections.emptyList());
 
         controller.listByObject(12, 34L);

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/web/controller/AttachmentMgmtControllerAuthorizationTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/web/controller/AttachmentMgmtControllerAuthorizationTest.java
@@ -106,7 +106,7 @@ class AttachmentMgmtControllerAuthorizationTest {
                 mock(studio.one.platform.text.extractor.FileParserFactory.class), 4);
 
         when(principalResolverProvider.getIfAvailable()).thenReturn(principalResolver);
-        when(principalResolver.currentOrNull()).thenReturn(principal(1L, "ADMIN"));
+        when(principalResolver.currentOrNull()).thenReturn(principal(1L, "ROLE_ADMIN"));
         when(textExtractionProvider.getIfAvailable()).thenReturn(extractor);
         when(attachmentService.getAttachmentById(10L)).thenReturn(attachment);
         when(attachment.getName()).thenReturn("large.txt");

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/web/controller/AttachmentMgmtControllerAuthorizationTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/web/controller/AttachmentMgmtControllerAuthorizationTest.java
@@ -77,7 +77,7 @@ class AttachmentMgmtControllerAuthorizationTest {
         AttachmentMgmtController controller = controller();
 
         when(principalResolverProvider.getIfAvailable()).thenReturn(principalResolver);
-        when(principalResolver.currentOrNull()).thenReturn(principal(1L, "ROLE_ADMIN"));
+        when(principalResolver.currentOrNull()).thenReturn(principal(1L, "ADMIN"));
         when(attachmentService.getAttachments(12, 34L)).thenReturn(Collections.emptyList());
 
         controller.listByObject(12, 34L);

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/web/controller/AttachmentWebSupportTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/web/controller/AttachmentWebSupportTest.java
@@ -2,14 +2,9 @@ package studio.one.application.web.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
-
-import studio.one.platform.identity.ApplicationPrincipal;
 
 class AttachmentWebSupportTest {
 
@@ -24,30 +19,5 @@ class AttachmentWebSupportTest {
     void resolveMediaTypeFallsBackToOctetStream() {
         assertEquals(MediaType.APPLICATION_OCTET_STREAM, AttachmentWebSupport.resolveMediaType(null));
         assertEquals(MediaType.APPLICATION_OCTET_STREAM, AttachmentWebSupport.resolveMediaType("not a type"));
-    }
-
-    @Test
-    void isAdminAcceptsLegacyAndSpringSecurityRoleNames() {
-        assertTrue(AttachmentAccessSupport.isAdmin(principal("ADMIN")));
-        assertTrue(AttachmentAccessSupport.isAdmin(principal("ROLE_ADMIN")));
-    }
-
-    private ApplicationPrincipal principal(String role) {
-        return new ApplicationPrincipal() {
-            @Override
-            public Long getUserId() {
-                return 1L;
-            }
-
-            @Override
-            public String getUsername() {
-                return "admin";
-            }
-
-            @Override
-            public Set<String> getRoles() {
-                return Set.of(role);
-            }
-        };
     }
 }

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/web/controller/AttachmentWebSupportTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/web/controller/AttachmentWebSupportTest.java
@@ -1,10 +1,12 @@
 package studio.one.application.web.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
 import studio.one.platform.identity.ApplicationPrincipal;
@@ -12,28 +14,22 @@ import studio.one.platform.identity.ApplicationPrincipal;
 class AttachmentWebSupportTest {
 
     @Test
-    void sanitizeFilenameKeepsLeafNameOnly() {
-        assertEquals("report.pdf", AttachmentWebSupport.sanitizeFilename("folder/subfolder/report.pdf"));
+    void sanitizeFilenameRemovesPathSegments() {
+        assertEquals("contract.pdf", AttachmentWebSupport.sanitizeFilename("dir/subdir/contract.pdf"));
+        assertEquals("contract.pdf", AttachmentWebSupport.sanitizeFilename("dir\\subdir\\contract.pdf"));
+        assertNull(AttachmentWebSupport.sanitizeFilename(" "));
     }
 
     @Test
     void resolveMediaTypeFallsBackToOctetStream() {
-        assertEquals(MediaType.APPLICATION_OCTET_STREAM, AttachmentWebSupport.resolveMediaType("not-a-type"));
+        assertEquals(MediaType.APPLICATION_OCTET_STREAM, AttachmentWebSupport.resolveMediaType(null));
+        assertEquals(MediaType.APPLICATION_OCTET_STREAM, AttachmentWebSupport.resolveMediaType("not a type"));
     }
 
     @Test
-    void downloadHeadersIncludeDispositionAndContentLength() {
-        HttpHeaders headers = AttachmentWebSupport.downloadHeaders("text/plain", 12L, "note.txt");
-
-        assertEquals(MediaType.TEXT_PLAIN, headers.getContentType());
-        assertEquals(12L, headers.getContentLength());
-        assertTrue(headers.getContentDisposition().isAttachment());
-    }
-
-    @Test
-    void isAdminAcceptsAdminAndRoleAdmin() {
-        assertTrue(AttachmentWebSupport.isAdmin(principal("ADMIN")));
-        assertTrue(AttachmentWebSupport.isAdmin(principal("ROLE_ADMIN")));
+    void isAdminAcceptsLegacyAndSpringSecurityRoleNames() {
+        assertTrue(AttachmentAccessSupport.isAdmin(principal("ADMIN")));
+        assertTrue(AttachmentAccessSupport.isAdmin(principal("ROLE_ADMIN")));
     }
 
     private ApplicationPrincipal principal(String role) {
@@ -49,8 +45,8 @@ class AttachmentWebSupportTest {
             }
 
             @Override
-            public java.util.Set<String> getRoles() {
-                return java.util.Set.of(role);
+            public Set<String> getRoles() {
+                return Set.of(role);
             }
         };
     }

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/web/controller/AttachmentWebSupportTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/web/controller/AttachmentWebSupportTest.java
@@ -1,0 +1,57 @@
+package studio.one.application.web.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import studio.one.platform.identity.ApplicationPrincipal;
+
+class AttachmentWebSupportTest {
+
+    @Test
+    void sanitizeFilenameKeepsLeafNameOnly() {
+        assertEquals("report.pdf", AttachmentWebSupport.sanitizeFilename("folder/subfolder/report.pdf"));
+    }
+
+    @Test
+    void resolveMediaTypeFallsBackToOctetStream() {
+        assertEquals(MediaType.APPLICATION_OCTET_STREAM, AttachmentWebSupport.resolveMediaType("not-a-type"));
+    }
+
+    @Test
+    void downloadHeadersIncludeDispositionAndContentLength() {
+        HttpHeaders headers = AttachmentWebSupport.downloadHeaders("text/plain", 12L, "note.txt");
+
+        assertEquals(MediaType.TEXT_PLAIN, headers.getContentType());
+        assertEquals(12L, headers.getContentLength());
+        assertTrue(headers.getContentDisposition().isAttachment());
+    }
+
+    @Test
+    void isAdminAcceptsAdminAndRoleAdmin() {
+        assertTrue(AttachmentWebSupport.isAdmin(principal("ADMIN")));
+        assertTrue(AttachmentWebSupport.isAdmin(principal("ROLE_ADMIN")));
+    }
+
+    private ApplicationPrincipal principal(String role) {
+        return new ApplicationPrincipal() {
+            @Override
+            public Long getUserId() {
+                return 1L;
+            }
+
+            @Override
+            public String getUsername() {
+                return "admin";
+            }
+
+            @Override
+            public java.util.Set<String> getRoles() {
+                return java.util.Set.of(role);
+            }
+        };
+    }
+}

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/web/controller/MeAttachmentControllerTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/web/controller/MeAttachmentControllerTest.java
@@ -1,0 +1,86 @@
+package studio.one.application.web.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+
+import studio.one.application.attachment.domain.model.Attachment;
+import studio.one.application.attachment.service.AttachmentService;
+import studio.one.application.web.dto.AttachmentDto;
+import studio.one.platform.identity.IdentityService;
+import studio.one.platform.text.service.FileContentExtractionService;
+import studio.one.platform.web.dto.ApiResponse;
+
+@ExtendWith(MockitoExtension.class)
+class MeAttachmentControllerTest {
+
+    @Mock
+    private AttachmentService attachmentService;
+
+    @Mock
+    private ObjectProvider<IdentityService> identityServiceProvider;
+
+    @Mock
+    private ObjectProvider<FileContentExtractionService> textExtractionProvider;
+
+    @Test
+    void getReturnsForbiddenWhenOwnerMismatch() throws Exception {
+        MeAttachmentController controller = new MeAttachmentController(
+                attachmentService,
+                identityServiceProvider,
+                textExtractionProvider);
+        Attachment attachment = mock(Attachment.class);
+
+        when(attachmentService.getAttachmentById(44L)).thenReturn(attachment);
+        when(attachment.getCreatedBy()).thenReturn(99L);
+
+        ResponseEntity<ApiResponse<AttachmentDto>> response = controller.get(44L, 7L);
+
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+    }
+
+    @Test
+    void uploadSanitizesFilenameAndNormalizesContentType() throws Exception {
+        MeAttachmentController controller = new MeAttachmentController(
+                attachmentService,
+                identityServiceProvider,
+                textExtractionProvider);
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "/tmp/report.txt",
+                "invalid content type",
+                new byte[] { 1, 2, 3, 4 });
+        Attachment saved = mock(Attachment.class);
+
+        when(attachmentService.createAttachment(
+                eq(10),
+                eq(20L),
+                eq("report.txt"),
+                eq("application/octet-stream"),
+                any(),
+                eq(4))).thenReturn(saved);
+
+        ResponseEntity<ApiResponse<AttachmentDto>> response = controller.upload(10, 20L, file, 7L);
+
+        assertEquals(200, response.getStatusCode().value());
+        verify(attachmentService).createAttachment(
+                eq(10),
+                eq(20L),
+                eq("report.txt"),
+                eq("application/octet-stream"),
+                any(),
+                eq(4));
+    }
+}


### PR DESCRIPTION
## Why
- #161
- attachment 웹 컨트롤러들에 업로드 검증, 파일명 정제, 다운로드 헤더, principal/owner 접근 판별이 중복돼 있었다.
- 관리자 판별이 "ADMIN" 문자열에 사실상 묶여 있어 Spring Security authority(`ROLE_ADMIN`)와 어긋날 여지가 있었다.

## What
- `AttachmentWebSupport`를 통해 업로드 요청 검증, 파일명 정제, MIME 정규화, 다운로드 응답 헤더, 작성자 DTO 변환 로직을 공통화했다.
- `AttachmentAccessSupport`를 통해 principal 조회, userId 강제, owner 접근 검사, admin role 정규화를 공통화했다.
- `AttachmentController`, `AttachmentMgmtController`, `MeAttachmentController`가 공통 support를 사용하도록 정리했다.
- `AttachmentMgmtControllerAuthorizationTest`를 `ROLE_ADMIN` 경로까지 검증하도록 보강했다.
- `AttachmentControllerTest`, `MeAttachmentControllerTest`, `AttachmentWebSupportTest`를 추가해 업로드/다운로드/권한 회귀를 고정했다.
- `CHANGELOG.md`에 변경과 검증 기록을 반영했다.

## Related Issues
- Closes #161

## Change Scope
- attachment-service 웹 계층 리팩토링 및 회귀 테스트 보강

## Security Impact
- 관리자 판별이 `ADMIN`과 `ROLE_ADMIN` 모두를 수용하도록 보강돼 권한 해석 불일치 위험을 줄였다.
- 기존 mgmt/service/me 엔드포인트 권한 경계는 유지했다.

## Validation
- `./gradlew -p /tmp/studio-api-issue-161 :studio-application-modules:attachment-service:test --tests 'studio.one.application.web.controller.AttachmentControllerTest' --tests 'studio.one.application.web.controller.AttachmentMgmtControllerAuthorizationTest' --tests 'studio.one.application.web.controller.AttachmentWebSupportTest' --tests 'studio.one.application.web.controller.MeAttachmentControllerTest'`
- `./gradlew -p /tmp/studio-api-issue-161 :studio-application-modules:attachment-service:compileJava`

## Subagent Usage
- coding: spring-boot-engineer style worker used for initial bounded refactor on attachment web controller support
- review: code-reviewer style explorer used to identify regression risks around `ROLE_ADMIN` and controller behavior drift
- docs: docs-agent style explorer used to confirm changelog/documentation impact
- main author validation: final diff review, test execution, changelog correction, and integration commit were performed in the main worktree owner flow

## Checklist
- [x] Issue linked
- [x] AI-assisted title/body format applied
- [x] Validation recorded
- [x] No unrelated files included
- [x] Human review completed before merge
- [x] CI / repository verification passed

## Deployment Notes
- 없음