### PR TITLE
[ai-assisted] [attachment] 저장 정합성 및 size 계산 개선

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 ## 2026-03-31 (follow-up)
 
 ### 변경됨
-- `AttachmentServiceImpl`의 `InputStream` 기반 size 계산을 `available()`에서 실제 byte materialization으로 바꿔 정확한 크기를 보장하도록 수정했다.
+- `AttachmentServiceImpl`의 `InputStream` 기반 size 계산을 `available()`에서 임시 파일 버퍼링으로 바꿔 정확한 크기를 보장하도록 수정했다.
 - `AttachmentServiceImpl`의 `File` 기반 업로드는 입력 스트림을 try-with-resources로 닫고, 너무 큰 파일은 명시적으로 실패하도록 정리했다.
-- storage save 실패 시 best-effort로 파일/메타데이터 cleanup을 수행하도록 정리해 orphan record 가능성을 줄였다.
-- `attachment-service`에 `AttachmentServiceImpl` 회귀 테스트를 추가해 size 계산과 storage failure cleanup 경로를 고정했다.
+- storage save 실패 시 partial binary만 best-effort로 정리하고, 메타데이터는 트랜잭션 rollback에 맡기도록 저장 경계를 명확히 했다.
+- `attachment-service`에 `AttachmentServiceImpl`, `LocalFileStore`, `JpaFileStore` 회귀 테스트를 추가해 unknown-size stream 처리, explicit size 유지, filesystem/database 저장 경로를 검증했다.
 
 ### 검증
-- `./gradlew :studio-application-modules:attachment-service:test --tests 'studio.one.application.attachment.service.AttachmentServiceImplTest'`
+- `./gradlew :studio-application-modules:attachment-service:test --tests 'studio.one.application.attachment.service.AttachmentServiceImplTest' --tests 'studio.one.application.attachment.storage.LocalFileStoreTest' --tests 'studio.one.application.attachment.storage.JpaFileStoreTest'`
 - `./gradlew :studio-application-modules:attachment-service:compileJava`
 
 ## 2026-03-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## 2026-03-31 (follow-up)
 
 ### 변경됨
-- `AttachmentServiceImpl`의 `InputStream` 기반 size 계산을 `available()`에서 임시 파일 버퍼링으로 바꿔 정확한 크기를 보장하도록 수정했다.
+- `AttachmentServiceImpl`의 `InputStream` 기반 size 계산을 `available()`에서 임시 파일 버퍼링으로 바꿔 정확한 크기를 보장하도록 수정했다. 서비스 레이어에서도 최대 50MB 상한을 다시 적용한다.
 - `AttachmentServiceImpl`의 `File` 기반 업로드는 입력 스트림을 try-with-resources로 닫고, 너무 큰 파일은 명시적으로 실패하도록 정리했다.
-- storage save 실패 시 partial binary만 best-effort로 정리하고, 메타데이터는 트랜잭션 rollback에 맡기도록 저장 경계를 명확히 했다.
+- storage save 실패 시 partial binary만 best-effort로 정리하고, 메타데이터는 트랜잭션 rollback에 맡기도록 저장 경계를 명확히 했다. 입력 스트림 close 실패는 경고로만 남기고 저장 성공을 뒤집지 않도록 정리했다.
 - `attachment-service`에 `AttachmentServiceImpl`, `LocalFileStore`, `JpaFileStore` 회귀 테스트를 추가해 unknown-size stream 처리, explicit size 유지, filesystem/database 저장 경로를 검증했다.
 
 ### 검증

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-03-31 (follow-up)
+
+### 변경됨
+- `AttachmentServiceImpl`의 `InputStream` 기반 size 계산을 `available()`에서 실제 byte materialization으로 바꿔 정확한 크기를 보장하도록 수정했다.
+- `AttachmentServiceImpl`의 `File` 기반 업로드는 입력 스트림을 try-with-resources로 닫고, 너무 큰 파일은 명시적으로 실패하도록 정리했다.
+- storage save 실패 시 best-effort로 파일/메타데이터 cleanup을 수행하도록 정리해 orphan record 가능성을 줄였다.
+- `attachment-service`에 `AttachmentServiceImpl` 회귀 테스트를 추가해 size 계산과 storage failure cleanup 경로를 고정했다.
+
+### 검증
+- `./gradlew :studio-application-modules:attachment-service:test --tests 'studio.one.application.attachment.service.AttachmentServiceImplTest'`
+- `./gradlew :studio-application-modules:attachment-service:compileJava`
+
 ## 2026-03-31
 
 ### 변경됨

--- a/studio-application-modules/attachment-service/README.md
+++ b/studio-application-modules/attachment-service/README.md
@@ -154,7 +154,7 @@ objecttypes:
 - 삭제는 메타데이터와 바이너리 모두 제거하며, 캐시 스토리지도 비운다.
 - 텍스트 추출은 선택 기능이므로, 빈이 없을 때 501(NOT_IMPLEMENTED)을 반환한다.
 - 업로드 시 파일명은 sanitize 처리되며, 최대 업로드 크기는 50MB로 제한한다(컨트롤러 수준).
-- 크기를 알 수 없는 `InputStream` 업로드는 내부 임시 파일로 stage한 뒤 실제 바이트 길이로 저장한다. storage save 실패 시 partial binary는 best-effort로 정리하고, 메타데이터는 트랜잭션 rollback에 맡긴다.
+- 크기를 알 수 없는 `InputStream` 업로드는 내부 임시 파일로 stage한 뒤 실제 바이트 길이로 저장한다. 서비스 레이어는 최대 50MB 상한을 다시 적용하며, storage save 실패 시 partial binary는 best-effort로 정리하고 메타데이터는 트랜잭션 rollback에 맡긴다.
 - `AttachmentMgmtController`, `AttachmentController`, `MeAttachmentController`는 공통 웹 helper를 통해 파일명 정제, MIME 정규화, 다운로드 헤더 구성을 공유한다.
 - objecttype 정책 검증이 활성화되면 용량/확장자/MIME 정책 위반 시 `POLICY_VIOLATION` 에러가 발생한다.
 - 기본 캐시 이름은 `attachments.byId`이며, 캐시 설정이 필요하면 전역 CacheManager에 매핑을 추가한다.

--- a/studio-application-modules/attachment-service/README.md
+++ b/studio-application-modules/attachment-service/README.md
@@ -154,6 +154,7 @@ objecttypes:
 - 삭제는 메타데이터와 바이너리 모두 제거하며, 캐시 스토리지도 비운다.
 - 텍스트 추출은 선택 기능이므로, 빈이 없을 때 501(NOT_IMPLEMENTED)을 반환한다.
 - 업로드 시 파일명은 sanitize 처리되며, 최대 업로드 크기는 50MB로 제한한다(컨트롤러 수준).
+- 크기를 알 수 없는 `InputStream` 업로드는 내부 임시 파일로 stage한 뒤 실제 바이트 길이로 저장한다. storage save 실패 시 partial binary는 best-effort로 정리하고, 메타데이터는 트랜잭션 rollback에 맡긴다.
 - `AttachmentMgmtController`, `AttachmentController`, `MeAttachmentController`는 공통 웹 helper를 통해 파일명 정제, MIME 정규화, 다운로드 헤더 구성을 공유한다.
 - objecttype 정책 검증이 활성화되면 용량/확장자/MIME 정책 위반 시 `POLICY_VIOLATION` 에러가 발생한다.
 - 기본 캐시 이름은 `attachments.byId`이며, 캐시 설정이 필요하면 전역 CacheManager에 매핑을 추가한다.

--- a/studio-application-modules/attachment-service/build.gradle.kts
+++ b/studio-application-modules/attachment-service/build.gradle.kts
@@ -33,4 +33,5 @@ dependencies {
     testImplementation(project(":studio-platform"))
     testImplementation(project(":studio-platform-data"))
     testImplementation(project(":studio-platform-identity"))
+    testImplementation(project(":studio-platform-objecttype"))
 }

--- a/studio-application-modules/attachment-service/build.gradle.kts
+++ b/studio-application-modules/attachment-service/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     testImplementation("org.mockito:mockito-core")
     testImplementation("org.mockito:mockito-junit-jupiter")
     testImplementation("org.springframework.boot:spring-boot-starter-web")
+    testImplementation("org.springframework.boot:spring-boot-starter-data-jpa")
     testImplementation("org.springframework.data:spring-data-commons")
     testImplementation("org.springframework.security:spring-security-core")
     testImplementation(project(":studio-platform"))

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/service/AttachmentServiceImpl.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/service/AttachmentServiceImpl.java
@@ -2,6 +2,7 @@ package studio.one.application.attachment.service;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
@@ -132,10 +133,12 @@ public class AttachmentServiceImpl implements AttachmentService {
 
     @Override
     public Attachment createAttachment(int objectType, long objectId, String name, String contentType, File file) {
-        try {
-            int size = (int) file.length();
-            InputStream inputStream = new FileInputStream(file);
-            return createAttachment(objectType, objectId, name, contentType, inputStream, size);
+        try (InputStream inputStream = new FileInputStream(file)) {
+            long size = file.length();
+            if (size > Integer.MAX_VALUE) {
+                throw new IllegalArgumentException("File size exceeds supported limit");
+            }
+            return createAttachment(objectType, objectId, name, contentType, inputStream, (int) size);
         } catch (IOException e) {
             throw new IllegalArgumentException(e.getMessage(), e);
         }
@@ -145,8 +148,14 @@ public class AttachmentServiceImpl implements AttachmentService {
     public Attachment createAttachment(int objectType, long objectId, String name, String contentType,
             InputStream inputStream) {
         try {
-            int size = inputStream.available();
-            return createAttachment(objectType, objectId, name, contentType, inputStream, size);
+            byte[] bytes = inputStream.readAllBytes();
+            return createAttachment(
+                    objectType,
+                    objectId,
+                    name,
+                    contentType,
+                    new ByteArrayInputStream(bytes),
+                    bytes.length);
         } catch (IOException e) {
             throw new IllegalArgumentException(e.getMessage(), e);
         }
@@ -175,8 +184,13 @@ public class AttachmentServiceImpl implements AttachmentService {
             }
         }
         Attachment savedAttachment = attachmentRepository.save(attachment);
-        fileStorage.save(savedAttachment, inputStream);
-        return savedAttachment;
+        try {
+            fileStorage.save(savedAttachment, inputStream);
+            return savedAttachment;
+        } catch (RuntimeException e) {
+            cleanupAfterStorageFailure(savedAttachment);
+            throw e;
+        }
     }
 
     @Override
@@ -224,5 +238,20 @@ public class AttachmentServiceImpl implements AttachmentService {
         }
         ValidateUploadCommand request = new ValidateUploadCommand(fileName, contentType, (long) sizeBytes);
         runtimeService.validateUpload(objectType, request);
+    }
+
+    private void cleanupAfterStorageFailure(Attachment savedAttachment) {
+        try {
+            fileStorage.delete(savedAttachment);
+        } catch (RuntimeException cleanupException) {
+            log.warn("Attachment storage cleanup failed for id={}: {}",
+                    savedAttachment.getAttachmentId(), cleanupException.getMessage());
+        }
+        try {
+            attachmentRepository.delete(toEntity(savedAttachment));
+        } catch (RuntimeException cleanupException) {
+            log.warn("Attachment metadata cleanup failed for id={}: {}",
+                    savedAttachment.getAttachmentId(), cleanupException.getMessage());
+        }
     }
 }

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/service/AttachmentServiceImpl.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/service/AttachmentServiceImpl.java
@@ -38,7 +38,8 @@ import studio.one.platform.objecttype.service.ValidateUploadCommand;
 @Slf4j
 public class AttachmentServiceImpl implements AttachmentService {
 
-    private static final String CACHE_BY_ID = "attachments.byId"; 
+    private static final String CACHE_BY_ID = "attachments.byId";
+    private static final long MAX_BUFFER_BYTES = 50L * 1024 * 1024;
 
     private final AttachmentRepository attachmentRepository;
     private final FileStorage fileStorage;
@@ -136,9 +137,7 @@ public class AttachmentServiceImpl implements AttachmentService {
     public Attachment createAttachment(int objectType, long objectId, String name, String contentType, File file) {
         try (InputStream inputStream = new FileInputStream(file)) {
             long size = file.length();
-            if (size > Integer.MAX_VALUE) {
-                throw new IllegalArgumentException("File size exceeds supported limit");
-            }
+            validateInputSize(size);
             return createAttachment(objectType, objectId, name, contentType, inputStream, (int) size);
         } catch (IOException e) {
             throw new IllegalArgumentException(e.getMessage(), e);
@@ -164,6 +163,7 @@ public class AttachmentServiceImpl implements AttachmentService {
     public Attachment createAttachment(int objectType, long objectId, String name, String contentType,
             InputStream inputStream,
             int size) {
+        validateInputSize(size);
 
         validateObjectTypePolicy(objectType, name, contentType, size);
         
@@ -182,17 +182,15 @@ public class AttachmentServiceImpl implements AttachmentService {
                 attachment.setCreatedBy(principal.getUserId());
             }
         }
-        try (InputStream in = inputStream) {
-            Attachment savedAttachment = attachmentRepository.save(attachment);
-            try {
-                fileStorage.save(savedAttachment, in);
-                return savedAttachment;
-            } catch (RuntimeException e) {
-                cleanupAfterStorageFailure(savedAttachment, e);
-                throw e;
-            }
-        } catch (IOException e) {
-            throw new IllegalArgumentException(e.getMessage(), e);
+        Attachment savedAttachment = attachmentRepository.save(attachment);
+        try {
+            fileStorage.save(savedAttachment, inputStream);
+            return savedAttachment;
+        } catch (RuntimeException e) {
+            cleanupAfterStorageFailure(savedAttachment, e);
+            throw e;
+        } finally {
+            closeQuietly(inputStream);
         }
     }
 
@@ -253,9 +251,13 @@ public class AttachmentServiceImpl implements AttachmentService {
 
     private int bufferToTempFile(InputStream inputStream, Path bufferedInput) throws IOException {
         try (InputStream in = inputStream; var out = Files.newOutputStream(bufferedInput)) {
-            long copied = in.transferTo(out);
-            if (copied > Integer.MAX_VALUE) {
-                throw new IllegalArgumentException("File size exceeds supported limit");
+            byte[] buffer = new byte[8192];
+            long copied = 0L;
+            int read;
+            while ((read = in.read(buffer)) != -1) {
+                copied += read;
+                validateInputSize(copied);
+                out.write(buffer, 0, read);
             }
             return (int) copied;
         }
@@ -279,6 +281,23 @@ public class AttachmentServiceImpl implements AttachmentService {
             Files.deleteIfExists(bufferedInput);
         } catch (IOException ex) {
             log.debug("Failed to delete buffered upload temp file {}: {}", bufferedInput, ex.getMessage());
+        }
+    }
+
+    private void closeQuietly(InputStream inputStream) {
+        if (inputStream == null) {
+            return;
+        }
+        try {
+            inputStream.close();
+        } catch (IOException ex) {
+            log.warn("Failed to close attachment input stream cleanly: {}", ex.getMessage());
+        }
+    }
+
+    private void validateInputSize(long sizeBytes) {
+        if (sizeBytes < 0 || sizeBytes > MAX_BUFFER_BYTES || sizeBytes > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("File size exceeds supported limit");
         }
     }
 }

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/service/AttachmentServiceImpl.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/service/AttachmentServiceImpl.java
@@ -2,9 +2,10 @@ package studio.one.application.attachment.service;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
 
@@ -147,17 +148,15 @@ public class AttachmentServiceImpl implements AttachmentService {
     @Override
     public Attachment createAttachment(int objectType, long objectId, String name, String contentType,
             InputStream inputStream) {
+        Path bufferedInput = null;
         try {
-            byte[] bytes = inputStream.readAllBytes();
-            return createAttachment(
-                    objectType,
-                    objectId,
-                    name,
-                    contentType,
-                    new ByteArrayInputStream(bytes),
-                    bytes.length);
+            bufferedInput = Files.createTempFile("attachment-upload-", ".bin");
+            int size = bufferToTempFile(inputStream, bufferedInput);
+            return createAttachment(objectType, objectId, name, contentType, bufferedInput.toFile(), size);
         } catch (IOException e) {
             throw new IllegalArgumentException(e.getMessage(), e);
+        } finally {
+            deleteQuietly(bufferedInput);
         }
     }
 
@@ -183,13 +182,17 @@ public class AttachmentServiceImpl implements AttachmentService {
                 attachment.setCreatedBy(principal.getUserId());
             }
         }
-        Attachment savedAttachment = attachmentRepository.save(attachment);
-        try {
-            fileStorage.save(savedAttachment, inputStream);
-            return savedAttachment;
-        } catch (RuntimeException e) {
-            cleanupAfterStorageFailure(savedAttachment);
-            throw e;
+        try (InputStream in = inputStream) {
+            Attachment savedAttachment = attachmentRepository.save(attachment);
+            try {
+                fileStorage.save(savedAttachment, in);
+                return savedAttachment;
+            } catch (RuntimeException e) {
+                cleanupAfterStorageFailure(savedAttachment, e);
+                throw e;
+            }
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
         }
     }
 
@@ -240,18 +243,42 @@ public class AttachmentServiceImpl implements AttachmentService {
         runtimeService.validateUpload(objectType, request);
     }
 
-    private void cleanupAfterStorageFailure(Attachment savedAttachment) {
+    private Attachment createAttachment(int objectType, long objectId, String name, String contentType, File file, int size) {
+        try (InputStream inputStream = new FileInputStream(file)) {
+            return createAttachment(objectType, objectId, name, contentType, inputStream, size);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+    }
+
+    private int bufferToTempFile(InputStream inputStream, Path bufferedInput) throws IOException {
+        try (InputStream in = inputStream; var out = Files.newOutputStream(bufferedInput)) {
+            long copied = in.transferTo(out);
+            if (copied > Integer.MAX_VALUE) {
+                throw new IllegalArgumentException("File size exceeds supported limit");
+            }
+            return (int) copied;
+        }
+    }
+
+    private void cleanupAfterStorageFailure(Attachment savedAttachment, RuntimeException original) {
         try {
             fileStorage.delete(savedAttachment);
         } catch (RuntimeException cleanupException) {
             log.warn("Attachment storage cleanup failed for id={}: {}",
                     savedAttachment.getAttachmentId(), cleanupException.getMessage());
+            original.addSuppressed(cleanupException);
+        }
+    }
+
+    private void deleteQuietly(Path bufferedInput) {
+        if (bufferedInput == null) {
+            return;
         }
         try {
-            attachmentRepository.delete(toEntity(savedAttachment));
-        } catch (RuntimeException cleanupException) {
-            log.warn("Attachment metadata cleanup failed for id={}: {}",
-                    savedAttachment.getAttachmentId(), cleanupException.getMessage());
+            Files.deleteIfExists(bufferedInput);
+        } catch (IOException ex) {
+            log.debug("Failed to delete buffered upload temp file {}: {}", bufferedInput, ex.getMessage());
         }
     }
 }

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/service/AttachmentServiceImplTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/service/AttachmentServiceImplTest.java
@@ -1,0 +1,172 @@
+package studio.one.application.attachment.service;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+
+import studio.one.application.attachment.domain.entity.ApplicationAttachment;
+import studio.one.application.attachment.persistence.AttachmentRepository;
+import studio.one.application.attachment.storage.FileStorage;
+import studio.one.application.attachment.thumbnail.ThumbnailService;
+import studio.one.platform.identity.ApplicationPrincipal;
+import studio.one.platform.identity.PrincipalResolver;
+
+@ExtendWith(MockitoExtension.class)
+class AttachmentServiceImplTest {
+
+    @Mock
+    private AttachmentRepository attachmentRepository;
+
+    @Mock
+    private FileStorage fileStorage;
+
+    @Mock
+    private ObjectProvider<PrincipalResolver> principalResolverProvider;
+
+    @Mock
+    private ObjectProvider objectTypeRuntimeServiceProvider;
+
+    @Mock
+    private ObjectProvider<ThumbnailService> thumbnailServiceProvider;
+
+    @Test
+    void createAttachmentReadsFullStreamAndUsesExactSize() throws Exception {
+        AttachmentServiceImpl service = service();
+        byte[] payload = new byte[] { 1, 2, 3, 4 };
+        InputStream input = new NoAvailableInputStream(payload);
+
+        when(attachmentRepository.save(any())).thenAnswer(invocation -> {
+            ApplicationAttachment attachment = invocation.getArgument(0);
+            attachment.setAttachmentId(99L);
+            return attachment;
+        });
+        when(fileStorage.save(any(), any(InputStream.class))).thenAnswer(invocation -> {
+            InputStream stored = invocation.getArgument(1);
+            assertArrayEquals(payload, stored.readAllBytes());
+            return "stored";
+        });
+
+        ApplicationAttachment result = (ApplicationAttachment) service.createAttachment(
+                12,
+                34L,
+                "contract.pdf",
+                "application/pdf",
+                input);
+
+        assertEquals(99L, result.getAttachmentId());
+        assertEquals(4L, result.getSize());
+    }
+
+    @Test
+    void createAttachmentDeletesSavedRecordWhenStorageSaveFails() {
+        AttachmentServiceImpl service = service();
+        byte[] payload = new byte[] { 9, 8, 7 };
+        RuntimeException storageFailure = new RuntimeException("storage failed");
+
+        when(attachmentRepository.save(any())).thenAnswer(invocation -> {
+            ApplicationAttachment attachment = invocation.getArgument(0);
+            attachment.setAttachmentId(77L);
+            return attachment;
+        });
+        when(fileStorage.save(any(), any(InputStream.class))).thenThrow(storageFailure);
+
+        RuntimeException thrown = assertThrows(RuntimeException.class, () -> service.createAttachment(
+                12,
+                34L,
+                "report.pdf",
+                "application/pdf",
+                new ByteArrayInputStream(payload)));
+
+        assertSame(storageFailure, thrown);
+        InOrder order = inOrder(attachmentRepository, fileStorage);
+        order.verify(attachmentRepository).save(any(ApplicationAttachment.class));
+        order.verify(fileStorage).save(any(ApplicationAttachment.class), any(InputStream.class));
+        order.verify(fileStorage).delete(any(ApplicationAttachment.class));
+        order.verify(attachmentRepository).delete(any(ApplicationAttachment.class));
+    }
+
+    @Test
+    void createAttachmentStillDeletesMetadataWhenStorageCleanupFails() {
+        AttachmentServiceImpl service = service();
+        RuntimeException storageFailure = new RuntimeException("storage failed");
+
+        when(attachmentRepository.save(any())).thenAnswer(invocation -> {
+            ApplicationAttachment attachment = invocation.getArgument(0);
+            attachment.setAttachmentId(77L);
+            return attachment;
+        });
+        doThrow(storageFailure).when(fileStorage).save(any(), any(InputStream.class));
+        doThrow(new RuntimeException("cleanup failed")).when(fileStorage).delete(any(ApplicationAttachment.class));
+
+        RuntimeException thrown = assertThrows(RuntimeException.class, () -> service.createAttachment(
+                12,
+                34L,
+                "report.pdf",
+                "application/pdf",
+                new ByteArrayInputStream(new byte[] { 9, 8, 7 })));
+
+        assertSame(storageFailure, thrown);
+        verify(attachmentRepository).delete(any(ApplicationAttachment.class));
+    }
+
+    @Test
+    void createAttachmentStillAttemptsMetadataCleanupWhenDeleteUsesSavedEntity() {
+        AttachmentServiceImpl service = service();
+        RuntimeException storageFailure = new RuntimeException("storage failed");
+
+        when(attachmentRepository.save(any())).thenAnswer(invocation -> {
+            ApplicationAttachment attachment = invocation.getArgument(0);
+            attachment.setAttachmentId(77L);
+            return attachment;
+        });
+        doThrow(storageFailure).when(fileStorage).save(any(), any(InputStream.class));
+
+        RuntimeException thrown = assertThrows(RuntimeException.class, () -> service.createAttachment(
+                12,
+                34L,
+                "report.pdf",
+                "application/pdf",
+                new ByteArrayInputStream(new byte[] { 9, 8, 7 })));
+
+        assertSame(storageFailure, thrown);
+        verify(fileStorage).delete(any(ApplicationAttachment.class));
+        verify(attachmentRepository).delete(any(ApplicationAttachment.class));
+    }
+
+    private AttachmentServiceImpl service() {
+        return new AttachmentServiceImpl(
+                attachmentRepository,
+                fileStorage,
+                principalResolverProvider,
+                objectTypeRuntimeServiceProvider,
+                thumbnailServiceProvider);
+    }
+
+    private static final class NoAvailableInputStream extends ByteArrayInputStream {
+        private NoAvailableInputStream(byte[] buf) {
+            super(buf);
+        }
+
+        @Override
+        public synchronized int available() {
+            throw new AssertionError("available() must not be called");
+        }
+    }
+}

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/service/AttachmentServiceImplTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/service/AttachmentServiceImplTest.java
@@ -1,18 +1,18 @@
 package studio.one.application.attachment.service;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,10 +22,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.ObjectProvider;
 
 import studio.one.application.attachment.domain.entity.ApplicationAttachment;
+import studio.one.application.attachment.domain.model.Attachment;
 import studio.one.application.attachment.persistence.AttachmentRepository;
 import studio.one.application.attachment.storage.FileStorage;
 import studio.one.application.attachment.thumbnail.ThumbnailService;
-import studio.one.platform.identity.ApplicationPrincipal;
 import studio.one.platform.identity.PrincipalResolver;
 
 @ExtendWith(MockitoExtension.class)
@@ -41,113 +41,111 @@ class AttachmentServiceImplTest {
     private ObjectProvider<PrincipalResolver> principalResolverProvider;
 
     @Mock
+    @SuppressWarnings("rawtypes")
     private ObjectProvider objectTypeRuntimeServiceProvider;
 
     @Mock
     private ObjectProvider<ThumbnailService> thumbnailServiceProvider;
 
     @Test
-    void createAttachmentReadsFullStreamAndUsesExactSize() throws Exception {
+    void createAttachmentBuffersStreamInsteadOfUsingAvailable() {
         AttachmentServiceImpl service = service();
-        byte[] payload = new byte[] { 1, 2, 3, 4 };
-        InputStream input = new NoAvailableInputStream(payload);
+        AtomicInteger savedSize = new AtomicInteger();
+        AtomicInteger storedBytes = new AtomicInteger();
 
-        when(attachmentRepository.save(any())).thenAnswer(invocation -> {
+        when(attachmentRepository.save(any(ApplicationAttachment.class))).thenAnswer(invocation -> {
             ApplicationAttachment attachment = invocation.getArgument(0);
-            attachment.setAttachmentId(99L);
+            attachment.setAttachmentId(91L);
+            savedSize.set((int) attachment.getSize());
             return attachment;
         });
-        when(fileStorage.save(any(), any(InputStream.class))).thenAnswer(invocation -> {
-            InputStream stored = invocation.getArgument(1);
-            assertArrayEquals(payload, stored.readAllBytes());
-            return "stored";
+        when(fileStorage.save(any(Attachment.class), any(InputStream.class))).thenAnswer(invocation -> {
+            try (InputStream in = invocation.getArgument(1)) {
+                storedBytes.set(in.readAllBytes().length);
+            }
+            return "91";
         });
 
-        ApplicationAttachment result = (ApplicationAttachment) service.createAttachment(
+        Attachment saved = service.createAttachment(
                 12,
                 34L,
-                "contract.pdf",
+                "report.pdf",
                 "application/pdf",
-                input);
+                new ZeroAvailableInputStream(new byte[] { 1, 2, 3, 4 }));
 
-        assertEquals(99L, result.getAttachmentId());
-        assertEquals(4L, result.getSize());
+        assertEquals(4, savedSize.get());
+        assertEquals(4, storedBytes.get());
+        assertEquals(4, saved.getSize());
     }
 
     @Test
-    void createAttachmentDeletesSavedRecordWhenStorageSaveFails() {
+    void createAttachmentCleansUpPartialBinaryWhenFileSaveFails() {
         AttachmentServiceImpl service = service();
-        byte[] payload = new byte[] { 9, 8, 7 };
         RuntimeException storageFailure = new RuntimeException("storage failed");
 
-        when(attachmentRepository.save(any())).thenAnswer(invocation -> {
+        when(attachmentRepository.save(any(ApplicationAttachment.class))).thenAnswer(invocation -> {
             ApplicationAttachment attachment = invocation.getArgument(0);
-            attachment.setAttachmentId(77L);
+            attachment.setAttachmentId(33L);
             return attachment;
         });
-        when(fileStorage.save(any(), any(InputStream.class))).thenThrow(storageFailure);
+        when(fileStorage.save(any(Attachment.class), any(InputStream.class))).thenThrow(storageFailure);
 
         RuntimeException thrown = assertThrows(RuntimeException.class, () -> service.createAttachment(
                 12,
                 34L,
                 "report.pdf",
                 "application/pdf",
-                new ByteArrayInputStream(payload)));
+                new ByteArrayInputStream(new byte[] { 1, 2, 3 }),
+                3));
 
         assertSame(storageFailure, thrown);
-        InOrder order = inOrder(attachmentRepository, fileStorage);
-        order.verify(attachmentRepository).save(any(ApplicationAttachment.class));
-        order.verify(fileStorage).save(any(ApplicationAttachment.class), any(InputStream.class));
-        order.verify(fileStorage).delete(any(ApplicationAttachment.class));
-        order.verify(attachmentRepository).delete(any(ApplicationAttachment.class));
+        InOrder inOrder = inOrder(attachmentRepository, fileStorage);
+        inOrder.verify(attachmentRepository).save(any(ApplicationAttachment.class));
+        inOrder.verify(fileStorage).save(any(Attachment.class), any(InputStream.class));
+        inOrder.verify(fileStorage).delete(any(Attachment.class));
+        verify(attachmentRepository, never()).delete(any(ApplicationAttachment.class));
     }
 
     @Test
-    void createAttachmentStillDeletesMetadataWhenStorageCleanupFails() {
+    void createAttachmentDoesNotTouchStorageWhenMetadataSaveFails() {
         AttachmentServiceImpl service = service();
-        RuntimeException storageFailure = new RuntimeException("storage failed");
+        RuntimeException metadataFailure = new RuntimeException("metadata failed");
 
-        when(attachmentRepository.save(any())).thenAnswer(invocation -> {
-            ApplicationAttachment attachment = invocation.getArgument(0);
-            attachment.setAttachmentId(77L);
-            return attachment;
-        });
-        doThrow(storageFailure).when(fileStorage).save(any(), any(InputStream.class));
-        doThrow(new RuntimeException("cleanup failed")).when(fileStorage).delete(any(ApplicationAttachment.class));
+        when(attachmentRepository.save(any(ApplicationAttachment.class))).thenThrow(metadataFailure);
 
         RuntimeException thrown = assertThrows(RuntimeException.class, () -> service.createAttachment(
                 12,
                 34L,
                 "report.pdf",
                 "application/pdf",
-                new ByteArrayInputStream(new byte[] { 9, 8, 7 })));
+                new ByteArrayInputStream(new byte[] { 1, 2, 3 }),
+                3));
 
-        assertSame(storageFailure, thrown);
-        verify(attachmentRepository).delete(any(ApplicationAttachment.class));
+        assertSame(metadataFailure, thrown);
+        verify(fileStorage, never()).save(any(Attachment.class), any(InputStream.class));
+        verify(fileStorage, never()).delete(any(Attachment.class));
     }
 
     @Test
-    void createAttachmentStillAttemptsMetadataCleanupWhenDeleteUsesSavedEntity() {
+    void createAttachmentWithExplicitSizePreservesProvidedSize() {
         AttachmentServiceImpl service = service();
-        RuntimeException storageFailure = new RuntimeException("storage failed");
 
-        when(attachmentRepository.save(any())).thenAnswer(invocation -> {
+        when(attachmentRepository.save(any(ApplicationAttachment.class))).thenAnswer(invocation -> {
             ApplicationAttachment attachment = invocation.getArgument(0);
-            attachment.setAttachmentId(77L);
+            attachment.setAttachmentId(44L);
             return attachment;
         });
-        doThrow(storageFailure).when(fileStorage).save(any(), any(InputStream.class));
 
-        RuntimeException thrown = assertThrows(RuntimeException.class, () -> service.createAttachment(
+        Attachment saved = service.createAttachment(
                 12,
                 34L,
                 "report.pdf",
                 "application/pdf",
-                new ByteArrayInputStream(new byte[] { 9, 8, 7 })));
+                new ByteArrayInputStream(new byte[] { 1, 2, 3 }),
+                3);
 
-        assertSame(storageFailure, thrown);
-        verify(fileStorage).delete(any(ApplicationAttachment.class));
-        verify(attachmentRepository).delete(any(ApplicationAttachment.class));
+        assertEquals(3L, saved.getSize());
+        verify(fileStorage).save(any(Attachment.class), any(InputStream.class));
     }
 
     private AttachmentServiceImpl service() {
@@ -159,14 +157,15 @@ class AttachmentServiceImplTest {
                 thumbnailServiceProvider);
     }
 
-    private static final class NoAvailableInputStream extends ByteArrayInputStream {
-        private NoAvailableInputStream(byte[] buf) {
-            super(buf);
+    private static final class ZeroAvailableInputStream extends ByteArrayInputStream {
+
+        private ZeroAvailableInputStream(byte[] data) {
+            super(data);
         }
 
         @Override
         public synchronized int available() {
-            throw new AssertionError("available() must not be called");
+            return 0;
         }
     }
 }

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/service/AttachmentServiceImplTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/service/AttachmentServiceImplTest.java
@@ -27,6 +27,7 @@ import studio.one.application.attachment.persistence.AttachmentRepository;
 import studio.one.application.attachment.storage.FileStorage;
 import studio.one.application.attachment.thumbnail.ThumbnailService;
 import studio.one.platform.identity.PrincipalResolver;
+import studio.one.platform.objecttype.service.ObjectTypeRuntimeService;
 
 @ExtendWith(MockitoExtension.class)
 class AttachmentServiceImplTest {
@@ -41,8 +42,7 @@ class AttachmentServiceImplTest {
     private ObjectProvider<PrincipalResolver> principalResolverProvider;
 
     @Mock
-    @SuppressWarnings("rawtypes")
-    private ObjectProvider objectTypeRuntimeServiceProvider;
+    private ObjectProvider<ObjectTypeRuntimeService> objectTypeRuntimeServiceProvider;
 
     @Mock
     private ObjectProvider<ThumbnailService> thumbnailServiceProvider;

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/storage/JpaFileStoreTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/storage/JpaFileStoreTest.java
@@ -1,0 +1,63 @@
+package studio.one.application.attachment.storage;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.sql.Blob;
+import java.util.Optional;
+
+import javax.sql.rowset.serial.SerialBlob;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import studio.one.application.attachment.domain.entity.ApplicationAttachment;
+import studio.one.application.attachment.domain.entity.ApplicationAttachmentData;
+import studio.one.application.attachment.persistence.jpa.AttachmentDataJpaRepository;
+
+@ExtendWith(MockitoExtension.class)
+class JpaFileStoreTest {
+
+    @Mock
+    private AttachmentDataJpaRepository attachmentDataRepository;
+
+    @Test
+    void savePersistsBlobPayload() throws Exception {
+        JpaFileStore store = new JpaFileStore(attachmentDataRepository);
+        ApplicationAttachment attachment = attachment(91L);
+
+        store.save(attachment, new ByteArrayInputStream(new byte[] { 1, 2, 3 }));
+
+        ArgumentCaptor<ApplicationAttachmentData> captor = ArgumentCaptor.forClass(ApplicationAttachmentData.class);
+        verify(attachmentDataRepository).save(captor.capture());
+        ApplicationAttachmentData saved = captor.getValue();
+        try (var in = saved.getBlob().getBinaryStream()) {
+            assertArrayEquals(new byte[] { 1, 2, 3 }, in.readAllBytes());
+        }
+    }
+
+    @Test
+    void loadReadsStoredBlob() throws Exception {
+        JpaFileStore store = new JpaFileStore(attachmentDataRepository);
+        ApplicationAttachment attachment = attachment(91L);
+        Blob blob = new SerialBlob(new byte[] { 4, 5, 6 });
+
+        when(attachmentDataRepository.findById(91L))
+                .thenReturn(Optional.of(new ApplicationAttachmentData(91L, blob)));
+
+        try (var in = store.load(attachment)) {
+            assertArrayEquals(new byte[] { 4, 5, 6 }, in.readAllBytes());
+        }
+    }
+
+    private ApplicationAttachment attachment(long attachmentId) {
+        ApplicationAttachment attachment = new ApplicationAttachment();
+        attachment.setAttachmentId(attachmentId);
+        return attachment;
+    }
+}

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/storage/LocalFileStoreTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/storage/LocalFileStoreTest.java
@@ -1,0 +1,44 @@
+package studio.one.application.attachment.storage;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import studio.one.application.attachment.domain.entity.ApplicationAttachment;
+
+class LocalFileStoreTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void saveLoadAndDeleteRoundTrip() throws Exception {
+        LocalFileStore store = new LocalFileStore(tempDir.toString());
+        ApplicationAttachment attachment = attachment(12, 91L);
+
+        store.save(attachment, new ByteArrayInputStream(new byte[] { 1, 2, 3 }));
+
+        try (var in = store.load(attachment)) {
+            assertArrayEquals(new byte[] { 1, 2, 3 }, in.readAllBytes());
+        }
+
+        store.delete(attachment);
+
+        assertThrows(RuntimeException.class, () -> store.load(attachment));
+        assertFalse(Files.exists(tempDir.resolve("12").resolve("91")));
+    }
+
+    private ApplicationAttachment attachment(int objectType, long attachmentId) {
+        ApplicationAttachment attachment = new ApplicationAttachment();
+        attachment.setObjectType(objectType);
+        attachment.setAttachmentId(attachmentId);
+        return attachment;
+    }
+}


### PR DESCRIPTION
## Why
- #162
- attachment 저장 경로에 `InputStream.available()` 기반 size 추론이 남아 있었고, storage save 실패 시 cleanup 경계도 더 명확히 할 필요가 있었다.
- filesystem/JPA-backed 저장 경로에 대한 회귀 테스트가 부족했다.

## What
- `AttachmentServiceImpl`의 `InputStream` 업로드를 임시 파일 버퍼링으로 바꿔 실제 바이트 길이로 size를 계산하도록 정리했다.
- `AttachmentServiceImpl`의 `File` 기반 업로드는 입력 스트림을 try-with-resources로 닫고, 너무 큰 파일은 명시적으로 실패하도록 유지/보강했다.
- storage save 실패 시 partial binary cleanup을 best-effort로 수행하고, cleanup 실패는 원래 예외의 suppressed 예외로 보존하도록 정리했다.
- `AttachmentServiceImplTest`를 보강해 unknown-size stream, explicit size, storage failure cleanup 경계를 검증했다.
- `LocalFileStoreTest`, `JpaFileStoreTest`를 추가해 filesystem/JPA-backed 저장 경로를 검증했다.
- JPA-backed storage 테스트를 위해 `attachment-service` test scope에 `spring-boot-starter-data-jpa`를 추가했다.
- `README.md`와 `CHANGELOG.md`를 현재 동작에 맞게 갱신했다.

## Related Issues
- Closes #162

## Change Scope
- attachment-service 저장 정합성 및 회귀 테스트 보강

## Security Impact
- unknown-size stream 처리와 storage failure cleanup 경계를 명확히 해 partial binary 잔존 가능성을 줄였다.
- 메타데이터는 기존 트랜잭션 rollback 경계를 유지한다.

## Validation
- `./gradlew -p /tmp/studio-api-issue-162 :studio-application-modules:attachment-service:test --tests 'studio.one.application.attachment.service.AttachmentServiceImplTest' --tests 'studio.one.application.attachment.storage.LocalFileStoreTest' --tests 'studio.one.application.attachment.storage.JpaFileStoreTest'`
- `./gradlew -p /tmp/studio-api-issue-162 :studio-application-modules:attachment-service:compileJava`

## Subagent Usage
- coding: spring-boot-engineer style worker used for bounded attachment service/storage refactor work
- review: code-reviewer style explorer reserved for regression risk scan on storage consistency boundaries
- docs: docs-agent style explorer reserved for changelog/README impact check
- main author validation: final diff review, dependency trimming, test execution, and PR preparation were performed in the main author flow

## Checklist
- [x] Issue linked
- [x] AI-assisted title/body format applied
- [x] Validation recorded
- [x] No unrelated files included
- [x] Human review completed before merge
- [x] CI / repository verification passed

## Deployment Notes
- 없음