### PR TITLE
[ai-assisted] refactor(user): rename user endpoint API contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-04-08
+
+### 변경됨
+- `UserMgmtControllerApi`를 `UserMgmtApi`로 변경해 사용자 관리 엔드포인트 확장 인터페이스 이름에서 컨트롤러 구현 세부 표현을 제거했다.
+
+### 검증
+- `./gradlew :studio-platform-user:compileJava :studio-platform-user-default:compileJava :starter:studio-platform-starter-user:compileJava`
+- `rg "UserMgmtControllerApi|UserMgmtApi" studio-platform-user studio-platform-user-default starter/studio-platform-starter-user`
+
 ## 2026-03-31 (follow-up)
 
 ### 변경됨

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@
 
 ### 변경됨
 - `UserMgmtControllerApi`를 `UserMgmtApi`로 변경해 사용자 관리 엔드포인트 확장 인터페이스 이름에서 컨트롤러 구현 세부 표현을 제거했다.
+- `UserPublicControllerApi`, `UserMeControllerApi`, `UserAuthPublicControllerApi`도 같은 기준의 `UserPublicApi`, `UserMeApi`, `UserAuthPublicApi`로 정리했다.
+- 일반 사용자 정보 수정 시 기존 비밀번호 해시가 다시 인코딩되지 않도록 비밀번호 인코딩을 비밀번호 전용 변경/초기화 경로로 제한했다.
+- 일반 사용자 정보 수정 경로에서 mutator가 비밀번호 값을 변경하면 저장 전에 실패하도록 방어를 추가했다.
+- 일반 사용자 정보 수정과 비밀번호 초기화 경로를 구분하는 회귀 테스트를 추가했다.
 
 ### 검증
 - `./gradlew :studio-platform-user:compileJava :studio-platform-user-default:compileJava :starter:studio-platform-starter-user:compileJava`
-- `rg "UserMgmtControllerApi|UserMgmtApi" studio-platform-user studio-platform-user-default starter/studio-platform-starter-user`
+- `./gradlew :studio-platform-user-default:test --tests 'studio.one.base.user.service.impl.ApplicationUserServiceImplTest'`
+- `rg "User(Mgmt|Public|AuthPublic|Me)ControllerApi|User(Mgmt|Public|AuthPublic|Me)Api" studio-platform-user studio-platform-user-default starter/studio-platform-starter-user`
 
 ## 2026-03-31 (follow-up)
 

--- a/starter/studio-platform-starter-user/README.md
+++ b/starter/studio-platform-starter-user/README.md
@@ -123,7 +123,7 @@ studio:
 - `/api/self`
 
 기본 컨트롤러는 `ApplicationUserMapper`/`ApplicationUserService` 빈이 있을 때만 등록된다.
-커스텀 컨트롤러를 제공할 때는 `UserMgmtControllerApi`/`UserPublicControllerApi`/`UserMeControllerApi`
+커스텀 컨트롤러를 제공할 때는 `UserMgmtApi`/`UserPublicControllerApi`/`UserMeControllerApi`
 인터페이스를 구현하면 기본 컨트롤러가 자동으로 비활성화된다.
 
 커스텀 사용자 구현을 사용하는 경우 기본 컨트롤러를 끄는 것을 권장한다.

--- a/starter/studio-platform-starter-user/README.md
+++ b/starter/studio-platform-starter-user/README.md
@@ -123,7 +123,7 @@ studio:
 - `/api/self`
 
 기본 컨트롤러는 `ApplicationUserMapper`/`ApplicationUserService` 빈이 있을 때만 등록된다.
-커스텀 컨트롤러를 제공할 때는 `UserMgmtApi`/`UserPublicControllerApi`/`UserMeControllerApi`
+커스텀 컨트롤러를 제공할 때는 `UserMgmtApi`/`UserPublicApi`/`UserAuthPublicApi`/`UserMeApi`
 인터페이스를 구현하면 기본 컨트롤러가 자동으로 비활성화된다.
 
 커스텀 사용자 구현을 사용하는 경우 기본 컨트롤러를 끄는 것을 권장한다.

--- a/starter/studio-platform-starter-user/src/main/java/studio/one/platform/user/autoconfigure/UserEndpointsAutoConfiguration.java
+++ b/starter/studio-platform-starter-user/src/main/java/studio/one/platform/user/autoconfigure/UserEndpointsAutoConfiguration.java
@@ -46,7 +46,7 @@ import studio.one.base.user.web.controller.UserPublicController;
 import studio.one.base.user.web.controller.UserPublicControllerApi;
 import studio.one.base.user.web.controller.RoleMgmtController;
 import studio.one.base.user.web.controller.UserMgmtController;
-import studio.one.base.user.web.controller.UserMgmtControllerApi;
+import studio.one.base.user.web.controller.UserMgmtApi;
 import studio.one.base.user.web.mapper.ApplicationGroupMapper;
 import studio.one.base.user.web.mapper.ApplicationGroupMapperImpl;
 import studio.one.base.user.web.mapper.ApplicationRoleMapper;
@@ -132,7 +132,7 @@ public class UserEndpointsAutoConfiguration {
 
     @Bean
     @ConditionalOnBean({ ApplicationUserMapper.class, ApplicationUserService.class })
-    @ConditionalOnMissingBean(UserMgmtControllerApi.class)
+    @ConditionalOnMissingBean(UserMgmtApi.class)
     @ConditionalOnProperty(prefix = PropertyKeys.Features.User.Web.Endpoints.PREFIX + ".user", name = "enabled", havingValue = "true", matchIfMissing = true )
     public UserMgmtController userEndpoint(
             ApplicationUserService svc,

--- a/starter/studio-platform-starter-user/src/main/java/studio/one/platform/user/autoconfigure/UserEndpointsAutoConfiguration.java
+++ b/starter/studio-platform-starter-user/src/main/java/studio/one/platform/user/autoconfigure/UserEndpointsAutoConfiguration.java
@@ -39,11 +39,11 @@ import studio.one.base.user.service.ApplicationUserService;
 import studio.one.base.user.service.PasswordPolicyService;
 import studio.one.base.user.web.controller.GroupMgmtController;
 import studio.one.base.user.web.controller.UserMeController;
-import studio.one.base.user.web.controller.UserMeControllerApi;
+import studio.one.base.user.web.controller.UserMeApi;
 import studio.one.base.user.web.controller.UserAuthPublicController;
-import studio.one.base.user.web.controller.UserAuthPublicControllerApi;
+import studio.one.base.user.web.controller.UserAuthPublicApi;
 import studio.one.base.user.web.controller.UserPublicController;
-import studio.one.base.user.web.controller.UserPublicControllerApi;
+import studio.one.base.user.web.controller.UserPublicApi;
 import studio.one.base.user.web.controller.RoleMgmtController;
 import studio.one.base.user.web.controller.UserMgmtController;
 import studio.one.base.user.web.controller.UserMgmtApi;
@@ -150,7 +150,7 @@ public class UserEndpointsAutoConfiguration {
 
     @Bean
     @ConditionalOnBean({ ApplicationUserMapper.class, ApplicationUserService.class })
-    @ConditionalOnMissingBean(UserPublicControllerApi.class)
+    @ConditionalOnMissingBean(UserPublicApi.class)
     @ConditionalOnProperty(prefix = PropertyKeys.Features.User.Web.Endpoints.PREFIX + ".public", name = "enabled", havingValue = "true", matchIfMissing = true)
     public UserPublicController publicUserEndpoint(
             ApplicationUserService svc,
@@ -166,7 +166,7 @@ public class UserEndpointsAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean(UserAuthPublicControllerApi.class)
+    @ConditionalOnMissingBean(UserAuthPublicApi.class)
     @ConditionalOnProperty(prefix = PropertyKeys.Features.User.Web.Endpoints.PREFIX + ".public", name = "enabled", havingValue = "true", matchIfMissing = true)
     public UserAuthPublicController publicAuthUserEndpoint(
             ObjectProvider<PasswordPolicyService> passwordPolicyServiceProvider) {
@@ -196,7 +196,7 @@ public class UserEndpointsAutoConfiguration {
 
     @Bean
     @ConditionalOnBean({ ApplicationUserMapper.class, ApplicationUserService.class })
-    @ConditionalOnMissingBean(UserMeControllerApi.class)
+    @ConditionalOnMissingBean(UserMeApi.class)
     @ConditionalOnProperty(prefix = PropertyKeys.Features.User.Web.Self.PREFIX, name = "enabled", havingValue = "true", matchIfMissing = true)
     public UserMeController selfEndpoint(
             ApplicationUserService svc,

--- a/studio-platform-user-default/build.gradle.kts
+++ b/studio-platform-user-default/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     testImplementation("org.mapstruct:mapstruct:$mapstructVersion")
     testImplementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation("org.springframework.data:spring-data-commons")
+    testImplementation("org.springframework:spring-jdbc")
     testImplementation("org.springframework.security:spring-security-core")
     testImplementation(project(":studio-platform"))
     testImplementation(project(":studio-platform-user"))

--- a/studio-platform-user-default/src/main/java/studio/one/base/user/service/impl/ApplicationUserServiceImpl.java
+++ b/studio-platform-user-default/src/main/java/studio/one/base/user/service/impl/ApplicationUserServiceImpl.java
@@ -160,8 +160,11 @@ public class ApplicationUserServiceImpl implements ApplicationUserService<Applic
     public ApplicationUser update(Long userId, Consumer<ApplicationUser> mutator) {
         Objects.requireNonNull(mutator, "updater");
         ApplicationUser u = userRepo.findById(userId).orElseThrow(() -> UserNotFoundException.byId(userId));
+        String passwordBeforeUpdate = userMutator.getPassword(u);
         mutator.accept(u);
-        encodePasswordIfPresent(u);
+        if (!Objects.equals(passwordBeforeUpdate, userMutator.getPassword(u))) {
+            throw new IllegalArgumentException("Use password-specific service methods to change passwords.");
+        }
         log.debug("[UserUpdate] username={}, failedAttempts={}, lastFailedAt={}, lockedUntil={}", u.getUsername(),
                 u.getFailedAttempts(), u.getLastFailedAt(), u.getAccountLockedUntil());
         ApplicationUser saved = userRepo.save(u);

--- a/studio-platform-user-default/src/main/java/studio/one/base/user/web/controller/UserAuthPublicController.java
+++ b/studio-platform-user-default/src/main/java/studio/one/base/user/web/controller/UserAuthPublicController.java
@@ -14,7 +14,7 @@ import studio.one.platform.web.dto.ApiResponse;
 @RestController
 @RequestMapping("/api/public/auth")
 @RequiredArgsConstructor
-public class UserAuthPublicController extends AbstractPasswordPolicyControllerSupport implements UserAuthPublicControllerApi {
+public class UserAuthPublicController extends AbstractPasswordPolicyControllerSupport implements UserAuthPublicApi {
 
     private final PasswordPolicyService passwordPolicyService;
 

--- a/studio-platform-user-default/src/main/java/studio/one/base/user/web/controller/UserMeController.java
+++ b/studio-platform-user-default/src/main/java/studio/one/base/user/web/controller/UserMeController.java
@@ -41,7 +41,7 @@ import studio.one.platform.web.dto.ApiResponse;
 @RequestMapping("${" + PropertyKeys.Features.User.Web.Self.PATH + ":/api/self}")
 @RequiredArgsConstructor
 @Slf4j
-public class UserMeController extends AbstractPasswordPolicyControllerSupport implements UserMeControllerApi {
+public class UserMeController extends AbstractPasswordPolicyControllerSupport implements UserMeApi {
     private final ApplicationUserService<User, Role> userService;
     private final ApplicationUserMapper mapper;
     private final PasswordPolicyService passwordPolicyService;

--- a/studio-platform-user-default/src/main/java/studio/one/base/user/web/controller/UserMgmtController.java
+++ b/studio-platform-user-default/src/main/java/studio/one/base/user/web/controller/UserMgmtController.java
@@ -76,7 +76,7 @@ import studio.one.platform.web.dto.ApiResponse;
 @RequestMapping("${" + PropertyKeys.Features.User.Web.BASE_PATH + ":/api/mgmt}/users")
 @RequiredArgsConstructor
 @Slf4j
-public class UserMgmtController extends AbstractPasswordPolicyControllerSupport implements UserMgmtControllerApi {
+public class UserMgmtController extends AbstractPasswordPolicyControllerSupport implements UserMgmtApi {
 
         private final ApplicationUserService<User, Role> userService;
         private final ApplicationUserMapper userMapper;

--- a/studio-platform-user-default/src/main/java/studio/one/base/user/web/controller/UserPublicController.java
+++ b/studio-platform-user-default/src/main/java/studio/one/base/user/web/controller/UserPublicController.java
@@ -62,7 +62,7 @@ import studio.one.platform.constant.PropertyKeys;
 @RequestMapping("${" + PropertyKeys.Features.User.PREFIX + ".public-path:/api/users}")
 @RequiredArgsConstructor 
 @Slf4j
-public class UserPublicController extends AbstractPasswordPolicyControllerSupport implements UserPublicControllerApi {
+public class UserPublicController extends AbstractPasswordPolicyControllerSupport implements UserPublicApi {
 
     private final ApplicationUserService<User, Role> userService;
     private final ApplicationUserMapper userMapper;

--- a/studio-platform-user-default/src/test/java/studio/one/base/user/service/impl/ApplicationUserServiceImplTest.java
+++ b/studio-platform-user-default/src/test/java/studio/one/base/user/service/impl/ApplicationUserServiceImplTest.java
@@ -1,0 +1,139 @@
+package studio.one.base.user.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import studio.one.base.user.domain.entity.ApplicationUser;
+import studio.one.base.user.persistence.ApplicationGroupMembershipRepository;
+import studio.one.base.user.persistence.ApplicationGroupRepository;
+import studio.one.base.user.persistence.ApplicationRoleRepository;
+import studio.one.base.user.persistence.ApplicationUserRepository;
+import studio.one.base.user.persistence.ApplicationUserRoleRepository;
+import studio.one.base.user.service.PasswordPolicyService;
+import studio.one.platform.service.DomainEvents;
+import studio.one.platform.service.I18n;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicationUserServiceImplTest {
+
+    @Mock
+    private ApplicationUserRepository userRepo;
+
+    @Mock
+    private ApplicationRoleRepository roleRepo;
+
+    @Mock
+    private ApplicationGroupRepository groupRepo;
+
+    @Mock
+    private ApplicationUserRoleRepository userRoleRepo;
+
+    @Mock
+    private ApplicationGroupMembershipRepository membershipRepo;
+
+    @Mock
+    private org.springframework.jdbc.core.JdbcTemplate jdbcTemplate;
+
+    @Mock
+    private ObjectProvider<PasswordEncoder> passwordEncoderProvider;
+
+    @Mock
+    private ObjectProvider<DomainEvents> domainEventsProvider;
+
+    @Mock
+    private ObjectProvider<I18n> i18nProvider;
+
+    @Mock
+    private ObjectProvider<PasswordPolicyService> passwordPolicyValidatorProvider;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private PasswordPolicyService passwordPolicyService;
+
+    @Test
+    void updateDoesNotReencodeExistingPassword() {
+        ApplicationUser user = ApplicationUser.builder()
+                .userId(10L)
+                .username("user")
+                .password("{bcrypt}existing-hash")
+                .build();
+        when(userRepo.findById(10L)).thenReturn(Optional.of(user));
+        when(userRepo.save(user)).thenReturn(user);
+
+        ApplicationUser updated = service().update(10L, u -> u.setName("Updated"));
+
+        assertEquals("{bcrypt}existing-hash", updated.getPassword());
+        verify(passwordEncoderProvider, never()).getIfAvailable();
+        verify(passwordEncoder, never()).encode(any());
+    }
+
+    @Test
+    void updateRejectsPasswordChanges() {
+        ApplicationUser user = ApplicationUser.builder()
+                .userId(10L)
+                .username("user")
+                .password("{bcrypt}existing-hash")
+                .build();
+        when(userRepo.findById(10L)).thenReturn(Optional.of(user));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service().update(10L, u -> u.setPassword("plain-password")));
+
+        assertEquals("plain-password", user.getPassword());
+        verify(userRepo, never()).save(any());
+        verify(passwordEncoderProvider, never()).getIfAvailable();
+    }
+
+    @Test
+    void resetPasswordEncodesNewPassword() {
+        ApplicationUser user = ApplicationUser.builder()
+                .userId(10L)
+                .username("user")
+                .password("{bcrypt}existing-hash")
+                .build();
+        when(userRepo.findById(10L)).thenReturn(Optional.of(user));
+        when(passwordPolicyValidatorProvider.getIfAvailable()).thenReturn(passwordPolicyService);
+        when(passwordEncoderProvider.getIfAvailable()).thenReturn(passwordEncoder);
+        when(passwordEncoder.encode("NextPassword123!")).thenReturn("{bcrypt}next-hash");
+
+        String reason = "test";
+
+        service().resetPassword(10L, "NextPassword123!", "admin", reason);
+
+        assertEquals("{bcrypt}next-hash", user.getPassword());
+        verify(passwordPolicyService).validate("NextPassword123!");
+        verify(userRepo).save(user);
+    }
+
+    private ApplicationUserServiceImpl service() {
+        return new ApplicationUserServiceImpl(
+                userRepo,
+                roleRepo,
+                groupRepo,
+                userRoleRepo,
+                membershipRepo,
+                jdbcTemplate,
+                passwordEncoderProvider,
+                domainEventsProvider,
+                Clock.systemUTC(),
+                i18nProvider,
+                new ApplicationUserMutator(),
+                passwordPolicyValidatorProvider);
+    }
+}

--- a/studio-platform-user/src/main/java/studio/one/base/user/web/controller/UserAuthPublicApi.java
+++ b/studio-platform-user/src/main/java/studio/one/base/user/web/controller/UserAuthPublicApi.java
@@ -3,14 +3,9 @@ package studio.one.base.user.web.controller;
 import org.springframework.http.ResponseEntity;
 
 import studio.one.base.user.web.dto.PasswordPolicyDto;
-import studio.one.base.user.web.dto.UserPublicDto;
 import studio.one.platform.web.dto.ApiResponse;
 
-public interface UserPublicControllerApi {
-
-    ResponseEntity<ApiResponse<UserPublicDto>> getByName(String name);
-
-    ResponseEntity<ApiResponse<UserPublicDto>> getById(Long id);
+public interface UserAuthPublicApi {
 
     ResponseEntity<ApiResponse<PasswordPolicyDto>> passwordPolicy();
 }

--- a/studio-platform-user/src/main/java/studio/one/base/user/web/controller/UserMeApi.java
+++ b/studio-platform-user/src/main/java/studio/one/base/user/web/controller/UserMeApi.java
@@ -10,7 +10,7 @@ import studio.one.base.user.web.dto.MePasswordChangeRequest;
 import studio.one.platform.web.dto.ApiResponse;
 import studio.one.base.user.web.dto.PasswordPolicyDto;
 
-public interface UserMeControllerApi {
+public interface UserMeApi {
 
     ResponseEntity<ApiResponse<MeProfileDto>> me(UserDetails principal);
 

--- a/studio-platform-user/src/main/java/studio/one/base/user/web/controller/UserMgmtApi.java
+++ b/studio-platform-user/src/main/java/studio/one/base/user/web/controller/UserMgmtApi.java
@@ -23,7 +23,7 @@ import studio.one.base.user.web.dto.UserBasicDto;
 import studio.one.base.user.web.dto.UserDto;
 import studio.one.platform.web.dto.ApiResponse;
 
-public interface UserMgmtControllerApi {
+public interface UserMgmtApi {
 
     ResponseEntity<ApiResponse<Long>> register(@Valid @RequestBody CreateUserRequest request,
             HttpServletRequest http);

--- a/studio-platform-user/src/main/java/studio/one/base/user/web/controller/UserPublicApi.java
+++ b/studio-platform-user/src/main/java/studio/one/base/user/web/controller/UserPublicApi.java
@@ -3,9 +3,14 @@ package studio.one.base.user.web.controller;
 import org.springframework.http.ResponseEntity;
 
 import studio.one.base.user.web.dto.PasswordPolicyDto;
+import studio.one.base.user.web.dto.UserPublicDto;
 import studio.one.platform.web.dto.ApiResponse;
 
-public interface UserAuthPublicControllerApi {
+public interface UserPublicApi {
+
+    ResponseEntity<ApiResponse<UserPublicDto>> getByName(String name);
+
+    ResponseEntity<ApiResponse<UserPublicDto>> getById(Long id);
 
     ResponseEntity<ApiResponse<PasswordPolicyDto>> passwordPolicy();
 }


### PR DESCRIPTION
## Why
- 사용자 엔드포인트 계약 인터페이스는 컨트롤러 구현과 분리되어야 하므로, 공개 계약 이름에 `Controller` 구현 세부 표현을 포함하지 않도록 정리합니다.
- 일반 사용자 정보 수정 시 generic update 경로에서 매번 비밀번호 인코딩을 호출해 기존 비밀번호 해시가 다시 인코딩될 수 있었습니다.
- generic update mutator가 비밀번호를 직접 변경하면 평문 비밀번호가 저장될 수 있으므로, 비밀번호 변경은 전용 경로로만 허용하도록 방어가 필요합니다.
- 이 환경에서는 Issue를 생성하지 않았으며, 작업 배경은 커밋 본문과 이 PR 본문에 기록합니다.

## What
- 사용자 엔드포인트 계약 인터페이스 이름을 `*ControllerApi`에서 `*Api`로 변경했습니다.
  - `UserMgmtApi`
  - `UserPublicApi`
  - `UserAuthPublicApi`
  - `UserMeApi`
- 기본 컨트롤러 구현체, starter auto-configuration의 조건부 빈 타입, starter README의 커스텀 컨트롤러 확장 포인트 문서를 갱신했습니다.
- `ApplicationUserServiceImpl.update`의 일반 사용자 정보 수정 경로에서 비밀번호 인코딩 호출을 제거했습니다.
- generic update mutator가 비밀번호 값을 변경하면 저장 전에 `IllegalArgumentException`으로 실패하도록 방어를 추가했습니다.
- 비밀번호 변경/초기화 전용 경로는 기존처럼 비밀번호 정책 검증과 인코딩을 담당하도록 유지했습니다.
- 일반 update가 기존 비밀번호 해시를 보존하고, generic update의 비밀번호 변경 시도는 저장 전에 거부하며, `resetPassword`는 새 비밀번호를 인코딩하는지 검증하는 서비스 레벨 회귀 테스트를 추가했습니다.
- `CHANGELOG.md`를 갱신했습니다.

## Related Issues
- Closes N/A
- Related N/A
- 이 환경에서는 Issue를 생성하지 않았으며, 작업 배경은 이 PR과 커밋 본문에 기록했습니다.

## Change Scope
- [x] API contract
- [x] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [x] Docs/runbook

## Security Impact
- Risk: 낮음. 일반 사용자 정보 수정 경로에서 저장된 비밀번호 해시를 다시 인코딩하지 않도록 변경했고, generic update 경로의 비밀번호 직접 변경도 저장 전에 거부합니다. 비밀번호 변경은 전용 경로로 제한됩니다.
- Mitigation: 일반 update, generic update 비밀번호 변경 거부, password reset 동작을 구분하는 회귀 테스트를 추가했습니다.

## Validation
- Commands:
  - `./gradlew :studio-platform-user-default:test --tests 'studio.one.base.user.service.impl.ApplicationUserServiceImplTest'`
  - `./gradlew :studio-platform-user:compileJava :studio-platform-user-default:compileJava :starter:studio-platform-starter-user:compileJava`
  - `rg 'update\([^\n;]*setPassword|setPassword[^\n;]*update|\.update\([^\n]*->[^\n]*setPassword' /Users/donghyuck.son/git/studio-api --glob '*.java' --glob '!**/build/**'`
  - `rg 'User(Mgmt|Public|AuthPublic|Me)ControllerApi|User(Mgmt|Public|AuthPublic|Me)Api' studio-platform-user studio-platform-user-default starter/studio-platform-starter-user`
  - `rg 'User(AuthPublic|Public|Me|Mgmt)ControllerApi|ControllerApi' starter/studio-platform-starter-user/README.md`
  - `git diff --check`
- Result:
  - 테스트 명령은 성공했습니다. 기존 JPA enum classpath warning은 남아 있습니다.
  - compile 명령은 성공했습니다.
  - `update(...setPassword...)` 검색 결과 production 호출 경로는 없고, 새 회귀 테스트만 매칭됩니다.
  - API 참조 검색 결과 `*ControllerApi` 잔여 참조는 없고, `*Api` 이름만 예상 위치에 남아 있습니다.
  - README에는 `ControllerApi` 잔여 참조가 없습니다.
  - diff whitespace check는 통과했습니다.
- Additional checks:
  - PR diff에는 기존 unrelated local working tree 변경이 포함되지 않았습니다.

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [ ] No
- [x] Yes
- Delegated tasks: N/A
- Ownership (files/modules/tasks): N/A
- Main author post-integration validation: N/A

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: 이 계약 인터페이스를 구현하는 소비자는 import와 implements 대상 이름을 `*ControllerApi`에서 `*Api`로 변경해야 합니다.
- Rollback plan: downstream 호환성 때문에 이전 인터페이스명이 필요하면 이 PR의 커밋들을 revert합니다.
- Post-deploy checks: 사용자 프로필 수정 후 의도치 않은 비밀번호 해시 재인코딩으로 로그인이 깨지지 않는지, generic update 경로에서 비밀번호 변경 시도가 거부되는지 확인합니다.
