### PR TITLE
[ai-assisted] chore(nexus): load local publish env file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `gradle.properties`를 수정하지 않고 로컬 Nexus로 배포할 수 있도록 `scripts/publish-local-nexus.sh`를 추가했다.
 - 로컬 Nexus에 같은 버전의 모듈이 이미 있을 때 `--delete-existing`로 전체 모듈을 확인해 삭제 후 재배포할 수 있도록 했다.
 - 특정 모듈만 처리할 수 있도록 `--delete-existing --module <gradle-path>`도 지원한다.
+- 로컬 Nexus 배포 스크립트가 기본적으로 `.env.local`을 읽어 `NEXUS_USERNAME`, `NEXUS_PASSWORD`, `NEXUS_URL` 값을 사용할 수 있도록 했다.
 - README에 로컬 Nexus 배포 절차와 특정 모듈 publish 예시를 추가했다.
 
 ### 검증

--- a/README.md
+++ b/README.md
@@ -128,10 +128,11 @@ gradle wrapper
 
 ## 로컬 Nexus 배포
 개발 중 로컬 Nexus에 배포할 때는 `gradle.properties`를 수정하지 말고 로컬 배포 스크립트를 사용한다.
+스크립트는 기본적으로 `.env.local`을 읽으며, 이미 셸에 설정된 환경변수는 덮어쓰지 않는다.
 
 ```bash
-export NEXUS_USERNAME=...
-export NEXUS_PASSWORD=...
+NEXUS_USERNAME=...
+NEXUS_PASSWORD=...
 scripts/publish-local-nexus.sh
 ```
 
@@ -158,6 +159,7 @@ scripts/publish-local-nexus.sh --delete-existing --module :studio-platform-user
 `http://localhost:8081/repository/maven-snapshots/`를 사용하며, repository URL과
 `nexus.allowInsecure=true` 값을 Gradle project property로 전달한다.
 로컬 Nexus base URL이 다르면 `NEXUS_URL` 환경변수로 변경할 수 있다.
+다른 env 파일을 쓰려면 `--env-file <path>`를 전달한다.
 
 ## 보안 설정
 - secret은 저장소에 커밋하지 않고 환경변수 또는 `~/.gradle/gradle.properties` 로만 주입한다.

--- a/scripts/publish-local-nexus.sh
+++ b/scripts/publish-local-nexus.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 LOCAL_NEXUS_RELEASES_URL="http://localhost:8081/repository/maven-releases/"
 LOCAL_NEXUS_SNAPSHOTS_URL="http://localhost:8081/repository/maven-snapshots/"
 LOCAL_NEXUS_BASE_URL="${NEXUS_URL:-http://localhost:8081}"
+ENV_FILE=".env.local"
 DELETE_EXISTING=false
 MODULE_PATH=""
 
@@ -14,6 +15,8 @@ Usage: scripts/publish-local-nexus.sh [options] [gradle-task-or-args...]
 Publishes to the local Nexus repositories without editing gradle.properties.
 
 Options:
+  --env-file <path>       Load environment variables from this file.
+                          Default: .env.local
   --delete-existing       Delete existing local Nexus components before publish.
   --module <gradle-path>  Module to delete/publish, for example :studio-platform-user.
                           If omitted with --delete-existing, all included modules are checked.
@@ -32,6 +35,44 @@ Examples:
   scripts/publish-local-nexus.sh --delete-existing
   scripts/publish-local-nexus.sh --delete-existing --module :studio-platform-user
 USAGE
+}
+
+load_env_file() {
+  local env_file="$1"
+  local line
+  local key
+  local value
+
+  [[ -f "${env_file}" ]] || return
+
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    [[ -z "${line}" || "${line}" == \#* ]] && continue
+    [[ "${line}" == export\ * ]] && line="${line#export }"
+    [[ "${line}" == *=* ]] || continue
+
+    key="${line%%=*}"
+    value="${line#*=}"
+    key="${key#"${key%%[![:space:]]*}"}"
+    key="${key%"${key##*[![:space:]]}"}"
+
+    if [[ ! "${key}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      continue
+    fi
+
+    if [[ -n "${!key:-}" ]]; then
+      continue
+    fi
+
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    if [[ "${value}" == \"*\" && "${value}" == *\" ]]; then
+      value="${value:1:${#value}-2}"
+    elif [[ "${value}" == \'*\' && "${value}" == *\' ]]; then
+      value="${value:1:${#value}-2}"
+    fi
+
+    export "${key}=${value}"
+  done < "${env_file}"
 }
 
 read_property() {
@@ -138,6 +179,14 @@ while [[ $# -gt 0 ]]; do
       usage
       exit 0
       ;;
+    --env-file)
+      if [[ -z "${2:-}" ]]; then
+        echo "[ERROR] --env-file requires a path." >&2
+        exit 1
+      fi
+      ENV_FILE="$2"
+      shift 2
+      ;;
     --delete-existing)
       DELETE_EXISTING=true
       shift
@@ -156,6 +205,9 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+load_env_file "${ENV_FILE}"
+LOCAL_NEXUS_BASE_URL="${NEXUS_URL:-${LOCAL_NEXUS_BASE_URL}}"
 
 if [[ -z "${NEXUS_USERNAME:-}" ]]; then
   echo "[ERROR] NEXUS_USERNAME is required for local Nexus publish." >&2


### PR DESCRIPTION
## Why
- 로컬 Nexus 배포 스크립트가 `NEXUS_USERNAME`/`NEXUS_PASSWORD`를 매번 셸에 export하지 않아도 `.env.local`에서 읽을 수 있어야 합니다.
- `.env.local`은 gitignore 대상이므로 로컬 credential을 저장소에 커밋하지 않고 사용할 수 있습니다.
- 이 환경에서는 Issue를 생성하지 않았으며, 작업 배경은 커밋 본문과 이 PR 본문에 기록합니다.

## What
- `scripts/publish-local-nexus.sh`가 기본적으로 `.env.local`을 읽도록 했습니다.
- 이미 셸에 export된 환경변수는 `.env.local` 값으로 덮어쓰지 않도록 했습니다.
- `--env-file <path>` 옵션으로 다른 env 파일을 지정할 수 있게 했습니다.
- README에 `.env.local` 사용 방식과 `--env-file` 옵션을 문서화했습니다.
- `CHANGELOG.md`에 `.env.local` 로드 지원을 기록했습니다.

## Related Issues
- Closes N/A
- Related N/A
- 이 환경에서는 Issue를 생성하지 않았으며, 작업 배경은 이 PR과 커밋 본문에 기록했습니다.

## Change Scope
- [ ] API contract
- [ ] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [x] Docs/runbook

## Security Impact
- Risk: 낮음. 인증 정보는 repository-tracked 파일에 쓰지 않고 환경변수 또는 gitignore 대상 `.env.local`에서만 읽습니다.
- Mitigation: `.env.local`은 `.gitignore` 대상임을 확인했고, 스크립트는 이미 export된 환경변수를 덮어쓰지 않습니다.

## Validation
- Commands:
  - `bash -n scripts/publish-local-nexus.sh`
  - `scripts/publish-local-nexus.sh --help`
  - `env -i PATH="$PATH" HOME="$HOME" scripts/publish-local-nexus.sh --env-file /tmp/nonexistent-env`
  - `git diff --check`
- Result:
  - shell 문법 검사는 통과했습니다.
  - help 출력에 `--env-file`, 전체 모듈 삭제 모드, 특정 모듈 삭제 모드가 표시되는 것을 확인했습니다.
  - env 파일과 환경변수가 모두 없으면 publish 전에 실패하는 것을 확인했습니다.
  - diff whitespace check는 통과했습니다.
- Additional checks:
  - 실제 Nexus delete/publish는 로컬 Nexus 실행/계정이 필요한 작업이라 수행하지 않았습니다.
  - PR 커밋에는 기존 local `gradle.properties`, `.claude/`, `.omx/`, `.env.local` 변경이 포함되지 않았습니다.

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [ ] No
- [x] Yes
- Delegated tasks: N/A
- Ownership (files/modules/tasks): N/A
- Main author post-integration validation: N/A

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: 개발자는 로컬 Nexus 배포 시 `.env.local`에 `NEXUS_USERNAME`/`NEXUS_PASSWORD`를 둘 수 있습니다.
- Rollback plan: 문제가 있으면 이 PR의 커밋을 revert합니다.
- Post-deploy checks: 로컬 Nexus가 실행 중인 환경에서 `.env.local` 기반 `scripts/publish-local-nexus.sh --delete-existing` 실행을 확인합니다.