### PR TITLE
fix(avatar): use lowercase column name in usingGeneratedKeyColumns for PostgreSQL

### DIFF
--- a/studio-application-modules/avatar-service/src/main/java/studio/one/application/avatar/persistence/jdbc/AvatarImageJdbcRepository.java
+++ b/studio-application-modules/avatar-service/src/main/java/studio/one/application/avatar/persistence/jdbc/AvatarImageJdbcRepository.java
@@ -33,7 +33,7 @@ public class AvatarImageJdbcRepository implements AvatarImageRepository {
         this.template = template;
         this.insert = new SimpleJdbcInsert(template.getJdbcTemplate())
                 .withTableName(TABLE)
-                .usingGeneratedKeyColumns("AVATAR_IMAGE_ID");
+                .usingGeneratedKeyColumns("avatar_image_id");
     }
 
     private static final RowMapper<AvatarImage> ROW_MAPPER = (rs, rowNum) -> AvatarImage.builder()


### PR DESCRIPTION
## Why
- `SimpleJdbcInsert.usingGeneratedKeyColumns("AVATAR_IMAGE_ID")` 에서 대문자 컬럼명을 사용하면 PostgreSQL이 이를 quoted identifier로 처리하여 `column "AVATAR_IMAGE_ID" does not exist` 오류가 발생합니다.
- PostgreSQL은 DDL의 unquoted identifier를 lowercase로 저장하므로, 실제 컬럼명은 `avatar_image_id`입니다.
- `POST /api/mgmt/users/{id}/avatars` 아바타 업로드 시 매번 실패하는 버그를 수정합니다.

## What
- `AvatarImageJdbcRepository` 생성자에서 `usingGeneratedKeyColumns("AVATAR_IMAGE_ID")` → `usingGeneratedKeyColumns("avatar_image_id")` 로 수정했습니다 (1줄).

## Related Issues
- Closes N/A
- Related N/A

## Change Scope
- [ ] API contract
- [x] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [ ] Docs/runbook

## Security Impact
- Risk: 없음. 컬럼명 케이스 수정으로 보안 영향 없습니다.
- Mitigation: N/A

## Validation
- Commands:
  - `POST /api/mgmt/users/1/avatars` 아바타 업로드 API 호출
- Result:
  - 수정 전: `org.postgresql.util.PSQLException: ERROR: column "AVATAR_IMAGE_ID" does not exist` 오류 발생
  - 수정 후: INSERT 성공 및 생성된 key 정상 반환 예상
- Additional checks:
  - `RowMapper`에서 `rs.getLong("AVATAR_IMAGE_ID")` 및 SELECT 쿼리의 대문자 컬럼명은 PostgreSQL에서 case-insensitive하게 동작하므로 추가 수정 불필요

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [ ] No
- [x] Yes
- Delegated tasks: N/A
- Ownership (files/modules/tasks): N/A
- Main author post-integration validation: N/A

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: 없음. 코드 수정만으로 적용됩니다.
- Rollback plan: 문제가 있으면 이 PR의 커밋을 revert합니다.
- Post-deploy checks: `POST /api/mgmt/users/{id}/avatars` 업로드 성공 및 업로드된 아바타 조회 정상 동작 확인.