### PR TITLE
fix(autoconfigure): rename entityScanRegistrar beans to avoid conflict

### DIFF
--- a/starter/studio-application-starter-attachment/src/main/java/studio/one/application/attachment/autoconfigure/AttachmentAutoConfiguration.java
+++ b/starter/studio-application-starter-attachment/src/main/java/studio/one/application/attachment/autoconfigure/AttachmentAutoConfiguration.java
@@ -260,7 +260,7 @@ public class AttachmentAutoConfiguration {
     @SuppressWarnings("java:S1118")
     static class EntityScanConfig {
         @Bean
-        static BeanDefinitionRegistryPostProcessor entityScanRegistrar(Environment env) {
+        static BeanDefinitionRegistryPostProcessor attachmentEntityScanRegistrar(Environment env) {
             String entityKey = PropertyKeys.Features.PREFIX + ".attachment.entity-packages";
             String packageName = ApplicationAttachment.class.getPackageName();
             return EntityScanRegistrarSupport.entityScanRegistrar(entityKey, packageName);

--- a/starter/studio-application-starter-avatar/src/main/java/studio/one/application/avatar/autoconfigure/AvatarAutoConfiguration.java
+++ b/starter/studio-application-starter-avatar/src/main/java/studio/one/application/avatar/autoconfigure/AvatarAutoConfiguration.java
@@ -126,7 +126,7 @@ public class AvatarAutoConfiguration {
     @SuppressWarnings("java:S1118")
     static class EntityScanConfig {
         @Bean
-        static BeanDefinitionRegistryPostProcessor  entityScanRegistrar(Environment env , ObjectProvider<I18n> i18nProvider) { 
+        static BeanDefinitionRegistryPostProcessor avatarEntityScanRegistrar(Environment env, ObjectProvider<I18n> i18nProvider) {
             I18n i18n = I18nUtils.resolve(i18nProvider);
             String entityKey = PropertyKeys.Features.PREFIX + ".avatar-image.entity-packages";
             String packageName = AvatarImage.class.getPackageName();


### PR DESCRIPTION
## Why
- `AttachmentAutoConfiguration`과 `AvatarAutoConfiguration` 모두 `entityScanRegistrar`라는 동일한 이름의 `@Bean` 메서드를 가지고 있어, 두 스타터가 함께 로드될 때 `BeanDefinitionOverrideException`이 발생하며 애플리케이션 기동에 실패합니다.
- 다른 모든 스타터(`jwtEntityScanRegistrar`, `auditEntityScanRegistrar`, `userEntityScanRegistrar` 등)는 모듈별 고유 이름을 사용하는 컨벤션을 따르고 있었으나 이 두 모듈에서 누락되었습니다.

## What
- `AttachmentAutoConfiguration$EntityScanConfig`: `entityScanRegistrar` → `attachmentEntityScanRegistrar`
- `AvatarAutoConfiguration$EntityScanConfig`: `entityScanRegistrar` → `avatarEntityScanRegistrar`

## Related Issues
- Closes N/A
- Related N/A

## Change Scope
- [ ] API contract
- [x] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [ ] Docs/runbook

## Security Impact
- Risk: 없음. Bean 이름 변경만으로 보안 영향 없습니다.
- Mitigation: N/A

## Validation
- Commands:
  - 애플리케이션 기동 (`avatar` + `attachment` 스타터 동시 활성화)
- Result:
  - 수정 전: `BeanDefinitionOverrideException: Cannot register bean definition ... for bean 'entityScanRegistrar' since there is already ... bound.`
  - 수정 후: 기동 성공 예상

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [x] No
- [ ] Yes
- Delegated tasks: N/A
- Ownership (files/modules/tasks): N/A
- Main author post-integration validation: N/A

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: 없음. 코드 수정만으로 적용됩니다.
- Rollback plan: 문제가 있으면 이 PR의 커밋을 revert합니다.
- Post-deploy checks: `avatar` + `attachment` 스타터 동시 활성화 환경에서 애플리케이션 정상 기동 확인.