### PR TITLE
fix(nexus): include parent modules in local delete-existing

### DIFF
--- a/scripts/publish-local-nexus.sh
+++ b/scripts/publish-local-nexus.sh
@@ -120,7 +120,25 @@ nexus_api_get() {
 }
 
 included_modules() {
-  sed -n 's/^[[:space:]]*include("\([^"]*\)").*/\1/p' settings.gradle.kts
+  local raw_modules=()
+  local module
+  local prefix
+  local segment
+
+  while IFS= read -r module; do
+    [[ -z "${module}" ]] && continue
+    raw_modules+=("${module}")
+  done < <(sed -n 's/^[[:space:]]*include("\([^"]*\)").*/\1/p' settings.gradle.kts)
+
+  for module in "${raw_modules[@]}"; do
+    prefix=""
+    IFS=':' read -r -a segments <<< "${module}"
+    for segment in "${segments[@]}"; do
+      [[ -z "${segment}" ]] && continue
+      prefix="${prefix}:${segment}"
+      printf '%s\n' "${prefix}"
+    done
+  done | sort -u
 }
 
 delete_existing_component() {


### PR DESCRIPTION
## Why
- `./scripts/publish-local-nexus.sh --delete-existing` 가 `settings.gradle.kts` 의 직접 `include(...)` 항목만 순회해 부모 publish 모듈(`:starter`, `:studio-application-modules`)을 삭제 대상에서 누락했습니다.
- Gradle `publish` 는 부모 publication 도 함께 올리므로, 기존 `studio.one.api:starter:2.0.0` 같은 artifact 가 남아 있으면 Nexus 가 `cannot be updated` 400으로 publish 를 거부합니다.
- Related #177

## What
- `included_modules()` 가 nested project 의 ancestor 경로까지 포함하도록 수정했습니다.
- 결과적으로 `:starter:...` 모듈이 있으면 `:starter` 도 함께 삭제 대상으로 처리됩니다.
- 기존 `jq` 기반 Nexus search/delete 파싱과 pagination 대응은 유지했습니다.

## Related Issues
- Closes N/A
- Related #177

## Change Scope
- [ ] API contract
- [x] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [ ] Docs/runbook

## Security Impact
- Risk: 없음. 로컬 Nexus 정리 스크립트의 삭제 대상 계산만 보정합니다.
- Mitigation: N/A

## Validation
- Commands:
  - `bash -n scripts/publish-local-nexus.sh`
  - `bash -lc 'while IFS= read -r module; do [[ -z "$module" ]] && continue; raw_modules+=("$module"); done < <(sed -n '\''s/^[[:space:]]*include("\([^"]*\)").*/\1/p'\'' settings.gradle.kts); for module in "${raw_modules[@]}"; do prefix=""; IFS='"'":"'"' read -r -a segments <<< "$module"; for segment in "${segments[@]}"; do [[ -z "$segment" ]] && continue; prefix="${prefix}:$segment"; printf "%s\n" "$prefix"; done; done | sort -u | sed -n "1,20p"'`
  - `./scripts/publish-local-nexus.sh --delete-existing`
- Result:
  - 수정 전: `studio.one.api:starter:2.0.0` 가 남아 `publishMavenJavaPublicationToNexusRepository` 에서 400 `cannot be updated` 오류 발생
  - 수정 후: 부모 publish 모듈도 삭제 대상에 포함되어 재배포가 진행됨
- Additional checks:
  - `jq` 미설치 시 fail-fast 유지

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [x] No
- [ ] Yes
- Delegated tasks: N/A
- Ownership (files/modules/tasks): N/A
- Main author post-integration validation: N/A

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: 없음. 로컬 배포 보조 스크립트 수정입니다.
- Rollback plan: 문제가 있으면 이 PR 커밋을 revert 합니다.
- Post-deploy checks: `./scripts/publish-local-nexus.sh --delete-existing` 후 로컬 Nexus publish 정상 완료 확인
