### PR TITLE
[ai-assisted] refactor(group): align member-summary ownership and delete API contract (#189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-04-10
+
+### 변경됨
+- `DELETE /groups/{id}/members`의 요청 body를 raw `List<Long>`에서 `{"userIds":[...]}` 형태의 `AddMembersRequest`로 교체해 `POST /groups/{id}/members`와 API 계약을 통일했다.
+- `GroupMgmtController`의 메서드명 오타 `removeaddMemberships`를 `removeMemberships`로 수정했다.
+- `GET /groups/{id}/member-summaries`의 `ApplicationGroupMemberSummary` → `GroupMemberSummaryDto` 매핑을 컨트롤러 인라인에서 `ApplicationGroupService.getMemberSummaryDtos()` default 메서드로 위임했다.
+- `GroupMgmtControllerTest`에 `removeMembershipsCallsServiceWithUserIds` 테스트를 추가했다.
+
+### 검증
+- `./gradlew :studio-platform-user:test`
+- `./gradlew :studio-platform-user:compileJava :studio-platform-user-default:compileJava`
+
 ## 2026-04-09
 
 ### 변경됨

--- a/studio-platform-user/src/main/java/studio/one/base/user/service/ApplicationGroupService.java
+++ b/studio-platform-user/src/main/java/studio/one/base/user/service/ApplicationGroupService.java
@@ -33,6 +33,7 @@ import org.springframework.lang.Nullable;
 import studio.one.base.user.domain.entity.ApplicationGroupMemberSummary;
 import studio.one.base.user.domain.model.Group;
 import studio.one.base.user.domain.model.Role;
+import studio.one.base.user.web.dto.GroupMemberSummaryDto;
 import studio.one.platform.constant.ServiceNames;
 
 /**
@@ -132,6 +133,14 @@ public interface ApplicationGroupService<G extends Group, R extends Role> {
 
     Page<ApplicationGroupMemberSummary> getMemberSummaries(Long groupId, @Nullable String q, Pageable pageable);
 
+    default Page<GroupMemberSummaryDto> getMemberSummaryDtos(Long groupId, @Nullable String q, Pageable pageable) {
+        return getMemberSummaries(groupId, q, pageable).map(s -> GroupMemberSummaryDto.builder()
+                .userId(s.getUserId())
+                .username(s.getUsername())
+                .name(s.getName())
+                .enabled(s.isEnabled())
+                .build());
+    }
 
     // ── Roles: Assign / Revoke / Read ────────────────────────────────────────
 

--- a/studio-platform-user/src/main/java/studio/one/base/user/web/controller/GroupMgmtController.java
+++ b/studio-platform-user/src/main/java/studio/one/base/user/web/controller/GroupMgmtController.java
@@ -209,13 +209,7 @@ public class GroupMgmtController {
             @PageableDefault(size = 15, direction = Sort.Direction.DESC) Pageable pageable) {
         Group group = groupService.getById(id);
         String keyword = RequestParamUtils.normalizeQuery(q).orElse(null);
-        Page<GroupMemberSummaryDto> dtoPage = groupService.getMemberSummaries(group.getGroupId(), keyword, pageable)
-                .map(summary -> GroupMemberSummaryDto.builder()
-                        .userId(summary.getUserId())
-                        .username(summary.getUsername())
-                        .name(summary.getName())
-                        .enabled(summary.isEnabled())
-                        .build());
+        Page<GroupMemberSummaryDto> dtoPage = groupService.getMemberSummaryDtos(group.getGroupId(), keyword, pageable);
         return ok(ApiResponse.ok(dtoPage));
     }
 
@@ -231,9 +225,9 @@ public class GroupMgmtController {
 
     @DeleteMapping("/{id}/members")
     @PreAuthorize("@endpointAuthz.can('features:group','write')")
-    public ResponseEntity<ApiResponse<Integer>> removeaddMemberships(@PathVariable Long id,
-            @RequestBody List<Long> userList) {
-        int result = groupService.removeMembers(id, userList);
+    public ResponseEntity<ApiResponse<Integer>> removeMemberships(@PathVariable Long id,
+            @Valid @RequestBody AddMembersRequest req) {
+        int result = groupService.removeMembers(id, req.getUserIds());
         return ok(ApiResponse.ok(result));
     }
 

--- a/studio-platform-user/src/test/java/studio/one/base/user/web/controller/GroupMgmtControllerTest.java
+++ b/studio-platform-user/src/test/java/studio/one/base/user/web/controller/GroupMgmtControllerTest.java
@@ -20,6 +20,7 @@ import studio.one.base.user.domain.entity.ApplicationGroupMemberSummary;
 import studio.one.base.user.domain.model.Group;
 import studio.one.base.user.domain.model.Role;
 import studio.one.base.user.service.ApplicationGroupService;
+import studio.one.base.user.web.dto.AddMembersRequest;
 import studio.one.base.user.web.dto.GroupMemberSummaryDto;
 import studio.one.base.user.web.mapper.ApplicationGroupMapper;
 import studio.one.base.user.web.mapper.ApplicationRoleMapper;
@@ -69,6 +70,20 @@ class GroupMgmtControllerTest {
         assertEquals(true, first.isEnabled());
 
         verify(groupService).getMemberSummaries(10L, "alice", pageable);
+    }
+
+    @Test
+    void removeMembershipsCallsServiceWithUserIds() {
+        GroupMgmtController controller = new GroupMgmtController(groupService, groupMapper, roleMapper, identityServiceProvider);
+        when(groupService.removeMembers(eq(10L), eq(List.of(1L, 2L)))).thenReturn(2);
+
+        AddMembersRequest req = new AddMembersRequest();
+        req.setUserIds(List.of(1L, 2L));
+
+        var response = controller.removeMemberships(10L, req);
+
+        assertEquals(2, response.getBody().getData());
+        verify(groupService).removeMembers(10L, List.of(1L, 2L));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `DELETE /groups/{id}/members` 요청 body를 raw `List<Long>` → `{"userIds":[...]}` (`AddMembersRequest`)로 교체해 `POST /groups/{id}/members`와 API 계약 통일
- `removeaddMemberships` → `removeMemberships` 메서드명 오타 수정
- `GroupMemberSummaryDto` 조립 책임을 컨트롤러 인라인에서 `ApplicationGroupService.getMemberSummaryDtos()` default 메서드로 위임

## Test plan
- [x] `GroupMgmtControllerTest.removeMembershipsCallsServiceWithUserIds` 테스트 추가 및 통과
- [x] `./gradlew :studio-platform-user:test --tests 'studio.one.base.user.web.controller.GroupMgmtControllerTest'` 통과
- [x] `./gradlew :studio-platform-user:compileJava :studio-platform-user-default:compileJava` 통과

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)