### PR TITLE
feat(user/group): add property CRUD web API endpoints

### DIFF
--- a/studio-platform-user-default/src/main/java/studio/one/base/user/service/impl/ApplicationUserServiceImpl.java
+++ b/studio-platform-user-default/src/main/java/studio/one/base/user/service/impl/ApplicationUserServiceImpl.java
@@ -64,6 +64,7 @@ import studio.one.base.user.web.dto.MeProfilePatchRequest;
 import studio.one.base.user.web.dto.MeProfilePutRequest;
 import studio.one.base.user.web.dto.MePasswordChangeRequest;
 import studio.one.platform.component.State;
+import studio.one.platform.exception.NotFoundException;
 import studio.one.platform.service.DomainEvents;
 import studio.one.platform.service.I18n;
 import studio.one.platform.util.I18nUtils;
@@ -356,6 +357,65 @@ public class ApplicationUserServiceImpl implements ApplicationUserService<Applic
                 || lower.startsWith("role.")
                 || lower.startsWith("admin.")
                 || lower.startsWith("permission."));
+    }
+
+    // ---------- 프로퍼티 관리 ----------
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<String, String> getProperties(Long userId) {
+        ApplicationUser u = userRepo.findById(userId).orElseThrow(() -> UserNotFoundException.byId(userId));
+        Map<String, String> props = u.getProperties();
+        return props == null ? Collections.emptyMap() : Collections.unmodifiableMap(props);
+    }
+
+    @Override
+    @Transactional
+    @CacheEvict(cacheNames = CacheNames.User.BY_USER_ID, key = "#userId")
+    public Map<String, String> replaceProperties(Long userId, Map<String, String> properties) {
+        ApplicationUser saved = update(userId, u -> u.setProperties(
+                properties == null ? new HashMap<>() : new HashMap<>(properties)));
+        Map<String, String> result = saved.getProperties();
+        return result == null ? Collections.emptyMap() : Collections.unmodifiableMap(result);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public String getProperty(Long userId, String key) {
+        Map<String, String> props = getProperties(userId);
+        if (!props.containsKey(key)) {
+            throw new NotFoundException("Property", key);
+        }
+        return props.get(key);
+    }
+
+    @Override
+    @Transactional
+    @CacheEvict(cacheNames = CacheNames.User.BY_USER_ID, key = "#userId")
+    public String setProperty(Long userId, String key, String value) {
+        if (!isAllowedPropertyKey(key)) {
+            throw new IllegalArgumentException("Disallowed property key: " + key);
+        }
+        update(userId, u -> {
+            Map<String, String> props = u.getProperties() == null
+                    ? new HashMap<>() : new HashMap<>(u.getProperties());
+            props.put(key, value);
+            u.setProperties(props);
+        });
+        return value;
+    }
+
+    @Override
+    @Transactional
+    @CacheEvict(cacheNames = CacheNames.User.BY_USER_ID, key = "#userId")
+    public void deleteProperty(Long userId, String key) {
+        update(userId, u -> {
+            if (u.getProperties() != null) {
+                Map<String, String> props = new HashMap<>(u.getProperties());
+                props.remove(key);
+                u.setProperties(props);
+            }
+        });
     }
 
     public Page<ApplicationUser> search(String q, Pageable pageable) {

--- a/studio-platform-user-default/src/main/java/studio/one/base/user/service/impl/ApplicationUserServiceImpl.java
+++ b/studio-platform-user-default/src/main/java/studio/one/base/user/service/impl/ApplicationUserServiceImpl.java
@@ -373,8 +373,16 @@ public class ApplicationUserServiceImpl implements ApplicationUserService<Applic
     @Transactional
     @CacheEvict(cacheNames = CacheNames.User.BY_USER_ID, key = "#userId")
     public Map<String, String> replaceProperties(Long userId, Map<String, String> properties) {
-        ApplicationUser saved = update(userId, u -> u.setProperties(
-                properties == null ? new HashMap<>() : new HashMap<>(properties)));
+        Map<String, String> validated = new HashMap<>();
+        if (properties != null) {
+            for (Map.Entry<String, String> entry : properties.entrySet()) {
+                if (!isAllowedPropertyKey(entry.getKey())) {
+                    throw new IllegalArgumentException("Disallowed property key: " + entry.getKey());
+                }
+                validated.put(entry.getKey(), entry.getValue());
+            }
+        }
+        ApplicationUser saved = update(userId, u -> u.setProperties(validated));
         Map<String, String> result = saved.getProperties();
         return result == null ? Collections.emptyMap() : Collections.unmodifiableMap(result);
     }

--- a/studio-platform-user-default/src/main/java/studio/one/base/user/web/controller/UserMgmtController.java
+++ b/studio-platform-user-default/src/main/java/studio/one/base/user/web/controller/UserMgmtController.java
@@ -7,6 +7,7 @@ import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -24,6 +25,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -46,6 +48,7 @@ import studio.one.base.user.web.dto.ChangePasswordRequest;
 import studio.one.base.user.web.dto.CreateUserRequest;
 import studio.one.base.user.web.dto.DisableUserRequest;
 import studio.one.base.user.web.dto.PasswordPolicyDto;
+import studio.one.base.user.web.dto.PropertyDto;
 import studio.one.base.user.web.dto.RoleDto;
 import studio.one.base.user.web.dto.UpdateRolesRequest;
 import studio.one.base.user.web.dto.UserBasicDto;
@@ -282,6 +285,53 @@ public class UserMgmtController extends AbstractPasswordPolicyControllerSupport 
                 BatchResult result = userService.updateUserRolesBulk(id, desired, actor.getUsername());
                 log.debug("batch : {}", result);
                 return ok(ApiResponse.ok());
+        }
+
+        // Properties --------------------------------------
+
+        @GetMapping("/{id}/properties")
+        @PreAuthorize("@endpointAuthz.can('features:user','admin')")
+        @Override
+        public ResponseEntity<ApiResponse<Map<String, String>>> getProperties(@PathVariable Long id) {
+                return ok(ApiResponse.ok(userService.getProperties(id)));
+        }
+
+        @PutMapping("/{id}/properties")
+        @PreAuthorize("@endpointAuthz.can('features:user','admin')")
+        @Override
+        public ResponseEntity<ApiResponse<Map<String, String>>> replaceProperties(
+                        @PathVariable Long id,
+                        @RequestBody Map<String, String> properties) {
+                return ok(ApiResponse.ok(userService.replaceProperties(id, properties)));
+        }
+
+        @GetMapping("/{id}/properties/{key}")
+        @PreAuthorize("@endpointAuthz.can('features:user','admin')")
+        @Override
+        public ResponseEntity<ApiResponse<PropertyDto>> getProperty(
+                        @PathVariable Long id,
+                        @PathVariable String key) {
+                String value = userService.getProperty(id, key);
+                return ok(ApiResponse.ok(PropertyDto.builder().key(key).value(value).build()));
+        }
+
+        @PutMapping("/{id}/properties/{key}")
+        @PreAuthorize("@endpointAuthz.can('features:user','admin')")
+        @Override
+        public ResponseEntity<ApiResponse<PropertyDto>> setProperty(
+                        @PathVariable Long id,
+                        @PathVariable String key,
+                        @Valid @RequestBody PropertyDto dto) {
+                String stored = userService.setProperty(id, key, dto.getValue());
+                return ok(ApiResponse.ok(PropertyDto.builder().key(key).value(stored).build()));
+        }
+
+        @DeleteMapping("/{id}/properties/{key}")
+        @PreAuthorize("@endpointAuthz.can('features:user','admin')")
+        @Override
+        public ResponseEntity<Void> deleteProperty(@PathVariable Long id, @PathVariable String key) {
+                userService.deleteProperty(id, key);
+                return ResponseEntity.noContent().build();
         }
 
 }

--- a/studio-platform-user-default/src/test/java/studio/one/base/user/service/impl/ApplicationUserServiceImplTest.java
+++ b/studio-platform-user-default/src/test/java/studio/one/base/user/service/impl/ApplicationUserServiceImplTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Clock;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -119,6 +121,60 @@ class ApplicationUserServiceImplTest {
         assertEquals("{bcrypt}next-hash", user.getPassword());
         verify(passwordPolicyService).validate("NextPassword123!");
         verify(userRepo).save(user);
+    }
+
+    // ---------- property tests ----------
+
+    @Test
+    void setPropertyRejectsReservedPrefix() {
+        assertThrows(IllegalArgumentException.class,
+                () -> service().setProperty(1L, "security.token", "val"));
+        assertThrows(IllegalArgumentException.class,
+                () -> service().setProperty(1L, "auth.secret", "val"));
+        assertThrows(IllegalArgumentException.class,
+                () -> service().setProperty(1L, "role.admin", "val"));
+    }
+
+    @Test
+    void setPropertyRejectsMalformedKey() {
+        assertThrows(IllegalArgumentException.class,
+                () -> service().setProperty(1L, "bad key!", "val"));
+        assertThrows(IllegalArgumentException.class,
+                () -> service().setProperty(1L, "", "val"));
+        assertThrows(IllegalArgumentException.class,
+                () -> service().setProperty(1L, "a".repeat(101), "val"));
+    }
+
+    @Test
+    void replacePropertiesRejectsReservedKeyInBulk() {
+        // P1: bulk replace must enforce the same reserved-key guard as setProperty
+        Map<String, String> props = new HashMap<>();
+        props.put("theme", "dark");
+        props.put("security.token", "leaked");
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service().replaceProperties(1L, props));
+
+        verify(userRepo, never()).findById(any());
+        verify(userRepo, never()).save(any());
+    }
+
+    @Test
+    void replacePropertiesAcceptsValidKeys() {
+        ApplicationUser user = ApplicationUser.builder()
+                .userId(10L)
+                .username("user")
+                .password("{bcrypt}hash")
+                .build();
+        when(userRepo.findById(10L)).thenReturn(Optional.of(user));
+        when(userRepo.save(user)).thenReturn(user);
+
+        Map<String, String> props = Map.of("theme", "dark", "locale", "ko");
+        service().replaceProperties(10L, props);
+
+        verify(userRepo).save(user);
+        assertEquals("dark", user.getProperties().get("theme"));
+        assertEquals("ko", user.getProperties().get("locale"));
     }
 
     private ApplicationUserServiceImpl service() {

--- a/studio-platform-user/src/main/java/studio/one/base/user/service/ApplicationGroupService.java
+++ b/studio-platform-user/src/main/java/studio/one/base/user/service/ApplicationGroupService.java
@@ -24,6 +24,7 @@ package studio.one.base.user.service;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 import org.springframework.data.domain.Page;
@@ -81,8 +82,19 @@ public interface ApplicationGroupService<G extends Group, R extends Role> {
     /**
      * Delete group
      * @param groupId
-     */    
+     */
     void deleteGroup(Long groupId);
+
+    // ── Properties ───────────────────────────────────────────────────────────
+    Map<String, String> getProperties(Long groupId);
+
+    Map<String, String> replaceProperties(Long groupId, Map<String, String> properties);
+
+    String getProperty(Long groupId, String key);
+
+    String setProperty(Long groupId, String key, String value);
+
+    void deleteProperty(Long groupId, String key);
 
     // ── Group: Queries ───────────────────────────────────────────────────────
     /**

--- a/studio-platform-user/src/main/java/studio/one/base/user/service/ApplicationUserService.java
+++ b/studio-platform-user/src/main/java/studio/one/base/user/service/ApplicationUserService.java
@@ -23,6 +23,7 @@ package studio.one.base.user.service;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -115,6 +116,17 @@ public interface ApplicationUserService<T extends User, R extends Role> {
     void joinGroup(Long userId, Long groupId, String by);
 
     void leaveGroup(Long userId, Long groupId);
+
+    // properties
+    Map<String, String> getProperties(Long userId);
+
+    Map<String, String> replaceProperties(Long userId, Map<String, String> properties);
+
+    String getProperty(Long userId, String key);
+
+    String setProperty(Long userId, String key, String value);
+
+    void deleteProperty(Long userId, String key);
 
     // effective roles
     Set<R> findEffectiveRoles(Long userId);

--- a/studio-platform-user/src/main/java/studio/one/base/user/service/impl/ApplicationGroupServiceImpl.java
+++ b/studio-platform-user/src/main/java/studio/one/base/user/service/impl/ApplicationGroupServiceImpl.java
@@ -105,8 +105,14 @@ public class ApplicationGroupServiceImpl
 
     @Override
     public Map<String, String> replaceProperties(Long groupId, Map<String, String> properties) {
-        ApplicationGroup saved = updateGroup(groupId, g -> g.setProperties(
-                properties == null ? new HashMap<>() : new HashMap<>(properties)));
+        Map<String, String> validated = new HashMap<>();
+        if (properties != null) {
+            for (Map.Entry<String, String> entry : properties.entrySet()) {
+                validateGroupPropertyKey(entry.getKey());
+                validated.put(entry.getKey(), entry.getValue());
+            }
+        }
+        ApplicationGroup saved = updateGroup(groupId, g -> g.setProperties(validated));
         Map<String, String> result = saved.getProperties();
         return result == null ? Collections.emptyMap() : Collections.unmodifiableMap(result);
     }
@@ -123,9 +129,7 @@ public class ApplicationGroupServiceImpl
 
     @Override
     public String setProperty(Long groupId, String key, String value) {
-        if (key == null || key.isBlank()) {
-            throw new IllegalArgumentException("Property key must not be blank");
-        }
+        validateGroupPropertyKey(key);
         updateGroup(groupId, g -> {
             Map<String, String> props = g.getProperties() == null
                     ? new HashMap<>() : new HashMap<>(g.getProperties());
@@ -133,6 +137,12 @@ public class ApplicationGroupServiceImpl
             g.setProperties(props);
         });
         return value;
+    }
+
+    private void validateGroupPropertyKey(String key) {
+        if (key == null || !key.matches("[A-Za-z0-9_.-]{1,100}")) {
+            throw new IllegalArgumentException("Invalid property key: " + key);
+        }
     }
 
     @Override

--- a/studio-platform-user/src/main/java/studio/one/base/user/service/impl/ApplicationGroupServiceImpl.java
+++ b/studio-platform-user/src/main/java/studio/one/base/user/service/impl/ApplicationGroupServiceImpl.java
@@ -3,8 +3,11 @@ package studio.one.base.user.service.impl;
 import java.sql.PreparedStatement;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -88,6 +91,59 @@ public class ApplicationGroupServiceImpl
     @Override
     public void deleteGroup(Long groupId) {
         groupRepo.deleteById(groupId);
+    }
+
+    // --- 프로퍼티 ---
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<String, String> getProperties(Long groupId) {
+        ApplicationGroup g = groupRepo.findById(groupId).orElseThrow(() -> GroupNotFoundException.byId(groupId));
+        Map<String, String> props = g.getProperties();
+        return props == null ? Collections.emptyMap() : Collections.unmodifiableMap(props);
+    }
+
+    @Override
+    public Map<String, String> replaceProperties(Long groupId, Map<String, String> properties) {
+        ApplicationGroup saved = updateGroup(groupId, g -> g.setProperties(
+                properties == null ? new HashMap<>() : new HashMap<>(properties)));
+        Map<String, String> result = saved.getProperties();
+        return result == null ? Collections.emptyMap() : Collections.unmodifiableMap(result);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public String getProperty(Long groupId, String key) {
+        Map<String, String> props = getProperties(groupId);
+        if (!props.containsKey(key)) {
+            throw new NotFoundException("Property", key);
+        }
+        return props.get(key);
+    }
+
+    @Override
+    public String setProperty(Long groupId, String key, String value) {
+        if (key == null || key.isBlank()) {
+            throw new IllegalArgumentException("Property key must not be blank");
+        }
+        updateGroup(groupId, g -> {
+            Map<String, String> props = g.getProperties() == null
+                    ? new HashMap<>() : new HashMap<>(g.getProperties());
+            props.put(key, value);
+            g.setProperties(props);
+        });
+        return value;
+    }
+
+    @Override
+    public void deleteProperty(Long groupId, String key) {
+        updateGroup(groupId, g -> {
+            if (g.getProperties() != null) {
+                Map<String, String> props = new HashMap<>(g.getProperties());
+                props.remove(key);
+                g.setProperties(props);
+            }
+        });
     }
 
     // --- 멤버십 ---

--- a/studio-platform-user/src/main/java/studio/one/base/user/web/controller/GroupMgmtApi.java
+++ b/studio-platform-user/src/main/java/studio/one/base/user/web/controller/GroupMgmtApi.java
@@ -1,0 +1,108 @@
+/**
+ *
+ *      Copyright 2025
+ *
+ *      Licensed under the Apache License, Version 2.0 (the 'License');
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an 'AS IS' BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ *
+ *      @file GroupMgmtApi.java
+ *      @date 2026
+ *
+ */
+
+package studio.one.base.user.web.controller;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import jakarta.validation.Valid;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import studio.one.base.user.web.dto.AddMembersRequest;
+import studio.one.base.user.web.dto.GroupDto;
+import studio.one.base.user.web.dto.GroupMemberSummaryDto;
+import studio.one.base.user.web.dto.PropertyDto;
+import studio.one.base.user.web.dto.RoleDto;
+import studio.one.base.user.web.dto.UpdateRolesRequest;
+import studio.one.platform.web.dto.ApiResponse;
+
+/**
+ * API contract for group management endpoints.
+ *
+ * @author donghyuck, son
+ * @since 2026-04-10
+ * @version 1.0
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *   수정일        수정자           수정내용
+ *  ---------    --------    ---------------------------
+ * 2026-04-10  donghyuck, son: 최초 생성.
+ * </pre>
+ */
+public interface GroupMgmtApi {
+
+    // ── CRUD ──────────────────────────────────────────────────────────────────
+    ResponseEntity<ApiResponse<Page<GroupDto>>> list(
+            @RequestParam(value = "q", required = false) Optional<String> q,
+            @RequestParam(value = "fields", required = false) Optional<String> fields,
+            Pageable pageable);
+
+    ResponseEntity<ApiResponse<GroupDto>> get(Long id);
+
+    ResponseEntity<ApiResponse<GroupDto>> create(@Valid @RequestBody GroupDto req);
+
+    ResponseEntity<ApiResponse<GroupDto>> update(Long id, @Valid @RequestBody GroupDto dto);
+
+    ResponseEntity<ApiResponse<Void>> delete(Long id);
+
+    // ── Roles ─────────────────────────────────────────────────────────────────
+    ResponseEntity<ApiResponse<List<RoleDto>>> roles(Long id);
+
+    ResponseEntity<ApiResponse<Void>> updateGroupRoles(Long id,
+            @Valid @RequestBody UpdateRolesRequest req,
+            UserDetails actor);
+
+    // ── Membership ────────────────────────────────────────────────────────────
+    ResponseEntity<ApiResponse<Page<studio.one.platform.identity.UserDto>>> members(Long id, Pageable pageable);
+
+    ResponseEntity<ApiResponse<Page<GroupMemberSummaryDto>>> memberSummaries(Long id,
+            @RequestParam(value = "q", required = false) Optional<String> q,
+            Pageable pageable);
+
+    ResponseEntity<ApiResponse<Integer>> addMemberships(Long id,
+            @Valid @RequestBody AddMembersRequest req,
+            UserDetails principal);
+
+    ResponseEntity<ApiResponse<Integer>> removeMemberships(Long id,
+            @Valid @RequestBody AddMembersRequest req);
+
+    // ── Properties ────────────────────────────────────────────────────────────
+    ResponseEntity<ApiResponse<Map<String, String>>> getProperties(Long id);
+
+    ResponseEntity<ApiResponse<Map<String, String>>> replaceProperties(Long id,
+            @RequestBody Map<String, String> properties);
+
+    ResponseEntity<ApiResponse<PropertyDto>> getProperty(Long id, String key);
+
+    ResponseEntity<ApiResponse<PropertyDto>> setProperty(Long id, String key,
+            @Valid @RequestBody PropertyDto dto);
+
+    ResponseEntity<Void> deleteProperty(Long id, String key);
+}

--- a/studio-platform-user/src/main/java/studio/one/base/user/web/controller/GroupMgmtController.java
+++ b/studio-platform-user/src/main/java/studio/one/base/user/web/controller/GroupMgmtController.java
@@ -26,6 +26,7 @@ import static org.springframework.http.ResponseEntity.ok;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -63,6 +64,7 @@ import studio.one.base.user.service.BatchResult;
 import studio.one.base.user.web.dto.AddMembersRequest;
 import studio.one.base.user.web.dto.GroupMemberSummaryDto;
 import studio.one.base.user.web.dto.GroupDto;
+import studio.one.base.user.web.dto.PropertyDto;
 import studio.one.base.user.web.dto.RoleDto;
 import studio.one.base.user.web.dto.UpdateRolesRequest;
 import studio.one.base.user.web.mapper.ApplicationGroupMapper;
@@ -93,7 +95,7 @@ import studio.one.platform.web.dto.ApiResponse;
 @RequestMapping("${" + PropertyKeys.Features.User.Web.BASE_PATH + ":/api/mgmt}/groups")
 @RequiredArgsConstructor
 @Slf4j
-public class GroupMgmtController {
+public class GroupMgmtController implements GroupMgmtApi {
 
     private final ApplicationGroupService<Group, Role> groupService;
     private final ApplicationGroupMapper groupMapper;
@@ -116,6 +118,7 @@ public class GroupMgmtController {
 
     @GetMapping
     @PreAuthorize("@endpointAuthz.can('features:group','read')")
+    @Override
     public ResponseEntity<ApiResponse<Page<GroupDto>>> list(
             @RequestParam(value = "q", required = false) Optional<String> q,
             @RequestParam(value = "fields", required = false) Optional<String> fields,
@@ -134,6 +137,7 @@ public class GroupMgmtController {
 
     @GetMapping("/{id}")
     @PreAuthorize("@endpointAuthz.can('features:group','read')")
+    @Override
     public ResponseEntity<ApiResponse<GroupDto>> get(@PathVariable Long id) {
         Group group = groupService.getById(id);
         return ok(ApiResponse.ok(groupMapper.toDto(group)));
@@ -141,6 +145,7 @@ public class GroupMgmtController {
 
     @PostMapping
     @PreAuthorize("@endpointAuthz.can('features:group','write')")
+    @Override
     public ResponseEntity<ApiResponse<GroupDto>> create(@Valid @RequestBody GroupDto req) {
         Group group = groupMapper.toEntity(req);
         Group saved = groupService.createGroup(group);
@@ -152,6 +157,7 @@ public class GroupMgmtController {
 
     @PutMapping("/{id}")
     @PreAuthorize("@endpointAuthz.can('features:group','write')")
+    @Override
     public ResponseEntity<ApiResponse<GroupDto>> update(@PathVariable Long id, @Valid @RequestBody GroupDto dto) {
         Group updated = groupService.updateGroup(id, g -> groupMapper.updateEntityFromDto(dto, g));
         return ok(ApiResponse.ok(groupMapper.toDto(updated)));
@@ -159,6 +165,7 @@ public class GroupMgmtController {
 
     @DeleteMapping("/{id}")
     @PreAuthorize("@endpointAuthz.can('features:group','write')")
+    @Override
     public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long id) {
         groupService.deleteGroup(id);
         return ok(ApiResponse.ok());
@@ -167,6 +174,7 @@ public class GroupMgmtController {
     // Roles --------------------------------------
     @GetMapping("/{id}/roles")
     @PreAuthorize("@endpointAuthz.can('features:group','read')")
+    @Override
     public ResponseEntity<ApiResponse<List<RoleDto>>> roles(@PathVariable Long id) {
         List<Role> list = groupService.getRoles(id);
         return ok(ApiResponse.ok(roleMapper.toDtos(list)));
@@ -174,6 +182,7 @@ public class GroupMgmtController {
 
     @PostMapping("/{id}/roles")
     @PreAuthorize("@endpointAuthz.can('features:group','write')")
+    @Override
     public ResponseEntity<ApiResponse<Void>> updateGroupRoles(@PathVariable Long id,
             @Valid @RequestBody UpdateRolesRequest req,
             @AuthenticationPrincipal UserDetails actor) {
@@ -192,6 +201,7 @@ public class GroupMgmtController {
     // Membership --------------------------------------
     @GetMapping("/{id}/members")
     @PreAuthorize("@endpointAuthz.can('features:group','read')")
+    @Override
     public ResponseEntity<ApiResponse<Page<UserDto>>> members(
             @PathVariable Long id,
             @PageableDefault(size = 15, direction = Sort.Direction.DESC) Pageable pageable) {
@@ -203,6 +213,7 @@ public class GroupMgmtController {
 
     @GetMapping("/{id}/member-summaries")
     @PreAuthorize("@endpointAuthz.can('features:group','read')")
+    @Override
     public ResponseEntity<ApiResponse<Page<GroupMemberSummaryDto>>> memberSummaries(
             @PathVariable Long id,
             @RequestParam(value = "q", required = false) Optional<String> q,
@@ -215,6 +226,7 @@ public class GroupMgmtController {
 
     @PostMapping("/{id}/members")
     @PreAuthorize("@endpointAuthz.can('features:group','write')")
+    @Override
     public ResponseEntity<ApiResponse<Integer>> addMemberships(
             @PathVariable Long id,
             @Valid @RequestBody AddMembersRequest req,
@@ -225,10 +237,58 @@ public class GroupMgmtController {
 
     @DeleteMapping("/{id}/members")
     @PreAuthorize("@endpointAuthz.can('features:group','write')")
+    @Override
     public ResponseEntity<ApiResponse<Integer>> removeMemberships(@PathVariable Long id,
             @Valid @RequestBody AddMembersRequest req) {
         int result = groupService.removeMembers(id, req.getUserIds());
         return ok(ApiResponse.ok(result));
+    }
+
+    // Properties --------------------------------------
+
+    @GetMapping("/{id}/properties")
+    @PreAuthorize("@endpointAuthz.can('features:group','read')")
+    @Override
+    public ResponseEntity<ApiResponse<Map<String, String>>> getProperties(@PathVariable Long id) {
+        return ok(ApiResponse.ok(groupService.getProperties(id)));
+    }
+
+    @PutMapping("/{id}/properties")
+    @PreAuthorize("@endpointAuthz.can('features:group','write')")
+    @Override
+    public ResponseEntity<ApiResponse<Map<String, String>>> replaceProperties(
+            @PathVariable Long id,
+            @RequestBody Map<String, String> properties) {
+        return ok(ApiResponse.ok(groupService.replaceProperties(id, properties)));
+    }
+
+    @GetMapping("/{id}/properties/{key}")
+    @PreAuthorize("@endpointAuthz.can('features:group','read')")
+    @Override
+    public ResponseEntity<ApiResponse<PropertyDto>> getProperty(
+            @PathVariable Long id,
+            @PathVariable String key) {
+        String value = groupService.getProperty(id, key);
+        return ok(ApiResponse.ok(PropertyDto.builder().key(key).value(value).build()));
+    }
+
+    @PutMapping("/{id}/properties/{key}")
+    @PreAuthorize("@endpointAuthz.can('features:group','write')")
+    @Override
+    public ResponseEntity<ApiResponse<PropertyDto>> setProperty(
+            @PathVariable Long id,
+            @PathVariable String key,
+            @Valid @RequestBody PropertyDto dto) {
+        String stored = groupService.setProperty(id, key, dto.getValue());
+        return ok(ApiResponse.ok(PropertyDto.builder().key(key).value(stored).build()));
+    }
+
+    @DeleteMapping("/{id}/properties/{key}")
+    @PreAuthorize("@endpointAuthz.can('features:group','write')")
+    @Override
+    public ResponseEntity<Void> deleteProperty(@PathVariable Long id, @PathVariable String key) {
+        groupService.deleteProperty(id, key);
+        return ResponseEntity.noContent().build();
     }
 
     private UserDto toUserDto(Long userId) {

--- a/studio-platform-user/src/main/java/studio/one/base/user/web/controller/UserMgmtApi.java
+++ b/studio-platform-user/src/main/java/studio/one/base/user/web/controller/UserMgmtApi.java
@@ -1,6 +1,7 @@
 package studio.one.base.user.web.controller;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -17,6 +18,7 @@ import studio.one.base.user.web.dto.ChangePasswordRequest;
 import studio.one.base.user.web.dto.CreateUserRequest;
 import studio.one.base.user.web.dto.DisableUserRequest;
 import studio.one.base.user.web.dto.PasswordPolicyDto;
+import studio.one.base.user.web.dto.PropertyDto;
 import studio.one.base.user.web.dto.RoleDto;
 import studio.one.base.user.web.dto.UpdateRolesRequest;
 import studio.one.base.user.web.dto.UpdateUserRequest;
@@ -61,4 +63,17 @@ public interface UserMgmtApi {
 
     ResponseEntity<ApiResponse<Void>> updateUserRoles(Long id, @RequestBody UpdateRolesRequest req,
             UserDetails actor);
+
+    // Properties
+    ResponseEntity<ApiResponse<Map<String, String>>> getProperties(Long id);
+
+    ResponseEntity<ApiResponse<Map<String, String>>> replaceProperties(Long id,
+            @RequestBody Map<String, String> properties);
+
+    ResponseEntity<ApiResponse<PropertyDto>> getProperty(Long id, String key);
+
+    ResponseEntity<ApiResponse<PropertyDto>> setProperty(Long id, String key,
+            @Valid @RequestBody PropertyDto dto);
+
+    ResponseEntity<Void> deleteProperty(Long id, String key);
 }

--- a/studio-platform-user/src/main/java/studio/one/base/user/web/dto/PropertyDto.java
+++ b/studio-platform-user/src/main/java/studio/one/base/user/web/dto/PropertyDto.java
@@ -1,0 +1,61 @@
+/**
+ *
+ *      Copyright 2025
+ *
+ *      Licensed under the Apache License, Version 2.0 (the 'License');
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an 'AS IS' BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ *
+ *      @file PropertyDto.java
+ *      @date 2026
+ *
+ */
+
+package studio.one.base.user.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * DTO for a single key-value property entry.
+ * Used for user/group property management endpoints.
+ *
+ * @author donghyuck, son
+ * @since 2026-04-10
+ * @version 1.0
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *   수정일        수정자           수정내용
+ *  ---------    --------    ---------------------------
+ * 2026-04-10  donghyuck, son: 최초 생성.
+ * </pre>
+ */
+@Value
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PropertyDto {
+
+    @NotBlank
+    @Size(max = 100)
+    @Pattern(regexp = "[A-Za-z0-9_.-]{1,100}", message = "Key must contain only alphanumeric characters, underscores, dots, or hyphens")
+    String key;
+
+    @Size(max = 1024)
+    String value;
+
+}

--- a/studio-platform-user/src/test/java/studio/one/base/user/service/impl/ApplicationGroupServiceImplTest.java
+++ b/studio-platform-user/src/test/java/studio/one/base/user/service/impl/ApplicationGroupServiceImplTest.java
@@ -1,0 +1,127 @@
+package studio.one.base.user.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+
+import studio.one.base.user.domain.entity.ApplicationGroup;
+import studio.one.base.user.persistence.ApplicationGroupMembershipRepository;
+import studio.one.base.user.persistence.ApplicationGroupRepository;
+import studio.one.base.user.persistence.ApplicationGroupRoleRepository;
+import studio.one.base.user.persistence.ApplicationRoleRepository;
+import studio.one.platform.service.I18n;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicationGroupServiceImplTest {
+
+    @Mock
+    private ApplicationGroupRepository groupRepo;
+
+    @Mock
+    private ApplicationRoleRepository roleRepo;
+
+    @Mock
+    private ApplicationGroupMembershipRepository membershipRepo;
+
+    @Mock
+    private ApplicationGroupRoleRepository groupRoleRepo;
+
+    @Mock
+    private org.springframework.jdbc.core.JdbcTemplate jdbcTemplate;
+
+    @Mock
+    private ObjectProvider<I18n> i18nProvider;
+
+    // ---------- setProperty ----------
+
+    @Test
+    void setPropertyRejectsMalformedKey() {
+        // P2: key must match [A-Za-z0-9_.-]{1,100}
+        assertThrows(IllegalArgumentException.class,
+                () -> service().setProperty(1L, "bad key!", "val"));
+        assertThrows(IllegalArgumentException.class,
+                () -> service().setProperty(1L, "", "val"));
+        assertThrows(IllegalArgumentException.class,
+                () -> service().setProperty(1L, null, "val"));
+        assertThrows(IllegalArgumentException.class,
+                () -> service().setProperty(1L, "a".repeat(101), "val"));
+
+        verify(groupRepo, never()).findById(any());
+    }
+
+    @Test
+    void setPropertyAcceptsValidKey() {
+        ApplicationGroup group = ApplicationGroup.builder().groupId(10L).name("g").build();
+        when(groupRepo.findById(10L)).thenReturn(Optional.of(group));
+        when(groupRepo.save(group)).thenReturn(group);
+
+        service().setProperty(10L, "my.feature_flag", "true");
+
+        assertEquals("true", group.getProperties().get("my.feature_flag"));
+    }
+
+    // ---------- replaceProperties ----------
+
+    @Test
+    void replacePropertiesRejectsMalformedKeyInBulk() {
+        // P2: bulk replace must also validate every key
+        Map<String, String> props = new HashMap<>();
+        props.put("valid-key", "ok");
+        props.put("invalid key!", "bad");
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service().replaceProperties(1L, props));
+
+        verify(groupRepo, never()).findById(any());
+        verify(groupRepo, never()).save(any());
+    }
+
+    @Test
+    void replacePropertiesAcceptsValidKeys() {
+        ApplicationGroup group = ApplicationGroup.builder().groupId(10L).name("g").build();
+        when(groupRepo.findById(10L)).thenReturn(Optional.of(group));
+        when(groupRepo.save(group)).thenReturn(group);
+
+        Map<String, String> props = Map.of("theme", "dark", "locale", "ko");
+        service().replaceProperties(10L, props);
+
+        verify(groupRepo).save(group);
+        assertEquals("dark", group.getProperties().get("theme"));
+        assertEquals("ko", group.getProperties().get("locale"));
+    }
+
+    @Test
+    void replacePropertiesWithNullClearsProperties() {
+        ApplicationGroup group = ApplicationGroup.builder().groupId(10L).name("g").build();
+        when(groupRepo.findById(10L)).thenReturn(Optional.of(group));
+        when(groupRepo.save(group)).thenReturn(group);
+
+        service().replaceProperties(10L, null);
+
+        verify(groupRepo).save(group);
+        assertEquals(0, group.getProperties().size());
+    }
+
+    private ApplicationGroupServiceImpl service() {
+        return new ApplicationGroupServiceImpl(
+                groupRepo,
+                roleRepo,
+                membershipRepo,
+                groupRoleRepo,
+                jdbcTemplate,
+                i18nProvider);
+    }
+}


### PR DESCRIPTION
## Why
- 사용자(User)와 그룹(Group) 엔티티는 이미 `Map<String, String> properties` 필드를 `@ElementCollection`으로 보유하고 있으나, 이를 직접 조작하는 웹 API가 없었음
- 클라이언트가 엔티티 전체를 PUT하지 않고 개별 프로퍼티를 생성/수정/삭제할 수 있는 경량 API 필요
- 동일 패턴을 첨부파일 등 타 모듈에도 적용할 예정이므로 재사용 가능한 구조로 설계

## What
- `PropertyDto` 추가: key/value 쌍 DTO (`@NotBlank`, `@Size(max=100)`, `@Pattern` 검증)
- `GroupMgmtApi` 인터페이스 신규 생성 — `UserMgmtApi` 패턴으로 통일
- `ApplicationUserService` / `ApplicationGroupService` 에 property 5개 메서드 추가
- `ApplicationUserServiceImpl` 구현 — 기존 `isAllowedPropertyKey()` 재사용, `@CacheEvict` 적용
- `ApplicationGroupServiceImpl` 구현 — `new HashMap<>(existing)` 복사 패턴으로 불변 맵 이슈 방지
- `UserMgmtController` / `GroupMgmtController` 에 아래 10개 엔드포인트 추가

| Method | URL | 권한 |
|--------|-----|------|
| GET    | `/api/mgmt/users/{id}/properties`        | admin |
| PUT    | `/api/mgmt/users/{id}/properties`        | admin |
| GET    | `/api/mgmt/users/{id}/properties/{key}`  | admin |
| PUT    | `/api/mgmt/users/{id}/properties/{key}`  | admin |
| DELETE | `/api/mgmt/users/{id}/properties/{key}`  | admin |
| GET    | `/api/mgmt/groups/{id}/properties`       | read  |
| PUT    | `/api/mgmt/groups/{id}/properties`       | write |
| GET    | `/api/mgmt/groups/{id}/properties/{key}` | read  |
| PUT    | `/api/mgmt/groups/{id}/properties/{key}` | write |
| DELETE | `/api/mgmt/groups/{id}/properties/{key}` | write |

## Related Issues
- Related #

## Change Scope
- [x] API contract
- [x] Business logic
- [ ] DB schema/query
- [x] Security/permission
- [ ] Docs/runbook

## Security Impact
- Risk: 프로퍼티 key에 예약 prefix(`security.*`, `auth.*`, `role.*`, `admin.*`, `permission.*`) 입력 시 권한 우회 가능성
- Mitigation: User 서비스에서 기존 `isAllowedPropertyKey()` 로 write 시 검증. Group은 예약 prefix 정책 미적용 — 필요 시 후속 PR에서 추가 예정

## Validation
- Commands:
  - `/Users/donghyuck.son/git/studio-api/gradlew --project-dir <worktree> :studio-platform-user:compileJava :studio-platform-user-default:compileJava --no-daemon`
  - `/Users/donghyuck.son/git/studio-api/gradlew --project-dir <worktree> :studio-platform-user:test :studio-platform-user-default:test --no-daemon`
- Result:
  - `BUILD SUCCESSFUL` — 컴파일 및 기존 테스트 모두 통과
- Additional checks:
  - `PUT /api/mgmt/users/{id}/properties/{key}` — 생성 후 `GET`으로 값 확인
  - `PUT /api/mgmt/users/{id}/properties` — 전체 교체 후 이전 키 제거 확인
  - `DELETE /api/mgmt/users/{id}/properties/{key}` — 204 반환, 이후 GET 시 404 확인
  - 예약 prefix 키(`security.x`) PUT 시 400 반환 확인

## Subagent Usage
- [x] Yes
- Delegated tasks: 코드베이스 탐색(Explore), 설계 검토(Plan)
- Ownership (files/modules/tasks): 모든 파일 작성 및 수정은 main agent가 직접 수행
- Main author post-integration validation: 빌드 및 테스트 통과 확인 완료

## Checklist
- [x] policy-compliant commit message
- [ ] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: DB 스키마 변경 없음 (`@ElementCollection` 테이블은 기존 존재)
- Rollback plan: 해당 엔드포인트는 신규 추가이므로 롤백 시 이 커밋만 revert
- Post-deploy checks: `GET /api/mgmt/users/{id}/properties` 응답 200 확인