### PR TITLE
fix(objectstorage): accept trailing slash on providers and buckets endpoints

### DIFF
--- a/studio-platform-storage/src/main/java/studio/one/platform/storage/web/controller/ObjectStorageController.java
+++ b/studio-platform-storage/src/main/java/studio/one/platform/storage/web/controller/ObjectStorageController.java
@@ -90,7 +90,7 @@ public class ObjectStorageController {
     private final I18n i18n;
 
 
-    @GetMapping(value = "/providers")
+    @GetMapping(value = {"/providers", "/providers/"})
     @PreAuthorize("@endpointAuthz.can('services:storage_cloud','read')")
     public ResponseEntity<ApiResponse<List<ProviderInfoDto>>> listProviders(
             @RequestParam(defaultValue = "false") boolean health) {
@@ -98,7 +98,7 @@ public class ObjectStorageController {
         return ok(ApiResponse.ok(catalog.list(health)));
     }
 
-    @GetMapping(value = "/providers/{providerId}/buckets")
+    @GetMapping(value = {"/providers/{providerId}/buckets", "/providers/{providerId}/buckets/"})
     @PreAuthorize("@endpointAuthz.can('services:storage_cloud','read')")
     public ResponseEntity<ApiResponse<List<BucketInfo>>> listBuckets(@PathVariable String providerId) {
         requireAdmin();


### PR DESCRIPTION
## Why
- Spring Framework 6.x removed trailing slash matching by default
- 클라이언트가 `GET /api/mgmt/objectstorage/providers/naver_cufit/buckets/` (trailing slash 포함)로 요청 시 Spring MVC가 핸들러를 찾지 못하고 static resource handler로 낙오, `NoResourceFoundException` 404 반환

## What
- `ObjectStorageController`의 `listProviders`, `listBuckets` `@GetMapping`에 trailing slash 경로 변형을 명시적으로 추가
  - `/providers` → `{"/providers", "/providers/"}`
  - `/providers/{providerId}/buckets` → `{"/providers/{providerId}/buckets", "/providers/{providerId}/buckets/"}`

## Related Issues
- Closes #
- Related #

## Change Scope
- [x] API contract
- [ ] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [ ] Docs/runbook

## Security Impact
- Risk: None
- Mitigation: N/A

## Validation
- Commands:
  - `GET /api/mgmt/objectstorage/providers/` → 200 OK (기존 404)
  - `GET /api/mgmt/objectstorage/providers/{providerId}/buckets/` → 200 OK (기존 404)
  - `GET /api/mgmt/objectstorage/providers` → 200 OK (기존 동작 유지)
  - `GET /api/mgmt/objectstorage/providers/{providerId}/buckets` → 200 OK (기존 동작 유지)
- Result:
  - 로그에서 `NoResourceFoundException` 미발생 확인
- Additional checks:

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [ ] No
- [x] Yes
- Delegated tasks: 장애 원인 분석, 스타터 코드 점검, 수정 범위 결정
- Ownership (files/modules/tasks): `ObjectStorageController.java` 수정은 사람이 검토 및 승인
- Main author post-integration validation: trailing slash 요청/응답 직접 확인 필요

## Checklist
- [x] policy-compliant commit message
- [ ] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [ ] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: 없음
- Rollback plan: revert 1 commit
- Post-deploy checks: trailing slash URL 재호출하여 200 응답 확인