### PR TITLE
feat(objecttype): add DELETE /api/mgmt/object-types/{objectType} endpoint

### DIFF
--- a/studio-platform-objecttype/src/main/java/studio/one/platform/objecttype/db/ObjectTypeStore.java
+++ b/studio-platform-objecttype/src/main/java/studio/one/platform/objecttype/db/ObjectTypeStore.java
@@ -25,4 +25,6 @@ public interface ObjectTypeStore {
     Optional<ObjectTypePolicyRow> findPolicy(int objectType);
 
     ObjectTypePolicyRow upsertPolicy(ObjectTypePolicyRow row);
+
+    void delete(int objectType);
 }

--- a/studio-platform-objecttype/src/main/java/studio/one/platform/objecttype/db/jpa/JpaObjectTypeStore.java
+++ b/studio-platform-objecttype/src/main/java/studio/one/platform/objecttype/db/jpa/JpaObjectTypeStore.java
@@ -162,6 +162,11 @@ public class JpaObjectTypeStore implements ObjectTypeStore {
     }
 
     @Override
+    public void delete(int objectType) {
+        typeRepository.deleteById(objectType);
+    }
+
+    @Override
     public ObjectTypePolicyRow upsertPolicy(ObjectTypePolicyRow row) {
         String sql = """
             INSERT INTO tb_application_object_type_policy (

--- a/studio-platform-objecttype/src/main/java/studio/one/platform/objecttype/service/DefaultObjectTypeAdminService.java
+++ b/studio-platform-objecttype/src/main/java/studio/one/platform/objecttype/service/DefaultObjectTypeAdminService.java
@@ -115,6 +115,12 @@ public class DefaultObjectTypeAdminService implements ObjectTypeAdminService {
         return toPolicyView(saved);
     }
 
+    @Override
+    public void delete(int objectType) {
+        ensureTypeExists(objectType);
+        store.delete(objectType);
+    }
+
     private void ensureTypeExists(int objectType) {
         store.findByType(objectType)
                 .orElseThrow(() -> PlatformRuntimeException.of(ObjectTypeErrorCodes.UNKNOWN_OBJECT_TYPE, objectType));

--- a/studio-platform-objecttype/src/main/java/studio/one/platform/objecttype/service/ObjectTypeAdminService.java
+++ b/studio-platform-objecttype/src/main/java/studio/one/platform/objecttype/service/ObjectTypeAdminService.java
@@ -18,4 +18,6 @@ public interface ObjectTypeAdminService {
     ObjectTypePolicyView getPolicy(int objectType);
 
     ObjectTypePolicyView upsertPolicy(int objectType, ObjectTypePolicyUpsertCommand request);
+
+    void delete(int objectType);
 }

--- a/studio-platform-objecttype/src/main/java/studio/one/platform/objecttype/web/controller/ObjectTypeMgmtController.java
+++ b/studio-platform-objecttype/src/main/java/studio/one/platform/objecttype/web/controller/ObjectTypeMgmtController.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Min;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -88,6 +89,12 @@ public class ObjectTypeMgmtController {
             @PathVariable @Min(1) int objectType,
             @Valid @RequestBody ObjectTypePolicyUpsertRequest request) {
         return ResponseEntity.ok(ApiResponse.ok(toDto(adminService.upsertPolicy(objectType, toCommand(request)))));
+    }
+
+    @DeleteMapping("/{objectType}")
+    public ResponseEntity<ApiResponse<Void>> delete(@PathVariable @Min(1) int objectType) {
+        adminService.delete(objectType);
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/reload")


### PR DESCRIPTION
## Why
- `DELETE /api/mgmt/object-types/{id}` 호출 시 `405 Method Not Allowed` 반환
- `ObjectTypeMgmtController`에 `@DeleteMapping`이 없었으며, 서비스·스토어 레이어에도 delete 메서드 미구현

## What
- `ObjectTypeStore` 인터페이스에 `void delete(int objectType)` 추가
- `JpaObjectTypeStore`에서 `typeRepository.deleteById()` 위임
- `ObjectTypeAdminService` 인터페이스에 `void delete(int objectType)` 추가
- `DefaultObjectTypeAdminService`에서 `ensureTypeExists()` 후 `store.delete()` 호출
- `ObjectTypeMgmtController`에 `DELETE /{objectType}` → `204 No Content` 추가

## Related Issues
- Closes #
- Related #

## Change Scope
- [x] API contract
- [x] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [ ] Docs/runbook

## Security Impact
- Risk: None
- Mitigation: N/A — 기존 인증·인가 필터 그대로 적용됨

## Validation
- Commands:
  - `DELETE /api/mgmt/object-types/{존재하는 id}` → 204 No Content
  - `DELETE /api/mgmt/object-types/{없는 id}` → 404 UNKNOWN_OBJECT_TYPE
  - `GET /api/mgmt/object-types/{삭제한 id}` → 404 UNKNOWN_OBJECT_TYPE
  - `GET /api/mgmt/object-types/{삭제한 id}/policy` → 404 (CASCADE 확인)
- Result:
  - 정상 삭제 시 `tb_application_object_type_policy`도 ON DELETE CASCADE로 자동 제거
- Additional checks:

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [ ] No
- [x] Yes
- Delegated tasks: 모듈 구조 탐색, 레이어별 변경 범위 확인, FK/CASCADE 분석
- Ownership (files/modules/tasks): 5개 파일 수정, 사람이 검토 및 승인 후 병합
- Main author post-integration validation: 위 Validation 시나리오 직접 호출 확인 필요

## Checklist
- [x] policy-compliant commit message
- [ ] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [ ] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: 없음 (DB 스키마 변경 없음)
- Rollback plan: revert 1 commit
- Post-deploy checks: `DELETE /api/mgmt/object-types/{id}` → 204 확인