### PR TITLE
feat(objecttype): expose effective policy for clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-04-15
+
+### 변경됨
+- `ObjectTypeMgmtController`에 `GET /api/mgmt/object-types/{objectType}/policy/effective`를 추가해 저장 정책이 없을 때도 클라이언트가 실제 적용 정책(`source=default`, 제한 없음)을 안내할 수 있도록 했다.
+
+### 검증
+- `./gradlew :studio-platform-objecttype:test`
+- `./gradlew :starter:studio-platform-starter-objecttype:compileJava`
+
 ## 2026-04-14
 
 ### 변경됨

--- a/starter/studio-platform-starter-objecttype/README.md
+++ b/starter/studio-platform-starter-objecttype/README.md
@@ -144,6 +144,7 @@ studio:
 
 - `ObjectTypeController` — 공개 조회 엔드포인트 (YAML·DB 모드 모두 활성화 가능)
 - `ObjectTypeMgmtController` — 관리 엔드포인트 (DB 모드에서 `ObjectTypeAdminService` 빈이 있을 때만 등록됨)
+- `GET /api/mgmt/object-types/{objectType}/policy/effective` — 저장 정책이 없을 때도 클라이언트 안내용 적용 정책을 반환한다. 저장 정책이면 `source=stored`, 내부 기본 정책이면 `source=default`다. 기본 정책은 현재 제한 없음(`maxFileMb`, `allowedExt`, `allowedMime`, `policyJson` 모두 `null`)이다.
 
 ## 6) 참고 사항
 - `studio-platform-objecttype` 모듈이 도메인 모델, 레지스트리, 정책 리졸버 구현을 제공하며,

--- a/studio-platform-objecttype/README.md
+++ b/studio-platform-objecttype/README.md
@@ -159,8 +159,20 @@ Flyway 버전 범위는 `docs/flyway-versioning.md`의 objecttype 범위(V200-V2
 - `PUT    /api/mgmt/object-types/{objectType}` (upsert)
 - `PATCH  /api/mgmt/object-types/{objectType}` (status/description/etc)
 - `GET    /api/mgmt/object-types/{objectType}/policy`
+- `GET    /api/mgmt/object-types/{objectType}/policy/effective`
 - `PUT    /api/mgmt/object-types/{objectType}/policy` (upsert)
 - `POST   /api/mgmt/object-types/reload` (cache evict/rebind)
+
+### 적용 정책 조회
+`GET /api/mgmt/object-types/{objectType}/policy/effective`는 클라이언트가 실제 적용 정책을 안내할 때 사용한다.
+
+- 저장된 정책이 있으면 저장 정책값과 `source=stored`를 반환한다.
+- 저장된 정책이 없으면 내부 기본 정책값과 `source=default`를 반환한다.
+- `source=default`의 현재 의미는 제한 없음이다. `maxFileMb`, `allowedExt`, `allowedMime`, `policyJson`은 모두 `null`로 내려간다.
+
+클라이언트 안내 기준:
+- `source=stored`: “저장된 정책이 적용됩니다.”
+- `source=default`: “저장된 정책이 없어 기본 정책이 적용됩니다. 현재 기본 정책은 제한 없음입니다.”
 
 ## 런타임(클라이언트용 API) 가이드
 런타임 API는 업로드 검증/정의 조회를 위한 엔드포인트다.

--- a/studio-platform-objecttype/src/main/java/studio/one/platform/objecttype/service/DefaultObjectTypeAdminService.java
+++ b/studio-platform-objecttype/src/main/java/studio/one/platform/objecttype/service/DefaultObjectTypeAdminService.java
@@ -96,6 +96,14 @@ public class DefaultObjectTypeAdminService implements ObjectTypeAdminService {
                 .orElse(null);
     }
 
+    @Override
+    public ObjectTypeEffectivePolicyView getEffectivePolicy(int objectType) {
+        ensureTypeExists(objectType);
+        return store.findPolicy(objectType)
+                .map(DefaultObjectTypeAdminService::toStoredEffectivePolicyView)
+                .orElseGet(() -> defaultEffectivePolicyView(objectType));
+    }
+
     @Transactional
     @Override
     public ObjectTypePolicyView upsertPolicy(int objectType, ObjectTypePolicyUpsertCommand request) {
@@ -167,6 +175,26 @@ public class DefaultObjectTypeAdminService implements ObjectTypeAdminService {
                 row.getUpdatedBy(),
                 row.getUpdatedById(),
                 toOffset(row.getUpdatedAt()));
+    }
+
+    static ObjectTypeEffectivePolicyView toStoredEffectivePolicyView(ObjectTypePolicyRow row) {
+        return new ObjectTypeEffectivePolicyView(
+                row.getObjectType(),
+                row.getMaxFileMb(),
+                row.getAllowedExt(),
+                row.getAllowedMime(),
+                row.getPolicyJson(),
+                ObjectTypeEffectivePolicyView.Source.STORED);
+    }
+
+    static ObjectTypeEffectivePolicyView defaultEffectivePolicyView(int objectType) {
+        return new ObjectTypeEffectivePolicyView(
+                objectType,
+                null,
+                null,
+                null,
+                null,
+                ObjectTypeEffectivePolicyView.Source.DEFAULT);
     }
 
     private static OffsetDateTime toOffset(Instant instant) {

--- a/studio-platform-objecttype/src/main/java/studio/one/platform/objecttype/service/ObjectTypeAdminService.java
+++ b/studio-platform-objecttype/src/main/java/studio/one/platform/objecttype/service/ObjectTypeAdminService.java
@@ -17,6 +17,8 @@ public interface ObjectTypeAdminService {
 
     ObjectTypePolicyView getPolicy(int objectType);
 
+    ObjectTypeEffectivePolicyView getEffectivePolicy(int objectType);
+
     ObjectTypePolicyView upsertPolicy(int objectType, ObjectTypePolicyUpsertCommand request);
 
     void delete(int objectType);

--- a/studio-platform-objecttype/src/main/java/studio/one/platform/objecttype/service/ObjectTypeEffectivePolicyView.java
+++ b/studio-platform-objecttype/src/main/java/studio/one/platform/objecttype/service/ObjectTypeEffectivePolicyView.java
@@ -1,0 +1,26 @@
+package studio.one.platform.objecttype.service;
+
+public record ObjectTypeEffectivePolicyView(
+        int objectType,
+        Integer maxFileMb,
+        String allowedExt,
+        String allowedMime,
+        String policyJson,
+        Source source
+) {
+
+    public enum Source {
+        STORED("stored"),
+        DEFAULT("default");
+
+        private final String value;
+
+        Source(String value) {
+            this.value = value;
+        }
+
+        public String value() {
+            return value;
+        }
+    }
+}

--- a/studio-platform-objecttype/src/main/java/studio/one/platform/objecttype/web/controller/ObjectTypeMgmtController.java
+++ b/studio-platform-objecttype/src/main/java/studio/one/platform/objecttype/web/controller/ObjectTypeMgmtController.java
@@ -24,6 +24,7 @@ import studio.one.platform.objecttype.service.ObjectTypePolicyUpsertCommand;
 import studio.one.platform.objecttype.service.ObjectTypeUpsertCommand;
 import studio.one.platform.objecttype.service.ObjectTypeView;
 import studio.one.platform.objecttype.web.dto.ObjectTypeDto;
+import studio.one.platform.objecttype.web.dto.ObjectTypeEffectivePolicyDto;
 import studio.one.platform.objecttype.web.dto.ObjectTypePatchRequest;
 import studio.one.platform.objecttype.web.dto.ObjectTypePolicyDto;
 import studio.one.platform.objecttype.web.dto.ObjectTypePolicyUpsertRequest;
@@ -84,6 +85,12 @@ public class ObjectTypeMgmtController {
         return ResponseEntity.ok(ApiResponse.ok(toDto(adminService.getPolicy(objectType))));
     }
 
+    @GetMapping("/{objectType}/policy/effective")
+    public ResponseEntity<ApiResponse<ObjectTypeEffectivePolicyDto>> getEffectivePolicy(
+            @PathVariable @Min(1) int objectType) {
+        return ResponseEntity.ok(ApiResponse.ok(toDto(adminService.getEffectivePolicy(objectType))));
+    }
+
     @PutMapping("/{objectType}/policy")
     public ResponseEntity<ApiResponse<ObjectTypePolicyDto>> upsertPolicy(
             @PathVariable @Min(1) int objectType,
@@ -136,6 +143,18 @@ public class ObjectTypeMgmtController {
                 .updatedBy(view.updatedBy())
                 .updatedById(view.updatedById())
                 .updatedAt(view.updatedAt())
+                .build();
+    }
+
+    private ObjectTypeEffectivePolicyDto toDto(
+            studio.one.platform.objecttype.service.ObjectTypeEffectivePolicyView view) {
+        return ObjectTypeEffectivePolicyDto.builder()
+                .objectType(view.objectType())
+                .maxFileMb(view.maxFileMb())
+                .allowedExt(view.allowedExt())
+                .allowedMime(view.allowedMime())
+                .policyJson(view.policyJson())
+                .source(view.source().value())
                 .build();
     }
 

--- a/studio-platform-objecttype/src/main/java/studio/one/platform/objecttype/web/dto/ObjectTypeEffectivePolicyDto.java
+++ b/studio-platform-objecttype/src/main/java/studio/one/platform/objecttype/web/dto/ObjectTypeEffectivePolicyDto.java
@@ -1,0 +1,15 @@
+package studio.one.platform.objecttype.web.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ObjectTypeEffectivePolicyDto {
+    private final int objectType;
+    private final Integer maxFileMb;
+    private final String allowedExt;
+    private final String allowedMime;
+    private final String policyJson;
+    private final String source;
+}

--- a/studio-platform-objecttype/src/test/java/studio/one/platform/objecttype/DefaultObjectTypeAdminServiceTest.java
+++ b/studio-platform-objecttype/src/test/java/studio/one/platform/objecttype/DefaultObjectTypeAdminServiceTest.java
@@ -1,0 +1,97 @@
+package studio.one.platform.objecttype;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.exception.PlatformRuntimeException;
+import studio.one.platform.objecttype.db.ObjectTypeStore;
+import studio.one.platform.objecttype.db.model.ObjectTypePolicyRow;
+import studio.one.platform.objecttype.db.model.ObjectTypeRow;
+import studio.one.platform.objecttype.error.ObjectTypeErrorCodes;
+import studio.one.platform.objecttype.service.DefaultObjectTypeAdminService;
+import studio.one.platform.objecttype.service.ObjectTypeEffectivePolicyView;
+
+class DefaultObjectTypeAdminServiceTest {
+
+    @Test
+    void effectivePolicyReturnsStoredPolicyWhenPresent() {
+        ObjectTypeStore store = mock(ObjectTypeStore.class);
+        DefaultObjectTypeAdminService service = new DefaultObjectTypeAdminService(store);
+        ObjectTypePolicyRow policy = policyRow(1001);
+
+        when(store.findByType(1001)).thenReturn(Optional.of(typeRow(1001)));
+        when(store.findPolicy(1001)).thenReturn(Optional.of(policy));
+
+        ObjectTypeEffectivePolicyView result = service.getEffectivePolicy(1001);
+
+        assertEquals(1001, result.objectType());
+        assertEquals(12, result.maxFileMb());
+        assertEquals("png", result.allowedExt());
+        assertEquals("image/png", result.allowedMime());
+        assertEquals("{\"x\":1}", result.policyJson());
+        assertEquals(ObjectTypeEffectivePolicyView.Source.STORED, result.source());
+    }
+
+    @Test
+    void effectivePolicyReturnsDefaultPolicyWhenStoredPolicyMissing() {
+        ObjectTypeStore store = mock(ObjectTypeStore.class);
+        DefaultObjectTypeAdminService service = new DefaultObjectTypeAdminService(store);
+
+        when(store.findByType(1001)).thenReturn(Optional.of(typeRow(1001)));
+        when(store.findPolicy(1001)).thenReturn(Optional.empty());
+
+        ObjectTypeEffectivePolicyView result = service.getEffectivePolicy(1001);
+
+        assertEquals(1001, result.objectType());
+        assertNull(result.maxFileMb());
+        assertNull(result.allowedExt());
+        assertNull(result.allowedMime());
+        assertNull(result.policyJson());
+        assertEquals(ObjectTypeEffectivePolicyView.Source.DEFAULT, result.source());
+    }
+
+    @Test
+    void effectivePolicyRejectsUnknownObjectType() {
+        ObjectTypeStore store = mock(ObjectTypeStore.class);
+        DefaultObjectTypeAdminService service = new DefaultObjectTypeAdminService(store);
+
+        when(store.findByType(1001)).thenReturn(Optional.empty());
+
+        PlatformRuntimeException ex = assertThrows(PlatformRuntimeException.class,
+                () -> service.getEffectivePolicy(1001));
+
+        assertEquals(ObjectTypeErrorCodes.UNKNOWN_OBJECT_TYPE, ex.getType());
+    }
+
+    private ObjectTypeRow typeRow(int objectType) {
+        ObjectTypeRow row = new ObjectTypeRow();
+        row.setObjectType(objectType);
+        row.setCode("attachment");
+        row.setName("Attachment");
+        row.setDomain("media");
+        row.setStatus("active");
+        row.setCreatedAt(Instant.parse("2026-04-15T00:00:00Z"));
+        row.setUpdatedAt(Instant.parse("2026-04-15T00:00:00Z"));
+        return row;
+    }
+
+    private ObjectTypePolicyRow policyRow(int objectType) {
+        ObjectTypePolicyRow row = new ObjectTypePolicyRow();
+        row.setObjectType(objectType);
+        row.setMaxFileMb(12);
+        row.setAllowedExt("png");
+        row.setAllowedMime("image/png");
+        row.setPolicyJson("{\"x\":1}");
+        row.setCreatedAt(Instant.parse("2026-04-15T00:00:00Z"));
+        row.setUpdatedAt(Instant.parse("2026-04-15T00:00:00Z"));
+        return row;
+    }
+}

--- a/studio-platform-objecttype/src/test/java/studio/one/platform/objecttype/web/controller/ObjectTypeMgmtControllerTest.java
+++ b/studio-platform-objecttype/src/test/java/studio/one/platform/objecttype/web/controller/ObjectTypeMgmtControllerTest.java
@@ -1,6 +1,7 @@
 package studio.one.platform.objecttype.web.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -14,10 +15,12 @@ import org.springframework.http.ResponseEntity;
 
 import studio.one.platform.objecttype.lifecycle.ObjectRebindService;
 import studio.one.platform.objecttype.service.ObjectTypeAdminService;
+import studio.one.platform.objecttype.service.ObjectTypeEffectivePolicyView;
 import studio.one.platform.objecttype.service.ObjectTypePolicyUpsertCommand;
 import studio.one.platform.objecttype.service.ObjectTypeUpsertCommand;
 import studio.one.platform.objecttype.service.ObjectTypeView;
 import studio.one.platform.objecttype.service.ObjectTypePolicyView;
+import studio.one.platform.objecttype.web.dto.ObjectTypeEffectivePolicyDto;
 import studio.one.platform.objecttype.web.dto.ObjectTypePolicyUpsertRequest;
 import studio.one.platform.objecttype.web.dto.ObjectTypeUpsertRequest;
 import studio.one.platform.web.dto.ApiResponse;
@@ -68,6 +71,48 @@ class ObjectTypeMgmtControllerTest {
         assertEquals("png", response.getBody().getData().getAllowedExt());
         verify(adminService).upsertPolicy(eq(1001), eq(new ObjectTypePolicyUpsertCommand(12, "png", "image/png",
                 "{\"x\":1}", "system", 1L, "system", 1L)));
+    }
+
+    @Test
+    void effectivePolicyMapsStoredPolicy() {
+        ObjectTypeAdminService adminService = mock(ObjectTypeAdminService.class);
+        ObjectRebindService rebindService = mock(ObjectRebindService.class);
+        ObjectTypeMgmtController controller = new ObjectTypeMgmtController(adminService, rebindService);
+
+        when(adminService.getEffectivePolicy(1001))
+                .thenReturn(new ObjectTypeEffectivePolicyView(1001, 12, "png", "image/png", "{\"x\":1}",
+                        ObjectTypeEffectivePolicyView.Source.STORED));
+
+        ResponseEntity<ApiResponse<ObjectTypeEffectivePolicyDto>> response = controller.getEffectivePolicy(1001);
+
+        assertEquals(1001, response.getBody().getData().getObjectType());
+        assertEquals(12, response.getBody().getData().getMaxFileMb());
+        assertEquals("png", response.getBody().getData().getAllowedExt());
+        assertEquals("image/png", response.getBody().getData().getAllowedMime());
+        assertEquals("{\"x\":1}", response.getBody().getData().getPolicyJson());
+        assertEquals("stored", response.getBody().getData().getSource());
+        verify(adminService).getEffectivePolicy(1001);
+    }
+
+    @Test
+    void effectivePolicyMapsDefaultPolicy() {
+        ObjectTypeAdminService adminService = mock(ObjectTypeAdminService.class);
+        ObjectRebindService rebindService = mock(ObjectRebindService.class);
+        ObjectTypeMgmtController controller = new ObjectTypeMgmtController(adminService, rebindService);
+
+        when(adminService.getEffectivePolicy(1001))
+                .thenReturn(new ObjectTypeEffectivePolicyView(1001, null, null, null, null,
+                        ObjectTypeEffectivePolicyView.Source.DEFAULT));
+
+        ResponseEntity<ApiResponse<ObjectTypeEffectivePolicyDto>> response = controller.getEffectivePolicy(1001);
+
+        assertEquals(1001, response.getBody().getData().getObjectType());
+        assertNull(response.getBody().getData().getMaxFileMb());
+        assertNull(response.getBody().getData().getAllowedExt());
+        assertNull(response.getBody().getData().getAllowedMime());
+        assertNull(response.getBody().getData().getPolicyJson());
+        assertEquals("default", response.getBody().getData().getSource());
+        verify(adminService).getEffectivePolicy(1001);
     }
 
     @Test


### PR DESCRIPTION
## Why
- 클라이언트가 ObjectType 저장 정책이 없는 경우에도 실제 적용 정책을 안내할 수 있어야 한다.
- 런타임은 저장 정책이 없으면 제한 없이 허용하지만, 관리 API에는 이 effective default를 구분해 조회하는 기능이 없었다.

## What
- `GET /api/mgmt/object-types/{objectType}/policy/effective`를 추가했다.
- 저장 정책이 있으면 `source=stored`, 저장 정책이 없으면 제한 없음 기본 정책과 `source=default`를 반환한다.
- 기존 `GET /{objectType}/policy`의 `null` 반환 동작은 유지했다.
- service/controller 테스트와 objecttype 문서, changelog를 갱신했다.

## Related Issues
- Closes #
- Related #

## Change Scope
- [x] API contract
- [ ] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [x] Docs/runbook

## Security Impact
- Risk: 낮음. 신규 조회 API이며 기존 저장/검증/권한 정책은 변경하지 않는다.
- Mitigation: 기존 관리 API base path에만 추가하고 기존 policy 조회 계약은 유지했다.

## Validation
- Commands:
  - `./gradlew :studio-platform-objecttype:test`
  - `./gradlew :starter:studio-platform-starter-objecttype:compileJava`
- Result:
  - PASS
- Additional checks:
  - `git diff --check`

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [ ] No
- [x] Yes
- Delegated tasks:
- Ownership (files/modules/tasks): main author handled objecttype service/controller/dto/tests/docs
- Main author post-integration validation: commands listed above

## Checklist
- [x] policy-compliant commit message
- [ ] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: 없음
- Rollback plan: PR revert
- Post-deploy checks: `GET /api/mgmt/object-types/{objectType}/policy/effective`가 저장 정책 없음에서 `source=default`를 반환하는지 확인
