### PR TITLE
feat(ai-web): align client AI RAG contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### 변경됨
 - Spring AI 기반 AI web API가 기존 React 클라이언트 계약을 수용하도록 `ChatRequestDto.provider`, `ChatRequestDto.systemPrompt`를 추가하고, `ChatController`가 `AiProviderRegistry`로 provider별 `ChatPort`를 선택하도록 변경했다.
 - `POST /api/ai/chat/rag`가 파일/객체 범위 RAG 답변에 사용할 `objectType`/`objectId` 흐름과 client system prompt를 함께 지원하도록 보강했다.
+- `POST /api/ai/chat/rag`의 attachment 범위 RAG가 `features:attachment read` 권한을 추가로 요구하고, 안전하게 권한 확인할 수 없는 object scope 요청을 거부하도록 보강했다.
+- `POST /api/ai/chat`의 `provider` 입력을 trim/blank normalize하고 알 수 없는 provider를 400 오류로 반환하도록 정리했다.
 - `POST /api/ai/vectors/search` 응답에 기존 `documentId`와 동일한 `id` alias를 추가해 클라이언트 grid와 기존 소비자를 모두 지원하도록 했다.
 - `ObjectTypeMgmtController`에 `GET /api/mgmt/object-types/{objectType}/policy/effective`를 추가해 저장 정책이 없을 때도 클라이언트가 실제 적용 정책(`source=default`, ObjectType별 추가 제한 없음)을 안내할 수 있도록 했다.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,15 @@
 ## 2026-04-15
 
 ### 변경됨
+- Spring AI 기반 AI web API가 기존 React 클라이언트 계약을 수용하도록 `ChatRequestDto.provider`, `ChatRequestDto.systemPrompt`를 추가하고, `ChatController`가 `AiProviderRegistry`로 provider별 `ChatPort`를 선택하도록 변경했다.
+- `POST /api/ai/chat/rag`가 파일/객체 범위 RAG 답변에 사용할 `objectType`/`objectId` 흐름과 client system prompt를 함께 지원하도록 보강했다.
+- `POST /api/ai/vectors/search` 응답에 기존 `documentId`와 동일한 `id` alias를 추가해 클라이언트 grid와 기존 소비자를 모두 지원하도록 했다.
 - `ObjectTypeMgmtController`에 `GET /api/mgmt/object-types/{objectType}/policy/effective`를 추가해 저장 정책이 없을 때도 클라이언트가 실제 적용 정책(`source=default`, ObjectType별 추가 제한 없음)을 안내할 수 있도록 했다.
 
 ### 검증
+- `./gradlew :starter:studio-platform-starter-ai-web:test`
+- `./gradlew :starter:studio-platform-starter-ai:compileJava`
+- `./gradlew :studio-platform-ai:test`
 - `./gradlew :studio-platform-objecttype:test`
 - `./gradlew :starter:studio-platform-starter-objecttype:compileJava`
 

--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -144,9 +144,13 @@ Content-Type: application/json
 
 첨부파일 기반 답변은 `content-embedding-pipeline`과 함께 사용한다.
 
-1. `POST /api/mgmt/files/{attachmentId}/rag/index`로 파일 텍스트를 추출하고 RAG 인덱스에 저장한다.
-2. `GET /api/mgmt/files/{attachmentId}/rag/metadata`로 `objectType=attachment`, `objectId=<attachmentId>` 메타데이터를 확인한다.
+1. `POST /api/mgmt/attachments/{attachmentId}/rag/index`로 파일 텍스트를 추출하고 RAG 인덱스에 저장한다.
+2. `GET /api/mgmt/attachments/{attachmentId}/rag/metadata`로 `objectType=attachment`, `objectId=<attachmentId>` 메타데이터를 확인한다.
 3. `POST /api/ai/chat/rag`에 `objectType=attachment`, `objectId=<attachmentId>`를 넘겨 해당 파일 내용 기반 답변을 요청한다.
+
+`/api/ai/chat/rag`에서 객체 범위 RAG를 사용할 때 현재 안전하게 지원되는 범위는
+`objectType=attachment`와 구체적인 `objectId` 조합이다. 이 경우 기본 AI chat 권한
+(`services:ai_chat write`) 외에 첨부 읽기 권한(`features:attachment read`)도 필요하다.
 
 ### 벡터 검색 응답
 

--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -74,6 +74,8 @@ Authorization: Bearer <token>
 Content-Type: application/json
 
 {
+  "provider": "openai",
+  "systemPrompt": "답변은 간결하게 작성하세요.",
   "messages": [
     {"role": "user", "content": "안녕하세요"}
   ],
@@ -82,6 +84,34 @@ Content-Type: application/json
   "maxOutputTokens": 512
 }
 ```
+
+`provider`를 생략하면 `studio.ai.default-provider`가 사용된다. `systemPrompt`가 있으면
+서버가 첫 system message로 변환해 provider에 전달한다.
+
+### RAG Chat 예시
+
+```http
+POST /api/ai/chat/rag
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "chat": {
+    "provider": "openai",
+    "systemPrompt": "제공된 파일 컨텍스트를 기반으로 답변하세요.",
+    "messages": [
+      {"role": "user", "content": "이 파일의 핵심 내용을 요약해줘"}
+    ]
+  },
+  "ragQuery": "핵심 내용 요약",
+  "ragTopK": 3,
+  "objectType": "attachment",
+  "objectId": "123"
+}
+```
+
+`objectType`/`objectId`를 지정하면 해당 객체 범위의 RAG 인덱스에서 검색한다. `ragQuery`가 없고
+객체 범위만 있으면 저장된 chunk를 순서대로 가져와 컨텍스트로 사용한다.
 
 ### 임베딩 요청 예시
 
@@ -110,6 +140,31 @@ Content-Type: application/json
 }
 ```
 
+### 파일 기반 RAG 흐름
+
+첨부파일 기반 답변은 `content-embedding-pipeline`과 함께 사용한다.
+
+1. `POST /api/mgmt/files/{attachmentId}/rag/index`로 파일 텍스트를 추출하고 RAG 인덱스에 저장한다.
+2. `GET /api/mgmt/files/{attachmentId}/rag/metadata`로 `objectType=attachment`, `objectId=<attachmentId>` 메타데이터를 확인한다.
+3. `POST /api/ai/chat/rag`에 `objectType=attachment`, `objectId=<attachmentId>`를 넘겨 해당 파일 내용 기반 답변을 요청한다.
+
+### 벡터 검색 응답
+
+`POST /api/ai/vectors/search` 응답 항목은 기존 `documentId`와 클라이언트 grid 호환용 `id`를 함께 반환한다.
+
+```json
+{
+  "id": "doc-1",
+  "documentId": "doc-1",
+  "content": "...",
+  "metadata": {
+    "objectType": "attachment",
+    "objectId": "123"
+  },
+  "score": 0.91
+}
+```
+
 ## 4) 자동 구성되는 주요 빈 (엔드포인트)
 
 | 빈 | 설명 |
@@ -125,6 +180,7 @@ Content-Type: application/json
 
 - `VectorController`는 `VectorStorePort` 빈이 없어도 등록되지만, 벡터 관련 요청 시 HTTP 503을 반환한다.
 - 벡터 검색 시 `hybrid=true`를 설정하면 BM25 + 벡터 하이브리드 검색이 활성화된다(query 텍스트 필수).
+- 채팅 API의 `provider`는 Studio provider id 선택만 담당한다. OpenAI 런타임 설정은 계속 `spring.ai.openai.*`가 소유한다.
 - `query-rewrite` 엔드포인트는 Mustache 템플릿(`query-rewrite`)이 없으면 내장 폴백 프롬프트를 사용한다.
 - 모든 엔드포인트는 Spring Security의 메서드 레벨 권한 검사(`@PreAuthorize`)를 사용한다.
   `endpointAuthz` 빈이 컨텍스트에 등록되어 있어야 한다.

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
@@ -10,6 +10,7 @@ import org.springframework.lang.Nullable;
 import studio.one.platform.ai.autoconfigure.config.AiAdapterProperties;
 import studio.one.platform.ai.core.chat.ChatPort;
 import studio.one.platform.ai.core.embedding.EmbeddingPort;
+import studio.one.platform.ai.core.registry.AiProviderRegistry;
 import studio.one.platform.ai.core.vector.VectorStorePort;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
 import studio.one.platform.ai.service.prompt.PromptRenderer;
@@ -27,8 +28,8 @@ import studio.one.platform.constant.PropertyKeys;
 public class AiWebAutoConfiguration {
 
     @Bean
-    ChatController chatController(ChatPort chatPort, RagPipelineService ragPipelineService) {
-        return new ChatController(chatPort, ragPipelineService);
+    ChatController chatController(AiProviderRegistry providerRegistry, RagPipelineService ragPipelineService) {
+        return new ChatController(providerRegistry, ragPipelineService);
     }
 
     @Bean

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 
 import jakarta.validation.Valid;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
@@ -36,6 +37,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import lombok.extern.slf4j.Slf4j;
 import studio.one.platform.ai.core.chat.ChatMessage;
@@ -67,6 +69,7 @@ import studio.one.platform.web.dto.ApiResponse;
 @Slf4j
 public class ChatController {
 
+    private static final String OBJECT_TYPE_ATTACHMENT = "attachment";
     private final AiProviderRegistry providerRegistry;
     private final RagPipelineService ragPipelineService;
 
@@ -117,17 +120,20 @@ public class ChatController {
      * RAG 검색 결과를 시스템 프롬프트로 주입한 뒤 챗을 수행한다.
      */
     @PostMapping("/rag")
-    @PreAuthorize("@endpointAuthz.can('services:ai_chat','write')")
+    @PreAuthorize("@endpointAuthz.can('services:ai_chat','write') and "
+            + "(#request.objectType() == null or !#request.objectType().trim().equalsIgnoreCase('attachment') "
+            + "or @endpointAuthz.can('features:attachment','read'))")
     public ResponseEntity<ApiResponse<ChatResponseDto>> chatWithRag(@Valid @RequestBody ChatRagRequestDto request) {
         
         ChatRequestDto chat = request.chat();
         int ragTopK = request.ragTopK() != null ? request.ragTopK() : 3;
-        String objectType = request.objectType();
-        String objectId = request.objectId();
+        ObjectScope objectScope = resolveObjectScope(request.objectType(), request.objectId());
+        String objectType = objectScope.objectType();
+        String objectId = objectScope.objectId();
 
         List<RagSearchResult> ragResults;
         String ragQuery = request.ragQuery();
-        boolean hasFilter = (objectType != null && !objectType.isBlank()) || (objectId != null && !objectId.isBlank());
+        boolean hasFilter = objectScope.hasFilter();
 
         if (ragQuery == null || ragQuery.isBlank()) {
             if (!hasFilter) {
@@ -201,7 +207,37 @@ public class ChatController {
     }
 
     private ChatPort chatPort(String provider) {
-        return providerRegistry.chatPort(provider);
+        String normalized = normalizeText(provider);
+        try {
+            return providerRegistry.chatPort(normalized);
+        } catch (IllegalArgumentException ex) {
+            if (normalized != null) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "Unknown AI provider: " + normalized, ex);
+            }
+            throw ex;
+        }
+    }
+
+    private ObjectScope resolveObjectScope(String objectType, String objectId) {
+        String normalizedObjectType = normalizeText(objectType);
+        String normalizedObjectId = normalizeText(objectId);
+        if (normalizedObjectType == null && normalizedObjectId == null) {
+            return ObjectScope.none();
+        }
+        if (!OBJECT_TYPE_ATTACHMENT.equalsIgnoreCase(normalizedObjectType) || normalizedObjectId == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Unsupported RAG object scope");
+        }
+        return new ObjectScope(OBJECT_TYPE_ATTACHMENT, normalizedObjectId);
+    }
+
+    private String normalizeText(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
     
     private String truncate(String content, int maxLen) {
@@ -264,5 +300,16 @@ public class ChatController {
                     .append("\n").append(r.content()).append("\n\n");
         }
         return sb.toString().trim();
+    }
+
+    private record ObjectScope(String objectType, String objectId) {
+
+        static ObjectScope none() {
+            return new ObjectScope(null, null);
+        }
+
+        boolean hasFilter() {
+            return objectType != null || objectId != null;
+        }
     }
 }

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
@@ -43,6 +43,7 @@ import studio.one.platform.ai.core.chat.ChatMessageRole;
 import studio.one.platform.ai.core.chat.ChatPort;
 import studio.one.platform.ai.core.chat.ChatRequest;
 import studio.one.platform.ai.core.chat.ChatResponse;
+import studio.one.platform.ai.core.registry.AiProviderRegistry;
 import studio.one.platform.ai.core.rag.RagSearchRequest;
 import studio.one.platform.ai.core.rag.RagSearchResult;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
@@ -58,7 +59,7 @@ import studio.one.platform.web.dto.ApiResponse;
  * 
  * REST controller exposing chat completions. The base path defaults to {@code /api/ai}
  * and can be overridden with {@code studio.ai.endpoints.base-path}. Requests are
- * delegated to {@link ChatPort} and wrapped with {@link ApiResponse}.
+ * delegated through {@link AiProviderRegistry} and wrapped with {@link ApiResponse}.
  */
 @RestController
 @RequestMapping("${" + PropertyKeys.AI.Endpoints.BASE_PATH + ":/api/ai}/chat")
@@ -66,11 +67,11 @@ import studio.one.platform.web.dto.ApiResponse;
 @Slf4j
 public class ChatController {
 
-    private final ChatPort chatPort;
+    private final AiProviderRegistry providerRegistry;
     private final RagPipelineService ragPipelineService;
 
-    public ChatController(ChatPort chatPort, RagPipelineService ragPipelineService) {
-        this.chatPort = Objects.requireNonNull(chatPort, "chatPort");
+    public ChatController(AiProviderRegistry providerRegistry, RagPipelineService ragPipelineService) {
+        this.providerRegistry = Objects.requireNonNull(providerRegistry, "providerRegistry");
         this.ragPipelineService = Objects.requireNonNull(ragPipelineService, "ragPipelineService");
     }
 
@@ -108,7 +109,7 @@ public class ChatController {
     @PostMapping
     @PreAuthorize("@endpointAuthz.can('services:ai_chat','write')")
     public ResponseEntity<ApiResponse<ChatResponseDto>> chat(@Valid @RequestBody ChatRequestDto request) {
-        ChatResponse response = chatPort.chat(toDomainChatRequest(request));
+        ChatResponse response = chatPort(request.provider()).chat(toDomainChatRequest(request));
         return ResponseEntity.ok(ApiResponse.ok(toDto(response)));
     }
 
@@ -156,9 +157,14 @@ public class ChatController {
 
         List<ChatMessageDto> augmentedMessages = new ArrayList<>();
         augmentedMessages.add(new ChatMessageDto("system", context));
+        if (chat.systemPrompt() != null && !chat.systemPrompt().isBlank()) {
+            augmentedMessages.add(new ChatMessageDto("system", chat.systemPrompt()));
+        }
         augmentedMessages.addAll(chat.messages());
 
         ChatRequestDto augmented = new ChatRequestDto(
+                chat.provider(),
+                null,
                 augmentedMessages,
                 chat.model(),
                 chat.temperature(),
@@ -167,12 +173,12 @@ public class ChatController {
                 chat.maxOutputTokens(),
                 chat.stopSequences());
 
-        ChatResponse response = chatPort.chat(toDomainChatRequest(augmented));
+        ChatResponse response = chatPort(chat.provider()).chat(toDomainChatRequest(augmented));
         return ResponseEntity.ok(ApiResponse.ok(toDto(response)));
     }
 
     private ChatRequest toDomainChatRequest(ChatRequestDto request) {
-        ChatRequest.Builder builder = ChatRequest.builder().messages(toDomainMessages(request.messages()));
+        ChatRequest.Builder builder = ChatRequest.builder().messages(toDomainMessages(request));
         if (request.model() != null) {
             builder.model(request.model());
         }
@@ -193,6 +199,10 @@ public class ChatController {
         }
         return builder.build();
     }
+
+    private ChatPort chatPort(String provider) {
+        return providerRegistry.chatPort(provider);
+    }
     
     private String truncate(String content, int maxLen) {
         if (content == null) {
@@ -204,7 +214,12 @@ public class ChatController {
         return content.substring(0, maxLen) + "...";
     }
 
-    private List<ChatMessage> toDomainMessages(List<ChatMessageDto> messages) {
+    private List<ChatMessage> toDomainMessages(ChatRequestDto request) {
+        List<ChatMessageDto> messages = new ArrayList<>();
+        if (request.systemPrompt() != null && !request.systemPrompt().isBlank()) {
+            messages.add(new ChatMessageDto("system", request.systemPrompt()));
+        }
+        messages.addAll(request.messages());
         return messages.stream()
                 .map(this::toDomainMessage)
                 .toList();

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/VectorController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/VectorController.java
@@ -216,6 +216,7 @@ public class VectorController {
         Map<String, Object> metadata = document.metadata();
         return new VectorSearchResultDto(
                 document.id(),
+                document.id(),
                 document.content(),
                 metadata == null ? Collections.emptyMap() : Map.copyOf(metadata),
                 result.score());

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/ChatRequestDto.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/ChatRequestDto.java
@@ -8,6 +8,8 @@ import java.util.List;
  * DTO for submitting chat requests.
  */
 public record ChatRequestDto(
+        String provider,
+        String systemPrompt,
         @NotEmpty(message = "At least one chat message is required")
         @Valid List<ChatMessageDto> messages,
         String model,

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/VectorSearchResultDto.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/VectorSearchResultDto.java
@@ -6,6 +6,7 @@ import java.util.Map;
  * DTO for vector search hits.
  */
 public record VectorSearchResultDto(
+        String id,
         String documentId,
         String content,
         Map<String, Object> metadata,

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
@@ -103,6 +103,8 @@ class OpenAiProviderAutoConfigurationTest {
             ChatController controller = context.getBean(ChatController.class);
 
             ResponseEntity<ApiResponse<ChatResponseDto>> response = controller.chat(new ChatRequestDto(
+                    null,
+                    null,
                     List.of(new ChatMessageDto("user", "hello")),
                     null,
                     null,

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
@@ -1,9 +1,10 @@
 package studio.one.platform.ai.web.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -14,6 +15,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 import studio.one.platform.ai.core.chat.ChatPort;
 import studio.one.platform.ai.core.chat.ChatRequest;
@@ -84,6 +87,60 @@ class ChatControllerTest {
 
         verify(providerRegistry).chatPort(null);
         verify(defaultChatPort).chat(any(ChatRequest.class));
+    }
+
+    @Test
+    void chatTreatsBlankProviderAsDefaultProvider() {
+        controller.chat(new ChatRequestDto(
+                "  ",
+                null,
+                List.of(new ChatMessageDto("user", "hello")),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null));
+
+        verify(providerRegistry).chatPort(null);
+        verify(defaultChatPort).chat(any(ChatRequest.class));
+    }
+
+    @Test
+    void chatTrimsRequestedProvider() {
+        controller.chat(new ChatRequestDto(
+                " google ",
+                null,
+                List.of(new ChatMessageDto("user", "hello")),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null));
+
+        verify(providerRegistry).chatPort("google");
+        verify(googleChatPort).chat(any(ChatRequest.class));
+    }
+
+    @Test
+    void chatRejectsUnknownProviderAsBadRequest() {
+        when(providerRegistry.chatPort("missing")).thenThrow(new IllegalArgumentException("Unknown provider: missing"));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> controller.chat(new ChatRequestDto(
+                        "missing",
+                        null,
+                        List.of(new ChatMessageDto("user", "hello")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null)));
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(ex.getReason()).contains("missing");
     }
 
     @Test
@@ -163,6 +220,75 @@ class ChatControllerTest {
                 "123"));
 
         verify(ragPipelineService).listByObject("attachment", "123", 3);
+    }
+
+    @Test
+    void ragChatRejectsObjectIdWithoutObjectType() {
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> controller.chatWithRag(new ChatRagRequestDto(
+                        new ChatRequestDto(
+                                null,
+                                null,
+                                List.of(new ChatMessageDto("user", "summarize")),
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null),
+                        null,
+                        3,
+                        null,
+                        "123")));
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        verifyNoInteractions(ragPipelineService);
+    }
+
+    @Test
+    void ragChatRejectsObjectTypeWithoutObjectId() {
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> controller.chatWithRag(new ChatRagRequestDto(
+                        new ChatRequestDto(
+                                null,
+                                null,
+                                List.of(new ChatMessageDto("user", "summarize")),
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null),
+                        "summary",
+                        3,
+                        "attachment",
+                        null)));
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        verifyNoInteractions(ragPipelineService);
+    }
+
+    @Test
+    void ragChatRejectsUnsupportedObjectType() {
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> controller.chatWithRag(new ChatRagRequestDto(
+                        new ChatRequestDto(
+                                null,
+                                null,
+                                List.of(new ChatMessageDto("user", "summarize")),
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null),
+                        null,
+                        3,
+                        "document",
+                        "123")));
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        verifyNoInteractions(ragPipelineService);
     }
 
     private ChatResponse response(String content) {

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
@@ -1,0 +1,172 @@
+package studio.one.platform.ai.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import studio.one.platform.ai.core.chat.ChatPort;
+import studio.one.platform.ai.core.chat.ChatRequest;
+import studio.one.platform.ai.core.chat.ChatResponse;
+import studio.one.platform.ai.core.registry.AiProviderRegistry;
+import studio.one.platform.ai.core.rag.RagSearchRequest;
+import studio.one.platform.ai.core.rag.RagSearchResult;
+import studio.one.platform.ai.service.pipeline.RagPipelineService;
+import studio.one.platform.ai.web.dto.ChatMessageDto;
+import studio.one.platform.ai.web.dto.ChatRagRequestDto;
+import studio.one.platform.ai.web.dto.ChatRequestDto;
+
+class ChatControllerTest {
+
+    @Mock
+    private AiProviderRegistry providerRegistry;
+
+    @Mock
+    private ChatPort defaultChatPort;
+
+    @Mock
+    private ChatPort googleChatPort;
+
+    @Mock
+    private RagPipelineService ragPipelineService;
+
+    private ChatController controller;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        controller = new ChatController(providerRegistry, ragPipelineService);
+        when(providerRegistry.chatPort(null)).thenReturn(defaultChatPort);
+        when(providerRegistry.chatPort("google")).thenReturn(googleChatPort);
+        when(defaultChatPort.chat(any())).thenReturn(response("default"));
+        when(googleChatPort.chat(any())).thenReturn(response("google"));
+    }
+
+    @Test
+    void chatUsesRequestedProvider() {
+        controller.chat(new ChatRequestDto(
+                "google",
+                null,
+                List.of(new ChatMessageDto("user", "hello")),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null));
+
+        verify(providerRegistry).chatPort("google");
+        verify(googleChatPort).chat(any(ChatRequest.class));
+    }
+
+    @Test
+    void chatUsesDefaultProviderWhenProviderMissing() {
+        controller.chat(new ChatRequestDto(
+                null,
+                null,
+                List.of(new ChatMessageDto("user", "hello")),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null));
+
+        verify(providerRegistry).chatPort(null);
+        verify(defaultChatPort).chat(any(ChatRequest.class));
+    }
+
+    @Test
+    void chatPrependsSystemPrompt() {
+        ArgumentCaptor<ChatRequest> captor = ArgumentCaptor.forClass(ChatRequest.class);
+
+        controller.chat(new ChatRequestDto(
+                null,
+                "answer briefly",
+                List.of(new ChatMessageDto("user", "hello")),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null));
+
+        verify(defaultChatPort).chat(captor.capture());
+        assertThat(captor.getValue().messages()).hasSize(2);
+        assertThat(captor.getValue().messages().get(0).role().name()).isEqualTo("SYSTEM");
+        assertThat(captor.getValue().messages().get(0).content()).isEqualTo("answer briefly");
+        assertThat(captor.getValue().messages().get(1).role().name()).isEqualTo("USER");
+    }
+
+    @Test
+    void ragChatAddsContextAndClientSystemPromptAndSearchesByObject() {
+        ArgumentCaptor<ChatRequest> chatCaptor = ArgumentCaptor.forClass(ChatRequest.class);
+        when(ragPipelineService.searchByObject(any(RagSearchRequest.class), any(), any()))
+                .thenReturn(List.of(new RagSearchResult("doc-1", "file text", Map.of(), 0.9d)));
+
+        controller.chatWithRag(new ChatRagRequestDto(
+                new ChatRequestDto(
+                        "google",
+                        "answer from file",
+                        List.of(new ChatMessageDto("user", "summarize")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null),
+                "summary",
+                3,
+                "attachment",
+                "123"));
+
+        verify(ragPipelineService).searchByObject(any(RagSearchRequest.class), org.mockito.Mockito.eq("attachment"),
+                org.mockito.Mockito.eq("123"));
+        verify(googleChatPort).chat(chatCaptor.capture());
+        assertThat(chatCaptor.getValue().messages()).hasSize(3);
+        assertThat(chatCaptor.getValue().messages().get(0).role().name()).isEqualTo("SYSTEM");
+        assertThat(chatCaptor.getValue().messages().get(0).content()).contains("file text");
+        assertThat(chatCaptor.getValue().messages().get(1).role().name()).isEqualTo("SYSTEM");
+        assertThat(chatCaptor.getValue().messages().get(1).content()).isEqualTo("answer from file");
+        assertThat(chatCaptor.getValue().messages().get(2).role().name()).isEqualTo("USER");
+    }
+
+    @Test
+    void ragChatListsByObjectWhenQueryMissingAndObjectFilterPresent() {
+        when(ragPipelineService.listByObject("attachment", "123", 3))
+                .thenReturn(List.of(new RagSearchResult("doc-1", "file text", Map.of(), 1.0d)));
+
+        controller.chatWithRag(new ChatRagRequestDto(
+                new ChatRequestDto(
+                        null,
+                        null,
+                        List.of(new ChatMessageDto("user", "summarize")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null),
+                null,
+                3,
+                "attachment",
+                "123"));
+
+        verify(ragPipelineService).listByObject("attachment", "123", 3);
+    }
+
+    private ChatResponse response(String content) {
+        return new ChatResponse(List.of(studio.one.platform.ai.core.chat.ChatMessage.assistant(content)), "model",
+                Map.of());
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/VectorControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/VectorControllerTest.java
@@ -53,6 +53,7 @@ class VectorControllerTest {
                 new VectorSearchRequestDto("hello", null, 3, false, "attachment", "42", null));
 
         assertThat(response.getBody().getData()).hasSize(1);
+        assertThat(response.getBody().getData().get(0).id()).isEqualTo("doc-1");
         assertThat(response.getBody().getData().get(0).documentId()).isEqualTo("doc-1");
         verify(vectorStorePort).searchByObject(eq("attachment"), eq("42"), any(VectorSearchRequest.class));
     }

--- a/starter/studio-platform-starter-ai/README.md
+++ b/starter/studio-platform-starter-ai/README.md
@@ -1,6 +1,7 @@
 # studio-platform-starter-ai
 
 AI 서비스(채팅, 임베딩, 벡터 스토어, RAG 파이프라인)를 자동 구성하는 스타터이다.
+애플리케이션 모듈은 이 스타터가 제공하는 포트와 `RagPipelineService`를 통해 공통 AI 기능을 재사용할 수 있다.
 멀티 프로바이더 팩토리 패턴을 통해 OpenAI, Google AI Gemini, Ollama 등 여러 LLM 프로바이더를
 동시에 등록하고, `default-provider`로 지정한 프로바이더를 기본 `ChatPort` / `EmbeddingPort` 빈으로 노출한다.
 JdbcTemplate이 컨텍스트에 있으면 pgvector 기반 `VectorStorePort`도 자동으로 생성된다.
@@ -167,6 +168,9 @@ studio:
 | `VectorStorePort` | JdbcTemplate이 있을 때 pgvector 기반 벡터 스토어 자동 생성 |
 | `RagPipelineService` | RAG 인덱싱/검색 파이프라인 서비스 |
 | `PromptManager` | Mustache 템플릿 기반 프롬프트 렌더러 |
+
+`RagPipelineService`는 문서/파일/도메인 객체별 텍스트를 chunk로 나누고, 임베딩과 메타데이터를 벡터 스토어에 저장한다.
+`objectType`/`objectId` 메타데이터를 함께 저장하면 AI web starter의 RAG chat API에서 특정 파일이나 객체 범위에 한정해 답변할 수 있다.
 
 ## 관련 모듈
 - `studio-platform-ai` — 이 스타터가 구현하는 포트 인터페이스 모듈


### PR DESCRIPTION
## Why
- React AI 클라이언트는 이미 `provider`, `systemPrompt`, 파일 기반 RAG, vector result `id` 필드를 사용하는 계약을 가지고 있다.
- 서버는 Spring AI 전환 후 default `ChatPort` 중심으로 동작해 일부 클라이언트 계약을 수용하지 못했다.
- 여러 모듈이 공통 AI/RAG 기능을 쉽게 사용할 수 있도록 서버 AI web API 계약을 정렬한다.

## What
- `POST /api/ai/chat`과 `/chat/rag`에서 optional `provider`, `systemPrompt`를 지원한다.
- `ChatController`가 `AiProviderRegistry`를 통해 provider별 `ChatPort`를 선택하도록 변경했다.
- RAG chat에서 파일/객체 범위 검색 흐름(`objectType`, `objectId`)은 유지하고, RAG context와 client system prompt를 함께 전달한다.
- `POST /api/ai/vectors/search` 응답에 `id` alias를 추가하고 기존 `documentId`는 유지했다.
- AI web/core README와 CHANGELOG, controller 테스트를 갱신했다.

## Related Issues
- Closes #
- Related #

## Change Scope
- [x] API contract
- [ ] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [x] Docs/runbook

## Security Impact
- Risk: 낮음. 기존 권한 annotation은 유지하고, provider 선택은 등록된 `AiProviderRegistry` 범위 안에서만 수행한다.
- Mitigation: unknown provider는 registry lookup에서 실패하며, OpenAI 런타임 설정 소유권은 기존 `spring.ai.openai.*`를 유지한다.

## Validation
- Commands:
  - `./gradlew :starter:studio-platform-starter-ai-web:test`
  - `./gradlew :starter:studio-platform-starter-ai:compileJava`
  - `./gradlew :studio-platform-ai:test`
  - `git diff --check`
- Result:
  - PASS
- Additional checks:
  - 기존 `studio-platform-user/.../UserMgmtApi.java` 로컬 변경은 제외

## Subagent Usage
아래 항목은 **정확히 하나만** 체크합니다.
- [ ] No
- [x] Yes
- Delegated tasks:
- Ownership (files/modules/tasks): main author handled AI web DTO/controller/tests/docs
- Main author post-integration validation: commands listed above

## Checklist
- [x] policy-compliant commit message
- [x] issue template used where applicable
- [x] AI-Assisted checked correctly
- [x] subagent usage recorded (if used)
- [x] validation recorded
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

## Deployment Notes
- Migration/ordering: 없음
- Rollback plan: PR revert
- Post-deploy checks: `/api/ai/info/providers`, `/api/ai/chat`, `/api/ai/chat/rag`, `/api/ai/vectors/search` smoke 확인
