### PR TITLE
[ai-assisted] feat(ai-rag): add configurable retrieval and context limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - 이슈 #202 대응으로 `RagPipelineService`의 hybrid 검색 weight, 최소 relevance score, keyword/semantic fallback 사용 여부를 `studio.ai.pipeline.retrieval.*` 설정으로 조정할 수 있도록 했다.
 - query 없는 object-scope RAG 조회가 과도한 chunk를 반환하지 않도록 `studio.ai.pipeline.object-scope.default-list-limit`, `max-list-limit` 설정과 service layer clamp를 추가했다.
 - `POST /api/ai/chat/rag`가 system context에 포함하는 RAG chunk 수/문자 수와 score 포함 여부를 `studio.ai.endpoints.rag.context.*` 설정으로 제한하도록 했다.
+- hybrid search weight는 합계가 0보다 커야 하며, context 문자 수 한도 초과 시 chunk를 중간 절단하지 않고 제외하도록 명확히 했다.
 
 ### 검증
 - `gradle :studio-platform-ai:test :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test --rerun-tasks`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-04-16
+
+### 변경됨
+- 이슈 #202 대응으로 `RagPipelineService`의 hybrid 검색 weight, 최소 relevance score, keyword/semantic fallback 사용 여부를 `studio.ai.pipeline.retrieval.*` 설정으로 조정할 수 있도록 했다.
+- query 없는 object-scope RAG 조회가 과도한 chunk를 반환하지 않도록 `studio.ai.pipeline.object-scope.default-list-limit`, `max-list-limit` 설정과 service layer clamp를 추가했다.
+- `POST /api/ai/chat/rag`가 system context에 포함하는 RAG chunk 수/문자 수와 score 포함 여부를 `studio.ai.endpoints.rag.context.*` 설정으로 제한하도록 했다.
+
+### 검증
+- `gradle :studio-platform-ai:test :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test --rerun-tasks`
+- `git diff --check`
+
 ## 2026-04-15
 
 ### 변경됨

--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -114,6 +114,7 @@ Content-Type: application/json
 객체 범위만 있으면 저장된 chunk를 순서대로 가져와 컨텍스트로 사용한다.
 
 RAG context는 이슈 #202부터 설정된 chunk 수와 문자 수를 넘지 않도록 제한된다.
+문자 수 한도는 context header를 포함해 계산하며, 한도를 초과하는 chunk는 문장 중간에서 자르지 않고 통째로 제외한다.
 
 ```yaml
 studio:
@@ -129,7 +130,7 @@ studio:
 | 설정 | 기본값 | 설명 |
 |---|---:|---|
 | `studio.ai.endpoints.rag.context.max-chunks` | `8` | chat system context에 포함할 최대 RAG chunk 수 |
-| `studio.ai.endpoints.rag.context.max-chars` | `12000` | chat system context 최대 문자 수 |
+| `studio.ai.endpoints.rag.context.max-chars` | `12000` | header 포함 chat system context 최대 문자 수 |
 | `studio.ai.endpoints.rag.context.include-scores` | `true` | context에 retrieval score를 포함할지 여부 |
 
 ### 임베딩 요청 예시

--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -113,6 +113,25 @@ Content-Type: application/json
 `objectType`/`objectId`를 지정하면 해당 객체 범위의 RAG 인덱스에서 검색한다. `ragQuery`가 없고
 객체 범위만 있으면 저장된 chunk를 순서대로 가져와 컨텍스트로 사용한다.
 
+RAG context는 이슈 #202부터 설정된 chunk 수와 문자 수를 넘지 않도록 제한된다.
+
+```yaml
+studio:
+  ai:
+    endpoints:
+      rag:
+        context:
+          max-chunks: 8
+          max-chars: 12000
+          include-scores: true
+```
+
+| 설정 | 기본값 | 설명 |
+|---|---:|---|
+| `studio.ai.endpoints.rag.context.max-chunks` | `8` | chat system context에 포함할 최대 RAG chunk 수 |
+| `studio.ai.endpoints.rag.context.max-chars` | `12000` | chat system context 최대 문자 수 |
+| `studio.ai.endpoints.rag.context.include-scores` | `true` | context에 retrieval score를 포함할지 여부 |
+
 ### 임베딩 요청 예시
 
 ```http

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
@@ -2,6 +2,7 @@ package studio.one.platform.ai.autoconfigure;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -19,17 +20,27 @@ import studio.one.platform.ai.web.controller.ChatController;
 import studio.one.platform.ai.web.controller.EmbeddingController;
 import studio.one.platform.ai.web.controller.QueryRewriteController;
 import studio.one.platform.ai.web.controller.RagController;
+import studio.one.platform.ai.web.controller.RagContextBuilder;
 import studio.one.platform.ai.web.controller.VectorController;
 import studio.one.platform.constant.PropertyKeys;
 
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(ChatPort.class)
 @ConditionalOnProperty(prefix = PropertyKeys.AI.PREFIX, name = "enabled", havingValue = "true", matchIfMissing = false)
+@EnableConfigurationProperties(AiWebRagProperties.class)
 public class AiWebAutoConfiguration {
 
     @Bean
-    ChatController chatController(AiProviderRegistry providerRegistry, RagPipelineService ragPipelineService) {
-        return new ChatController(providerRegistry, ragPipelineService);
+    RagContextBuilder ragContextBuilder(AiWebRagProperties properties) {
+        return new RagContextBuilder(properties);
+    }
+
+    @Bean
+    ChatController chatController(
+            AiProviderRegistry providerRegistry,
+            RagPipelineService ragPipelineService,
+            RagContextBuilder ragContextBuilder) {
+        return new ChatController(providerRegistry, ragPipelineService, ragContextBuilder);
     }
 
     @Bean

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebRagProperties.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebRagProperties.java
@@ -1,0 +1,45 @@
+package studio.one.platform.ai.autoconfigure;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import studio.one.platform.constant.PropertyKeys;
+
+@ConfigurationProperties(prefix = PropertyKeys.AI.Endpoints.PREFIX + ".rag")
+public class AiWebRagProperties {
+
+    private final ContextProperties context = new ContextProperties();
+
+    public ContextProperties getContext() {
+        return context;
+    }
+
+    public static class ContextProperties {
+        private int maxChunks = 8;
+        private int maxChars = 12_000;
+        private boolean includeScores = true;
+
+        public int getMaxChunks() {
+            return maxChunks;
+        }
+
+        public void setMaxChunks(int maxChunks) {
+            this.maxChunks = maxChunks;
+        }
+
+        public int getMaxChars() {
+            return maxChars;
+        }
+
+        public void setMaxChars(int maxChars) {
+            this.maxChars = maxChars;
+        }
+
+        public boolean isIncludeScores() {
+            return includeScores;
+        }
+
+        public void setIncludeScores(boolean includeScores) {
+            this.includeScores = includeScores;
+        }
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
@@ -72,10 +72,19 @@ public class ChatController {
     private static final String OBJECT_TYPE_ATTACHMENT = "attachment";
     private final AiProviderRegistry providerRegistry;
     private final RagPipelineService ragPipelineService;
+    private final RagContextBuilder ragContextBuilder;
 
     public ChatController(AiProviderRegistry providerRegistry, RagPipelineService ragPipelineService) {
+        this(providerRegistry, ragPipelineService, RagContextBuilder.defaults());
+    }
+
+    public ChatController(
+            AiProviderRegistry providerRegistry,
+            RagPipelineService ragPipelineService,
+            RagContextBuilder ragContextBuilder) {
         this.providerRegistry = Objects.requireNonNull(providerRegistry, "providerRegistry");
         this.ragPipelineService = Objects.requireNonNull(ragPipelineService, "ragPipelineService");
+        this.ragContextBuilder = Objects.requireNonNull(ragContextBuilder, "ragContextBuilder");
     }
 
     /**
@@ -159,7 +168,7 @@ public class ChatController {
         }
 
 
-        String context = buildContext(ragResults);
+        String context = ragContextBuilder.build(ragResults);
 
         List<ChatMessageDto> augmentedMessages = new ArrayList<>();
         augmentedMessages.add(new ChatMessageDto("system", context));
@@ -286,20 +295,6 @@ public class ChatController {
             }
         }
         throw new IllegalArgumentException("RAG query is empty");
-    }
-
-    private String buildContext(List<RagSearchResult> results) {
-        if (results == null || results.isEmpty()) {
-            return "참고할 문서가 없습니다. 일반적으로 답변하세요.";
-        }
-        StringBuilder sb = new StringBuilder("다음 문서 내용을 참고해 답변하세요:\n");
-        for (int i = 0; i < results.size(); i++) {
-            RagSearchResult r = results.get(i);
-            sb.append("[").append(i + 1).append("] docId=").append(r.documentId())
-                    .append(" score=").append(String.format("%.3f", r.score()))
-                    .append("\n").append(r.content()).append("\n\n");
-        }
-        return sb.toString().trim();
     }
 
     private record ObjectScope(String objectType, String objectId) {

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagContextBuilder.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagContextBuilder.java
@@ -1,0 +1,75 @@
+package studio.one.platform.ai.web.controller;
+
+import java.util.List;
+
+import studio.one.platform.ai.autoconfigure.AiWebRagProperties;
+import studio.one.platform.ai.core.rag.RagSearchResult;
+
+/**
+ * Builds bounded RAG context prompts for chat completion requests.
+ */
+public class RagContextBuilder {
+
+    private static final String NO_CONTEXT_MESSAGE = "참고할 문서가 없습니다. 일반적으로 답변하세요.";
+    private static final String HEADER = "다음 문서 내용을 참고해 답변하세요:\n";
+
+    private final int maxChunks;
+    private final int maxChars;
+    private final boolean includeScores;
+
+    public RagContextBuilder(AiWebRagProperties properties) {
+        this(properties.getContext().getMaxChunks(),
+                properties.getContext().getMaxChars(),
+                properties.getContext().isIncludeScores());
+    }
+
+    public RagContextBuilder(int maxChunks, int maxChars, boolean includeScores) {
+        this.maxChunks = Math.max(0, maxChunks);
+        this.maxChars = Math.max(0, maxChars);
+        this.includeScores = includeScores;
+    }
+
+    public static RagContextBuilder defaults() {
+        return new RagContextBuilder(8, 12_000, true);
+    }
+
+    public String build(List<RagSearchResult> results) {
+        if (results == null || results.isEmpty() || maxChunks == 0 || maxChars == 0) {
+            return NO_CONTEXT_MESSAGE;
+        }
+        StringBuilder sb = new StringBuilder(HEADER);
+        int count = Math.min(maxChunks, results.size());
+        for (int i = 0; i < count; i++) {
+            RagSearchResult result = results.get(i);
+            String chunk = formatChunk(i + 1, result);
+            if (!appendWithinLimit(sb, chunk)) {
+                break;
+            }
+        }
+        String context = sb.toString().trim();
+        return HEADER.trim().equals(context) ? NO_CONTEXT_MESSAGE : context;
+    }
+
+    private boolean appendWithinLimit(StringBuilder sb, String chunk) {
+        int remaining = maxChars - sb.length();
+        if (remaining <= 0) {
+            return false;
+        }
+        if (chunk.length() <= remaining) {
+            sb.append(chunk);
+            return true;
+        }
+        sb.append(chunk, 0, remaining);
+        return false;
+    }
+
+    private String formatChunk(int index, RagSearchResult result) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("[").append(index).append("] docId=").append(result.documentId());
+        if (includeScores) {
+            sb.append(" score=").append(String.format("%.3f", result.score()));
+        }
+        sb.append("\n").append(result.content()).append("\n\n");
+        return sb.toString();
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagContextBuilder.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagContextBuilder.java
@@ -38,6 +38,9 @@ public class RagContextBuilder {
             return NO_CONTEXT_MESSAGE;
         }
         StringBuilder sb = new StringBuilder(HEADER);
+        if (sb.length() > maxChars) {
+            return NO_CONTEXT_MESSAGE;
+        }
         int count = Math.min(maxChunks, results.size());
         for (int i = 0; i < count; i++) {
             RagSearchResult result = results.get(i);
@@ -51,16 +54,11 @@ public class RagContextBuilder {
     }
 
     private boolean appendWithinLimit(StringBuilder sb, String chunk) {
-        int remaining = maxChars - sb.length();
-        if (remaining <= 0) {
+        if (sb.length() + chunk.length() > maxChars) {
             return false;
         }
-        if (chunk.length() <= remaining) {
-            sb.append(chunk);
-            return true;
-        }
-        sb.append(chunk, 0, remaining);
-        return false;
+        sb.append(chunk);
+        return true;
     }
 
     private String formatChunk(int index, RagSearchResult result) {

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
@@ -258,7 +258,8 @@ class ChatControllerTest {
                 null));
 
         verify(defaultChatPort).chat(chatCaptor.capture());
-        assertThat(chatCaptor.getValue().messages().get(0).content()).hasSizeLessThanOrEqualTo(80);
+        assertThat(chatCaptor.getValue().messages().get(0).content())
+                .isEqualTo("참고할 문서가 없습니다. 일반적으로 답변하세요.");
     }
 
     @Test

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
@@ -199,6 +199,98 @@ class ChatControllerTest {
     }
 
     @Test
+    void ragChatLimitsContextChunks() {
+        controller = new ChatController(providerRegistry, ragPipelineService, new RagContextBuilder(2, 12_000, true));
+        ArgumentCaptor<ChatRequest> chatCaptor = ArgumentCaptor.forClass(ChatRequest.class);
+        when(ragPipelineService.search(any(RagSearchRequest.class)))
+                .thenReturn(List.of(
+                        new RagSearchResult("doc-1", "first", Map.of(), 0.9d),
+                        new RagSearchResult("doc-2", "second", Map.of(), 0.8d),
+                        new RagSearchResult("doc-3", "third", Map.of(), 0.7d)));
+
+        controller.chatWithRag(new ChatRagRequestDto(
+                new ChatRequestDto(
+                        null,
+                        null,
+                        List.of(new ChatMessageDto("user", "summarize")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null),
+                "summary",
+                3,
+                null,
+                null));
+
+        verify(defaultChatPort).chat(chatCaptor.capture());
+        String context = chatCaptor.getValue().messages().get(0).content();
+        assertThat(context).contains("doc-1", "doc-2");
+        assertThat(context).doesNotContain("doc-3");
+    }
+
+    @Test
+    void ragChatLimitsContextCharacters() {
+        controller = new ChatController(providerRegistry, ragPipelineService, new RagContextBuilder(8, 80, true));
+        ArgumentCaptor<ChatRequest> chatCaptor = ArgumentCaptor.forClass(ChatRequest.class);
+        when(ragPipelineService.search(any(RagSearchRequest.class)))
+                .thenReturn(List.of(new RagSearchResult(
+                        "doc-1",
+                        "0123456789".repeat(20),
+                        Map.of(),
+                        0.9d)));
+
+        controller.chatWithRag(new ChatRagRequestDto(
+                new ChatRequestDto(
+                        null,
+                        null,
+                        List.of(new ChatMessageDto("user", "summarize")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null),
+                "summary",
+                3,
+                null,
+                null));
+
+        verify(defaultChatPort).chat(chatCaptor.capture());
+        assertThat(chatCaptor.getValue().messages().get(0).content()).hasSizeLessThanOrEqualTo(80);
+    }
+
+    @Test
+    void ragChatCanOmitScoresFromContext() {
+        controller = new ChatController(providerRegistry, ragPipelineService, new RagContextBuilder(8, 12_000, false));
+        ArgumentCaptor<ChatRequest> chatCaptor = ArgumentCaptor.forClass(ChatRequest.class);
+        when(ragPipelineService.search(any(RagSearchRequest.class)))
+                .thenReturn(List.of(new RagSearchResult("doc-1", "first", Map.of(), 0.9d)));
+
+        controller.chatWithRag(new ChatRagRequestDto(
+                new ChatRequestDto(
+                        null,
+                        null,
+                        List.of(new ChatMessageDto("user", "summarize")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null),
+                "summary",
+                3,
+                null,
+                null));
+
+        verify(defaultChatPort).chat(chatCaptor.capture());
+        assertThat(chatCaptor.getValue().messages().get(0).content())
+                .contains("docId=doc-1")
+                .doesNotContain("score=");
+    }
+
+    @Test
     void ragChatListsByObjectWhenQueryMissingAndObjectFilterPresent() {
         when(ragPipelineService.listByObject("attachment", "123", 3))
                 .thenReturn(List.of(new RagSearchResult("doc-1", "file text", Map.of(), 1.0d)));

--- a/starter/studio-platform-starter-ai/README.md
+++ b/starter/studio-platform-starter-ai/README.md
@@ -202,6 +202,8 @@ studio:
 | `studio.ai.pipeline.object-scope.default-list-limit` | `20` | query 없는 object-scope list 기본 limit |
 | `studio.ai.pipeline.object-scope.max-list-limit` | `100` | object-scope list 최대 limit |
 
+`vector-weight`와 `lexical-weight`는 각각 0 이상이어야 하며 두 값의 합은 0보다 커야 한다.
+
 ## 관련 모듈
 - `studio-platform-ai` — 이 스타터가 구현하는 포트 인터페이스 모듈
 - `studio-platform-starter-ai-web` — AI HTTP 엔드포인트를 노출하는 짝 스타터 (이 스타터와 함께 사용)

--- a/starter/studio-platform-starter-ai/README.md
+++ b/starter/studio-platform-starter-ai/README.md
@@ -172,6 +172,36 @@ studio:
 `RagPipelineService`는 문서/파일/도메인 객체별 텍스트를 chunk로 나누고, 임베딩과 메타데이터를 벡터 스토어에 저장한다.
 `objectType`/`objectId` 메타데이터를 함께 저장하면 AI web starter의 RAG chat API에서 특정 파일이나 객체 범위에 한정해 답변할 수 있다.
 
+### RAG 파이프라인 튜닝
+
+이슈 #202부터 RAG 검색과 객체 범위 조회 제한은 운영 설정으로 조정할 수 있다. 기본값은 기존 동작과 유사하게 유지하되,
+query 없는 객체 범위 조회가 과도한 chunk를 반환하지 않도록 service layer에서 limit을 보정한다.
+
+```yaml
+studio:
+  ai:
+    pipeline:
+      retrieval:
+        vector-weight: 0.7
+        lexical-weight: 0.3
+        min-relevance-score: 0.15
+        keyword-fallback-enabled: true
+        semantic-fallback-enabled: true
+      object-scope:
+        default-list-limit: 20
+        max-list-limit: 100
+```
+
+| 설정 | 기본값 | 설명 |
+|---|---:|---|
+| `studio.ai.pipeline.retrieval.vector-weight` | `0.7` | hybrid 검색의 벡터 점수 비중 |
+| `studio.ai.pipeline.retrieval.lexical-weight` | `0.3` | hybrid 검색의 lexical 점수 비중 |
+| `studio.ai.pipeline.retrieval.min-relevance-score` | `0.15` | fallback 성공으로 판단할 최소 relevance score |
+| `studio.ai.pipeline.retrieval.keyword-fallback-enabled` | `true` | keyword-enriched hybrid fallback 사용 여부 |
+| `studio.ai.pipeline.retrieval.semantic-fallback-enabled` | `true` | semantic fallback 사용 여부 |
+| `studio.ai.pipeline.object-scope.default-list-limit` | `20` | query 없는 object-scope list 기본 limit |
+| `studio.ai.pipeline.object-scope.max-list-limit` | `100` | object-scope list 최대 limit |
+
 ## 관련 모듈
 - `studio-platform-ai` — 이 스타터가 구현하는 포트 인터페이스 모듈
 - `studio-platform-starter-ai-web` — AI HTTP 엔드포인트를 노출하는 짝 스타터 (이 스타터와 함께 사용)

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfiguration.java
@@ -20,6 +20,7 @@ import studio.one.platform.ai.core.embedding.EmbeddingPort;
 import studio.one.platform.ai.core.vector.VectorStorePort;
 import studio.one.platform.ai.service.chunk.OverlapTextChunker;
 import studio.one.platform.ai.service.keyword.KeywordExtractor;
+import studio.one.platform.ai.service.pipeline.RagPipelineOptions;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
 import studio.one.platform.autoconfigure.I18nKeys;
 import studio.one.platform.component.State;
@@ -86,7 +87,7 @@ public class RagPipelineConfiguration {
         @Bean(RagPipelineService.SERVICE_NAME)
         RagPipelineService ragPipelineService(EmbeddingPort embeddingPort, VectorStorePort vectorStorePort,
                         TextChunker textChunker, Cache<String, List<Double>> embeddingCache, Retry embeddingRetry,
-                        ObjectProvider<KeywordExtractor> keywordExtractorProvider) {
+                        ObjectProvider<KeywordExtractor> keywordExtractorProvider, RagPipelineProperties properties) {
 
                 I18n i18n = I18nUtils.resolve(i18nProvider);
                 log.info(LogUtils.format(i18n, I18nKeys.AutoConfig.Feature.Service.DETAILS,
@@ -94,7 +95,20 @@ public class RagPipelineConfiguration {
                                 LogUtils.blue(RagPipelineService.class, true), LogUtils.red(State.CREATED.toString())));
 
                 return new RagPipelineService(embeddingPort, vectorStorePort, textChunker, embeddingCache,
-                                embeddingRetry, keywordExtractorProvider.getIfAvailable());
+                                embeddingRetry, keywordExtractorProvider.getIfAvailable(), ragPipelineOptions(properties));
+        }
+
+        private RagPipelineOptions ragPipelineOptions(RagPipelineProperties properties) {
+                RagPipelineProperties.RetrievalProperties retrieval = properties.getRetrieval();
+                RagPipelineProperties.ObjectScopeProperties objectScope = properties.getObjectScope();
+                return new RagPipelineOptions(
+                                retrieval.getVectorWeight(),
+                                retrieval.getLexicalWeight(),
+                                retrieval.getMinRelevanceScore(),
+                                retrieval.isKeywordFallbackEnabled(),
+                                retrieval.isSemanticFallbackEnabled(),
+                                objectScope.getDefaultListLimit(),
+                                objectScope.getMaxListLimit());
         }
 
 }

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineProperties.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineProperties.java
@@ -3,6 +3,7 @@ package studio.one.platform.ai.autoconfigure.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import studio.one.platform.constant.PropertyKeys;
+import studio.one.platform.ai.service.pipeline.RagPipelineOptions;
 
 import java.time.Duration;
 
@@ -13,6 +14,8 @@ public class RagPipelineProperties {
     private int chunkOverlap = 50;
     private final CacheProperties cache = new CacheProperties();
     private final RetryProperties retry = new RetryProperties();
+    private final RetrievalProperties retrieval = new RetrievalProperties();
+    private final ObjectScopeProperties objectScope = new ObjectScopeProperties();
 
     public int getChunkSize() {
         return chunkSize;
@@ -36,6 +39,14 @@ public class RagPipelineProperties {
 
     public RetryProperties getRetry() {
         return retry;
+    }
+
+    public RetrievalProperties getRetrieval() {
+        return retrieval;
+    }
+
+    public ObjectScopeProperties getObjectScope() {
+        return objectScope;
     }
 
     public static class CacheProperties {
@@ -77,6 +88,75 @@ public class RagPipelineProperties {
 
         public void setWaitDuration(Duration waitDuration) {
             this.waitDuration = waitDuration;
+        }
+    }
+
+    public static class RetrievalProperties {
+        private double vectorWeight = RagPipelineOptions.DEFAULT_VECTOR_WEIGHT;
+        private double lexicalWeight = RagPipelineOptions.DEFAULT_LEXICAL_WEIGHT;
+        private double minRelevanceScore = RagPipelineOptions.DEFAULT_MIN_RELEVANCE_SCORE;
+        private boolean keywordFallbackEnabled = RagPipelineOptions.DEFAULT_KEYWORD_FALLBACK_ENABLED;
+        private boolean semanticFallbackEnabled = RagPipelineOptions.DEFAULT_SEMANTIC_FALLBACK_ENABLED;
+
+        public double getVectorWeight() {
+            return vectorWeight;
+        }
+
+        public void setVectorWeight(double vectorWeight) {
+            this.vectorWeight = vectorWeight;
+        }
+
+        public double getLexicalWeight() {
+            return lexicalWeight;
+        }
+
+        public void setLexicalWeight(double lexicalWeight) {
+            this.lexicalWeight = lexicalWeight;
+        }
+
+        public double getMinRelevanceScore() {
+            return minRelevanceScore;
+        }
+
+        public void setMinRelevanceScore(double minRelevanceScore) {
+            this.minRelevanceScore = minRelevanceScore;
+        }
+
+        public boolean isKeywordFallbackEnabled() {
+            return keywordFallbackEnabled;
+        }
+
+        public void setKeywordFallbackEnabled(boolean keywordFallbackEnabled) {
+            this.keywordFallbackEnabled = keywordFallbackEnabled;
+        }
+
+        public boolean isSemanticFallbackEnabled() {
+            return semanticFallbackEnabled;
+        }
+
+        public void setSemanticFallbackEnabled(boolean semanticFallbackEnabled) {
+            this.semanticFallbackEnabled = semanticFallbackEnabled;
+        }
+    }
+
+    public static class ObjectScopeProperties {
+        private int defaultListLimit = RagPipelineOptions.DEFAULT_LIST_LIMIT;
+        private int maxListLimit = RagPipelineOptions.DEFAULT_MAX_LIST_LIMIT;
+
+        public int getDefaultListLimit() {
+            return defaultListLimit;
+        }
+
+        public void setDefaultListLimit(int defaultListLimit) {
+            this.defaultListLimit = defaultListLimit;
+        }
+
+        public int getMaxListLimit() {
+            return maxListLimit;
+        }
+
+        public void setMaxListLimit(int maxListLimit) {
+            this.maxListLimit = maxListLimit;
         }
     }
 }

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/RagPipelinePropertiesTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/RagPipelinePropertiesTest.java
@@ -1,0 +1,51 @@
+package studio.one.platform.ai.autoconfigure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+class RagPipelinePropertiesTest {
+
+    @Test
+    void shouldExposeRetrievalAndObjectScopeDefaults() {
+        RagPipelineProperties properties = new RagPipelineProperties();
+
+        assertThat(properties.getRetrieval().getVectorWeight()).isEqualTo(0.7d);
+        assertThat(properties.getRetrieval().getLexicalWeight()).isEqualTo(0.3d);
+        assertThat(properties.getRetrieval().getMinRelevanceScore()).isEqualTo(0.15d);
+        assertThat(properties.getRetrieval().isKeywordFallbackEnabled()).isTrue();
+        assertThat(properties.getRetrieval().isSemanticFallbackEnabled()).isTrue();
+        assertThat(properties.getObjectScope().getDefaultListLimit()).isEqualTo(20);
+        assertThat(properties.getObjectScope().getMaxListLimit()).isEqualTo(100);
+    }
+
+    @Test
+    void shouldBindRetrievalAndObjectScopeOverrides() {
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().addFirst(new MapPropertySource("test", java.util.Map.of(
+                "studio.ai.pipeline.retrieval.vector-weight", "0.2",
+                "studio.ai.pipeline.retrieval.lexical-weight", "0.8",
+                "studio.ai.pipeline.retrieval.min-relevance-score", "0.4",
+                "studio.ai.pipeline.retrieval.keyword-fallback-enabled", "false",
+                "studio.ai.pipeline.retrieval.semantic-fallback-enabled", "false",
+                "studio.ai.pipeline.object-scope.default-list-limit", "5",
+                "studio.ai.pipeline.object-scope.max-list-limit", "10")));
+
+        RagPipelineProperties properties = new Binder(ConfigurationPropertySources.get(environment))
+                .bind("studio.ai.pipeline", Bindable.of(RagPipelineProperties.class))
+                .orElseThrow(() -> new AssertionError("RagPipelineProperties binding failed"));
+
+        assertThat(properties.getRetrieval().getVectorWeight()).isEqualTo(0.2d);
+        assertThat(properties.getRetrieval().getLexicalWeight()).isEqualTo(0.8d);
+        assertThat(properties.getRetrieval().getMinRelevanceScore()).isEqualTo(0.4d);
+        assertThat(properties.getRetrieval().isKeywordFallbackEnabled()).isFalse();
+        assertThat(properties.getRetrieval().isSemanticFallbackEnabled()).isFalse();
+        assertThat(properties.getObjectScope().getDefaultListLimit()).isEqualTo(5);
+        assertThat(properties.getObjectScope().getMaxListLimit()).isEqualTo(10);
+    }
+}

--- a/studio-platform-ai/README.md
+++ b/studio-platform-ai/README.md
@@ -11,7 +11,8 @@ AI 추상화 계층이다. 챗 완성, 임베딩 생성, 벡터 스토어 접근
 - `AiProviderRegistry`: 공급자 이름을 키로 ChatPort/EmbeddingPort를 관리하는 레지스트리
 - `TextChunker`: 긴 문서를 임베딩에 적합한 크기로 분할하는 전략 인터페이스
 - `RagPipelineService`: 인덱싱(`index`)과 검색(`search`, `searchByObject`, `listByObject`)을 조율하는 파이프라인 서비스
-  - 하이브리드 검색(벡터 0.7 + 렉시컬 0.3) → 쿼리 보강 → 순수 시맨틱 검색 순으로 폴백
+  - 설정된 하이브리드 검색 비중 → 쿼리 보강 → 순수 시맨틱 검색 순으로 폴백
+  - query 없는 object-scope 조회는 설정된 기본/최대 limit 안에서 chunk를 반환
   - Caffeine 캐시 + Resilience4j Retry로 임베딩 호출을 보호
 
 ## 주요 타입

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineOptions.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineOptions.java
@@ -27,6 +27,9 @@ public record RagPipelineOptions(
         if (lexicalWeight < 0.0d) {
             throw new IllegalArgumentException("lexicalWeight must be greater than or equal to 0");
         }
+        if (vectorWeight + lexicalWeight <= 0.0d) {
+            throw new IllegalArgumentException("vectorWeight and lexicalWeight must have a positive sum");
+        }
         if (minRelevanceScore < 0.0d) {
             throw new IllegalArgumentException("minRelevanceScore must be greater than or equal to 0");
         }

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineOptions.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineOptions.java
@@ -1,0 +1,61 @@
+package studio.one.platform.ai.service.pipeline;
+
+/**
+ * Runtime options for RAG retrieval and object-scoped listing.
+ */
+public record RagPipelineOptions(
+        double vectorWeight,
+        double lexicalWeight,
+        double minRelevanceScore,
+        boolean keywordFallbackEnabled,
+        boolean semanticFallbackEnabled,
+        int defaultListLimit,
+        int maxListLimit) {
+
+    public static final double DEFAULT_VECTOR_WEIGHT = 0.7;
+    public static final double DEFAULT_LEXICAL_WEIGHT = 0.3;
+    public static final double DEFAULT_MIN_RELEVANCE_SCORE = 0.15;
+    public static final boolean DEFAULT_KEYWORD_FALLBACK_ENABLED = true;
+    public static final boolean DEFAULT_SEMANTIC_FALLBACK_ENABLED = true;
+    public static final int DEFAULT_LIST_LIMIT = 20;
+    public static final int DEFAULT_MAX_LIST_LIMIT = 100;
+
+    public RagPipelineOptions {
+        if (vectorWeight < 0.0d) {
+            throw new IllegalArgumentException("vectorWeight must be greater than or equal to 0");
+        }
+        if (lexicalWeight < 0.0d) {
+            throw new IllegalArgumentException("lexicalWeight must be greater than or equal to 0");
+        }
+        if (minRelevanceScore < 0.0d) {
+            throw new IllegalArgumentException("minRelevanceScore must be greater than or equal to 0");
+        }
+        if (defaultListLimit < 1) {
+            throw new IllegalArgumentException("defaultListLimit must be greater than 0");
+        }
+        if (maxListLimit < 1) {
+            throw new IllegalArgumentException("maxListLimit must be greater than 0");
+        }
+        if (defaultListLimit > maxListLimit) {
+            throw new IllegalArgumentException("defaultListLimit must be less than or equal to maxListLimit");
+        }
+    }
+
+    public static RagPipelineOptions defaults() {
+        return new RagPipelineOptions(
+                DEFAULT_VECTOR_WEIGHT,
+                DEFAULT_LEXICAL_WEIGHT,
+                DEFAULT_MIN_RELEVANCE_SCORE,
+                DEFAULT_KEYWORD_FALLBACK_ENABLED,
+                DEFAULT_SEMANTIC_FALLBACK_ENABLED,
+                DEFAULT_LIST_LIMIT,
+                DEFAULT_MAX_LIST_LIMIT);
+    }
+
+    public int clampListLimit(Integer requestedLimit) {
+        if (requestedLimit == null || requestedLimit <= 0) {
+            return defaultListLimit;
+        }
+        return Math.min(requestedLimit, maxListLimit);
+    }
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineService.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineService.java
@@ -32,16 +32,13 @@ import studio.one.platform.constant.ServiceNames;
 public class RagPipelineService {
     public static final String SERVICE_NAME = ServiceNames.Featrues.PREFIX + ":ai:rag-pipelien-service";
 
-    private static final double HYBRID_VECTOR_WEIGHT = 0.7;
-    private static final double HYBRID_LEXICAL_WEIGHT = 0.3;
-    private static final double MIN_RELEVANCE_SCORE = 0.15;
-
     private final EmbeddingPort embeddingPort;
     private final VectorStorePort vectorStorePort;
     private final TextChunker textChunker;
     private final Cache<String, List<Double>> embeddingCache;
     private final Retry retry;
     private final KeywordExtractor keywordExtractor;
+    private final RagPipelineOptions options;
 
     public RagPipelineService(EmbeddingPort embeddingPort,
             VectorStorePort vectorStorePort,
@@ -49,6 +46,17 @@ public class RagPipelineService {
             Cache<String, List<Double>> embeddingCache,
             Retry retry,
             KeywordExtractor keywordExtractor) {
+        this(embeddingPort, vectorStorePort, textChunker, embeddingCache, retry, keywordExtractor,
+                RagPipelineOptions.defaults());
+    }
+
+    public RagPipelineService(EmbeddingPort embeddingPort,
+            VectorStorePort vectorStorePort,
+            TextChunker textChunker,
+            Cache<String, List<Double>> embeddingCache,
+            Retry retry,
+            KeywordExtractor keywordExtractor,
+            RagPipelineOptions options) {
 
         this.embeddingPort = Objects.requireNonNull(embeddingPort, "embeddingPort");
         this.vectorStorePort = Objects.requireNonNull(vectorStorePort, "vectorStorePort");
@@ -56,6 +64,7 @@ public class RagPipelineService {
         this.embeddingCache = Objects.requireNonNull(embeddingCache, "embeddingCache");
         this.retry = Objects.requireNonNull(retry, "retry");
         this.keywordExtractor = keywordExtractor;
+        this.options = Objects.requireNonNull(options, "options");
     }
 
     public void index(RagIndexRequest request) {
@@ -90,7 +99,7 @@ public class RagPipelineService {
         List<VectorSearchResult> results = searchWithFallback(
                 request.query(),
                 searchRequest,
-                query -> vectorStorePort.hybridSearch(query, searchRequest, HYBRID_VECTOR_WEIGHT, HYBRID_LEXICAL_WEIGHT),
+                query -> vectorStorePort.hybridSearch(query, searchRequest, options.vectorWeight(), options.lexicalWeight()),
                 () -> vectorStorePort.search(searchRequest));
         return toRagSearchResults(results);
     }
@@ -106,14 +115,14 @@ public class RagPipelineService {
                         objectType,
                         objectId,
                         searchRequest,
-                        HYBRID_VECTOR_WEIGHT,
-                        HYBRID_LEXICAL_WEIGHT),
+                        options.vectorWeight(),
+                        options.lexicalWeight()),
                 () -> vectorStorePort.searchByObject(objectType, objectId, searchRequest));
         return toRagSearchResults(results);
     }
 
     public List<RagSearchResult> listByObject(String objectType, String objectId, Integer limit) {
-        List<VectorSearchResult> results = vectorStorePort.listByObject(objectType, objectId, limit);
+        List<VectorSearchResult> results = vectorStorePort.listByObject(objectType, objectId, options.clampListLimit(limit));
         return results.stream()
                 .map(result -> new RagSearchResult(
                         result.document().id(),
@@ -165,17 +174,19 @@ public class RagPipelineService {
             return results;
         }
 
-        String enrichedQuery = enrichQuery(query);
-        if (!enrichedQuery.equals(query)) {
+        String enrichedQuery = options.keywordFallbackEnabled() ? enrichQuery(query) : query;
+        if (options.keywordFallbackEnabled() && !enrichedQuery.equals(query)) {
             List<VectorSearchResult> enrichedResults = hybridSearch.apply(enrichedQuery);
             if (hasRelevantResults(enrichedResults)) {
                 return enrichedResults;
             }
         }
 
-        List<VectorSearchResult> semanticResults = semanticSearch.get();
-        if (hasRelevantResults(semanticResults)) {
-            return semanticResults;
+        if (options.semanticFallbackEnabled()) {
+            List<VectorSearchResult> semanticResults = semanticSearch.get();
+            if (hasRelevantResults(semanticResults)) {
+                return semanticResults;
+            }
         }
         return List.of();
     }
@@ -211,7 +222,7 @@ public class RagPipelineService {
         if (results == null || results.isEmpty()) {
             return false;
         }
-        return results.stream().anyMatch(result -> result.score() >= MIN_RELEVANCE_SCORE);
+        return results.stream().anyMatch(result -> result.score() >= options.minRelevanceScore());
     }
 
     private List<RagSearchResult> toRagSearchResults(List<VectorSearchResult> results) {

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -264,6 +265,13 @@ class RagPipelineServiceTest {
 
         assertThat(results).hasSize(1);
         verify(vectorStorePort).hybridSearch(eq("hello"), any(VectorSearchRequest.class), eq(0.2d), eq(0.8d));
+    }
+
+    @Test
+    void shouldRejectNonPositiveCombinedHybridWeights() {
+        assertThatThrownBy(() -> new RagPipelineOptions(0.0d, 0.0d, 0.15d, true, true, 20, 100))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("positive sum");
     }
 
     @Test

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
@@ -37,6 +37,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -61,6 +62,9 @@ class RagPipelineServiceTest {
 
     @Captor
     private ArgumentCaptor<List<VectorDocument>> documentsCaptor;
+
+    @Captor
+    private ArgumentCaptor<Integer> limitCaptor;
 
     @BeforeEach
     void setUp() {
@@ -243,5 +247,97 @@ class RagPipelineServiceTest {
         List<RagSearchResult> results = ragPipelineService.searchByObject(request, "attachment", "42");
 
         assertThat(results).isEmpty();
+    }
+
+    @Test
+    void shouldPassConfiguredWeightsToHybridSearch() {
+        ragPipelineService = new RagPipelineService(embeddingPort, vectorStorePort, textChunker, cache, retry,
+                keywordExtractor, new RagPipelineOptions(0.2d, 0.8d, 0.15d, true, true, 20, 100));
+        RagSearchRequest request = new RagSearchRequest("hello", 2);
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("hello", List.of(0.5, 0.6)))));
+        when(vectorStorePort.hybridSearch(anyString(), any(VectorSearchRequest.class), eq(0.2d), eq(0.8d)))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-weighted", "weighted", Map.of(), List.of(0.5, 0.6)), 0.9)));
+
+        List<RagSearchResult> results = ragPipelineService.search(request);
+
+        assertThat(results).hasSize(1);
+        verify(vectorStorePort).hybridSearch(eq("hello"), any(VectorSearchRequest.class), eq(0.2d), eq(0.8d));
+    }
+
+    @Test
+    void shouldUseConfiguredMinimumRelevanceScore() {
+        ragPipelineService = new RagPipelineService(embeddingPort, vectorStorePort, textChunker, cache, retry,
+                keywordExtractor, new RagPipelineOptions(0.7d, 0.3d, 0.5d, false, false, 20, 100));
+        RagSearchRequest request = new RagSearchRequest("hello", 2);
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("hello", List.of(0.5, 0.6)))));
+        when(vectorStorePort.hybridSearch(anyString(), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-low", "weak", Map.of(), List.of(0.5, 0.6)), 0.49)));
+
+        List<RagSearchResult> results = ragPipelineService.search(request);
+
+        assertThat(results).isEmpty();
+        verify(keywordExtractor, never()).extract(anyString());
+        verify(vectorStorePort, never()).search(any(VectorSearchRequest.class));
+    }
+
+    @Test
+    void shouldSkipKeywordFallbackWhenDisabled() {
+        ragPipelineService = new RagPipelineService(embeddingPort, vectorStorePort, textChunker, cache, retry,
+                keywordExtractor, new RagPipelineOptions(0.7d, 0.3d, 0.15d, false, true, 20, 100));
+        RagSearchRequest request = new RagSearchRequest("hello", 2);
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("hello", List.of(0.5, 0.6)))));
+        when(vectorStorePort.hybridSearch(anyString(), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-low", "weak", Map.of(), List.of(0.5, 0.6)), 0.01)));
+        when(vectorStorePort.search(any(VectorSearchRequest.class)))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-semantic", "semantic", Map.of(), List.of(0.5, 0.6)), 0.9)));
+
+        List<RagSearchResult> results = ragPipelineService.search(request);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).documentId()).isEqualTo("doc-semantic");
+        verify(keywordExtractor, never()).extract(anyString());
+        verify(vectorStorePort, times(1)).hybridSearch(eq("hello"), any(VectorSearchRequest.class), anyDouble(), anyDouble());
+    }
+
+    @Test
+    void shouldSkipSemanticFallbackWhenDisabled() {
+        ragPipelineService = new RagPipelineService(embeddingPort, vectorStorePort, textChunker, cache, retry,
+                keywordExtractor, new RagPipelineOptions(0.7d, 0.3d, 0.15d, true, false, 20, 100));
+        RagSearchRequest request = new RagSearchRequest("hello", 2);
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("hello", List.of(0.5, 0.6)))));
+        when(keywordExtractor.extract("hello")).thenReturn(List.of());
+        when(vectorStorePort.hybridSearch(anyString(), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-low", "weak", Map.of(), List.of(0.5, 0.6)), 0.01)));
+
+        List<RagSearchResult> results = ragPipelineService.search(request);
+
+        assertThat(results).isEmpty();
+        verify(vectorStorePort, never()).search(any(VectorSearchRequest.class));
+    }
+
+    @Test
+    void shouldClampObjectListLimitInServiceLayer() {
+        ragPipelineService = new RagPipelineService(embeddingPort, vectorStorePort, textChunker, cache, retry,
+                keywordExtractor, new RagPipelineOptions(0.7d, 0.3d, 0.15d, true, true, 5, 10));
+        when(vectorStorePort.listByObject(eq("attachment"), eq("42"), any()))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc", "content", Map.of(), List.of()), 1.0d)));
+
+        ragPipelineService.listByObject("attachment", "42", null);
+        ragPipelineService.listByObject("attachment", "42", 0);
+        ragPipelineService.listByObject("attachment", "42", 30);
+        ragPipelineService.listByObject("attachment", "42", 7);
+
+        verify(vectorStorePort, times(4)).listByObject(eq("attachment"), eq("42"), limitCaptor.capture());
+        assertThat(limitCaptor.getAllValues()).containsExactly(5, 5, 10, 7);
     }
 }


### PR DESCRIPTION
## Why

RAG retrieval weights, relevance thresholds, fallback behavior, object-scope list limits, and chat RAG context size were hard-coded. Large object-scoped RAG flows could inject excessive context, and operators could not tune retrieval behavior per environment.

## What

- Added immutable `RagPipelineOptions` and `studio.ai.pipeline.retrieval.*` / `studio.ai.pipeline.object-scope.*` properties.
- Moved hybrid weights, minimum relevance score, and fallback toggles out of hard-coded `RagPipelineService` constants.
- Added service-layer clamp for query-less object-scope `listByObject` limits without changing `VectorStorePort` or `PgVectorStoreAdapterV2` contracts.
- Added `studio.ai.endpoints.rag.context.*` properties and `RagContextBuilder` to enforce max chunks, max chars, and optional score inclusion in `/api/ai/chat/rag` context.
- Addressed review feedback by validating positive combined hybrid weights and skipping over-limit chunks instead of cutting them mid-sentence.
- Updated tests, README docs, and CHANGELOG.

## Related Issues

- Closes #202

## Validation

- Command: `gradle :studio-platform-ai:test :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test --rerun-tasks`
- Result: PASS
- Command: `git diff --check`
- Result: PASS
- Note: `./gradlew` could not be used in this worktree because `gradle/wrapper/gradle-wrapper.jar` is not present; installed `gradle` was used instead.

## Risk / Rollback

- Risk: RAG retrieval ranking and context composition behavior can change because tunable defaults are now applied through `RagPipelineOptions` and `RagContextBuilder`.
- Rollback: Revert this PR to restore hard-coded retrieval values and previous context construction behavior.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: Yes
- Delegated scope: Worker 1 implemented Phase 1 in `studio-api-rag-config`; main author reviewed, addressed review feedback, reran validation, committed, and opened this PR.
- Main author validation: `gradle :studio-platform-ai:test :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test --rerun-tasks`, `git diff --check`

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included
