### PR TITLE
[ai-assisted] feat(ai-rag): add optional indexing text cleaner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## 2026-04-16
 
 ### 변경됨
+- 이슈 #204 대응으로 `studio.ai.pipeline.cleaner.*` 설정을 추가해 RAG 색인 전 LLM 기반 텍스트 정제를 선택적으로 적용할 수 있도록 했다.
+- `TextCleaner`/`LlmTextCleaner`를 추가하고 `rag-cleaner` prompt의 `clean_text` JSON 응답을 색인 텍스트로 사용하도록 했다.
+- `RagPipelineService.index()`가 cleaner 적용 여부, 원문/색인 텍스트 길이, chunk 수, chunk 길이를 vector metadata에 additive로 기록하도록 했다.
+- 첨부 RAG 인덱싱 metadata에 `filename`, `sourceType=attachment`, `indexedAt`을 `putIfAbsent`로 추가해 클라이언트/운영 추적 정보를 보강했다.
 - 이슈 #202 대응으로 `RagPipelineService`의 hybrid 검색 weight, 최소 relevance score, keyword/semantic fallback 사용 여부를 `studio.ai.pipeline.retrieval.*` 설정으로 조정할 수 있도록 했다.
 - query 없는 object-scope RAG 조회가 과도한 chunk를 반환하지 않도록 `studio.ai.pipeline.object-scope.default-list-limit`, `max-list-limit` 설정과 service layer clamp를 추가했다.
 - `POST /api/ai/chat/rag`가 system context에 포함하는 RAG chunk 수/문자 수와 score 포함 여부를 `studio.ai.endpoints.rag.context.*` 설정으로 제한하도록 했다.
@@ -15,6 +19,9 @@
 ### 검증
 - `gradle :studio-platform-ai:test :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test --rerun-tasks`
 - `gradle :studio-platform-ai:test --tests 'studio.one.platform.ai.service.pipeline.RagQualitySmokeTest'`
+- `gradle :studio-platform-ai:test`
+- `gradle :starter:studio-platform-starter-ai:test`
+- `gradle :studio-application-modules:content-embedding-pipeline:test`
 - `./gradlew :studio-platform-ai:test`
 - `./gradlew :starter:studio-platform-starter-ai-web:test`
 - `git diff --check`

--- a/starter/studio-platform-starter-ai/README.md
+++ b/starter/studio-platform-starter-ai/README.md
@@ -168,6 +168,7 @@ studio:
 | `VectorStorePort` | JdbcTemplate이 있을 때 pgvector 기반 벡터 스토어 자동 생성 |
 | `RagPipelineService` | RAG 인덱싱/검색 파이프라인 서비스 |
 | `PromptManager` | Mustache 템플릿 기반 프롬프트 렌더러 |
+| `TextCleaner` | `studio.ai.pipeline.cleaner.enabled=true`일 때 색인 전 텍스트 정제 |
 
 `RagPipelineService`는 문서/파일/도메인 객체별 텍스트를 chunk로 나누고, 임베딩과 메타데이터를 벡터 스토어에 저장한다.
 `objectType`/`objectId` 메타데이터를 함께 저장하면 AI web starter의 RAG chat API에서 특정 파일이나 객체 범위에 한정해 답변할 수 있다.
@@ -203,6 +204,34 @@ studio:
 | `studio.ai.pipeline.object-scope.max-list-limit` | `100` | object-scope list 최대 limit |
 
 `vector-weight`와 `lexical-weight`는 각각 0 이상이어야 하며 두 값의 합은 0보다 커야 한다.
+
+### RAG 색인 전 텍스트 정제
+
+이슈 #204부터 RAG 색인 전에 LLM 기반 텍스트 정제를 선택적으로 적용할 수 있다. 기본값은 비활성화이므로
+기존 raw indexing 동작은 유지된다. 활성화하면 `rag-cleaner` Mustache prompt를 렌더링해 LLM에 전달하고,
+응답 JSON의 `clean_text` 필드를 색인 대상 텍스트로 사용한다.
+
+```yaml
+studio:
+  ai:
+    pipeline:
+      cleaner:
+        enabled: false
+        prompt: rag-cleaner
+        max-input-chars: 20000
+        fail-open: true
+```
+
+| 설정 | 기본값 | 설명 |
+|---|---:|---|
+| `studio.ai.pipeline.cleaner.enabled` | `false` | 색인 전 LLM text cleaner 사용 여부 |
+| `studio.ai.pipeline.cleaner.prompt` | `rag-cleaner` | 사용할 Mustache prompt 이름 |
+| `studio.ai.pipeline.cleaner.max-input-chars` | `20000` | cleaner에 전달할 입력 최대 길이 |
+| `studio.ai.pipeline.cleaner.fail-open` | `true` | cleaner 호출/파싱 실패 시 원문으로 색인을 계속할지 여부 |
+
+정제 결과는 vector metadata에 additive key로 기록된다.
+`cleaned`, `cleanerPrompt`, `originalTextLength`, `indexedTextLength`, `chunkCount`, `chunkLength`가 추가되며,
+호출자가 같은 key를 이미 전달한 경우 기존 metadata 값을 보존한다.
 
 ## 관련 모듈
 - `studio-platform-ai` — 이 스타터가 구현하는 포트 인터페이스 모듈

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/PromptProperties.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/PromptProperties.java
@@ -13,6 +13,15 @@ import studio.one.platform.constant.PropertyKeys;
 @Getter @Setter
 public class PromptProperties {
 
-    private Map<String, String> prompts = new HashMap<>();
+    private Map<String, String> prompts = defaultPrompts();
+
+    private static Map<String, String> defaultPrompts() {
+        Map<String, String> defaults = new HashMap<>();
+        defaults.put("keyword-extraction", "classpath:/prompts/keyword-extraction.v1.prompt");
+        defaults.put("query-rewrite", "classpath:/prompts/query-rewrite.v1.prompt");
+        defaults.put("rag-cleaner", "classpath:/prompts/rag-cleaner.v1.prompt");
+        defaults.put("summarization", "classpath:/prompts/summarization.v1.prompt");
+        return defaults;
+    }
  
 }

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfiguration.java
@@ -123,6 +123,7 @@ public class RagPipelineConfiguration {
                                 LogUtils.blue(LlmTextCleaner.class, true),
                                 LogUtils.green(ChatPort.class, true),
                                 LogUtils.red(State.CREATED.toString())));
+                promptRenderer.getRawPrompt(cleaner.getPrompt());
                 return new LlmTextCleaner(
                                 promptRenderer,
                                 chatPort,

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfiguration.java
@@ -3,7 +3,10 @@ package studio.one.platform.ai.autoconfigure.config;
 import java.time.Duration;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,13 +18,18 @@ import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import studio.one.platform.ai.core.chat.ChatPort;
 import studio.one.platform.ai.core.chunk.TextChunker;
 import studio.one.platform.ai.core.embedding.EmbeddingPort;
 import studio.one.platform.ai.core.vector.VectorStorePort;
+import studio.one.platform.ai.service.cleaning.LlmTextCleaner;
+import studio.one.platform.ai.service.cleaning.TextCleaner;
 import studio.one.platform.ai.service.chunk.OverlapTextChunker;
 import studio.one.platform.ai.service.keyword.KeywordExtractor;
 import studio.one.platform.ai.service.pipeline.RagPipelineOptions;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
+import studio.one.platform.ai.service.prompt.PromptRenderer;
+import studio.one.platform.constant.PropertyKeys;
 import studio.one.platform.autoconfigure.I18nKeys;
 import studio.one.platform.component.State;
 import studio.one.platform.service.I18n;
@@ -87,7 +95,9 @@ public class RagPipelineConfiguration {
         @Bean(RagPipelineService.SERVICE_NAME)
         RagPipelineService ragPipelineService(EmbeddingPort embeddingPort, VectorStorePort vectorStorePort,
                         TextChunker textChunker, Cache<String, List<Double>> embeddingCache, Retry embeddingRetry,
-                        ObjectProvider<KeywordExtractor> keywordExtractorProvider, RagPipelineProperties properties) {
+                        ObjectProvider<KeywordExtractor> keywordExtractorProvider,
+                        ObjectProvider<TextCleaner> textCleanerProvider,
+                        RagPipelineProperties properties) {
 
                 I18n i18n = I18nUtils.resolve(i18nProvider);
                 log.info(LogUtils.format(i18n, I18nKeys.AutoConfig.Feature.Service.DETAILS,
@@ -95,7 +105,31 @@ public class RagPipelineConfiguration {
                                 LogUtils.blue(RagPipelineService.class, true), LogUtils.red(State.CREATED.toString())));
 
                 return new RagPipelineService(embeddingPort, vectorStorePort, textChunker, embeddingCache,
-                                embeddingRetry, keywordExtractorProvider.getIfAvailable(), ragPipelineOptions(properties));
+                                embeddingRetry, keywordExtractorProvider.getIfAvailable(),
+                                textCleanerProvider.getIfAvailable(), ragPipelineOptions(properties));
+        }
+
+        @Bean
+        @ConditionalOnMissingBean(TextCleaner.class)
+        @ConditionalOnProperty(prefix = PropertyKeys.AI.PREFIX + ".pipeline.cleaner", name = "enabled", havingValue = "true")
+        TextCleaner textCleaner(PromptRenderer promptRenderer,
+                        ChatPort chatPort,
+                        ObjectProvider<ObjectMapper> objectMapperProvider,
+                        RagPipelineProperties properties) {
+                RagPipelineProperties.CleanerProperties cleaner = properties.getCleaner();
+                I18n i18n = I18nUtils.resolve(i18nProvider);
+                log.info(LogUtils.format(i18n, I18nKeys.AutoConfig.Feature.Service.DEPENDS_ON,
+                                AiProviderRegistryConfiguration.FEATURE_NAME,
+                                LogUtils.blue(LlmTextCleaner.class, true),
+                                LogUtils.green(ChatPort.class, true),
+                                LogUtils.red(State.CREATED.toString())));
+                return new LlmTextCleaner(
+                                promptRenderer,
+                                chatPort,
+                                objectMapperProvider.getIfAvailable(ObjectMapper::new),
+                                cleaner.getPrompt(),
+                                cleaner.getMaxInputChars(),
+                                cleaner.isFailOpen());
         }
 
         private RagPipelineOptions ragPipelineOptions(RagPipelineProperties properties) {

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineProperties.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineProperties.java
@@ -16,6 +16,7 @@ public class RagPipelineProperties {
     private final RetryProperties retry = new RetryProperties();
     private final RetrievalProperties retrieval = new RetrievalProperties();
     private final ObjectScopeProperties objectScope = new ObjectScopeProperties();
+    private final CleanerProperties cleaner = new CleanerProperties();
 
     public int getChunkSize() {
         return chunkSize;
@@ -47,6 +48,10 @@ public class RagPipelineProperties {
 
     public ObjectScopeProperties getObjectScope() {
         return objectScope;
+    }
+
+    public CleanerProperties getCleaner() {
+        return cleaner;
     }
 
     public static class CacheProperties {
@@ -157,6 +162,45 @@ public class RagPipelineProperties {
 
         public void setMaxListLimit(int maxListLimit) {
             this.maxListLimit = maxListLimit;
+        }
+    }
+
+    public static class CleanerProperties {
+        private boolean enabled = false;
+        private String prompt = "rag-cleaner";
+        private int maxInputChars = 20_000;
+        private boolean failOpen = true;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public String getPrompt() {
+            return prompt;
+        }
+
+        public void setPrompt(String prompt) {
+            this.prompt = prompt;
+        }
+
+        public int getMaxInputChars() {
+            return maxInputChars;
+        }
+
+        public void setMaxInputChars(int maxInputChars) {
+            this.maxInputChars = maxInputChars;
+        }
+
+        public boolean isFailOpen() {
+            return failOpen;
+        }
+
+        public void setFailOpen(boolean failOpen) {
+            this.failOpen = failOpen;
         }
     }
 }

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfigurationTextCleanerTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfigurationTextCleanerTest.java
@@ -1,0 +1,60 @@
+package studio.one.platform.ai.autoconfigure.config;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.ObjectProvider;
+
+import studio.one.platform.ai.core.chat.ChatPort;
+import studio.one.platform.ai.service.prompt.PromptRenderer;
+
+class RagPipelineConfigurationTextCleanerTest {
+
+    @Test
+    void textCleanerVerifiesPromptExistsBeforeCreatingBean() {
+        RagPipelineConfiguration configuration = new RagPipelineConfiguration(provider(null));
+        PromptRenderer promptRenderer = mock(PromptRenderer.class);
+        ChatPort chatPort = mock(ChatPort.class);
+        RagPipelineProperties properties = new RagPipelineProperties();
+        properties.getCleaner().setEnabled(true);
+        properties.getCleaner().setPrompt("missing-cleaner");
+
+        when(promptRenderer.getRawPrompt("missing-cleaner")).thenThrow(new IllegalArgumentException("missing"));
+
+        assertThatThrownBy(() -> configuration.textCleaner(
+                promptRenderer,
+                chatPort,
+                provider(new ObjectMapper()),
+                properties))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("missing");
+    }
+
+    private static <T> ObjectProvider<T> provider(T value) {
+        return new ObjectProvider<>() {
+            @Override
+            public T getObject(Object... args) throws BeansException {
+                return value;
+            }
+
+            @Override
+            public T getIfAvailable() throws BeansException {
+                return value;
+            }
+
+            @Override
+            public T getIfUnique() throws BeansException {
+                return value;
+            }
+
+            @Override
+            public T getObject() throws BeansException {
+                return value;
+            }
+        };
+    }
+}

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/RagPipelinePropertiesTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/RagPipelinePropertiesTest.java
@@ -9,6 +9,8 @@ import org.springframework.boot.context.properties.source.ConfigurationPropertyS
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.StandardEnvironment;
 
+import java.util.Map;
+
 class RagPipelinePropertiesTest {
 
     @Test
@@ -22,19 +24,27 @@ class RagPipelinePropertiesTest {
         assertThat(properties.getRetrieval().isSemanticFallbackEnabled()).isTrue();
         assertThat(properties.getObjectScope().getDefaultListLimit()).isEqualTo(20);
         assertThat(properties.getObjectScope().getMaxListLimit()).isEqualTo(100);
+        assertThat(properties.getCleaner().isEnabled()).isFalse();
+        assertThat(properties.getCleaner().getPrompt()).isEqualTo("rag-cleaner");
+        assertThat(properties.getCleaner().getMaxInputChars()).isEqualTo(20_000);
+        assertThat(properties.getCleaner().isFailOpen()).isTrue();
     }
 
     @Test
     void shouldBindRetrievalAndObjectScopeOverrides() {
         StandardEnvironment environment = new StandardEnvironment();
-        environment.getPropertySources().addFirst(new MapPropertySource("test", java.util.Map.of(
-                "studio.ai.pipeline.retrieval.vector-weight", "0.2",
-                "studio.ai.pipeline.retrieval.lexical-weight", "0.8",
-                "studio.ai.pipeline.retrieval.min-relevance-score", "0.4",
-                "studio.ai.pipeline.retrieval.keyword-fallback-enabled", "false",
-                "studio.ai.pipeline.retrieval.semantic-fallback-enabled", "false",
-                "studio.ai.pipeline.object-scope.default-list-limit", "5",
-                "studio.ai.pipeline.object-scope.max-list-limit", "10")));
+        environment.getPropertySources().addFirst(new MapPropertySource("test", Map.ofEntries(
+                Map.entry("studio.ai.pipeline.retrieval.vector-weight", "0.2"),
+                Map.entry("studio.ai.pipeline.retrieval.lexical-weight", "0.8"),
+                Map.entry("studio.ai.pipeline.retrieval.min-relevance-score", "0.4"),
+                Map.entry("studio.ai.pipeline.retrieval.keyword-fallback-enabled", "false"),
+                Map.entry("studio.ai.pipeline.retrieval.semantic-fallback-enabled", "false"),
+                Map.entry("studio.ai.pipeline.object-scope.default-list-limit", "5"),
+                Map.entry("studio.ai.pipeline.object-scope.max-list-limit", "10"),
+                Map.entry("studio.ai.pipeline.cleaner.enabled", "true"),
+                Map.entry("studio.ai.pipeline.cleaner.prompt", "custom-cleaner"),
+                Map.entry("studio.ai.pipeline.cleaner.max-input-chars", "1234"),
+                Map.entry("studio.ai.pipeline.cleaner.fail-open", "false"))));
 
         RagPipelineProperties properties = new Binder(ConfigurationPropertySources.get(environment))
                 .bind("studio.ai.pipeline", Bindable.of(RagPipelineProperties.class))
@@ -47,5 +57,9 @@ class RagPipelinePropertiesTest {
         assertThat(properties.getRetrieval().isSemanticFallbackEnabled()).isFalse();
         assertThat(properties.getObjectScope().getDefaultListLimit()).isEqualTo(5);
         assertThat(properties.getObjectScope().getMaxListLimit()).isEqualTo(10);
+        assertThat(properties.getCleaner().isEnabled()).isTrue();
+        assertThat(properties.getCleaner().getPrompt()).isEqualTo("custom-cleaner");
+        assertThat(properties.getCleaner().getMaxInputChars()).isEqualTo(1234);
+        assertThat(properties.getCleaner().isFailOpen()).isFalse();
     }
 }

--- a/studio-application-modules/content-embedding-pipeline/README.md
+++ b/studio-application-modules/content-embedding-pipeline/README.md
@@ -31,6 +31,7 @@ EmbeddingPort.embed()                 ← studio-platform-ai 어댑터 제공
 ```
 
 청킹은 현재 단일 텍스트 단위로 처리되며, 멀티청크 지원은 `RagPipelineService` 구현체에 위임된다.
+`studio.ai.pipeline.cleaner.enabled=true`이면 `RagPipelineService`가 chunking 전에 추출 텍스트를 정제한다.
 
 ## 주요 서비스 클래스와 역할
 
@@ -96,6 +97,20 @@ Content-Type: application/json
   }
 }
 ```
+
+첨부 RAG 인덱싱은 metadata에 아래 값을 `putIfAbsent`로 보강한다. 요청 metadata에 같은 key가 있으면 요청 값을 유지한다.
+
+| key | 설명 |
+|---|---|
+| `objectType` | 기본값 `attachment` 또는 요청 값 |
+| `objectId` | 기본값 attachment ID 문자열 또는 요청 값 |
+| `attachmentId` | 첨부 ID |
+| `name` | 첨부 원본 이름 |
+| `filename` | 첨부 파일명. 클라이언트 표시용 alias |
+| `sourceType` | `attachment` |
+| `indexedAt` | RAG 인덱싱 요청 시각 |
+| `contentType` | 첨부 MIME 타입 |
+| `size` | 첨부 크기 |
 
 ### RAG 검색 요청 예시
 

--- a/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineController.java
+++ b/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineController.java
@@ -23,6 +23,7 @@ package studio.one.application.web.controller;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -320,6 +321,9 @@ public class AttachmentEmbeddingPipelineController {
         metadata.putIfAbsent("objectId", objectId);
         metadata.putIfAbsent("attachmentId", attachment.getAttachmentId());
         metadata.putIfAbsent("name", attachment.getName());
+        metadata.putIfAbsent("filename", attachment.getName());
+        metadata.putIfAbsent("sourceType", "attachment");
+        metadata.putIfAbsent("indexedAt", Instant.now().toString());
         metadata.putIfAbsent("contentType", attachment.getContentType());
         metadata.putIfAbsent("size", attachment.getSize());
         metadata.putIfAbsent("chunkOrder", 0);

--- a/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineControllerTest.java
+++ b/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineControllerTest.java
@@ -1,7 +1,9 @@
 package studio.one.application.web.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -30,6 +32,7 @@ import studio.one.application.attachment.service.AttachmentService;
 import studio.one.platform.ai.core.embedding.EmbeddingPort;
 import studio.one.platform.ai.core.embedding.EmbeddingResponse;
 import studio.one.platform.ai.core.embedding.EmbeddingVector;
+import studio.one.platform.ai.core.rag.RagIndexRequest;
 import studio.one.platform.ai.core.rag.RagSearchResult;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
 import studio.one.platform.constant.PropertyKeys;
@@ -122,6 +125,45 @@ class AttachmentEmbeddingPipelineControllerTest {
                                 }
                                 """))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void ragIndexAddsAttachmentMetadataWithoutOverwritingCallerMetadata() throws Exception {
+        Attachment attachment = mock(Attachment.class);
+        when(attachmentService.getAttachmentById(1L)).thenReturn(attachment);
+        when(attachmentService.getInputStream(attachment))
+                .thenReturn(new ByteArrayInputStream("hello".getBytes(StandardCharsets.UTF_8)));
+        when(attachment.getAttachmentId()).thenReturn(1L);
+        when(attachment.getContentType()).thenReturn("text/plain");
+        when(attachment.getName()).thenReturn("sample.txt");
+        when(attachment.getSize()).thenReturn(5L);
+        when(extractionService.extractText(any(), any(), any(InputStream.class))).thenReturn("hello");
+
+        mockMvc.perform(post(BASE_PATH + "/1/rag/index")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "metadata": {
+                                    "filename": "caller.txt",
+                                    "sourceType": "caller-source",
+                                    "indexedAt": "caller-time"
+                                  }
+                                }
+                                """))
+                .andExpect(status().isAccepted());
+
+        verify(ragPipelineService).index(argThat((RagIndexRequest request) -> {
+            Map<String, Object> metadata = request.metadata();
+            return "caller.txt".equals(metadata.get("filename"))
+                    && "caller-source".equals(metadata.get("sourceType"))
+                    && "caller-time".equals(metadata.get("indexedAt"))
+                    && "attachment".equals(metadata.get("objectType"))
+                    && "1".equals(metadata.get("objectId"))
+                    && Long.valueOf(1L).equals(metadata.get("attachmentId"))
+                    && "sample.txt".equals(metadata.get("name"))
+                    && "text/plain".equals(metadata.get("contentType"))
+                    && Long.valueOf(5L).equals(metadata.get("size"));
+        }));
     }
 
     private static <T> ObjectProvider<T> provider(T value) {

--- a/studio-platform-ai/README.md
+++ b/studio-platform-ai/README.md
@@ -11,6 +11,7 @@ AI 추상화 계층이다. 챗 완성, 임베딩 생성, 벡터 스토어 접근
 - `AiProviderRegistry`: 공급자 이름을 키로 ChatPort/EmbeddingPort를 관리하는 레지스트리
 - `TextChunker`: 긴 문서를 임베딩에 적합한 크기로 분할하는 전략 인터페이스
 - `RagPipelineService`: 인덱싱(`index`)과 검색(`search`, `searchByObject`, `listByObject`)을 조율하는 파이프라인 서비스
+  - 선택적 `TextCleaner`가 있으면 chunking 전에 추출 텍스트를 정제
   - 설정된 하이브리드 검색 비중 → 쿼리 보강 → 순수 시맨틱 검색 순으로 폴백
   - query 없는 object-scope 조회는 설정된 기본/최대 limit 안에서 chunk를 반환
   - Caffeine 캐시 + Resilience4j Retry로 임베딩 호출을 보호
@@ -24,8 +25,21 @@ AI 추상화 계층이다. 챗 완성, 임베딩 생성, 벡터 스토어 접근
 | `VectorStorePort` | `core.vector` | 벡터 저장/검색/하이브리드 검색 계약 |
 | `AiProviderRegistry` | `core.registry` | 공급자별 ChatPort/EmbeddingPort 룩업 |
 | `TextChunker` | `core.chunk` | 문서를 TextChunk 리스트로 분할 |
+| `TextCleaner` | `service.cleaning` | 색인 전 추출 텍스트 정제 계약 |
 | `RagPipelineService` | `service.pipeline` | 인덱싱/검색 파이프라인 오케스트레이터 |
 | `AiProvider` | `core` | 지원 공급자 열거형 (OPENAI, OLLAMA, GOOGLE_AI_GEMINI) |
+
+## RAG metadata
+`RagPipelineService.index()`는 색인 문서 metadata에 아래 key를 추가한다. 호출자가 같은 key를 전달한 경우 기존 값을 보존한다.
+
+| key | 설명 |
+|---|---|
+| `cleaned` | text cleaner가 성공적으로 정제 텍스트를 생성했는지 여부 |
+| `cleanerPrompt` | 사용한 cleaner prompt 이름. cleaner 미사용 시 빈 문자열 |
+| `originalTextLength` | 원본 추출 텍스트 길이 |
+| `indexedTextLength` | 실제 chunking/indexing에 사용한 텍스트 길이 |
+| `chunkCount` | 생성된 chunk 수 |
+| `chunkLength` | 개별 chunk content 길이 |
 
 ## 구현 분리 원칙
 이 모듈은 구현체를 포함하지 않는다. 의존성 역전 원칙에 따라 애플리케이션은 `ChatPort` 등 포트만 참조하며, 공급자별 어댑터는 스타터 모듈이 조건부로 등록한다. 공급자를 교체하거나 추가할 때 이 모듈을 수정할 필요가 없다.

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/service/cleaning/LlmTextCleaner.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/service/cleaning/LlmTextCleaner.java
@@ -1,0 +1,110 @@
+package studio.one.platform.ai.service.cleaning;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
+import studio.one.platform.ai.core.chat.ChatMessage;
+import studio.one.platform.ai.core.chat.ChatPort;
+import studio.one.platform.ai.core.chat.ChatRequest;
+import studio.one.platform.ai.core.chat.ChatResponse;
+import studio.one.platform.ai.service.prompt.PromptRenderer;
+
+/**
+ * LLM-backed text cleaner for noisy extracted document text.
+ */
+@Slf4j
+public class LlmTextCleaner implements TextCleaner {
+
+    private final PromptRenderer promptRenderer;
+    private final ChatPort chatPort;
+    private final ObjectMapper objectMapper;
+    private final String promptName;
+    private final int maxInputChars;
+    private final boolean failOpen;
+
+    public LlmTextCleaner(PromptRenderer promptRenderer,
+            ChatPort chatPort,
+            ObjectMapper objectMapper,
+            String promptName,
+            int maxInputChars,
+            boolean failOpen) {
+        this.promptRenderer = Objects.requireNonNull(promptRenderer, "promptRenderer");
+        this.chatPort = Objects.requireNonNull(chatPort, "chatPort");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
+        this.promptName = requireText(promptName, "promptName");
+        if (maxInputChars < 1) {
+            throw new IllegalArgumentException("maxInputChars must be greater than 0");
+        }
+        this.maxInputChars = maxInputChars;
+        this.failOpen = failOpen;
+    }
+
+    @Override
+    public TextCleaningResult clean(String text) {
+        if (text == null || text.isBlank()) {
+            return TextCleaningResult.skipped(text);
+        }
+        try {
+            String prompt = promptRenderer.render(promptName, Map.of("text", trimToLength(text, maxInputChars)));
+            ChatResponse response = chatPort.chat(ChatRequest.builder()
+                    .messages(List.of(ChatMessage.user(prompt)))
+                    .build());
+            String raw = response.messages().get(response.messages().size() - 1).content();
+            String cleaned = parseCleanText(raw);
+            return new TextCleaningResult(cleaned, true, promptName);
+        } catch (Exception ex) {
+            if (failOpen) {
+                log.warn("Failed to clean RAG text via LLM. Falling back to original text. cause={}", ex.toString());
+                return new TextCleaningResult(text, false, promptName);
+            }
+            throw new IllegalStateException("Failed to clean RAG text via LLM", ex);
+        }
+    }
+
+    private String parseCleanText(String raw) throws Exception {
+        if (raw == null || raw.isBlank()) {
+            throw new IllegalArgumentException("cleaner response is blank");
+        }
+        String value = stripFence(raw.trim());
+        JsonNode node = objectMapper.readTree(value);
+        JsonNode cleanText = node.get("clean_text");
+        if (cleanText == null || !cleanText.isTextual() || cleanText.asText().isBlank()) {
+            throw new IllegalArgumentException("cleaner response must contain non-blank clean_text");
+        }
+        return cleanText.asText();
+    }
+
+    private String stripFence(String value) {
+        if (value.startsWith("```")) {
+            int firstNewline = value.indexOf('\n');
+            if (firstNewline > 0) {
+                value = value.substring(firstNewline + 1);
+            }
+            int fence = value.lastIndexOf("```");
+            if (fence >= 0) {
+                value = value.substring(0, fence);
+            }
+            return value.trim();
+        }
+        return value;
+    }
+
+    private String trimToLength(String text, int max) {
+        if (text.length() <= max) {
+            return text;
+        }
+        return text.substring(0, max);
+    }
+
+    private static String requireText(String value, String name) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " must not be blank");
+        }
+        return value.trim();
+    }
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/service/cleaning/TextCleaner.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/service/cleaning/TextCleaner.java
@@ -1,0 +1,9 @@
+package studio.one.platform.ai.service.cleaning;
+
+/**
+ * Cleans extracted document text before it is split into RAG chunks.
+ */
+public interface TextCleaner {
+
+    TextCleaningResult clean(String text);
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/service/cleaning/TextCleaningResult.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/service/cleaning/TextCleaningResult.java
@@ -1,0 +1,14 @@
+package studio.one.platform.ai.service.cleaning;
+
+/**
+ * Result of a text cleaning attempt.
+ */
+public record TextCleaningResult(
+        String text,
+        boolean cleaned,
+        String cleanerPrompt) {
+
+    public static TextCleaningResult skipped(String text) {
+        return new TextCleaningResult(text, false, null);
+    }
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineService.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineService.java
@@ -25,6 +25,8 @@ import studio.one.platform.ai.core.vector.VectorDocument;
 import studio.one.platform.ai.core.vector.VectorSearchRequest;
 import studio.one.platform.ai.core.vector.VectorSearchResult;
 import studio.one.platform.ai.core.vector.VectorStorePort;
+import studio.one.platform.ai.service.cleaning.TextCleaner;
+import studio.one.platform.ai.service.cleaning.TextCleaningResult;
 import studio.one.platform.ai.service.keyword.KeywordExtractor;
 import studio.one.platform.constant.ServiceNames;
 
@@ -38,6 +40,7 @@ public class RagPipelineService {
     private final Cache<String, List<Double>> embeddingCache;
     private final Retry retry;
     private final KeywordExtractor keywordExtractor;
+    private final TextCleaner textCleaner;
     private final RagPipelineOptions options;
 
     public RagPipelineService(EmbeddingPort embeddingPort,
@@ -47,7 +50,7 @@ public class RagPipelineService {
             Retry retry,
             KeywordExtractor keywordExtractor) {
         this(embeddingPort, vectorStorePort, textChunker, embeddingCache, retry, keywordExtractor,
-                RagPipelineOptions.defaults());
+                null, RagPipelineOptions.defaults());
     }
 
     public RagPipelineService(EmbeddingPort embeddingPort,
@@ -57,6 +60,17 @@ public class RagPipelineService {
             Retry retry,
             KeywordExtractor keywordExtractor,
             RagPipelineOptions options) {
+        this(embeddingPort, vectorStorePort, textChunker, embeddingCache, retry, keywordExtractor, null, options);
+    }
+
+    public RagPipelineService(EmbeddingPort embeddingPort,
+            VectorStorePort vectorStorePort,
+            TextChunker textChunker,
+            Cache<String, List<Double>> embeddingCache,
+            Retry retry,
+            KeywordExtractor keywordExtractor,
+            TextCleaner textCleaner,
+            RagPipelineOptions options) {
 
         this.embeddingPort = Objects.requireNonNull(embeddingPort, "embeddingPort");
         this.vectorStorePort = Objects.requireNonNull(vectorStorePort, "vectorStorePort");
@@ -64,6 +78,7 @@ public class RagPipelineService {
         this.embeddingCache = Objects.requireNonNull(embeddingCache, "embeddingCache");
         this.retry = Objects.requireNonNull(retry, "retry");
         this.keywordExtractor = keywordExtractor;
+        this.textCleaner = textCleaner;
         this.options = Objects.requireNonNull(options, "options");
     }
 
@@ -71,10 +86,17 @@ public class RagPipelineService {
 
         log.debug("using llm keywords extract : {}", request.useLlmKeywordExtraction());
 
-        List<TextChunk> chunks = textChunker.chunk(request.documentId(), request.text());
+        TextCleaningResult cleaning = cleanText(request.text());
+        String indexedText = cleaning.text() == null ? request.text() : cleaning.text();
+        List<TextChunk> chunks = textChunker.chunk(request.documentId(), indexedText);
         List<VectorDocument> documents = new ArrayList<>(chunks.size());
-        List<String> keywords = resolveKeywords(request);
+        List<String> keywords = resolveKeywords(request, indexedText);
         Map<String, Object> baseMetadata = new HashMap<>(request.metadata());
+        baseMetadata.putIfAbsent("cleaned", cleaning.cleaned());
+        baseMetadata.putIfAbsent("cleanerPrompt", cleaning.cleanerPrompt() == null ? "" : cleaning.cleanerPrompt());
+        baseMetadata.putIfAbsent("originalTextLength", request.text().length());
+        baseMetadata.putIfAbsent("indexedTextLength", indexedText.length());
+        baseMetadata.putIfAbsent("chunkCount", chunks.size());
         if (!keywords.isEmpty()) {
             baseMetadata.put("keywords", keywords);
             baseMetadata.put("keywordsText", String.join(" ", keywords));
@@ -86,6 +108,7 @@ public class RagPipelineService {
             metadata.put("documentId", request.documentId());
             metadata.put("chunkId", chunk.id());
             metadata.put("chunkOrder", order++);
+            metadata.put("chunkLength", chunk.content().length());
             documents.add(new VectorDocument(chunk.id(), chunk.content(), metadata, embedding));
         }
         if (!documents.isEmpty()) {
@@ -149,7 +172,14 @@ public class RagPipelineService {
         return Retry.decorateSupplier(retry, supplier).get();
     }
 
-    private List<String> resolveKeywords(RagIndexRequest request) {
+    private TextCleaningResult cleanText(String text) {
+        if (textCleaner == null) {
+            return TextCleaningResult.skipped(text);
+        }
+        return textCleaner.clean(text);
+    }
+
+    private List<String> resolveKeywords(RagIndexRequest request, String indexedText) {
         if (request.keywords() != null && !request.keywords().isEmpty()) {
             return request.keywords();
         }
@@ -157,7 +187,7 @@ public class RagPipelineService {
             return List.of();
         }
         try {
-            List<String> extracted = keywordExtractor.extract(request.text());
+            List<String> extracted = keywordExtractor.extract(indexedText);
             return extracted == null ? List.of() : extracted;
         } catch (Exception ignored) {
             return List.of();

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/service/cleaning/LlmTextCleanerTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/service/cleaning/LlmTextCleanerTest.java
@@ -1,0 +1,104 @@
+package studio.one.platform.ai.service.cleaning;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import studio.one.platform.ai.core.chat.ChatMessage;
+import studio.one.platform.ai.core.chat.ChatPort;
+import studio.one.platform.ai.core.chat.ChatRequest;
+import studio.one.platform.ai.core.chat.ChatResponse;
+import studio.one.platform.ai.service.prompt.PromptRenderer;
+
+@ExtendWith(MockitoExtension.class)
+class LlmTextCleanerTest {
+
+    @Mock
+    private PromptRenderer promptRenderer;
+
+    @Mock
+    private ChatPort chatPort;
+
+    @Test
+    void shouldParseCleanTextFromJsonResponse() {
+        LlmTextCleaner cleaner = cleaner(true);
+        when(promptRenderer.render(eq("rag-cleaner"), any(Map.class))).thenReturn("clean prompt");
+        when(chatPort.chat(any(ChatRequest.class))).thenReturn(new ChatResponse(
+                List.of(ChatMessage.assistant("""
+                        ```json
+                        {"clean_text":"정제된 본문"}
+                        ```
+                        """)),
+                "test-model",
+                Map.of()));
+
+        TextCleaningResult result = cleaner.clean("원문");
+
+        assertThat(result.text()).isEqualTo("정제된 본문");
+        assertThat(result.cleaned()).isTrue();
+        assertThat(result.cleanerPrompt()).isEqualTo("rag-cleaner");
+    }
+
+    @Test
+    void shouldFallbackToOriginalTextWhenFailOpen() {
+        LlmTextCleaner cleaner = cleaner(true);
+        when(promptRenderer.render(eq("rag-cleaner"), any(Map.class))).thenReturn("clean prompt");
+        when(chatPort.chat(any(ChatRequest.class))).thenThrow(new RuntimeException("provider failure"));
+
+        TextCleaningResult result = cleaner.clean("원문");
+
+        assertThat(result.text()).isEqualTo("원문");
+        assertThat(result.cleaned()).isFalse();
+        assertThat(result.cleanerPrompt()).isEqualTo("rag-cleaner");
+    }
+
+    @Test
+    void shouldThrowWhenFailClosed() {
+        LlmTextCleaner cleaner = cleaner(false);
+        when(promptRenderer.render(eq("rag-cleaner"), any(Map.class))).thenReturn("clean prompt");
+        when(chatPort.chat(any(ChatRequest.class))).thenReturn(new ChatResponse(
+                List.of(ChatMessage.assistant("{\"unexpected\":\"value\"}")),
+                "test-model",
+                Map.of()));
+
+        assertThatThrownBy(() -> cleaner.clean("원문"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Failed to clean RAG text");
+    }
+
+    @Test
+    void shouldTrimInputBeforeRenderingPrompt() {
+        LlmTextCleaner cleaner = new LlmTextCleaner(promptRenderer, chatPort, new ObjectMapper(),
+                "rag-cleaner", 4, true);
+        when(promptRenderer.render(eq("rag-cleaner"), any(Map.class))).thenReturn("clean prompt");
+        when(chatPort.chat(any(ChatRequest.class))).thenReturn(new ChatResponse(
+                List.of(ChatMessage.assistant("{\"clean_text\":\"abcd\"}")),
+                "test-model",
+                Map.of()));
+
+        cleaner.clean("abcdef");
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(promptRenderer).render(eq("rag-cleaner"), paramsCaptor.capture());
+        assertThat(paramsCaptor.getValue()).containsEntry("text", "abcd");
+    }
+
+    private LlmTextCleaner cleaner(boolean failOpen) {
+        return new LlmTextCleaner(promptRenderer, chatPort, new ObjectMapper(),
+                "rag-cleaner", 20_000, failOpen);
+    }
+}

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/service/cleaning/LlmTextCleanerTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/service/cleaning/LlmTextCleanerTest.java
@@ -13,6 +13,8 @@ import java.util.Map;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -24,6 +26,7 @@ import studio.one.platform.ai.core.chat.ChatResponse;
 import studio.one.platform.ai.service.prompt.PromptRenderer;
 
 @ExtendWith(MockitoExtension.class)
+@ExtendWith(OutputCaptureExtension.class)
 class LlmTextCleanerTest {
 
     @Mock
@@ -53,7 +56,7 @@ class LlmTextCleanerTest {
     }
 
     @Test
-    void shouldFallbackToOriginalTextWhenFailOpen() {
+    void shouldFallbackToOriginalTextWhenFailOpen(CapturedOutput output) {
         LlmTextCleaner cleaner = cleaner(true);
         when(promptRenderer.render(eq("rag-cleaner"), any(Map.class))).thenReturn("clean prompt");
         when(chatPort.chat(any(ChatRequest.class))).thenThrow(new RuntimeException("provider failure"));
@@ -63,6 +66,8 @@ class LlmTextCleanerTest {
         assertThat(result.text()).isEqualTo("원문");
         assertThat(result.cleaned()).isFalse();
         assertThat(result.cleanerPrompt()).isEqualTo("rag-cleaner");
+        assertThat(output).contains("Failed to clean RAG text via LLM. Falling back to original text.");
+        assertThat(output).doesNotContain("\tat ");
     }
 
     @Test

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
@@ -24,6 +24,8 @@ import studio.one.platform.ai.core.vector.VectorDocument;
 import studio.one.platform.ai.core.vector.VectorSearchRequest;
 import studio.one.platform.ai.core.vector.VectorSearchResult;
 import studio.one.platform.ai.core.vector.VectorStorePort;
+import studio.one.platform.ai.service.cleaning.TextCleaner;
+import studio.one.platform.ai.service.cleaning.TextCleaningResult;
 import studio.one.platform.ai.service.keyword.KeywordExtractor;
 
 import java.time.Duration;
@@ -55,6 +57,9 @@ class RagPipelineServiceTest {
 
     @Mock
     private KeywordExtractor keywordExtractor;
+
+    @Mock
+    private TextCleaner textCleaner;
 
     private Cache<String, List<Double>> cache;
     private Retry retry;
@@ -90,8 +95,66 @@ class RagPipelineServiceTest {
         VectorDocument document = documents.get(0);
         assertThat(document.id()).isEqualTo("doc-1-0");
         assertThat(document.metadata()).containsEntry("author", "test");
+        assertThat(document.metadata()).containsEntry("cleaned", false);
+        assertThat(document.metadata()).containsEntry("cleanerPrompt", "");
+        assertThat(document.metadata()).containsEntry("originalTextLength", 11);
+        assertThat(document.metadata()).containsEntry("indexedTextLength", 11);
+        assertThat(document.metadata()).containsEntry("chunkCount", 1);
         assertThat(document.metadata()).containsEntry("chunkOrder", 0);
+        assertThat(document.metadata()).containsEntry("chunkLength", 11);
         assertThat(document.embedding()).containsExactly(0.1, 0.2, 0.3);
+    }
+
+    @Test
+    void shouldCleanTextBeforeChunkingWhenCleanerIsAvailable() {
+        ragPipelineService = new RagPipelineService(embeddingPort, vectorStorePort, textChunker, cache, retry,
+                keywordExtractor, textCleaner, RagPipelineOptions.defaults());
+        RagIndexRequest request = new RagIndexRequest("doc-clean", "noisy text", Map.of());
+        when(textCleaner.clean("noisy text"))
+                .thenReturn(new TextCleaningResult("clean text", true, "rag-cleaner"));
+        when(textChunker.chunk("doc-clean", "clean text"))
+                .thenReturn(List.of(new TextChunk("doc-clean-0", "clean text")));
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("doc-clean-0", List.of(0.1, 0.2)))));
+
+        ragPipelineService.index(request);
+
+        verify(textCleaner).clean("noisy text");
+        verify(textChunker).chunk("doc-clean", "clean text");
+        verify(vectorStorePort).upsert(documentsCaptor.capture());
+        VectorDocument document = documentsCaptor.getValue().get(0);
+        assertThat(document.content()).isEqualTo("clean text");
+        assertThat(document.metadata()).containsEntry("cleaned", true);
+        assertThat(document.metadata()).containsEntry("cleanerPrompt", "rag-cleaner");
+        assertThat(document.metadata()).containsEntry("originalTextLength", 10);
+        assertThat(document.metadata()).containsEntry("indexedTextLength", 10);
+        assertThat(document.metadata()).containsEntry("chunkCount", 1);
+        assertThat(document.metadata()).containsEntry("chunkLength", 10);
+    }
+
+    @Test
+    void shouldPreserveCallerMetadataWhenAddingCleanerMetadata() {
+        RagIndexRequest request = new RagIndexRequest("doc-meta", "hello world", Map.of(
+                "cleaned", "caller-cleaned",
+                "cleanerPrompt", "caller-prompt",
+                "originalTextLength", 999,
+                "indexedTextLength", 888,
+                "chunkCount", 777));
+        when(textChunker.chunk("doc-meta", "hello world"))
+                .thenReturn(List.of(new TextChunk("doc-meta-0", "hello world")));
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("doc-meta-0", List.of(0.1, 0.2, 0.3)))));
+
+        ragPipelineService.index(request);
+
+        verify(vectorStorePort).upsert(documentsCaptor.capture());
+        VectorDocument document = documentsCaptor.getValue().get(0);
+        assertThat(document.metadata()).containsEntry("cleaned", "caller-cleaned");
+        assertThat(document.metadata()).containsEntry("cleanerPrompt", "caller-prompt");
+        assertThat(document.metadata()).containsEntry("originalTextLength", 999);
+        assertThat(document.metadata()).containsEntry("indexedTextLength", 888);
+        assertThat(document.metadata()).containsEntry("chunkCount", 777);
+        assertThat(document.metadata()).containsEntry("chunkLength", 11);
     }
 
     @Test


### PR DESCRIPTION
## Why

- RAG 색인 전 PDF/문서 추출 잡음을 선택적으로 줄여 후속 검색 품질 개선 작업의 기반을 마련합니다.
- 기존 raw indexing 동작은 기본값으로 유지하면서, 운영 환경에서 `rag-cleaner` prompt 기반 LLM 정제를 opt-in으로 사용할 수 있게 합니다.

## What

- `TextCleaner` / `LlmTextCleaner`를 추가하고 `clean_text` JSON 응답을 파싱해 색인 텍스트로 사용하도록 했습니다.
- `studio.ai.pipeline.cleaner.*` 설정을 추가했습니다: `enabled=false`, `prompt=rag-cleaner`, `max-input-chars=20000`, `fail-open=true`.
- `RagPipelineService.index()`가 cleaner를 chunking 전에 적용하고 `cleaned`, `cleanerPrompt`, `originalTextLength`, `indexedTextLength`, `chunkCount`, `chunkLength` metadata를 additive로 기록하도록 했습니다.
- 첨부 RAG 인덱싱 metadata에 `filename`, `sourceType=attachment`, `indexedAt`을 `putIfAbsent`로 보강했습니다.
- README와 `CHANGELOG.md`에 설정, metadata, 검증 기록을 반영했습니다.

## Related Issues

- Closes #204

## Validation

- Command: `gradle :studio-platform-ai:test`
- Result: `BUILD SUCCESSFUL`
- Command: `gradle :starter:studio-platform-starter-ai:test`
- Result: `BUILD SUCCESSFUL`
- Command: `gradle :studio-application-modules:content-embedding-pipeline:test`
- Result: `BUILD SUCCESSFUL`
- Command: `git diff --check`
- Result: passed

## Risk / Rollback

- Risk: cleaner를 활성화하면 LLM 호출 비용/지연이 색인 경로에 추가되고, 정제 실패 정책에 따라 색인이 실패할 수 있습니다.
- Rollback: 기본값은 `enabled=false`라 배포 즉시 동작 변화는 없습니다. 문제가 있으면 `studio.ai.pipeline.cleaner.enabled=false`로 비활성화하거나 PR 커밋을 revert합니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: 위 validation command를 main author가 실행했습니다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included
