### PR TITLE
feat(ai-rag): add retrieval diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 2026-04-16
 
 ### 변경됨
+- 이슈 #205 대응으로 `studio.ai.pipeline.diagnostics.*`와 `studio.ai.endpoints.rag.diagnostics.allow-client-debug` 설정을 추가해 RAG 검색 fallback 전략과 결과 상태를 선택적으로 관찰할 수 있도록 했다.
+- `RagRetrievalDiagnostics`를 추가해 strategy, result count, score threshold, hybrid weight, object scope, topK를 기록하고, client debug 허용 시에만 `ChatResponseDto.metadata.ragDiagnostics`에 노출한다.
+- 기존 `POST /api/ai/chat/rag`의 per-hit info 로그를 제거하고, diagnostics result logging이 명시적으로 활성화된 경우에만 bounded debug snippet을 출력하도록 했다.
 - 이슈 #204 대응으로 `studio.ai.pipeline.cleaner.*` 설정을 추가해 RAG 색인 전 LLM 기반 텍스트 정제를 선택적으로 적용할 수 있도록 했다.
 - `TextCleaner`/`LlmTextCleaner`를 추가하고 `rag-cleaner` prompt의 `clean_text` JSON 응답을 색인 텍스트로 사용하도록 했다.
 - `RagPipelineService.index()`가 cleaner 적용 여부, 원문/색인 텍스트 길이, chunk 수, chunk 길이를 vector metadata에 additive로 기록하도록 했다.
@@ -18,6 +21,8 @@
 
 ### 검증
 - `gradle :studio-platform-ai:test :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test --rerun-tasks`
+- `gradle :studio-platform-ai:test`
+- `gradle :starter:studio-platform-starter-ai-web:test`
 - `gradle :studio-platform-ai:test --tests 'studio.one.platform.ai.service.pipeline.RagQualitySmokeTest'`
 - `gradle :studio-platform-ai:test`
 - `gradle :starter:studio-platform-starter-ai:test`

--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -125,6 +125,8 @@ studio:
           max-chunks: 8
           max-chars: 12000
           include-scores: true
+        diagnostics:
+          allow-client-debug: false
 ```
 
 | 설정 | 기본값 | 설명 |
@@ -132,6 +134,13 @@ studio:
 | `studio.ai.endpoints.rag.context.max-chunks` | `8` | chat system context에 포함할 최대 RAG chunk 수 |
 | `studio.ai.endpoints.rag.context.max-chars` | `12000` | header 포함 chat system context 최대 문자 수 |
 | `studio.ai.endpoints.rag.context.include-scores` | `true` | context에 retrieval score를 포함할지 여부 |
+| `studio.ai.endpoints.rag.diagnostics.allow-client-debug` | `false` | client `debug=true` 요청에 `metadata.ragDiagnostics` 노출 허용 여부 |
+
+이슈 #205부터 RAG retrieval diagnostics를 선택적으로 사용할 수 있다. 서버의
+`studio.ai.pipeline.diagnostics.enabled=true`가 켜진 경우 검색 fallback strategy를 기록하고,
+클라이언트 요청의 `debug=true`와 서버 `allow-client-debug=true`가 모두 만족될 때만 응답 metadata에
+`ragDiagnostics`를 추가한다. diagnostics metadata에는 chunk 본문이나 snippet을 포함하지 않는다.
+result snippet 로그는 `studio.ai.pipeline.diagnostics.log-results=true`일 때만 debug level로 제한 길이만 출력한다.
 
 ### 임베딩 요청 예시
 

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
@@ -39,8 +39,10 @@ public class AiWebAutoConfiguration {
     ChatController chatController(
             AiProviderRegistry providerRegistry,
             RagPipelineService ragPipelineService,
-            RagContextBuilder ragContextBuilder) {
-        return new ChatController(providerRegistry, ragPipelineService, ragContextBuilder);
+            RagContextBuilder ragContextBuilder,
+            AiWebRagProperties properties) {
+        return new ChatController(providerRegistry, ragPipelineService, ragContextBuilder,
+                properties.getDiagnostics().isAllowClientDebug());
     }
 
     @Bean

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebRagProperties.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebRagProperties.java
@@ -8,9 +8,14 @@ import studio.one.platform.constant.PropertyKeys;
 public class AiWebRagProperties {
 
     private final ContextProperties context = new ContextProperties();
+    private final DiagnosticsProperties diagnostics = new DiagnosticsProperties();
 
     public ContextProperties getContext() {
         return context;
+    }
+
+    public DiagnosticsProperties getDiagnostics() {
+        return diagnostics;
     }
 
     public static class ContextProperties {
@@ -40,6 +45,18 @@ public class AiWebRagProperties {
 
         public void setIncludeScores(boolean includeScores) {
             this.includeScores = includeScores;
+        }
+    }
+
+    public static class DiagnosticsProperties {
+        private boolean allowClientDebug = false;
+
+        public boolean isAllowClientDebug() {
+            return allowClientDebug;
+        }
+
+        public void setAllowClientDebug(boolean allowClientDebug) {
+            this.allowClientDebug = allowClientDebug;
         }
     }
 }

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
@@ -22,6 +22,7 @@
 package studio.one.platform.ai.web.controller;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -39,20 +40,20 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
-import lombok.extern.slf4j.Slf4j;
 import studio.one.platform.ai.core.chat.ChatMessage;
 import studio.one.platform.ai.core.chat.ChatMessageRole;
 import studio.one.platform.ai.core.chat.ChatPort;
 import studio.one.platform.ai.core.chat.ChatRequest;
 import studio.one.platform.ai.core.chat.ChatResponse;
 import studio.one.platform.ai.core.registry.AiProviderRegistry;
+import studio.one.platform.ai.core.rag.RagRetrievalDiagnostics;
 import studio.one.platform.ai.core.rag.RagSearchRequest;
 import studio.one.platform.ai.core.rag.RagSearchResult;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
 import studio.one.platform.ai.web.dto.ChatMessageDto;
+import studio.one.platform.ai.web.dto.ChatRagRequestDto;
 import studio.one.platform.ai.web.dto.ChatRequestDto;
 import studio.one.platform.ai.web.dto.ChatResponseDto;
-import studio.one.platform.ai.web.dto.ChatRagRequestDto;
 import studio.one.platform.constant.PropertyKeys;
 import studio.one.platform.web.dto.ApiResponse;
 
@@ -66,13 +67,14 @@ import studio.one.platform.web.dto.ApiResponse;
 @RestController
 @RequestMapping("${" + PropertyKeys.AI.Endpoints.BASE_PATH + ":/api/ai}/chat")
 @Validated
-@Slf4j
 public class ChatController {
 
     private static final String OBJECT_TYPE_ATTACHMENT = "attachment";
+
     private final AiProviderRegistry providerRegistry;
     private final RagPipelineService ragPipelineService;
     private final RagContextBuilder ragContextBuilder;
+    private final boolean allowClientDebug;
 
     public ChatController(AiProviderRegistry providerRegistry, RagPipelineService ragPipelineService) {
         this(providerRegistry, ragPipelineService, RagContextBuilder.defaults());
@@ -82,9 +84,18 @@ public class ChatController {
             AiProviderRegistry providerRegistry,
             RagPipelineService ragPipelineService,
             RagContextBuilder ragContextBuilder) {
+        this(providerRegistry, ragPipelineService, ragContextBuilder, false);
+    }
+
+    public ChatController(
+            AiProviderRegistry providerRegistry,
+            RagPipelineService ragPipelineService,
+            RagContextBuilder ragContextBuilder,
+            boolean allowClientDebug) {
         this.providerRegistry = Objects.requireNonNull(providerRegistry, "providerRegistry");
         this.ragPipelineService = Objects.requireNonNull(ragPipelineService, "ragPipelineService");
         this.ragContextBuilder = Objects.requireNonNull(ragContextBuilder, "ragContextBuilder");
+        this.allowClientDebug = allowClientDebug;
     }
 
     /**
@@ -133,7 +144,6 @@ public class ChatController {
             + "(#request.objectType() == null or !#request.objectType().trim().equalsIgnoreCase('attachment') "
             + "or @endpointAuthz.can('features:attachment','read'))")
     public ResponseEntity<ApiResponse<ChatResponseDto>> chatWithRag(@Valid @RequestBody ChatRagRequestDto request) {
-        
         ChatRequestDto chat = request.chat();
         int ragTopK = request.ragTopK() != null ? request.ragTopK() : 3;
         ObjectScope objectScope = resolveObjectScope(request.objectType(), request.objectId());
@@ -152,21 +162,13 @@ public class ChatController {
         } else {
             String resolvedQuery = resolveRagQuery(request);
             if (hasFilter) {
-                ragResults = ragPipelineService.searchByObject(new RagSearchRequest(resolvedQuery, ragTopK), objectType, objectId);
+                ragResults = ragPipelineService.searchByObject(
+                        new RagSearchRequest(resolvedQuery, ragTopK), objectType, objectId);
             } else {
                 ragResults = ragPipelineService.search(new RagSearchRequest(resolvedQuery, ragTopK));
             }
         }
-        if (log.isInfoEnabled()) {
-            log.info("RAG results count={}, objectType={}, objectId={}, ragQuery={}",
-                    ragResults.size(), objectType, objectId, ragQuery);
-            ragResults.stream().limit(5).forEach(r ->
-                    log.info("RAG hit docId={}, score={}, snippet={}",
-                            r.documentId(),
-                            String.format("%.3f", r.score()),
-                            truncate(r.content(), 120)));
-        }
-
+        RagRetrievalDiagnostics diagnostics = ragPipelineService.latestDiagnostics().orElse(null);
 
         String context = ragContextBuilder.build(ragResults);
 
@@ -189,7 +191,7 @@ public class ChatController {
                 chat.stopSequences());
 
         ChatResponse response = chatPort(chat.provider()).chat(toDomainChatRequest(augmented));
-        return ResponseEntity.ok(ApiResponse.ok(toDto(response)));
+        return ResponseEntity.ok(ApiResponse.ok(toDto(response, diagnostics, shouldExposeDiagnostics(request))));
     }
 
     private ChatRequest toDomainChatRequest(ChatRequestDto request) {
@@ -248,16 +250,6 @@ public class ChatController {
         String trimmed = value.trim();
         return trimmed.isEmpty() ? null : trimmed;
     }
-    
-    private String truncate(String content, int maxLen) {
-        if (content == null) {
-            return "";
-        }
-        if (content.length() <= maxLen) {
-            return content;
-        }
-        return content.substring(0, maxLen) + "...";
-    }
 
     private List<ChatMessage> toDomainMessages(ChatRequestDto request) {
         List<ChatMessageDto> messages = new ArrayList<>();
@@ -276,11 +268,25 @@ public class ChatController {
     }
 
     private ChatResponseDto toDto(ChatResponse response) {
+        return toDto(response, null, false);
+    }
+
+    private ChatResponseDto toDto(
+            ChatResponse response,
+            RagRetrievalDiagnostics diagnostics,
+            boolean exposeDiagnostics) {
         List<ChatMessageDto> messages = response.messages().stream()
                 .map(message -> new ChatMessageDto(message.role().name().toLowerCase(Locale.ROOT), message.content()))
                 .toList();
-        Map<String, Object> metadata = Map.copyOf(response.metadata());
+        Map<String, Object> metadata = new HashMap<>(response.metadata());
+        if (exposeDiagnostics && diagnostics != null) {
+            metadata.put("ragDiagnostics", diagnostics.toMetadata());
+        }
         return new ChatResponseDto(messages, response.model(), metadata);
+    }
+
+    private boolean shouldExposeDiagnostics(ChatRagRequestDto request) {
+        return allowClientDebug && Boolean.TRUE.equals(request.debug());
     }
 
     private String resolveRagQuery(ChatRagRequestDto request) {

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/ChatRagRequestDto.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/ChatRagRequestDto.java
@@ -11,6 +11,15 @@ public record ChatRagRequestDto(
         String ragQuery,
         Integer ragTopK,
         String objectType,
-        String objectId
+        String objectId,
+        Boolean debug
 ) {
+    public ChatRagRequestDto(
+            ChatRequestDto chat,
+            String ragQuery,
+            Integer ragTopK,
+            String objectType,
+            String objectId) {
+        this(chat, ragQuery, ragTopK, objectType, objectId, null);
+    }
 }

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/AiWebRagPropertiesTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/AiWebRagPropertiesTest.java
@@ -1,0 +1,35 @@
+package studio.one.platform.ai.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+class AiWebRagPropertiesTest {
+
+    @Test
+    void shouldExposeDiagnosticsDefaults() {
+        AiWebRagProperties properties = new AiWebRagProperties();
+
+        assertThat(properties.getDiagnostics().isAllowClientDebug()).isFalse();
+    }
+
+    @Test
+    void shouldBindDiagnosticsOverrides() {
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().addFirst(new MapPropertySource("test", Map.of(
+                "studio.ai.endpoints.rag.diagnostics.allow-client-debug", "true")));
+
+        AiWebRagProperties properties = new Binder(ConfigurationPropertySources.get(environment))
+                .bind("studio.ai.endpoints.rag", Bindable.of(AiWebRagProperties.class))
+                .orElseThrow(() -> new AssertionError("AiWebRagProperties binding failed"));
+
+        assertThat(properties.getDiagnostics().isAllowClientDebug()).isTrue();
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
@@ -9,12 +9,14 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -22,12 +24,15 @@ import studio.one.platform.ai.core.chat.ChatPort;
 import studio.one.platform.ai.core.chat.ChatRequest;
 import studio.one.platform.ai.core.chat.ChatResponse;
 import studio.one.platform.ai.core.registry.AiProviderRegistry;
+import studio.one.platform.ai.core.rag.RagRetrievalDiagnostics;
 import studio.one.platform.ai.core.rag.RagSearchRequest;
 import studio.one.platform.ai.core.rag.RagSearchResult;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
 import studio.one.platform.ai.web.dto.ChatMessageDto;
 import studio.one.platform.ai.web.dto.ChatRagRequestDto;
 import studio.one.platform.ai.web.dto.ChatRequestDto;
+import studio.one.platform.ai.web.dto.ChatResponseDto;
+import studio.one.platform.web.dto.ApiResponse;
 
 class ChatControllerTest {
 
@@ -53,6 +58,7 @@ class ChatControllerTest {
         when(providerRegistry.chatPort("google")).thenReturn(googleChatPort);
         when(defaultChatPort.chat(any())).thenReturn(response("default"));
         when(googleChatPort.chat(any())).thenReturn(response("google"));
+        when(ragPipelineService.latestDiagnostics()).thenReturn(Optional.empty());
     }
 
     @Test
@@ -292,6 +298,97 @@ class ChatControllerTest {
     }
 
     @Test
+    void ragChatDoesNotExposeDiagnosticsWhenClientDebugIsDisabled() {
+        controller = new ChatController(providerRegistry, ragPipelineService, RagContextBuilder.defaults(), true);
+        when(ragPipelineService.search(any(RagSearchRequest.class)))
+                .thenReturn(List.of(new RagSearchResult("doc-1", "sensitive file body", Map.of(), 0.9d)));
+        when(ragPipelineService.latestDiagnostics()).thenReturn(Optional.of(diagnostics()));
+
+        ChatResponseDto response = controller.chatWithRag(new ChatRagRequestDto(
+                new ChatRequestDto(
+                        null,
+                        null,
+                        List.of(new ChatMessageDto("user", "summarize")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null),
+                "summary",
+                3,
+                null,
+                null,
+                false)).getBody().getData();
+
+        assertThat(response.metadata()).doesNotContainKey("ragDiagnostics");
+    }
+
+    @Test
+    void ragChatDoesNotExposeDiagnosticsWhenServerDebugIsDisabled() {
+        when(ragPipelineService.search(any(RagSearchRequest.class)))
+                .thenReturn(List.of(new RagSearchResult("doc-1", "sensitive file body", Map.of(), 0.9d)));
+        when(ragPipelineService.latestDiagnostics()).thenReturn(Optional.of(diagnostics()));
+
+        ChatResponseDto response = controller.chatWithRag(new ChatRagRequestDto(
+                new ChatRequestDto(
+                        null,
+                        null,
+                        List.of(new ChatMessageDto("user", "summarize")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null),
+                "summary",
+                3,
+                null,
+                null,
+                true)).getBody().getData();
+
+        assertThat(response.metadata()).doesNotContainKey("ragDiagnostics");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void ragChatExposesSafeDiagnosticsWhenClientAndServerDebugAreEnabled() {
+        controller = new ChatController(providerRegistry, ragPipelineService, RagContextBuilder.defaults(), true);
+        when(ragPipelineService.search(any(RagSearchRequest.class)))
+                .thenReturn(List.of(new RagSearchResult("doc-1", "sensitive file body", Map.of(), 0.9d)));
+        when(ragPipelineService.latestDiagnostics()).thenReturn(Optional.of(diagnostics()));
+
+        ResponseEntity<ApiResponse<ChatResponseDto>> response = controller.chatWithRag(new ChatRagRequestDto(
+                new ChatRequestDto(
+                        null,
+                        null,
+                        List.of(new ChatMessageDto("user", "summarize")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null),
+                "summary",
+                3,
+                null,
+                null,
+                true));
+
+        Map<String, Object> ragDiagnostics = (Map<String, Object>) response.getBody()
+                .getData()
+                .metadata()
+                .get("ragDiagnostics");
+        assertThat(ragDiagnostics)
+                .containsEntry("strategy", "hybrid")
+                .containsEntry("initialResultCount", 1)
+                .containsEntry("finalResultCount", 1)
+                .containsEntry("topK", 3)
+                .doesNotContainKeys("content", "snippet", "text", "chunk");
+        assertThat(ragDiagnostics.values()).doesNotContain("sensitive file body");
+    }
+
+    @Test
     void ragChatListsByObjectWhenQueryMissingAndObjectFilterPresent() {
         when(ragPipelineService.listByObject("attachment", "123", 3))
                 .thenReturn(List.of(new RagSearchResult("doc-1", "file text", Map.of(), 1.0d)));
@@ -387,5 +484,18 @@ class ChatControllerTest {
     private ChatResponse response(String content) {
         return new ChatResponse(List.of(studio.one.platform.ai.core.chat.ChatMessage.assistant(content)), "model",
                 Map.of());
+    }
+
+    private RagRetrievalDiagnostics diagnostics() {
+        return new RagRetrievalDiagnostics(
+                RagRetrievalDiagnostics.Strategy.HYBRID,
+                1,
+                1,
+                0.15d,
+                0.7d,
+                0.3d,
+                null,
+                null,
+                3);
     }
 }

--- a/starter/studio-platform-starter-ai/README.md
+++ b/starter/studio-platform-starter-ai/README.md
@@ -191,6 +191,10 @@ studio:
       object-scope:
         default-list-limit: 20
         max-list-limit: 100
+      diagnostics:
+        enabled: false
+        log-results: false
+        max-snippet-chars: 120
 ```
 
 | 설정 | 기본값 | 설명 |
@@ -202,8 +206,12 @@ studio:
 | `studio.ai.pipeline.retrieval.semantic-fallback-enabled` | `true` | semantic fallback 사용 여부 |
 | `studio.ai.pipeline.object-scope.default-list-limit` | `20` | query 없는 object-scope list 기본 limit |
 | `studio.ai.pipeline.object-scope.max-list-limit` | `100` | object-scope list 최대 limit |
+| `studio.ai.pipeline.diagnostics.enabled` | `false` | RAG 검색 fallback 전략과 결과 카운트 수집 여부 |
+| `studio.ai.pipeline.diagnostics.log-results` | `false` | diagnostics 활성화 시 bounded result snippet debug log 출력 여부 |
+| `studio.ai.pipeline.diagnostics.max-snippet-chars` | `120` | result snippet debug log 최대 문자 수 |
 
 `vector-weight`와 `lexical-weight`는 각각 0 이상이어야 하며 두 값의 합은 0보다 커야 한다.
+diagnostics metadata에는 chunk 본문을 포함하지 않고 strategy, 결과 수, threshold, weight, object scope, topK만 기록한다.
 
 ### RAG 색인 전 텍스트 정제
 

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfiguration.java
@@ -26,6 +26,7 @@ import studio.one.platform.ai.service.cleaning.LlmTextCleaner;
 import studio.one.platform.ai.service.cleaning.TextCleaner;
 import studio.one.platform.ai.service.chunk.OverlapTextChunker;
 import studio.one.platform.ai.service.keyword.KeywordExtractor;
+import studio.one.platform.ai.service.pipeline.RagPipelineDiagnosticsOptions;
 import studio.one.platform.ai.service.pipeline.RagPipelineOptions;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
 import studio.one.platform.ai.service.prompt.PromptRenderer;
@@ -106,7 +107,8 @@ public class RagPipelineConfiguration {
 
                 return new RagPipelineService(embeddingPort, vectorStorePort, textChunker, embeddingCache,
                                 embeddingRetry, keywordExtractorProvider.getIfAvailable(),
-                                textCleanerProvider.getIfAvailable(), ragPipelineOptions(properties));
+                                textCleanerProvider.getIfAvailable(), ragPipelineOptions(properties),
+                                ragPipelineDiagnosticsOptions(properties));
         }
 
         @Bean
@@ -144,6 +146,14 @@ public class RagPipelineConfiguration {
                                 retrieval.isSemanticFallbackEnabled(),
                                 objectScope.getDefaultListLimit(),
                                 objectScope.getMaxListLimit());
+        }
+
+        private RagPipelineDiagnosticsOptions ragPipelineDiagnosticsOptions(RagPipelineProperties properties) {
+                RagPipelineProperties.DiagnosticsProperties diagnostics = properties.getDiagnostics();
+                return new RagPipelineDiagnosticsOptions(
+                                diagnostics.isEnabled(),
+                                diagnostics.isLogResults(),
+                                diagnostics.getMaxSnippetChars());
         }
 
 }

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineProperties.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineProperties.java
@@ -3,6 +3,7 @@ package studio.one.platform.ai.autoconfigure.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import studio.one.platform.constant.PropertyKeys;
+import studio.one.platform.ai.service.pipeline.RagPipelineDiagnosticsOptions;
 import studio.one.platform.ai.service.pipeline.RagPipelineOptions;
 
 import java.time.Duration;
@@ -17,6 +18,7 @@ public class RagPipelineProperties {
     private final RetrievalProperties retrieval = new RetrievalProperties();
     private final ObjectScopeProperties objectScope = new ObjectScopeProperties();
     private final CleanerProperties cleaner = new CleanerProperties();
+    private final DiagnosticsProperties diagnostics = new DiagnosticsProperties();
 
     public int getChunkSize() {
         return chunkSize;
@@ -52,6 +54,10 @@ public class RagPipelineProperties {
 
     public CleanerProperties getCleaner() {
         return cleaner;
+    }
+
+    public DiagnosticsProperties getDiagnostics() {
+        return diagnostics;
     }
 
     public static class CacheProperties {
@@ -201,6 +207,36 @@ public class RagPipelineProperties {
 
         public void setFailOpen(boolean failOpen) {
             this.failOpen = failOpen;
+        }
+    }
+
+    public static class DiagnosticsProperties {
+        private boolean enabled = RagPipelineDiagnosticsOptions.DEFAULT_ENABLED;
+        private boolean logResults = RagPipelineDiagnosticsOptions.DEFAULT_LOG_RESULTS;
+        private int maxSnippetChars = RagPipelineDiagnosticsOptions.DEFAULT_MAX_SNIPPET_CHARS;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public boolean isLogResults() {
+            return logResults;
+        }
+
+        public void setLogResults(boolean logResults) {
+            this.logResults = logResults;
+        }
+
+        public int getMaxSnippetChars() {
+            return maxSnippetChars;
+        }
+
+        public void setMaxSnippetChars(int maxSnippetChars) {
+            this.maxSnippetChars = maxSnippetChars;
         }
     }
 }

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/RagPipelinePropertiesTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/RagPipelinePropertiesTest.java
@@ -28,6 +28,9 @@ class RagPipelinePropertiesTest {
         assertThat(properties.getCleaner().getPrompt()).isEqualTo("rag-cleaner");
         assertThat(properties.getCleaner().getMaxInputChars()).isEqualTo(20_000);
         assertThat(properties.getCleaner().isFailOpen()).isTrue();
+        assertThat(properties.getDiagnostics().isEnabled()).isFalse();
+        assertThat(properties.getDiagnostics().isLogResults()).isFalse();
+        assertThat(properties.getDiagnostics().getMaxSnippetChars()).isEqualTo(120);
     }
 
     @Test
@@ -44,7 +47,10 @@ class RagPipelinePropertiesTest {
                 Map.entry("studio.ai.pipeline.cleaner.enabled", "true"),
                 Map.entry("studio.ai.pipeline.cleaner.prompt", "custom-cleaner"),
                 Map.entry("studio.ai.pipeline.cleaner.max-input-chars", "1234"),
-                Map.entry("studio.ai.pipeline.cleaner.fail-open", "false"))));
+                Map.entry("studio.ai.pipeline.cleaner.fail-open", "false"),
+                Map.entry("studio.ai.pipeline.diagnostics.enabled", "true"),
+                Map.entry("studio.ai.pipeline.diagnostics.log-results", "true"),
+                Map.entry("studio.ai.pipeline.diagnostics.max-snippet-chars", "42"))));
 
         RagPipelineProperties properties = new Binder(ConfigurationPropertySources.get(environment))
                 .bind("studio.ai.pipeline", Bindable.of(RagPipelineProperties.class))
@@ -61,5 +67,8 @@ class RagPipelinePropertiesTest {
         assertThat(properties.getCleaner().getPrompt()).isEqualTo("custom-cleaner");
         assertThat(properties.getCleaner().getMaxInputChars()).isEqualTo(1234);
         assertThat(properties.getCleaner().isFailOpen()).isFalse();
+        assertThat(properties.getDiagnostics().isEnabled()).isTrue();
+        assertThat(properties.getDiagnostics().isLogResults()).isTrue();
+        assertThat(properties.getDiagnostics().getMaxSnippetChars()).isEqualTo(42);
     }
 }

--- a/studio-platform-ai/README.md
+++ b/studio-platform-ai/README.md
@@ -27,6 +27,7 @@ AI 추상화 계층이다. 챗 완성, 임베딩 생성, 벡터 스토어 접근
 | `TextChunker` | `core.chunk` | 문서를 TextChunk 리스트로 분할 |
 | `TextCleaner` | `service.cleaning` | 색인 전 추출 텍스트 정제 계약 |
 | `RagPipelineService` | `service.pipeline` | 인덱싱/검색 파이프라인 오케스트레이터 |
+| `RagRetrievalDiagnostics` | `core.rag` | RAG 검색 fallback 전략과 결과 상태 진단 모델 |
 | `AiProvider` | `core` | 지원 공급자 열거형 (OPENAI, OLLAMA, GOOGLE_AI_GEMINI) |
 
 ## RAG metadata
@@ -40,6 +41,11 @@ AI 추상화 계층이다. 챗 완성, 임베딩 생성, 벡터 스토어 접근
 | `indexedTextLength` | 실제 chunking/indexing에 사용한 텍스트 길이 |
 | `chunkCount` | 생성된 chunk 수 |
 | `chunkLength` | 개별 chunk content 길이 |
+
+## RAG diagnostics
+`RagPipelineService`는 diagnostics가 활성화된 경우 마지막 RAG 검색의 strategy, result count, score threshold,
+hybrid weight, object scope, topK를 `RagRetrievalDiagnostics`로 기록한다. 진단 metadata에는 chunk 본문을 포함하지 않는다.
+Web API에서 client debug 노출 여부는 `studio-platform-starter-ai-web` 설정이 결정한다.
 
 ## 구현 분리 원칙
 이 모듈은 구현체를 포함하지 않는다. 의존성 역전 원칙에 따라 애플리케이션은 `ChatPort` 등 포트만 참조하며, 공급자별 어댑터는 스타터 모듈이 조건부로 등록한다. 공급자를 교체하거나 추가할 때 이 모듈을 수정할 필요가 없다.

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/rag/RagRetrievalDiagnostics.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/rag/RagRetrievalDiagnostics.java
@@ -1,0 +1,54 @@
+package studio.one.platform.ai.core.rag;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Safe diagnostics for a RAG retrieval attempt.
+ */
+public record RagRetrievalDiagnostics(
+        Strategy strategy,
+        int initialResultCount,
+        int finalResultCount,
+        double minScore,
+        double vectorWeight,
+        double lexicalWeight,
+        String objectType,
+        String objectId,
+        int topK) {
+
+    public RagRetrievalDiagnostics {
+        strategy = strategy == null ? Strategy.NONE : strategy;
+    }
+
+    public Map<String, Object> toMetadata() {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("strategy", strategy.value());
+        metadata.put("initialResultCount", initialResultCount);
+        metadata.put("finalResultCount", finalResultCount);
+        metadata.put("minScore", minScore);
+        metadata.put("vectorWeight", vectorWeight);
+        metadata.put("lexicalWeight", lexicalWeight);
+        metadata.put("objectType", objectType);
+        metadata.put("objectId", objectId);
+        metadata.put("topK", topK);
+        return metadata;
+    }
+
+    public enum Strategy {
+        HYBRID("hybrid"),
+        KEYWORD_ENRICHED_HYBRID("keyword_enriched_hybrid"),
+        SEMANTIC("semantic"),
+        NONE("none");
+
+        private final String value;
+
+        Strategy(String value) {
+            this.value = value;
+        }
+
+        public String value() {
+            return value;
+        }
+    }
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineDiagnosticsOptions.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineDiagnosticsOptions.java
@@ -1,0 +1,27 @@
+package studio.one.platform.ai.service.pipeline;
+
+/**
+ * Runtime options for RAG retrieval diagnostics.
+ */
+public record RagPipelineDiagnosticsOptions(
+        boolean enabled,
+        boolean logResults,
+        int maxSnippetChars) {
+
+    public static final boolean DEFAULT_ENABLED = false;
+    public static final boolean DEFAULT_LOG_RESULTS = false;
+    public static final int DEFAULT_MAX_SNIPPET_CHARS = 120;
+
+    public RagPipelineDiagnosticsOptions {
+        if (maxSnippetChars < 0) {
+            throw new IllegalArgumentException("maxSnippetChars must be greater than or equal to 0");
+        }
+    }
+
+    public static RagPipelineDiagnosticsOptions defaults() {
+        return new RagPipelineDiagnosticsOptions(
+                DEFAULT_ENABLED,
+                DEFAULT_LOG_RESULTS,
+                DEFAULT_MAX_SNIPPET_CHARS);
+    }
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineService.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineService.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -19,6 +20,7 @@ import studio.one.platform.ai.core.embedding.EmbeddingRequest;
 import studio.one.platform.ai.core.embedding.EmbeddingResponse;
 import studio.one.platform.ai.core.embedding.EmbeddingVector;
 import studio.one.platform.ai.core.rag.RagIndexRequest;
+import studio.one.platform.ai.core.rag.RagRetrievalDiagnostics;
 import studio.one.platform.ai.core.rag.RagSearchRequest;
 import studio.one.platform.ai.core.rag.RagSearchResult;
 import studio.one.platform.ai.core.vector.VectorDocument;
@@ -42,6 +44,8 @@ public class RagPipelineService {
     private final KeywordExtractor keywordExtractor;
     private final TextCleaner textCleaner;
     private final RagPipelineOptions options;
+    private final RagPipelineDiagnosticsOptions diagnosticsOptions;
+    private final ThreadLocal<RagRetrievalDiagnostics> latestDiagnostics = new ThreadLocal<>();
 
     public RagPipelineService(EmbeddingPort embeddingPort,
             VectorStorePort vectorStorePort,
@@ -50,7 +54,7 @@ public class RagPipelineService {
             Retry retry,
             KeywordExtractor keywordExtractor) {
         this(embeddingPort, vectorStorePort, textChunker, embeddingCache, retry, keywordExtractor,
-                null, RagPipelineOptions.defaults());
+                null, RagPipelineOptions.defaults(), RagPipelineDiagnosticsOptions.defaults());
     }
 
     public RagPipelineService(EmbeddingPort embeddingPort,
@@ -71,6 +75,19 @@ public class RagPipelineService {
             KeywordExtractor keywordExtractor,
             TextCleaner textCleaner,
             RagPipelineOptions options) {
+        this(embeddingPort, vectorStorePort, textChunker, embeddingCache, retry, keywordExtractor, textCleaner,
+                options, RagPipelineDiagnosticsOptions.defaults());
+    }
+
+    public RagPipelineService(EmbeddingPort embeddingPort,
+            VectorStorePort vectorStorePort,
+            TextChunker textChunker,
+            Cache<String, List<Double>> embeddingCache,
+            Retry retry,
+            KeywordExtractor keywordExtractor,
+            TextCleaner textCleaner,
+            RagPipelineOptions options,
+            RagPipelineDiagnosticsOptions diagnosticsOptions) {
 
         this.embeddingPort = Objects.requireNonNull(embeddingPort, "embeddingPort");
         this.vectorStorePort = Objects.requireNonNull(vectorStorePort, "vectorStorePort");
@@ -80,6 +97,7 @@ public class RagPipelineService {
         this.keywordExtractor = keywordExtractor;
         this.textCleaner = textCleaner;
         this.options = Objects.requireNonNull(options, "options");
+        this.diagnosticsOptions = Objects.requireNonNull(diagnosticsOptions, "diagnosticsOptions");
     }
 
     public void index(RagIndexRequest request) {
@@ -117,17 +135,21 @@ public class RagPipelineService {
     }
 
     public List<RagSearchResult> search(RagSearchRequest request) {
+        clearDiagnostics();
         List<Double> queryEmbedding = embedWithCache(request.query());
         VectorSearchRequest searchRequest = new VectorSearchRequest(queryEmbedding, request.topK());
         List<VectorSearchResult> results = searchWithFallback(
                 request.query(),
                 searchRequest,
                 query -> vectorStorePort.hybridSearch(query, searchRequest, options.vectorWeight(), options.lexicalWeight()),
-                () -> vectorStorePort.search(searchRequest));
+                () -> vectorStorePort.search(searchRequest),
+                null,
+                null);
         return toRagSearchResults(results);
     }
 
     public List<RagSearchResult> searchByObject(RagSearchRequest request, String objectType, String objectId) {
+        clearDiagnostics();
         List<Double> queryEmbedding = embedWithCache(request.query());
         VectorSearchRequest searchRequest = new VectorSearchRequest(queryEmbedding, request.topK());
         List<VectorSearchResult> results = searchWithFallback(
@@ -140,11 +162,14 @@ public class RagPipelineService {
                         searchRequest,
                         options.vectorWeight(),
                         options.lexicalWeight()),
-                () -> vectorStorePort.searchByObject(objectType, objectId, searchRequest));
+                () -> vectorStorePort.searchByObject(objectType, objectId, searchRequest),
+                objectType,
+                objectId);
         return toRagSearchResults(results);
     }
 
     public List<RagSearchResult> listByObject(String objectType, String objectId, Integer limit) {
+        clearDiagnostics();
         List<VectorSearchResult> results = vectorStorePort.listByObject(objectType, objectId, options.clampListLimit(limit));
         return results.stream()
                 .map(result -> new RagSearchResult(
@@ -153,6 +178,12 @@ public class RagPipelineService {
                         result.document().metadata(),
                         result.score()))
                 .toList();
+    }
+
+    public Optional<RagRetrievalDiagnostics> latestDiagnostics() {
+        return diagnosticsOptions.enabled()
+                ? Optional.ofNullable(latestDiagnostics.get())
+                : Optional.empty();
     }
 
     private List<Double> embedWithCache(String text) {
@@ -198,16 +229,23 @@ public class RagPipelineService {
             String query,
             VectorSearchRequest searchRequest,
             Function<String, List<VectorSearchResult>> hybridSearch,
-            Supplier<List<VectorSearchResult>> semanticSearch) {
+            Supplier<List<VectorSearchResult>> semanticSearch,
+            String objectType,
+            String objectId) {
         List<VectorSearchResult> results = hybridSearch.apply(query);
         if (hasRelevantResults(results)) {
+            recordDiagnostics(RagRetrievalDiagnostics.Strategy.HYBRID,
+                    results.size(), results.size(), searchRequest, objectType, objectId, results);
             return results;
         }
+        int initialResultCount = safeSize(results);
 
         String enrichedQuery = options.keywordFallbackEnabled() ? enrichQuery(query) : query;
         if (options.keywordFallbackEnabled() && !enrichedQuery.equals(query)) {
             List<VectorSearchResult> enrichedResults = hybridSearch.apply(enrichedQuery);
             if (hasRelevantResults(enrichedResults)) {
+                recordDiagnostics(RagRetrievalDiagnostics.Strategy.KEYWORD_ENRICHED_HYBRID,
+                        initialResultCount, enrichedResults.size(), searchRequest, objectType, objectId, enrichedResults);
                 return enrichedResults;
             }
         }
@@ -215,9 +253,13 @@ public class RagPipelineService {
         if (options.semanticFallbackEnabled()) {
             List<VectorSearchResult> semanticResults = semanticSearch.get();
             if (hasRelevantResults(semanticResults)) {
+                recordDiagnostics(RagRetrievalDiagnostics.Strategy.SEMANTIC,
+                        initialResultCount, semanticResults.size(), searchRequest, objectType, objectId, semanticResults);
                 return semanticResults;
             }
         }
+        recordDiagnostics(RagRetrievalDiagnostics.Strategy.NONE,
+                initialResultCount, 0, searchRequest, objectType, objectId, List.of());
         return List.of();
     }
 
@@ -263,5 +305,70 @@ public class RagPipelineService {
                         result.document().metadata(),
                         result.score()))
                 .toList();
+    }
+
+    private void clearDiagnostics() {
+        latestDiagnostics.remove();
+    }
+
+    private void recordDiagnostics(
+            RagRetrievalDiagnostics.Strategy strategy,
+            int initialResultCount,
+            int finalResultCount,
+            VectorSearchRequest searchRequest,
+            String objectType,
+            String objectId,
+            List<VectorSearchResult> results) {
+        if (!diagnosticsOptions.enabled()) {
+            return;
+        }
+        RagRetrievalDiagnostics diagnostics = new RagRetrievalDiagnostics(
+                strategy,
+                initialResultCount,
+                finalResultCount,
+                options.minRelevanceScore(),
+                options.vectorWeight(),
+                options.lexicalWeight(),
+                objectType,
+                objectId,
+                searchRequest.topK());
+        latestDiagnostics.set(diagnostics);
+        logDiagnostics(diagnostics, results);
+    }
+
+    private void logDiagnostics(RagRetrievalDiagnostics diagnostics, List<VectorSearchResult> results) {
+        if (!diagnosticsOptions.logResults() || !log.isDebugEnabled()) {
+            return;
+        }
+        log.debug("RAG retrieval diagnostics strategy={}, initialResultCount={}, finalResultCount={}, minScore={}, "
+                        + "vectorWeight={}, lexicalWeight={}, objectType={}, objectId={}, topK={}",
+                diagnostics.strategy().value(),
+                diagnostics.initialResultCount(),
+                diagnostics.finalResultCount(),
+                diagnostics.minScore(),
+                diagnostics.vectorWeight(),
+                diagnostics.lexicalWeight(),
+                diagnostics.objectType(),
+                diagnostics.objectId(),
+                diagnostics.topK());
+        results.stream().limit(diagnostics.topK()).forEach(result ->
+                log.debug("RAG diagnostic hit docId={}, score={}, snippet={}",
+                        result.document().id(),
+                        String.format("%.3f", result.score()),
+                        truncate(result.document().content(), diagnosticsOptions.maxSnippetChars())));
+    }
+
+    private int safeSize(List<VectorSearchResult> results) {
+        return results == null ? 0 : results.size();
+    }
+
+    private String truncate(String content, int maxLen) {
+        if (content == null || maxLen == 0) {
+            return "";
+        }
+        if (content.length() <= maxLen) {
+            return content;
+        }
+        return content.substring(0, maxLen);
     }
 }

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
@@ -18,6 +18,7 @@ import studio.one.platform.ai.core.embedding.EmbeddingRequest;
 import studio.one.platform.ai.core.embedding.EmbeddingResponse;
 import studio.one.platform.ai.core.embedding.EmbeddingVector;
 import studio.one.platform.ai.core.rag.RagIndexRequest;
+import studio.one.platform.ai.core.rag.RagRetrievalDiagnostics;
 import studio.one.platform.ai.core.rag.RagSearchRequest;
 import studio.one.platform.ai.core.rag.RagSearchResult;
 import studio.one.platform.ai.core.vector.VectorDocument;
@@ -410,5 +411,147 @@ class RagPipelineServiceTest {
 
         verify(vectorStorePort, times(4)).listByObject(eq("attachment"), eq("42"), limitCaptor.capture());
         assertThat(limitCaptor.getAllValues()).containsExactly(5, 5, 10, 7);
+    }
+
+    @Test
+    void shouldNotExposeDiagnosticsWhenDisabled() {
+        RagSearchRequest request = new RagSearchRequest("hello", 2);
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("hello", List.of(0.5, 0.6)))));
+        when(vectorStorePort.hybridSearch(anyString(), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-1", "chunk", Map.of(), List.of(0.5, 0.6)), 0.9)));
+
+        ragPipelineService.search(request);
+
+        assertThat(ragPipelineService.latestDiagnostics()).isEmpty();
+    }
+
+    @Test
+    void shouldTrackHybridRetrievalDiagnosticsWhenEnabled() {
+        ragPipelineService = new RagPipelineService(embeddingPort, vectorStorePort, textChunker, cache, retry,
+                keywordExtractor,
+                null,
+                new RagPipelineOptions(0.2d, 0.8d, 0.4d, true, true, 20, 100),
+                new RagPipelineDiagnosticsOptions(true, false, 120));
+        RagSearchRequest request = new RagSearchRequest("hello", 7);
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("hello", List.of(0.5, 0.6)))));
+        when(vectorStorePort.hybridSearch(anyString(), any(VectorSearchRequest.class), eq(0.2d), eq(0.8d)))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-1", "chunk", Map.of(), List.of(0.5, 0.6)), 0.9)));
+
+        ragPipelineService.search(request);
+
+        assertThat(ragPipelineService.latestDiagnostics()).hasValueSatisfying(diagnostics -> {
+            assertThat(diagnostics.strategy()).isEqualTo(RagRetrievalDiagnostics.Strategy.HYBRID);
+            assertThat(diagnostics.initialResultCount()).isEqualTo(1);
+            assertThat(diagnostics.finalResultCount()).isEqualTo(1);
+            assertThat(diagnostics.minScore()).isEqualTo(0.4d);
+            assertThat(diagnostics.vectorWeight()).isEqualTo(0.2d);
+            assertThat(diagnostics.lexicalWeight()).isEqualTo(0.8d);
+            assertThat(diagnostics.objectType()).isNull();
+            assertThat(diagnostics.objectId()).isNull();
+            assertThat(diagnostics.topK()).isEqualTo(7);
+        });
+    }
+
+    @Test
+    void shouldTrackKeywordFallbackDiagnosticsWhenEnabled() {
+        ragPipelineService = new RagPipelineService(embeddingPort, vectorStorePort, textChunker, cache, retry,
+                keywordExtractor,
+                null,
+                RagPipelineOptions.defaults(),
+                new RagPipelineDiagnosticsOptions(true, false, 120));
+        RagSearchRequest request = new RagSearchRequest("hello", 2);
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("hello", List.of(0.5, 0.6)))));
+        when(keywordExtractor.extract("hello")).thenReturn(List.of("greeting"));
+        when(vectorStorePort.hybridSearch(eq("hello"), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-low", "weak", Map.of(), List.of(0.5, 0.6)), 0.01)));
+        when(vectorStorePort.hybridSearch(eq("hello greeting"), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-strong", "strong", Map.of(), List.of(0.5, 0.6)), 0.9)));
+
+        ragPipelineService.search(request);
+
+        assertThat(ragPipelineService.latestDiagnostics()).hasValueSatisfying(diagnostics -> {
+            assertThat(diagnostics.strategy()).isEqualTo(RagRetrievalDiagnostics.Strategy.KEYWORD_ENRICHED_HYBRID);
+            assertThat(diagnostics.initialResultCount()).isEqualTo(1);
+            assertThat(diagnostics.finalResultCount()).isEqualTo(1);
+        });
+    }
+
+    @Test
+    void shouldTrackObjectScopedSemanticFallbackDiagnosticsWhenEnabled() {
+        ragPipelineService = new RagPipelineService(embeddingPort, vectorStorePort, textChunker, cache, retry,
+                keywordExtractor,
+                null,
+                RagPipelineOptions.defaults(),
+                new RagPipelineDiagnosticsOptions(true, false, 120));
+        RagSearchRequest request = new RagSearchRequest("hello", 3);
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("hello", List.of(0.5, 0.6)))));
+        when(keywordExtractor.extract("hello")).thenReturn(List.of());
+        when(vectorStorePort.hybridSearchByObject(anyString(), eq("attachment"), eq("42"), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of());
+        when(vectorStorePort.searchByObject(eq("attachment"), eq("42"), any(VectorSearchRequest.class)))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-semantic", "semantic", Map.of(), List.of(0.5, 0.6)), 0.9)));
+
+        ragPipelineService.searchByObject(request, "attachment", "42");
+
+        assertThat(ragPipelineService.latestDiagnostics()).hasValueSatisfying(diagnostics -> {
+            assertThat(diagnostics.strategy()).isEqualTo(RagRetrievalDiagnostics.Strategy.SEMANTIC);
+            assertThat(diagnostics.objectType()).isEqualTo("attachment");
+            assertThat(diagnostics.objectId()).isEqualTo("42");
+            assertThat(diagnostics.topK()).isEqualTo(3);
+        });
+    }
+
+    @Test
+    void shouldTrackNoneDiagnosticsWhenNoRelevantResultsRemain() {
+        ragPipelineService = new RagPipelineService(embeddingPort, vectorStorePort, textChunker, cache, retry,
+                keywordExtractor,
+                null,
+                RagPipelineOptions.defaults(),
+                new RagPipelineDiagnosticsOptions(true, false, 120));
+        RagSearchRequest request = new RagSearchRequest("hello", 2);
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("hello", List.of(0.5, 0.6)))));
+        when(keywordExtractor.extract("hello")).thenReturn(List.of());
+        when(vectorStorePort.hybridSearch(anyString(), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-low", "weak", Map.of(), List.of(0.5, 0.6)), 0.01)));
+        when(vectorStorePort.search(any(VectorSearchRequest.class)))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-semantic-low", "weak semantic", Map.of(), List.of(0.5, 0.6)), 0.01)));
+
+        ragPipelineService.search(request);
+
+        assertThat(ragPipelineService.latestDiagnostics()).hasValueSatisfying(diagnostics -> {
+            assertThat(diagnostics.strategy()).isEqualTo(RagRetrievalDiagnostics.Strategy.NONE);
+            assertThat(diagnostics.initialResultCount()).isEqualTo(1);
+            assertThat(diagnostics.finalResultCount()).isZero();
+        });
+    }
+
+    @Test
+    void shouldNotIncludeSensitiveContentInDiagnosticsMetadata() {
+        RagRetrievalDiagnostics diagnostics = new RagRetrievalDiagnostics(
+                RagRetrievalDiagnostics.Strategy.HYBRID,
+                1,
+                1,
+                0.15d,
+                0.7d,
+                0.3d,
+                "attachment",
+                "42",
+                3);
+
+        assertThat(diagnostics.toMetadata())
+                .containsEntry("strategy", "hybrid")
+                .doesNotContainKeys("content", "snippet", "text", "chunk");
     }
 }


### PR DESCRIPTION
## Why

- RAG 검색 fallback 전략과 결과 상태를 운영/개발 환경에서 안전하게 관찰할 수 있어야 한다.
- 기존 `POST /api/ai/chat/rag`는 per-hit info 로그를 항상 남겨 로그 노이즈와 민감 chunk 노출 위험이 있었다.

## What

- `RagRetrievalDiagnostics`와 `RagPipelineDiagnosticsOptions`를 추가했다.
- `studio.ai.pipeline.diagnostics.*` 설정을 추가해 diagnostics 수집과 bounded result debug logging을 선택적으로 제어한다.
- `studio.ai.endpoints.rag.diagnostics.allow-client-debug` 설정을 추가해 client `debug=true` 요청의 diagnostics metadata 노출을 서버에서 별도로 허용하도록 했다.
- `ChatRagRequestDto.debug`를 optional field로 추가하고, 조건 충족 시에만 `ChatResponseDto.metadata.ragDiagnostics`를 추가한다.
- 기존 RAG hit info 로그를 제거하고, `log-results=true`일 때만 debug level로 제한 길이 snippet을 기록하도록 했다.
- README와 CHANGELOG, 관련 테스트를 갱신했다.

## Related Issues

- Closes #205

## Validation

- Command: `gradle :studio-platform-ai:test`
- Result: `BUILD SUCCESSFUL`
- Command: `gradle :starter:studio-platform-starter-ai-web:test`
- Result: `BUILD SUCCESSFUL`
- Command: `git diff --check`
- Result: passed
- Command: `git diff --cached --check`
- Result: passed

## Risk / Rollback

- Risk: diagnostics 설정을 켠 환경에서 검색 요청별 ThreadLocal 상태가 잘못 노출되면 응답 metadata가 예상과 달라질 수 있다. 기본값은 비활성화라 기존 API 응답 shape는 유지된다.
- Rollback: 이 커밋을 revert하면 diagnostics 모델, 설정, debug metadata 노출, 관련 문서/테스트가 제거되고 기존 RAG 검색 동작으로 돌아간다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: `gradle :studio-platform-ai:test`, `gradle :starter:studio-platform-starter-ai-web:test`, `git diff --check`

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
