### PR TITLE
[ai-assisted] feat(ai-rag): improve keyword and Korean lexical quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## 2026-04-16
 
 ### 변경됨
+- 이슈 #206 대응으로 `studio.ai.pipeline.keywords.scope`, `max-input-chars`와 `studio.ai.pipeline.retrieval.query-expansion.*` 설정을 추가해 keyword metadata 범위와 query expansion 동작을 조정할 수 있도록 했다.
+- 기본 `keywords.scope=document`는 기존 문서 단위 `keywords`/`keywordsText` 동작을 유지하고, `chunk` 또는 `both` 설정 시 chunk metadata에 `chunkKeywords`/`chunkKeywordsText`를 추가한다.
+- `LlmKeywordExtractor`의 입력 최대 길이 4000자 제한을 설정으로 이동하고, keyword trim/blank 제거/case-insensitive de-duplication을 적용했다.
+- `studio.ai.vector.postgres.text-search-config=simple` 기본 설정을 추가하되, 이번 작업에서는 기존 PostgreSQL SQL ranking 동작과 DB migration은 변경하지 않았다.
 - 이슈 #205 대응으로 `studio.ai.pipeline.diagnostics.*`와 `studio.ai.endpoints.rag.diagnostics.allow-client-debug` 설정을 추가해 RAG 검색 fallback 전략과 결과 상태를 선택적으로 관찰할 수 있도록 했다.
 - `RagRetrievalDiagnostics`를 추가해 strategy, result count, score threshold, hybrid weight, object scope, topK를 기록하고, client debug 허용 시에만 `ChatResponseDto.metadata.ragDiagnostics`에 노출한다.
 - 기존 `POST /api/ai/chat/rag`의 per-hit info 로그를 제거하고, diagnostics result logging이 명시적으로 활성화된 경우에만 bounded debug snippet을 출력하도록 했다.
@@ -20,6 +24,8 @@
 - 이 작업은 PR #207의 RAG 설정화 변경과 통합 검증되도록 `2.x` 최신으로 rebase했다.
 
 ### 검증
+- `gradle :studio-platform-ai:test`
+- `gradle :starter:studio-platform-starter-ai:test`
 - `gradle :studio-platform-ai:test :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test --rerun-tasks`
 - `gradle :studio-platform-ai:test`
 - `gradle :starter:studio-platform-starter-ai-web:test`

--- a/starter/studio-platform-starter-ai/README.md
+++ b/starter/studio-platform-starter-ai/README.md
@@ -188,6 +188,12 @@ studio:
         min-relevance-score: 0.15
         keyword-fallback-enabled: true
         semantic-fallback-enabled: true
+        query-expansion:
+          enabled: true
+          max-keywords: 10
+      keywords:
+        scope: document
+        max-input-chars: 4000
       object-scope:
         default-list-limit: 20
         max-list-limit: 100
@@ -195,6 +201,9 @@ studio:
         enabled: false
         log-results: false
         max-snippet-chars: 120
+    vector:
+      postgres:
+        text-search-config: simple
 ```
 
 | 설정 | 기본값 | 설명 |
@@ -204,6 +213,10 @@ studio:
 | `studio.ai.pipeline.retrieval.min-relevance-score` | `0.15` | fallback 성공으로 판단할 최소 relevance score |
 | `studio.ai.pipeline.retrieval.keyword-fallback-enabled` | `true` | keyword-enriched hybrid fallback 사용 여부 |
 | `studio.ai.pipeline.retrieval.semantic-fallback-enabled` | `true` | semantic fallback 사용 여부 |
+| `studio.ai.pipeline.retrieval.query-expansion.enabled` | `true` | keyword fallback에서 LLM keyword extractor로 query를 보강할지 여부 |
+| `studio.ai.pipeline.retrieval.query-expansion.max-keywords` | `10` | query 보강에 사용할 최대 keyword 수 |
+| `studio.ai.pipeline.keywords.scope` | `document` | 색인 metadata keyword 범위. `document`, `chunk`, `both` 지원 |
+| `studio.ai.pipeline.keywords.max-input-chars` | `4000` | LLM keyword extractor에 전달할 입력 최대 길이 |
 | `studio.ai.pipeline.object-scope.default-list-limit` | `20` | query 없는 object-scope list 기본 limit |
 | `studio.ai.pipeline.object-scope.max-list-limit` | `100` | object-scope list 최대 limit |
 | `studio.ai.pipeline.diagnostics.enabled` | `false` | RAG 검색 fallback 전략과 결과 카운트 수집 여부 |
@@ -212,6 +225,10 @@ studio:
 
 `vector-weight`와 `lexical-weight`는 각각 0 이상이어야 하며 두 값의 합은 0보다 커야 한다.
 diagnostics metadata에는 chunk 본문을 포함하지 않고 strategy, 결과 수, threshold, weight, object scope, topK만 기록한다.
+`keywords.scope=document`는 기존 동작과 동일하게 문서 단위 `keywords`/`keywordsText`만 기록한다.
+`chunk` 또는 `both`를 사용하면 chunk metadata에 `chunkKeywords`/`chunkKeywordsText`를 추가한다.
+Keyword 값은 trim, blank 제거, case-insensitive de-duplication을 거친다.
+PostgreSQL lexical 검색은 현재 SQL ranking 동작을 유지하며, 기본 text search config는 `studio.ai.vector.postgres.text-search-config=simple`로 문서화한다.
 
 ### RAG 색인 전 텍스트 정제
 

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/KeywordExtractorConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/KeywordExtractorConfiguration.java
@@ -3,6 +3,7 @@ package studio.one.platform.ai.autoconfigure.config;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -20,6 +21,7 @@ import studio.one.platform.util.LogUtils;
 
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(LlmKeywordExtractor.class)
+@EnableConfigurationProperties(RagPipelineProperties.class)
 @RequiredArgsConstructor
 @Slf4j
 public class KeywordExtractorConfiguration {
@@ -28,13 +30,15 @@ public class KeywordExtractorConfiguration {
 
     @Bean
     @ConditionalOnMissingBean(KeywordExtractor.class)
-    public KeywordExtractor keywordExtractor(PromptRenderer promptRenderer, ChatPort chatPort) {
+    public KeywordExtractor keywordExtractor(PromptRenderer promptRenderer,
+            ChatPort chatPort,
+            RagPipelineProperties properties) {
         I18n i18n = I18nUtils.resolve(i18nProvider);
         log.info(LogUtils.format(i18n, I18nKeys.AutoConfig.Feature.Service.DEPENDS_ON,
                 AiProviderRegistryConfiguration.FEATURE_NAME,
                 LogUtils.blue(LlmKeywordExtractor.class, true),
                 LogUtils.green(ChatPort.class, true),
                 LogUtils.red(State.CREATED.toString())));
-        return new LlmKeywordExtractor(promptRenderer, chatPort);
+        return new LlmKeywordExtractor(promptRenderer, chatPort, properties.getKeywords().getMaxInputChars());
     }
 }

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfiguration.java
@@ -26,6 +26,7 @@ import studio.one.platform.ai.service.cleaning.LlmTextCleaner;
 import studio.one.platform.ai.service.cleaning.TextCleaner;
 import studio.one.platform.ai.service.chunk.OverlapTextChunker;
 import studio.one.platform.ai.service.keyword.KeywordExtractor;
+import studio.one.platform.ai.service.pipeline.RagKeywordOptions;
 import studio.one.platform.ai.service.pipeline.RagPipelineDiagnosticsOptions;
 import studio.one.platform.ai.service.pipeline.RagPipelineOptions;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
@@ -108,7 +109,8 @@ public class RagPipelineConfiguration {
                 return new RagPipelineService(embeddingPort, vectorStorePort, textChunker, embeddingCache,
                                 embeddingRetry, keywordExtractorProvider.getIfAvailable(),
                                 textCleanerProvider.getIfAvailable(), ragPipelineOptions(properties),
-                                ragPipelineDiagnosticsOptions(properties));
+                                ragPipelineDiagnosticsOptions(properties),
+                                ragKeywordOptions(properties));
         }
 
         @Bean
@@ -154,6 +156,17 @@ public class RagPipelineConfiguration {
                                 diagnostics.isEnabled(),
                                 diagnostics.isLogResults(),
                                 diagnostics.getMaxSnippetChars());
+        }
+
+        private RagKeywordOptions ragKeywordOptions(RagPipelineProperties properties) {
+                RagPipelineProperties.KeywordsProperties keywords = properties.getKeywords();
+                RagPipelineProperties.QueryExpansionProperties queryExpansion =
+                                properties.getRetrieval().getQueryExpansion();
+                return new RagKeywordOptions(
+                                RagKeywordOptions.KeywordScope.from(keywords.getScope()),
+                                keywords.getMaxInputChars(),
+                                queryExpansion.isEnabled(),
+                                queryExpansion.getMaxKeywords());
         }
 
 }

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineProperties.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineProperties.java
@@ -4,6 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import studio.one.platform.constant.PropertyKeys;
 import studio.one.platform.ai.service.pipeline.RagPipelineDiagnosticsOptions;
+import studio.one.platform.ai.service.pipeline.RagKeywordOptions;
 import studio.one.platform.ai.service.pipeline.RagPipelineOptions;
 
 import java.time.Duration;
@@ -19,6 +20,7 @@ public class RagPipelineProperties {
     private final ObjectScopeProperties objectScope = new ObjectScopeProperties();
     private final CleanerProperties cleaner = new CleanerProperties();
     private final DiagnosticsProperties diagnostics = new DiagnosticsProperties();
+    private final KeywordsProperties keywords = new KeywordsProperties();
 
     public int getChunkSize() {
         return chunkSize;
@@ -58,6 +60,10 @@ public class RagPipelineProperties {
 
     public DiagnosticsProperties getDiagnostics() {
         return diagnostics;
+    }
+
+    public KeywordsProperties getKeywords() {
+        return keywords;
     }
 
     public static class CacheProperties {
@@ -108,6 +114,7 @@ public class RagPipelineProperties {
         private double minRelevanceScore = RagPipelineOptions.DEFAULT_MIN_RELEVANCE_SCORE;
         private boolean keywordFallbackEnabled = RagPipelineOptions.DEFAULT_KEYWORD_FALLBACK_ENABLED;
         private boolean semanticFallbackEnabled = RagPipelineOptions.DEFAULT_SEMANTIC_FALLBACK_ENABLED;
+        private final QueryExpansionProperties queryExpansion = new QueryExpansionProperties();
 
         public double getVectorWeight() {
             return vectorWeight;
@@ -147,6 +154,31 @@ public class RagPipelineProperties {
 
         public void setSemanticFallbackEnabled(boolean semanticFallbackEnabled) {
             this.semanticFallbackEnabled = semanticFallbackEnabled;
+        }
+
+        public QueryExpansionProperties getQueryExpansion() {
+            return queryExpansion;
+        }
+    }
+
+    public static class QueryExpansionProperties {
+        private boolean enabled = RagKeywordOptions.DEFAULT_QUERY_EXPANSION_ENABLED;
+        private int maxKeywords = RagKeywordOptions.DEFAULT_QUERY_EXPANSION_MAX_KEYWORDS;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public int getMaxKeywords() {
+            return maxKeywords;
+        }
+
+        public void setMaxKeywords(int maxKeywords) {
+            this.maxKeywords = maxKeywords;
         }
     }
 
@@ -237,6 +269,27 @@ public class RagPipelineProperties {
 
         public void setMaxSnippetChars(int maxSnippetChars) {
             this.maxSnippetChars = maxSnippetChars;
+        }
+    }
+
+    public static class KeywordsProperties {
+        private String scope = RagKeywordOptions.DEFAULT_SCOPE.name().toLowerCase();
+        private int maxInputChars = RagKeywordOptions.DEFAULT_MAX_INPUT_CHARS;
+
+        public String getScope() {
+            return scope;
+        }
+
+        public void setScope(String scope) {
+            this.scope = scope;
+        }
+
+        public int getMaxInputChars() {
+            return maxInputChars;
+        }
+
+        public void setMaxInputChars(int maxInputChars) {
+            this.maxInputChars = maxInputChars;
         }
     }
 }

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/VectorStoreConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/VectorStoreConfiguration.java
@@ -3,6 +3,7 @@ package studio.one.platform.ai.autoconfigure.config;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -17,6 +18,7 @@ import studio.one.platform.util.I18nUtils;
 import studio.one.platform.util.LogUtils;
 
 @Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(VectorStoreProperties.class)
 @Slf4j
 public class VectorStoreConfiguration {
 

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/VectorStoreProperties.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/VectorStoreProperties.java
@@ -1,0 +1,27 @@
+package studio.one.platform.ai.autoconfigure.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import studio.one.platform.constant.PropertyKeys;
+
+@ConfigurationProperties(prefix = PropertyKeys.AI.PREFIX + ".vector")
+public class VectorStoreProperties {
+
+    private final PostgresProperties postgres = new PostgresProperties();
+
+    public PostgresProperties getPostgres() {
+        return postgres;
+    }
+
+    public static class PostgresProperties {
+        private String textSearchConfig = "simple";
+
+        public String getTextSearchConfig() {
+            return textSearchConfig;
+        }
+
+        public void setTextSearchConfig(String textSearchConfig) {
+            this.textSearchConfig = textSearchConfig;
+        }
+    }
+}

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/RagPipelinePropertiesTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/RagPipelinePropertiesTest.java
@@ -22,8 +22,12 @@ class RagPipelinePropertiesTest {
         assertThat(properties.getRetrieval().getMinRelevanceScore()).isEqualTo(0.15d);
         assertThat(properties.getRetrieval().isKeywordFallbackEnabled()).isTrue();
         assertThat(properties.getRetrieval().isSemanticFallbackEnabled()).isTrue();
+        assertThat(properties.getRetrieval().getQueryExpansion().isEnabled()).isTrue();
+        assertThat(properties.getRetrieval().getQueryExpansion().getMaxKeywords()).isEqualTo(10);
         assertThat(properties.getObjectScope().getDefaultListLimit()).isEqualTo(20);
         assertThat(properties.getObjectScope().getMaxListLimit()).isEqualTo(100);
+        assertThat(properties.getKeywords().getScope()).isEqualTo("document");
+        assertThat(properties.getKeywords().getMaxInputChars()).isEqualTo(4_000);
         assertThat(properties.getCleaner().isEnabled()).isFalse();
         assertThat(properties.getCleaner().getPrompt()).isEqualTo("rag-cleaner");
         assertThat(properties.getCleaner().getMaxInputChars()).isEqualTo(20_000);
@@ -42,8 +46,12 @@ class RagPipelinePropertiesTest {
                 Map.entry("studio.ai.pipeline.retrieval.min-relevance-score", "0.4"),
                 Map.entry("studio.ai.pipeline.retrieval.keyword-fallback-enabled", "false"),
                 Map.entry("studio.ai.pipeline.retrieval.semantic-fallback-enabled", "false"),
+                Map.entry("studio.ai.pipeline.retrieval.query-expansion.enabled", "false"),
+                Map.entry("studio.ai.pipeline.retrieval.query-expansion.max-keywords", "4"),
                 Map.entry("studio.ai.pipeline.object-scope.default-list-limit", "5"),
                 Map.entry("studio.ai.pipeline.object-scope.max-list-limit", "10"),
+                Map.entry("studio.ai.pipeline.keywords.scope", "both"),
+                Map.entry("studio.ai.pipeline.keywords.max-input-chars", "2048"),
                 Map.entry("studio.ai.pipeline.cleaner.enabled", "true"),
                 Map.entry("studio.ai.pipeline.cleaner.prompt", "custom-cleaner"),
                 Map.entry("studio.ai.pipeline.cleaner.max-input-chars", "1234"),
@@ -61,8 +69,12 @@ class RagPipelinePropertiesTest {
         assertThat(properties.getRetrieval().getMinRelevanceScore()).isEqualTo(0.4d);
         assertThat(properties.getRetrieval().isKeywordFallbackEnabled()).isFalse();
         assertThat(properties.getRetrieval().isSemanticFallbackEnabled()).isFalse();
+        assertThat(properties.getRetrieval().getQueryExpansion().isEnabled()).isFalse();
+        assertThat(properties.getRetrieval().getQueryExpansion().getMaxKeywords()).isEqualTo(4);
         assertThat(properties.getObjectScope().getDefaultListLimit()).isEqualTo(5);
         assertThat(properties.getObjectScope().getMaxListLimit()).isEqualTo(10);
+        assertThat(properties.getKeywords().getScope()).isEqualTo("both");
+        assertThat(properties.getKeywords().getMaxInputChars()).isEqualTo(2048);
         assertThat(properties.getCleaner().isEnabled()).isTrue();
         assertThat(properties.getCleaner().getPrompt()).isEqualTo("custom-cleaner");
         assertThat(properties.getCleaner().getMaxInputChars()).isEqualTo(1234);
@@ -70,5 +82,21 @@ class RagPipelinePropertiesTest {
         assertThat(properties.getDiagnostics().isEnabled()).isTrue();
         assertThat(properties.getDiagnostics().isLogResults()).isTrue();
         assertThat(properties.getDiagnostics().getMaxSnippetChars()).isEqualTo(42);
+    }
+
+    @Test
+    void shouldExposeVectorStoreDefaultsAndOverrides() {
+        VectorStoreProperties defaults = new VectorStoreProperties();
+        assertThat(defaults.getPostgres().getTextSearchConfig()).isEqualTo("simple");
+
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().addFirst(new MapPropertySource("test", Map.of(
+                "studio.ai.vector.postgres.text-search-config", "simple")));
+
+        VectorStoreProperties properties = new Binder(ConfigurationPropertySources.get(environment))
+                .bind("studio.ai.vector", Bindable.of(VectorStoreProperties.class))
+                .orElseThrow(() -> new AssertionError("VectorStoreProperties binding failed"));
+
+        assertThat(properties.getPostgres().getTextSearchConfig()).isEqualTo("simple");
     }
 }

--- a/studio-platform-ai/README.md
+++ b/studio-platform-ai/README.md
@@ -41,6 +41,15 @@ AI 추상화 계층이다. 챗 완성, 임베딩 생성, 벡터 스토어 접근
 | `indexedTextLength` | 실제 chunking/indexing에 사용한 텍스트 길이 |
 | `chunkCount` | 생성된 chunk 수 |
 | `chunkLength` | 개별 chunk content 길이 |
+| `keywords` | 문서 단위 keyword 목록. `studio.ai.pipeline.keywords.scope=document|both`일 때 기록 |
+| `keywordsText` | 문서 단위 keyword를 공백으로 연결한 lexical 검색용 문자열 |
+| `chunkKeywords` | chunk 단위 keyword 목록. `scope=chunk|both`일 때 기록 |
+| `chunkKeywordsText` | chunk 단위 keyword를 공백으로 연결한 lexical 검색용 문자열 |
+
+Keyword metadata는 trim, blank 제거, case-insensitive 중복 제거를 거친다.
+기본 `scope=document`는 기존 동작과 동일하게 문서 단위 keyword만 기록한다.
+`scope=chunk` 또는 `both`는 chunk별 keyword를 추가해 긴 파일에서 chunk 의미가 희석되는 문제를 줄이는 기반을 제공한다.
+현재 PostgreSQL hybrid SQL ranking은 기존 `simple` text search config 동작을 유지한다.
 
 ## RAG diagnostics
 `RagPipelineService`는 diagnostics가 활성화된 경우 마지막 RAG 검색의 strategy, result count, score threshold,

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/service/keyword/LlmKeywordExtractor.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/service/keyword/LlmKeywordExtractor.java
@@ -3,12 +3,10 @@ package studio.one.platform.ai.service.keyword;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import studio.one.platform.ai.core.chat.ChatMessage;
 import studio.one.platform.ai.core.chat.ChatPort;
@@ -19,7 +17,6 @@ import studio.one.platform.ai.service.prompt.PromptRenderer;
 /**
  * LLM 기반 키워드 추출기. 입력 텍스트에서 5~10개의 핵심 키워드를 JSON 배열로 받아 파싱한다.
  */
-@RequiredArgsConstructor
 @Slf4j
 public class LlmKeywordExtractor implements KeywordExtractor {
 
@@ -32,7 +29,21 @@ public class LlmKeywordExtractor implements KeywordExtractor {
 
     private final PromptRenderer promptRenderer;
     private final ChatPort chatPort;
+    private final int maxInputChars;
     private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public LlmKeywordExtractor(PromptRenderer promptRenderer, ChatPort chatPort) {
+        this(promptRenderer, chatPort, 4_000);
+    }
+
+    public LlmKeywordExtractor(PromptRenderer promptRenderer, ChatPort chatPort, int maxInputChars) {
+        if (maxInputChars < 1) {
+            throw new IllegalArgumentException("maxInputChars must be greater than 0");
+        }
+        this.promptRenderer = Objects.requireNonNull(promptRenderer, "promptRenderer");
+        this.chatPort = Objects.requireNonNull(chatPort, "chatPort");
+        this.maxInputChars = maxInputChars;
+    }
 
     @Override
     public List<String> extract(String text) {
@@ -63,7 +74,7 @@ public class LlmKeywordExtractor implements KeywordExtractor {
         return ChatRequest.builder()
                 .messages(List.of(
                         ChatMessage.system(systemPrompt),
-                        ChatMessage.user(trimToLength(text, 4000))))
+                        ChatMessage.user(trimToLength(text, maxInputChars))))
                 .build();
     }
 
@@ -76,23 +87,32 @@ public class LlmKeywordExtractor implements KeywordExtractor {
         if (!parsed.isEmpty()) {
             return parsed;
         }
-        return Arrays.stream(cleaned.split("[,\\n]"))
+        return normalizeKeywords(Arrays.stream(cleaned.split("[,\\n]"))
                 .map(String::trim)
-                .filter(s -> !s.isEmpty())
-                .toList();
+                .toList());
     }
 
     private List<String> tryParseJson(String cleaned) {
         try {
             List<String> list = objectMapper.readValue(cleaned, new TypeReference<List<String>>() {});
-            return list.stream()
-                    .filter(Objects::nonNull)
-                    .map(String::trim)
-                    .filter(s -> !s.isEmpty())
-                    .collect(Collectors.toList());
+            return normalizeKeywords(list);
         } catch (Exception ignored) {
             return List.of();
         }
+    }
+
+    private List<String> normalizeKeywords(List<String> keywords) {
+        List<String> normalized = new java.util.ArrayList<>();
+        for (String keyword : keywords) {
+            if (keyword == null || keyword.isBlank()) {
+                continue;
+            }
+            String trimmed = keyword.trim();
+            if (normalized.stream().noneMatch(trimmed::equalsIgnoreCase)) {
+                normalized.add(trimmed);
+            }
+        }
+        return normalized;
     }
 
     private String stripFence(String value) {

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagKeywordOptions.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagKeywordOptions.java
@@ -1,0 +1,55 @@
+package studio.one.platform.ai.service.pipeline;
+
+/**
+ * Runtime options for RAG keyword metadata and query expansion.
+ */
+public record RagKeywordOptions(
+        KeywordScope scope,
+        int maxInputChars,
+        boolean queryExpansionEnabled,
+        int queryExpansionMaxKeywords) {
+
+    public static final KeywordScope DEFAULT_SCOPE = KeywordScope.DOCUMENT;
+    public static final int DEFAULT_MAX_INPUT_CHARS = 4_000;
+    public static final boolean DEFAULT_QUERY_EXPANSION_ENABLED = true;
+    public static final int DEFAULT_QUERY_EXPANSION_MAX_KEYWORDS = 10;
+
+    public RagKeywordOptions {
+        scope = scope == null ? DEFAULT_SCOPE : scope;
+        if (maxInputChars < 1) {
+            throw new IllegalArgumentException("maxInputChars must be greater than 0");
+        }
+        if (queryExpansionMaxKeywords < 1) {
+            throw new IllegalArgumentException("queryExpansionMaxKeywords must be greater than 0");
+        }
+    }
+
+    public static RagKeywordOptions defaults() {
+        return new RagKeywordOptions(
+                DEFAULT_SCOPE,
+                DEFAULT_MAX_INPUT_CHARS,
+                DEFAULT_QUERY_EXPANSION_ENABLED,
+                DEFAULT_QUERY_EXPANSION_MAX_KEYWORDS);
+    }
+
+    public enum KeywordScope {
+        DOCUMENT,
+        CHUNK,
+        BOTH;
+
+        public static KeywordScope from(String value) {
+            if (value == null || value.isBlank()) {
+                return DEFAULT_SCOPE;
+            }
+            return KeywordScope.valueOf(value.trim().replace('-', '_').toUpperCase());
+        }
+
+        public boolean includesDocument() {
+            return this == DOCUMENT || this == BOTH;
+        }
+
+        public boolean includesChunk() {
+            return this == CHUNK || this == BOTH;
+        }
+    }
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineService.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineService.java
@@ -45,6 +45,7 @@ public class RagPipelineService {
     private final TextCleaner textCleaner;
     private final RagPipelineOptions options;
     private final RagPipelineDiagnosticsOptions diagnosticsOptions;
+    private final RagKeywordOptions keywordOptions;
     private final ThreadLocal<RagRetrievalDiagnostics> latestDiagnostics = new ThreadLocal<>();
 
     public RagPipelineService(EmbeddingPort embeddingPort,
@@ -54,7 +55,8 @@ public class RagPipelineService {
             Retry retry,
             KeywordExtractor keywordExtractor) {
         this(embeddingPort, vectorStorePort, textChunker, embeddingCache, retry, keywordExtractor,
-                null, RagPipelineOptions.defaults(), RagPipelineDiagnosticsOptions.defaults());
+                null, RagPipelineOptions.defaults(), RagPipelineDiagnosticsOptions.defaults(),
+                RagKeywordOptions.defaults());
     }
 
     public RagPipelineService(EmbeddingPort embeddingPort,
@@ -76,7 +78,7 @@ public class RagPipelineService {
             TextCleaner textCleaner,
             RagPipelineOptions options) {
         this(embeddingPort, vectorStorePort, textChunker, embeddingCache, retry, keywordExtractor, textCleaner,
-                options, RagPipelineDiagnosticsOptions.defaults());
+                options, RagPipelineDiagnosticsOptions.defaults(), RagKeywordOptions.defaults());
     }
 
     public RagPipelineService(EmbeddingPort embeddingPort,
@@ -88,6 +90,20 @@ public class RagPipelineService {
             TextCleaner textCleaner,
             RagPipelineOptions options,
             RagPipelineDiagnosticsOptions diagnosticsOptions) {
+        this(embeddingPort, vectorStorePort, textChunker, embeddingCache, retry, keywordExtractor, textCleaner,
+                options, diagnosticsOptions, RagKeywordOptions.defaults());
+    }
+
+    public RagPipelineService(EmbeddingPort embeddingPort,
+            VectorStorePort vectorStorePort,
+            TextChunker textChunker,
+            Cache<String, List<Double>> embeddingCache,
+            Retry retry,
+            KeywordExtractor keywordExtractor,
+            TextCleaner textCleaner,
+            RagPipelineOptions options,
+            RagPipelineDiagnosticsOptions diagnosticsOptions,
+            RagKeywordOptions keywordOptions) {
 
         this.embeddingPort = Objects.requireNonNull(embeddingPort, "embeddingPort");
         this.vectorStorePort = Objects.requireNonNull(vectorStorePort, "vectorStorePort");
@@ -98,6 +114,7 @@ public class RagPipelineService {
         this.textCleaner = textCleaner;
         this.options = Objects.requireNonNull(options, "options");
         this.diagnosticsOptions = Objects.requireNonNull(diagnosticsOptions, "diagnosticsOptions");
+        this.keywordOptions = Objects.requireNonNull(keywordOptions, "keywordOptions");
     }
 
     public void index(RagIndexRequest request) {
@@ -108,21 +125,30 @@ public class RagPipelineService {
         String indexedText = cleaning.text() == null ? request.text() : cleaning.text();
         List<TextChunk> chunks = textChunker.chunk(request.documentId(), indexedText);
         List<VectorDocument> documents = new ArrayList<>(chunks.size());
-        List<String> keywords = resolveKeywords(request, indexedText);
+        List<String> documentKeywords = keywordOptions.scope().includesDocument()
+                ? resolveDocumentKeywords(request, indexedText)
+                : List.of();
         Map<String, Object> baseMetadata = new HashMap<>(request.metadata());
         baseMetadata.putIfAbsent("cleaned", cleaning.cleaned());
         baseMetadata.putIfAbsent("cleanerPrompt", cleaning.cleanerPrompt() == null ? "" : cleaning.cleanerPrompt());
         baseMetadata.putIfAbsent("originalTextLength", request.text().length());
         baseMetadata.putIfAbsent("indexedTextLength", indexedText.length());
         baseMetadata.putIfAbsent("chunkCount", chunks.size());
-        if (!keywords.isEmpty()) {
-            baseMetadata.put("keywords", keywords);
-            baseMetadata.put("keywordsText", String.join(" ", keywords));
+        if (!documentKeywords.isEmpty()) {
+            baseMetadata.put("keywords", documentKeywords);
+            baseMetadata.put("keywordsText", String.join(" ", documentKeywords));
         }
         int order = 0;
         for (TextChunk chunk : chunks) {
             List<Double> embedding = embedWithCache(chunk.content());
             Map<String, Object> metadata = new HashMap<>(baseMetadata);
+            List<String> chunkKeywords = keywordOptions.scope().includesChunk()
+                    ? resolveChunkKeywords(request, chunk.content())
+                    : List.of();
+            if (!chunkKeywords.isEmpty()) {
+                metadata.put("chunkKeywords", chunkKeywords);
+                metadata.put("chunkKeywordsText", String.join(" ", chunkKeywords));
+            }
             metadata.put("documentId", request.documentId());
             metadata.put("chunkId", chunk.id());
             metadata.put("chunkOrder", order++);
@@ -210,16 +236,26 @@ public class RagPipelineService {
         return textCleaner.clean(text);
     }
 
-    private List<String> resolveKeywords(RagIndexRequest request, String indexedText) {
+    private List<String> resolveDocumentKeywords(RagIndexRequest request, String indexedText) {
         if (request.keywords() != null && !request.keywords().isEmpty()) {
-            return request.keywords();
+            return normalizeKeywords(request.keywords());
         }
         if (!request.useLlmKeywordExtraction() || keywordExtractor == null) {
             return List.of();
         }
         try {
-            List<String> extracted = keywordExtractor.extract(indexedText);
-            return extracted == null ? List.of() : extracted;
+            return normalizeKeywords(keywordExtractor.extract(indexedText));
+        } catch (Exception ignored) {
+            return List.of();
+        }
+    }
+
+    private List<String> resolveChunkKeywords(RagIndexRequest request, String chunkText) {
+        if (!request.useLlmKeywordExtraction() || keywordExtractor == null) {
+            return List.of();
+        }
+        try {
+            return normalizeKeywords(keywordExtractor.extract(chunkText));
         } catch (Exception ignored) {
             return List.of();
         }
@@ -264,23 +300,22 @@ public class RagPipelineService {
     }
 
     private String enrichQuery(String query) {
-        if (keywordExtractor == null) {
+        if (keywordExtractor == null || !keywordOptions.queryExpansionEnabled()) {
             return query;
         }
         try {
-            List<String> extracted = keywordExtractor.extract(query);
+            List<String> extracted = normalizeKeywords(keywordExtractor.extract(query));
             if (extracted == null || extracted.isEmpty()) {
                 return query;
             }
             List<String> uniqueTerms = new ArrayList<>();
             uniqueTerms.add(query.trim());
             for (String keyword : extracted) {
-                if (keyword == null || keyword.isBlank()) {
-                    continue;
+                if (uniqueTerms.stream().noneMatch(keyword::equalsIgnoreCase)) {
+                    uniqueTerms.add(keyword);
                 }
-                String normalized = keyword.trim();
-                if (uniqueTerms.stream().noneMatch(normalized::equalsIgnoreCase)) {
-                    uniqueTerms.add(normalized);
+                if (uniqueTerms.size() > keywordOptions.queryExpansionMaxKeywords()) {
+                    break;
                 }
             }
             return String.join(" ", uniqueTerms);
@@ -288,6 +323,23 @@ public class RagPipelineService {
             log.debug("Failed to extract keywords for RAG search fallback. query={}", query, ex);
             return query;
         }
+    }
+
+    private List<String> normalizeKeywords(List<String> keywords) {
+        if (keywords == null || keywords.isEmpty()) {
+            return List.of();
+        }
+        List<String> normalized = new ArrayList<>();
+        for (String keyword : keywords) {
+            if (keyword == null || keyword.isBlank()) {
+                continue;
+            }
+            String trimmed = keyword.trim();
+            if (normalized.stream().noneMatch(trimmed::equalsIgnoreCase)) {
+                normalized.add(trimmed);
+            }
+        }
+        return normalized;
     }
 
     private boolean hasRelevantResults(List<VectorSearchResult> results) {

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/service/keyword/LlmKeywordExtractorTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/service/keyword/LlmKeywordExtractorTest.java
@@ -1,0 +1,60 @@
+package studio.one.platform.ai.service.keyword;
+
+import org.junit.jupiter.api.Test;
+import studio.one.platform.ai.core.chat.ChatMessage;
+import studio.one.platform.ai.core.chat.ChatPort;
+import studio.one.platform.ai.core.chat.ChatRequest;
+import studio.one.platform.ai.core.chat.ChatResponse;
+import studio.one.platform.ai.service.prompt.PromptRenderer;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LlmKeywordExtractorTest {
+
+    @Test
+    void shouldLimitInputWithConfiguredMaxInputChars() {
+        AtomicReference<ChatRequest> capturedRequest = new AtomicReference<>();
+        PromptRenderer promptRenderer = promptRenderer();
+        ChatPort chatPort = request -> {
+            capturedRequest.set(request);
+            return new ChatResponse(List.of(ChatMessage.assistant("[\"keyword\"]")), "test", Map.of());
+        };
+        LlmKeywordExtractor extractor = new LlmKeywordExtractor(promptRenderer, chatPort, 5);
+
+        extractor.extract("1234567890");
+
+        assertThat(capturedRequest.get().messages().get(1).content()).isEqualTo("12345");
+    }
+
+    @Test
+    void shouldNormalizeDuplicateKeywordsCaseInsensitively() {
+        PromptRenderer promptRenderer = promptRenderer();
+        ChatPort chatPort = request -> new ChatResponse(
+                List.of(ChatMessage.assistant("[\" Upload \", \"upload\", \"파일\", \" \", null, \"File\"]")),
+                "test",
+                Map.of());
+        LlmKeywordExtractor extractor = new LlmKeywordExtractor(promptRenderer, chatPort, 4_000);
+
+        List<String> keywords = extractor.extract("text");
+
+        assertThat(keywords).containsExactly("Upload", "파일", "File");
+    }
+
+    private PromptRenderer promptRenderer() {
+        return new PromptRenderer() {
+            @Override
+            public String render(String name, Map<String, Object> params) {
+                return "system prompt";
+            }
+
+            @Override
+            public String getRawPrompt(String name) {
+                return "system prompt";
+            }
+        };
+    }
+}

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
@@ -165,7 +165,7 @@ class RagPipelineServiceTest {
                 .thenReturn(List.of(new TextChunk("doc-kw-0", "hello world")));
         when(embeddingPort.embed(any(EmbeddingRequest.class)))
                 .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("doc-kw-0", List.of(0.1, 0.2, 0.3)))));
-        when(keywordExtractor.extract("hello world")).thenReturn(List.of("hello", "world"));
+        when(keywordExtractor.extract("hello world")).thenReturn(List.of(" hello ", "HELLO", "world", " "));
 
         ragPipelineService.index(request);
 
@@ -173,6 +173,81 @@ class RagPipelineServiceTest {
         verify(vectorStorePort).upsert(documentsCaptor.capture());
         VectorDocument document = documentsCaptor.getValue().get(0);
         assertThat(document.metadata()).containsEntry("keywords", List.of("hello", "world"));
+        assertThat(document.metadata()).containsEntry("keywordsText", "hello world");
+        assertThat(document.metadata()).doesNotContainKeys("chunkKeywords", "chunkKeywordsText");
+    }
+
+    @Test
+    void shouldAddChunkKeywordsWhenScopeIsChunk() {
+        ragPipelineService = new RagPipelineService(
+                embeddingPort,
+                vectorStorePort,
+                textChunker,
+                cache,
+                retry,
+                keywordExtractor,
+                null,
+                RagPipelineOptions.defaults(),
+                RagPipelineDiagnosticsOptions.defaults(),
+                new RagKeywordOptions(RagKeywordOptions.KeywordScope.CHUNK, 4_000, true, 10));
+        RagIndexRequest request = new RagIndexRequest("doc-chunk", "alpha beta", Map.of(), List.of(), true);
+        when(textChunker.chunk("doc-chunk", "alpha beta"))
+                .thenReturn(List.of(
+                        new TextChunk("doc-chunk-0", "alpha"),
+                        new TextChunk("doc-chunk-1", "beta")));
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("chunk", List.of(0.1, 0.2)))));
+        when(keywordExtractor.extract("alpha")).thenReturn(List.of(" Alpha ", "alpha", "first"));
+        when(keywordExtractor.extract("beta")).thenReturn(List.of("Beta", "second"));
+
+        ragPipelineService.index(request);
+
+        verify(keywordExtractor).extract("alpha");
+        verify(keywordExtractor).extract("beta");
+        verify(keywordExtractor, never()).extract("alpha beta");
+        verify(vectorStorePort).upsert(documentsCaptor.capture());
+        List<VectorDocument> documents = documentsCaptor.getValue();
+        assertThat(documents.get(0).metadata())
+                .containsEntry("chunkKeywords", List.of("Alpha", "first"))
+                .containsEntry("chunkKeywordsText", "Alpha first")
+                .doesNotContainKeys("keywords", "keywordsText");
+        assertThat(documents.get(1).metadata())
+                .containsEntry("chunkKeywords", List.of("Beta", "second"))
+                .containsEntry("chunkKeywordsText", "Beta second")
+                .doesNotContainKeys("keywords", "keywordsText");
+    }
+
+    @Test
+    void shouldAddDocumentAndChunkKeywordsWhenScopeIsBoth() {
+        ragPipelineService = new RagPipelineService(
+                embeddingPort,
+                vectorStorePort,
+                textChunker,
+                cache,
+                retry,
+                keywordExtractor,
+                null,
+                RagPipelineOptions.defaults(),
+                RagPipelineDiagnosticsOptions.defaults(),
+                new RagKeywordOptions(RagKeywordOptions.KeywordScope.BOTH, 4_000, true, 10));
+        RagIndexRequest request = new RagIndexRequest("doc-both", "alpha", Map.of(), List.of(), true);
+        when(textChunker.chunk("doc-both", "alpha"))
+                .thenReturn(List.of(new TextChunk("doc-both-0", "alpha")));
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("chunk", List.of(0.1, 0.2)))));
+        when(keywordExtractor.extract("alpha"))
+                .thenReturn(List.of("document"))
+                .thenReturn(List.of("chunk"));
+
+        ragPipelineService.index(request);
+
+        verify(keywordExtractor, times(2)).extract("alpha");
+        verify(vectorStorePort).upsert(documentsCaptor.capture());
+        VectorDocument document = documentsCaptor.getValue().get(0);
+        assertThat(document.metadata()).containsEntry("keywords", List.of("document"));
+        assertThat(document.metadata()).containsEntry("keywordsText", "document");
+        assertThat(document.metadata()).containsEntry("chunkKeywords", List.of("chunk"));
+        assertThat(document.metadata()).containsEntry("chunkKeywordsText", "chunk");
     }
 
     @Test
@@ -376,6 +451,64 @@ class RagPipelineServiceTest {
         assertThat(results.get(0).documentId()).isEqualTo("doc-semantic");
         verify(keywordExtractor, never()).extract(anyString());
         verify(vectorStorePort, times(1)).hybridSearch(eq("hello"), any(VectorSearchRequest.class), anyDouble(), anyDouble());
+    }
+
+    @Test
+    void shouldSkipQueryExpansionWhenDisabled() {
+        ragPipelineService = new RagPipelineService(
+                embeddingPort,
+                vectorStorePort,
+                textChunker,
+                cache,
+                retry,
+                keywordExtractor,
+                null,
+                RagPipelineOptions.defaults(),
+                RagPipelineDiagnosticsOptions.defaults(),
+                new RagKeywordOptions(RagKeywordOptions.KeywordScope.DOCUMENT, 4_000, false, 10));
+        RagSearchRequest request = new RagSearchRequest("hello", 2);
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("hello", List.of(0.5, 0.6)))));
+        when(vectorStorePort.hybridSearch(anyString(), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of());
+        when(vectorStorePort.search(any(VectorSearchRequest.class)))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-semantic", "semantic", Map.of(), List.of(0.5, 0.6)), 0.9)));
+
+        List<RagSearchResult> results = ragPipelineService.search(request);
+
+        assertThat(results).hasSize(1);
+        verify(keywordExtractor, never()).extract(anyString());
+        verify(vectorStorePort, times(1)).hybridSearch(eq("hello"), any(VectorSearchRequest.class), anyDouble(), anyDouble());
+    }
+
+    @Test
+    void shouldLimitQueryExpansionKeywords() {
+        ragPipelineService = new RagPipelineService(
+                embeddingPort,
+                vectorStorePort,
+                textChunker,
+                cache,
+                retry,
+                keywordExtractor,
+                null,
+                RagPipelineOptions.defaults(),
+                RagPipelineDiagnosticsOptions.defaults(),
+                new RagKeywordOptions(RagKeywordOptions.KeywordScope.DOCUMENT, 4_000, true, 2));
+        RagSearchRequest request = new RagSearchRequest("hello", 2);
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("hello", List.of(0.5, 0.6)))));
+        when(keywordExtractor.extract("hello")).thenReturn(List.of("alpha", "beta", "gamma"));
+        when(vectorStorePort.hybridSearch(eq("hello"), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of());
+        when(vectorStorePort.hybridSearch(eq("hello alpha beta"), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-expanded", "expanded", Map.of(), List.of(0.5, 0.6)), 0.9)));
+
+        List<RagSearchResult> results = ragPipelineService.search(request);
+
+        assertThat(results).hasSize(1);
+        verify(vectorStorePort).hybridSearch(eq("hello alpha beta"), any(VectorSearchRequest.class), anyDouble(), anyDouble());
     }
 
     @Test


### PR DESCRIPTION
## Why

RAG keyword metadata와 query expansion 동작을 설정화해 한국어 문서 검색 품질 개선 기반을 마련합니다. 기본 SQL ranking과 기존 document-level keyword 동작은 유지해 운영 영향은 최소화합니다.

## What

- `studio.ai.pipeline.keywords.scope`, `max-input-chars` 설정을 추가했습니다.
- `studio.ai.pipeline.retrieval.query-expansion.*` 설정을 추가했습니다.
- `scope=chunk|both`에서 chunk metadata에 `chunkKeywords`/`chunkKeywordsText`를 추가하도록 했습니다.
- `LlmKeywordExtractor` 입력 길이 제한을 설정으로 이동하고 keyword trim/blank 제거/case-insensitive de-duplication을 적용했습니다.
- `studio.ai.vector.postgres.text-search-config=simple` 설정을 문서/설정 클래스로 추가하되 SQL ranking과 DB migration은 변경하지 않았습니다.
- 관련 README, CHANGELOG, 단위 테스트를 갱신했습니다.

## Related Issues

- Closes #206

## Validation

- Command: `gradle :studio-platform-ai:test :starter:studio-platform-starter-ai:test --rerun-tasks`
- Result: `BUILD SUCCESSFUL`
- Command: `git diff --check`
- Result: passed
- Command: `git diff --cached --check`
- Result: passed

## Risk / Rollback

- Risk: `scope=chunk|both` 사용 시 색인 시점 LLM keyword extraction 호출 수가 chunk 수에 비례해 증가할 수 있습니다. 기본값은 `document`라 기존 동작을 유지합니다.
- Rollback: 이 PR 커밋을 revert하면 기존 document-level keyword extraction과 query fallback 동작으로 돌아갑니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: `studio-platform-ai:test`, `starter:studio-platform-starter-ai:test`, `git diff --check`

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included