### PR TITLE
fix(ai-rag): clarify keyword config behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - 이슈 #206 대응으로 `studio.ai.pipeline.keywords.scope`, `max-input-chars`와 `studio.ai.pipeline.retrieval.query-expansion.*` 설정을 추가해 keyword metadata 범위와 query expansion 동작을 조정할 수 있도록 했다.
 - 기본 `keywords.scope=document`는 기존 문서 단위 `keywords`/`keywordsText` 동작을 유지하고, `chunk` 또는 `both` 설정 시 chunk metadata에 `chunkKeywords`/`chunkKeywordsText`를 추가한다.
 - `LlmKeywordExtractor`의 입력 최대 길이 4000자 제한을 설정으로 이동하고, keyword trim/blank 제거/case-insensitive de-duplication을 적용했다.
-- `studio.ai.vector.postgres.text-search-config=simple` 기본 설정을 추가하되, 이번 작업에서는 기존 PostgreSQL SQL ranking 동작과 DB migration은 변경하지 않았다.
+- `studio.ai.vector.postgres.text-search-config=simple`은 향후 PostgreSQL FTS config 지원을 위한 문서화된 설정 후보로 남기고, 이번 작업에서는 기존 PostgreSQL SQL ranking 동작과 DB migration은 변경하지 않았다.
 - 이슈 #205 대응으로 `studio.ai.pipeline.diagnostics.*`와 `studio.ai.endpoints.rag.diagnostics.allow-client-debug` 설정을 추가해 RAG 검색 fallback 전략과 결과 상태를 선택적으로 관찰할 수 있도록 했다.
 - `RagRetrievalDiagnostics`를 추가해 strategy, result count, score threshold, hybrid weight, object scope, topK를 기록하고, client debug 허용 시에만 `ChatResponseDto.metadata.ragDiagnostics`에 노출한다.
 - 기존 `POST /api/ai/chat/rag`의 per-hit info 로그를 제거하고, diagnostics result logging이 명시적으로 활성화된 경우에만 bounded debug snippet을 출력하도록 했다.

--- a/starter/studio-platform-starter-ai/README.md
+++ b/starter/studio-platform-starter-ai/README.md
@@ -214,7 +214,7 @@ studio:
 | `studio.ai.pipeline.retrieval.keyword-fallback-enabled` | `true` | keyword-enriched hybrid fallback 사용 여부 |
 | `studio.ai.pipeline.retrieval.semantic-fallback-enabled` | `true` | semantic fallback 사용 여부 |
 | `studio.ai.pipeline.retrieval.query-expansion.enabled` | `true` | keyword fallback에서 LLM keyword extractor로 query를 보강할지 여부 |
-| `studio.ai.pipeline.retrieval.query-expansion.max-keywords` | `10` | query 보강에 사용할 최대 keyword 수 |
+| `studio.ai.pipeline.retrieval.query-expansion.max-keywords` | `10` | 원본 query 외에 추가할 최대 keyword 수 |
 | `studio.ai.pipeline.keywords.scope` | `document` | 색인 metadata keyword 범위. `document`, `chunk`, `both` 지원 |
 | `studio.ai.pipeline.keywords.max-input-chars` | `4000` | LLM keyword extractor에 전달할 입력 최대 길이 |
 | `studio.ai.pipeline.object-scope.default-list-limit` | `20` | query 없는 object-scope list 기본 limit |
@@ -227,8 +227,10 @@ studio:
 diagnostics metadata에는 chunk 본문을 포함하지 않고 strategy, 결과 수, threshold, weight, object scope, topK만 기록한다.
 `keywords.scope=document`는 기존 동작과 동일하게 문서 단위 `keywords`/`keywordsText`만 기록한다.
 `chunk` 또는 `both`를 사용하면 chunk metadata에 `chunkKeywords`/`chunkKeywordsText`를 추가한다.
+호출자가 제공한 `RagIndexRequest.keywords`는 document-level keyword로만 사용되며, `keywords.scope=chunk`에서는 저장되지 않는다.
+`query-expansion.enabled`는 `keyword-fallback-enabled=true`일 때만 효과가 있다.
 Keyword 값은 trim, blank 제거, case-insensitive de-duplication을 거친다.
-PostgreSQL lexical 검색은 현재 SQL ranking 동작을 유지하며, 기본 text search config는 `studio.ai.vector.postgres.text-search-config=simple`로 문서화한다.
+PostgreSQL lexical 검색은 현재 SQL ranking 동작을 유지한다. `studio.ai.vector.postgres.text-search-config=simple`은 향후 PostgreSQL FTS config 지원을 위한 문서화된 설정 후보이며, 이번 PR에서는 실제 SQL에 적용되지 않는다.
 
 ### RAG 색인 전 텍스트 정제
 

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagKeywordOptions.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagKeywordOptions.java
@@ -41,7 +41,12 @@ public record RagKeywordOptions(
             if (value == null || value.isBlank()) {
                 return DEFAULT_SCOPE;
             }
-            return KeywordScope.valueOf(value.trim().replace('-', '_').toUpperCase());
+            try {
+                return KeywordScope.valueOf(value.trim().toUpperCase());
+            } catch (IllegalArgumentException ex) {
+                throw new IllegalArgumentException("Invalid keyword scope '" + value
+                        + "'. Valid values are: DOCUMENT, CHUNK, BOTH", ex);
+            }
         }
 
         public boolean includesDocument() {

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineService.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineService.java
@@ -244,7 +244,7 @@ public class RagPipelineService {
             return List.of();
         }
         try {
-            return normalizeKeywords(keywordExtractor.extract(indexedText));
+            return keywordExtractor.extract(indexedText);
         } catch (Exception ignored) {
             return List.of();
         }
@@ -255,7 +255,7 @@ public class RagPipelineService {
             return List.of();
         }
         try {
-            return normalizeKeywords(keywordExtractor.extract(chunkText));
+            return keywordExtractor.extract(chunkText);
         } catch (Exception ignored) {
             return List.of();
         }
@@ -304,7 +304,7 @@ public class RagPipelineService {
             return query;
         }
         try {
-            List<String> extracted = normalizeKeywords(keywordExtractor.extract(query));
+            List<String> extracted = keywordExtractor.extract(query);
             if (extracted == null || extracted.isEmpty()) {
                 return query;
             }

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineService.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineService.java
@@ -244,7 +244,7 @@ public class RagPipelineService {
             return List.of();
         }
         try {
-            return keywordExtractor.extract(indexedText);
+            return normalizeKeywords(keywordExtractor.extract(indexedText));
         } catch (Exception ignored) {
             return List.of();
         }
@@ -255,7 +255,7 @@ public class RagPipelineService {
             return List.of();
         }
         try {
-            return keywordExtractor.extract(chunkText);
+            return normalizeKeywords(keywordExtractor.extract(chunkText));
         } catch (Exception ignored) {
             return List.of();
         }
@@ -304,7 +304,7 @@ public class RagPipelineService {
             return query;
         }
         try {
-            List<String> extracted = keywordExtractor.extract(query);
+            List<String> extracted = normalizeKeywords(keywordExtractor.extract(query));
             if (extracted == null || extracted.isEmpty()) {
                 return query;
             }

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
@@ -165,7 +165,7 @@ class RagPipelineServiceTest {
                 .thenReturn(List.of(new TextChunk("doc-kw-0", "hello world")));
         when(embeddingPort.embed(any(EmbeddingRequest.class)))
                 .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("doc-kw-0", List.of(0.1, 0.2, 0.3)))));
-        when(keywordExtractor.extract("hello world")).thenReturn(List.of(" hello ", "HELLO", "world", " "));
+        when(keywordExtractor.extract("hello world")).thenReturn(List.of("hello", "world"));
 
         ragPipelineService.index(request);
 
@@ -197,7 +197,7 @@ class RagPipelineServiceTest {
                         new TextChunk("doc-chunk-1", "beta")));
         when(embeddingPort.embed(any(EmbeddingRequest.class)))
                 .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("chunk", List.of(0.1, 0.2)))));
-        when(keywordExtractor.extract("alpha")).thenReturn(List.of(" Alpha ", "alpha", "first"));
+        when(keywordExtractor.extract("alpha")).thenReturn(List.of("Alpha", "first"));
         when(keywordExtractor.extract("beta")).thenReturn(List.of("Beta", "second"));
 
         ragPipelineService.index(request);
@@ -215,6 +215,38 @@ class RagPipelineServiceTest {
                 .containsEntry("chunkKeywords", List.of("Beta", "second"))
                 .containsEntry("chunkKeywordsText", "Beta second")
                 .doesNotContainKeys("keywords", "keywordsText");
+    }
+
+    @Test
+    void shouldIgnoreCallerKeywordsWhenScopeIsChunk() {
+        ragPipelineService = new RagPipelineService(
+                embeddingPort,
+                vectorStorePort,
+                textChunker,
+                cache,
+                retry,
+                keywordExtractor,
+                null,
+                RagPipelineOptions.defaults(),
+                RagPipelineDiagnosticsOptions.defaults(),
+                new RagKeywordOptions(RagKeywordOptions.KeywordScope.CHUNK, 4_000, true, 10));
+        RagIndexRequest request = new RagIndexRequest(
+                "doc-manual-chunk",
+                "alpha beta",
+                Map.of(),
+                List.of("manual1", "manual2"),
+                false);
+        when(textChunker.chunk("doc-manual-chunk", "alpha beta"))
+                .thenReturn(List.of(new TextChunk("doc-manual-chunk-0", "alpha beta")));
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("chunk", List.of(0.1, 0.2)))));
+
+        ragPipelineService.index(request);
+
+        verify(keywordExtractor, never()).extract(anyString());
+        verify(vectorStorePort).upsert(documentsCaptor.capture());
+        assertThat(documentsCaptor.getValue().get(0).metadata())
+                .doesNotContainKeys("keywords", "keywordsText", "chunkKeywords", "chunkKeywordsText");
     }
 
     @Test
@@ -509,6 +541,13 @@ class RagPipelineServiceTest {
 
         assertThat(results).hasSize(1);
         verify(vectorStorePort).hybridSearch(eq("hello alpha beta"), any(VectorSearchRequest.class), anyDouble(), anyDouble());
+    }
+
+    @Test
+    void shouldRejectInvalidKeywordScopeWithValidValuesMessage() {
+        assertThatThrownBy(() -> RagKeywordOptions.KeywordScope.from("document-scope"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Valid values are: DOCUMENT, CHUNK, BOTH");
     }
 
     @Test

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
@@ -165,7 +165,7 @@ class RagPipelineServiceTest {
                 .thenReturn(List.of(new TextChunk("doc-kw-0", "hello world")));
         when(embeddingPort.embed(any(EmbeddingRequest.class)))
                 .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("doc-kw-0", List.of(0.1, 0.2, 0.3)))));
-        when(keywordExtractor.extract("hello world")).thenReturn(List.of("hello", "world"));
+        when(keywordExtractor.extract("hello world")).thenReturn(List.of(" hello ", "HELLO", "world", " "));
 
         ragPipelineService.index(request);
 
@@ -541,6 +541,35 @@ class RagPipelineServiceTest {
 
         assertThat(results).hasSize(1);
         verify(vectorStorePort).hybridSearch(eq("hello alpha beta"), any(VectorSearchRequest.class), anyDouble(), anyDouble());
+    }
+
+    @Test
+    void shouldNormalizeExtractorKeywordsForQueryExpansion() {
+        ragPipelineService = new RagPipelineService(
+                embeddingPort,
+                vectorStorePort,
+                textChunker,
+                cache,
+                retry,
+                keywordExtractor,
+                null,
+                RagPipelineOptions.defaults(),
+                RagPipelineDiagnosticsOptions.defaults(),
+                new RagKeywordOptions(RagKeywordOptions.KeywordScope.DOCUMENT, 4_000, true, 2));
+        RagSearchRequest request = new RagSearchRequest("hello", 2);
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("hello", List.of(0.5, 0.6)))));
+        when(keywordExtractor.extract("hello")).thenReturn(List.of(" hello ", " Alpha ", "alpha", " beta "));
+        when(vectorStorePort.hybridSearch(eq("hello"), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of());
+        when(vectorStorePort.hybridSearch(eq("hello Alpha beta"), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-expanded", "expanded", Map.of(), List.of(0.5, 0.6)), 0.9)));
+
+        List<RagSearchResult> results = ragPipelineService.search(request);
+
+        assertThat(results).hasSize(1);
+        verify(vectorStorePort).hybridSearch(eq("hello Alpha beta"), any(VectorSearchRequest.class), anyDouble(), anyDouble());
     }
 
     @Test


### PR DESCRIPTION
## Why

PR #211 병합 후 리뷰 대응 후속 커밋(`80f0cd2`)이 `2.x`에 포함되지 않은 것을 확인했습니다. 해당 커밋은 keyword 설정/문서 동작 명확화와 작은 코드 정리를 포함하므로 별도 후속 PR로 반영합니다.

## What

- `studio.ai.vector.postgres.text-search-config`는 현재 SQL에 적용되지 않는 향후 PostgreSQL FTS 설정 후보임을 문서화했습니다.
- `keywords.scope=chunk`에서 caller-provided `RagIndexRequest.keywords`가 저장되지 않는 동작을 문서화했습니다.
- `query-expansion.enabled`는 `keyword-fallback-enabled=true`일 때만 효과가 있음을 문서화했습니다.
- `RagPipelineService`의 extractor 반환값 중복 normalize를 제거했습니다.
- `KeywordScope.from()`의 오류 메시지를 유효값 중심으로 명확히 했습니다.
- 관련 회귀 테스트를 추가했습니다.

## Related Issues

- Related #206

## Validation

- Command: `gradle :studio-platform-ai:test :starter:studio-platform-starter-ai:test --rerun-tasks`
- Result: PASS
- Command: `git diff --check`
- Result: PASS

## Risk / Rollback

- Risk: 낮음. PR #211 리뷰 대응 후속이며 SQL/DB migration은 변경하지 않습니다.
- Rollback: Revert this PR.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope:
- Main author validation: commands listed above

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included
