### PR TITLE
fix(ai-web): map provider quota errors to 429

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2026-04-16
 
 ### 변경됨
+- 이슈 #213 대응으로 AI web endpoint에서 provider quota/rate limit 예외를 500 대신 429 `ProblemDetails`로 반환하도록 했다.
 - 이슈 #206 대응으로 `studio.ai.pipeline.keywords.scope`, `max-input-chars`와 `studio.ai.pipeline.retrieval.query-expansion.*` 설정을 추가해 keyword metadata 범위와 query expansion 동작을 조정할 수 있도록 했다.
 - 기본 `keywords.scope=document`는 기존 문서 단위 `keywords`/`keywordsText` 동작을 유지하고, `chunk` 또는 `both` 설정 시 chunk metadata에 `chunkKeywords`/`chunkKeywordsText`를 추가한다.
 - `LlmKeywordExtractor`의 입력 최대 길이 4000자 제한을 설정으로 이동하고, keyword trim/blank 제거/case-insensitive de-duplication을 적용했다.
@@ -24,6 +25,7 @@
 - 이 작업은 PR #207의 RAG 설정화 변경과 통합 검증되도록 `2.x` 최신으로 rebase했다.
 
 ### 검증
+- `./gradlew :starter:studio-platform-starter-ai-web:test`
 - `gradle :studio-platform-ai:test`
 - `gradle :starter:studio-platform-starter-ai:test`
 - `gradle :studio-platform-ai:test :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test --rerun-tasks`

--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -208,12 +208,14 @@ Content-Type: application/json
 | `RagController` | RAG 인덱싱 및 검색 엔드포인트 |
 | `QueryRewriteController` | 쿼리 리라이트 엔드포인트 |
 | `AiInfoController` | AI 정보 조회 엔드포인트 (`endpoints.enabled=true` 필요) |
+| `AiWebExceptionHandler` | AI web endpoint의 `ProblemDetails` 오류 매핑 |
 
 ## 5) 참고 사항
 
 - `VectorController`는 `VectorStorePort` 빈이 없어도 등록되지만, 벡터 관련 요청 시 HTTP 503을 반환한다.
 - 벡터 검색 시 `hybrid=true`를 설정하면 BM25 + 벡터 하이브리드 검색이 활성화된다(query 텍스트 필수).
 - 채팅 API의 `provider`는 Studio provider id 선택만 담당한다. OpenAI 런타임 설정은 계속 `spring.ai.openai.*`가 소유한다.
+- Google GenAI 등 provider quota/rate limit 오류는 AI web exception handler가 HTTP 429 `ProblemDetails`로 변환한다.
 - `query-rewrite` 엔드포인트는 Mustache 템플릿(`query-rewrite`)이 없으면 내장 폴백 프롬프트를 사용한다.
 - 모든 엔드포인트는 Spring Security의 메서드 레벨 권한 검사(`@PreAuthorize`)를 사용한다.
   `endpointAuthz` 빈이 컨텍스트에 등록되어 있어야 한다.

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
@@ -15,6 +15,7 @@ import studio.one.platform.ai.core.registry.AiProviderRegistry;
 import studio.one.platform.ai.core.vector.VectorStorePort;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
 import studio.one.platform.ai.service.prompt.PromptRenderer;
+import studio.one.platform.ai.web.controller.AiWebExceptionHandler;
 import studio.one.platform.ai.web.controller.AiInfoController;
 import studio.one.platform.ai.web.controller.ChatController;
 import studio.one.platform.ai.web.controller.EmbeddingController;
@@ -43,6 +44,11 @@ public class AiWebAutoConfiguration {
             AiWebRagProperties properties) {
         return new ChatController(providerRegistry, ragPipelineService, ragContextBuilder,
                 properties.getDiagnostics().isAllowClientDebug());
+    }
+
+    @Bean
+    AiWebExceptionHandler aiWebExceptionHandler() {
+        return new AiWebExceptionHandler();
     }
 
     @Bean

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/AiWebExceptionHandler.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/AiWebExceptionHandler.java
@@ -50,11 +50,12 @@ public class AiWebExceptionHandler {
             RuntimeException ex,
             HttpServletRequest request) {
         if (isGoogleGenAiQuotaExceeded(ex)) {
-            log.warn("AI provider quota exceeded: {}", safeMessage(rootCause(ex)));
+            log.warn("AI provider quota exceeded. provider={}", rootCause(ex).getClass().getSimpleName());
             return problem(HttpStatus.TOO_MANY_REQUESTS,
                     "AI provider quota exceeded. Please retry later or check provider quota.",
                     request);
         }
+        // Keep non-AI-provider runtime failures on the application's existing global exception path.
         throw ex;
     }
 
@@ -83,10 +84,7 @@ public class AiWebExceptionHandler {
     }
 
     private boolean isGoogleGenAiClientException(Throwable ex) {
-        String className = ex.getClass().getName();
-        return GOOGLE_GENAI_CLIENT_EXCEPTION.equals(className)
-                || className.endsWith(".GoogleGenAiClientException")
-                || className.endsWith("$GoogleGenAiClientException");
+        return GOOGLE_GENAI_CLIENT_EXCEPTION.equals(ex.getClass().getName());
     }
 
     private boolean containsQuotaSignal(String message) {
@@ -94,7 +92,11 @@ public class AiWebExceptionHandler {
             return false;
         }
         String lower = message.toLowerCase(java.util.Locale.ROOT);
-        return lower.contains("429") && (lower.contains("quota") || lower.contains("rate"));
+        return lower.contains("quota")
+                || lower.contains("rate limit")
+                || lower.contains("resource_exhausted")
+                || lower.contains("too_many_requests")
+                || (lower.contains("429") && lower.contains("rate"));
     }
 
     private Throwable rootCause(Throwable ex) {
@@ -105,11 +107,4 @@ public class AiWebExceptionHandler {
         return current;
     }
 
-    private String safeMessage(Throwable ex) {
-        String message = ex == null ? null : ex.getMessage();
-        if (message == null || message.isBlank()) {
-            return "quota exceeded";
-        }
-        return message.replaceAll("(?i)(api[_-]?key|token|authorization)[^,\\s]*", "$1=<redacted>");
-    }
 }

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/AiWebExceptionHandler.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/AiWebExceptionHandler.java
@@ -1,0 +1,115 @@
+package studio.one.platform.ai.web.controller;
+
+import java.time.OffsetDateTime;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
+
+import studio.one.platform.web.dto.ProblemDetails;
+
+@RestControllerAdvice(assignableTypes = {
+        ChatController.class,
+        EmbeddingController.class,
+        VectorController.class,
+        RagController.class,
+        QueryRewriteController.class,
+        AiInfoController.class
+})
+@Slf4j
+public class AiWebExceptionHandler {
+
+    private static final String GOOGLE_GENAI_CLIENT_EXCEPTION = "com.google.genai.errors.ClientException";
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<ProblemDetails> handleResponseStatusException(
+            ResponseStatusException ex,
+            HttpServletRequest request) {
+        HttpStatus status = HttpStatus.resolve(ex.getStatusCode().value());
+        if (status == null) {
+            status = HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+        ProblemDetails body = ProblemDetails.builder()
+                .type("about:blank")
+                .title(status.getReasonPhrase())
+                .status(status.value())
+                .detail(ex.getReason())
+                .instance(request.getRequestURI())
+                .timestamp(OffsetDateTime.now())
+                .build();
+        return ResponseEntity.status(ex.getStatusCode()).body(body);
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ProblemDetails> handleRuntimeException(
+            RuntimeException ex,
+            HttpServletRequest request) {
+        if (isGoogleGenAiQuotaExceeded(ex)) {
+            log.warn("AI provider quota exceeded: {}", safeMessage(rootCause(ex)));
+            return problem(HttpStatus.TOO_MANY_REQUESTS,
+                    "AI provider quota exceeded. Please retry later or check provider quota.",
+                    request);
+        }
+        throw ex;
+    }
+
+    private ResponseEntity<ProblemDetails> problem(HttpStatus status, String detail, HttpServletRequest request) {
+        ProblemDetails body = ProblemDetails.builder()
+                .type("about:blank")
+                .title(status.getReasonPhrase())
+                .status(status.value())
+                .detail(detail)
+                .instance(request.getRequestURI())
+                .timestamp(OffsetDateTime.now())
+                .build();
+        return ResponseEntity.status(status).body(body);
+    }
+
+    private boolean isGoogleGenAiQuotaExceeded(Throwable ex) {
+        Throwable current = ex;
+        while (current != null) {
+            if (isGoogleGenAiClientException(current)
+                    && containsQuotaSignal(current.getMessage())) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private boolean isGoogleGenAiClientException(Throwable ex) {
+        String className = ex.getClass().getName();
+        return GOOGLE_GENAI_CLIENT_EXCEPTION.equals(className)
+                || className.endsWith(".GoogleGenAiClientException")
+                || className.endsWith("$GoogleGenAiClientException");
+    }
+
+    private boolean containsQuotaSignal(String message) {
+        if (message == null) {
+            return false;
+        }
+        String lower = message.toLowerCase(java.util.Locale.ROOT);
+        return lower.contains("429") && (lower.contains("quota") || lower.contains("rate"));
+    }
+
+    private Throwable rootCause(Throwable ex) {
+        Throwable current = ex;
+        while (current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current;
+    }
+
+    private String safeMessage(Throwable ex) {
+        String message = ex == null ? null : ex.getMessage();
+        if (message == null || message.isBlank()) {
+            return "quota exceeded";
+        }
+        return message.replaceAll("(?i)(api[_-]?key|token|authorization)[^,\\s]*", "$1=<redacted>");
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/test/java/com/google/genai/errors/ClientException.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/com/google/genai/errors/ClientException.java
@@ -1,0 +1,11 @@
+package com.google.genai.errors;
+
+/**
+ * Test stub for class-name based Google GenAI ClientException detection.
+ */
+public final class ClientException extends RuntimeException {
+
+    public ClientException(String message) {
+        super(message);
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/AiWebExceptionHandlerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/AiWebExceptionHandlerTest.java
@@ -1,0 +1,65 @@
+package studio.one.platform.ai.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+class AiWebExceptionHandlerTest {
+
+    @Test
+    void mapsResponseStatusExceptionToProblemDetailsStatus() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn("/api/ai/chat");
+
+        var response = new AiWebExceptionHandler().handleResponseStatusException(
+                new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unknown AI provider: missing"),
+                request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(response.getBody().getDetail()).isEqualTo("Unknown AI provider: missing");
+        assertThat(response.getBody().getInstance()).isEqualTo("/api/ai/chat");
+    }
+
+    @Test
+    void mapsGoogleGenAiQuotaExceptionToTooManyRequests() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn("/api/ai/chat");
+
+        RuntimeException ex = new RuntimeException("Failed to generate content",
+                new GoogleGenAiClientException("429 quota exceeded for generate_content_free_tier_requests"));
+
+        var response = new AiWebExceptionHandler().handleRuntimeException(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS.value());
+        assertThat(response.getBody().getDetail()).isEqualTo(
+                "AI provider quota exceeded. Please retry later or check provider quota.");
+        assertThat(response.getBody().getInstance()).isEqualTo("/api/ai/chat");
+    }
+
+    @Test
+    void rethrowsUnknownRuntimeException() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn("/api/ai/chat");
+        RuntimeException ex = new RuntimeException("unexpected");
+
+        org.junit.jupiter.api.Assertions.assertSame(ex,
+                org.junit.jupiter.api.Assertions.assertThrows(RuntimeException.class,
+                        () -> new AiWebExceptionHandler().handleRuntimeException(ex, request)));
+    }
+
+    private static final class GoogleGenAiClientException extends RuntimeException {
+        private GoogleGenAiClientException(String message) {
+            super(message);
+        }
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/AiWebExceptionHandlerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/AiWebExceptionHandlerTest.java
@@ -34,7 +34,8 @@ class AiWebExceptionHandlerTest {
         when(request.getRequestURI()).thenReturn("/api/ai/chat");
 
         RuntimeException ex = new RuntimeException("Failed to generate content",
-                new GoogleGenAiClientException("429 quota exceeded for generate_content_free_tier_requests"));
+                new com.google.genai.errors.ClientException(
+                        "RESOURCE_EXHAUSTED: Quota exceeded for generate_content_free_tier_requests"));
 
         var response = new AiWebExceptionHandler().handleRuntimeException(ex, request);
 
@@ -44,6 +45,18 @@ class AiWebExceptionHandlerTest {
         assertThat(response.getBody().getDetail()).isEqualTo(
                 "AI provider quota exceeded. Please retry later or check provider quota.");
         assertThat(response.getBody().getInstance()).isEqualTo("/api/ai/chat");
+    }
+
+    @Test
+    void rethrowsQuotaMessageFromUnexpectedExceptionClass() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn("/api/ai/chat");
+        RuntimeException ex = new RuntimeException("Failed to generate content",
+                new RuntimeException("RESOURCE_EXHAUSTED: Quota exceeded"));
+
+        org.junit.jupiter.api.Assertions.assertSame(ex,
+                org.junit.jupiter.api.Assertions.assertThrows(RuntimeException.class,
+                        () -> new AiWebExceptionHandler().handleRuntimeException(ex, request)));
     }
 
     @Test
@@ -57,9 +70,4 @@ class AiWebExceptionHandlerTest {
                         () -> new AiWebExceptionHandler().handleRuntimeException(ex, request)));
     }
 
-    private static final class GoogleGenAiClientException extends RuntimeException {
-        private GoogleGenAiClientException(String message) {
-            super(message);
-        }
-    }
 }


### PR DESCRIPTION
## Why

Google GenAI quota/rate limit 오류가 `RuntimeException: Failed to generate content`로 전파되어 AI web API에서 500으로 반환되었습니다. 클라이언트가 provider quota 문제를 서버 내부 오류로 오해하지 않도록 429 응답으로 매핑합니다.

## What

- AI web controller 전용 `AiWebExceptionHandler`를 추가했습니다.
- `ResponseStatusException`을 `ProblemDetails`로 매핑합니다.
- Google GenAI quota/rate limit cause chain을 감지해 HTTP 429 `ProblemDetails`로 반환합니다.
- provider 내부 stack trace나 민감 정보는 응답에 노출하지 않습니다.
- AI web auto-configuration에 handler bean을 등록했습니다.
- 관련 테스트를 추가했습니다.

## Related Issues

- Closes #213

## Validation

- Command: `./gradlew :starter:studio-platform-starter-ai-web:test`
- Result: PASS
- Command: `git diff --check`
- Result: PASS

## Risk / Rollback

- Risk: 낮음. AI web controller advice 범위에만 적용되며 알 수 없는 runtime exception은 기존 global handler로 전파됩니다.
- Rollback: Revert this PR.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope:
- Main author validation: commands listed above

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
