### PR TITLE
[codex] chat memory 옵션 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-04-17
+
+### 변경됨
+- `POST /api/ai/chat`와 `POST /api/ai/chat/rag`에 요청 단위 opt-in chat memory를 추가했다.
+- 기본 동작은 stateless로 유지하고, `studio.ai.endpoints.chat.memory.enabled=true`와 요청 `memory.enabled=true`가 모두 설정된 경우에만 `conversationId`별 최근 메시지를 in-memory로 보관한다.
+- chat memory는 `max-messages`, `max-conversations`, `ttl` 상한을 적용하며, 재시작 시 소실되고 다중 인스턴스 간 공유되지 않는 제약을 README에 문서화했다.
+- 응답 metadata에 memory 사용 여부와 conversation 상태를 노출하도록 했다.
+
+### 검증
+- `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-ai-web:test`
+
 ## 2026-04-16
 
 ### 변경됨

--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -97,6 +97,49 @@ Content-Type: application/json
 `provider`를 생략하면 `studio.ai.default-provider`가 사용된다. `systemPrompt`가 있으면
 서버가 첫 system message로 변환해 provider에 전달한다.
 
+기본 chat endpoint는 이전 대화를 서버에 저장하지 않는다. 요청에서 memory를 명시적으로 켜고,
+서버 설정도 활성화된 경우에만 `conversationId` 기준으로 최근 대화 메시지를 in-memory에 보관한다.
+memory 사용 시 클라이언트는 같은 `conversationId`와 새 턴 메시지만 보내야 한다.
+
+```yaml
+studio:
+  ai:
+    endpoints:
+      chat:
+        memory:
+          enabled: false
+          max-messages: 20
+          max-conversations: 1000
+          ttl: 30m
+```
+
+```http
+POST /api/ai/chat
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "provider": "openai",
+  "messages": [
+    {"role": "user", "content": "방금 이야기한 내용을 이어서 설명해줘"}
+  ],
+  "memory": {
+    "enabled": true,
+    "conversationId": "chat-123"
+  }
+}
+```
+
+| 설정 | 기본값 | 설명 |
+|---|---:|---|
+| `studio.ai.endpoints.chat.memory.enabled` | `false` | chat memory 요청 허용 여부 |
+| `studio.ai.endpoints.chat.memory.max-messages` | `20` | conversation별 보관할 최근 메시지 수 |
+| `studio.ai.endpoints.chat.memory.max-conversations` | `1000` | 인스턴스 메모리에 보관할 최대 conversation 수 |
+| `studio.ai.endpoints.chat.memory.ttl` | `30m` | 마지막 접근 이후 conversation 보관 시간 |
+
+이 memory는 단일 앱 인스턴스의 in-memory cache다. 애플리케이션 재시작 시 사라지며, 다중 인스턴스 간 공유되지 않는다.
+장기 보관, 감사 로그, conversation 목록 조회, 삭제 API 용도로 사용하지 않는다.
+
 ### RAG Chat 예시
 
 ```http

--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -100,6 +100,9 @@ Content-Type: application/json
 기본 chat endpoint는 이전 대화를 서버에 저장하지 않는다. 요청에서 memory를 명시적으로 켜고,
 서버 설정도 활성화된 경우에만 `conversationId` 기준으로 최근 대화 메시지를 in-memory에 보관한다.
 memory 사용 시 클라이언트는 같은 `conversationId`와 새 턴 메시지만 보내야 한다.
+이전 대화 전체를 `messages`에 다시 포함하면 서버 memory에 같은 턴이 중복 저장될 수 있다.
+서버는 인증된 사용자 식별자와 `conversationId`를 합성한 내부 key로 저장해 사용자 간
+동일한 `conversationId`가 충돌하지 않도록 분리한다.
 
 ```yaml
 studio:
@@ -138,6 +141,7 @@ Content-Type: application/json
 | `studio.ai.endpoints.chat.memory.ttl` | `30m` | 마지막 접근 이후 conversation 보관 시간 |
 
 이 memory는 단일 앱 인스턴스의 in-memory cache다. 애플리케이션 재시작 시 사라지며, 다중 인스턴스 간 공유되지 않는다.
+운영에서 여러 인스턴스 간 대화 memory가 필요하면 `ChatMemoryStore`를 외부 저장소 기반 구현으로 교체한다.
 장기 보관, 감사 로그, conversation 목록 조회, 삭제 API 용도로 사용하지 않는다.
 
 ### RAG Chat 예시

--- a/starter/studio-platform-starter-ai-web/build.gradle.kts
+++ b/starter/studio-platform-starter-ai-web/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     compileOnly("org.springframework.boot:spring-boot-starter-validation")
     compileOnly("org.springframework.boot:spring-boot-starter-security")
     compileOnly("com.fasterxml.jackson.core:jackson-databind")
+    implementation("com.github.ben-manes.caffeine:caffeine:${property("caffeineVersion")}")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.mockito:mockito-core")

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
@@ -22,11 +22,11 @@ import studio.one.platform.ai.web.controller.AiWebExceptionHandler;
 import studio.one.platform.ai.web.controller.AiInfoController;
 import studio.one.platform.ai.web.controller.ChatController;
 import studio.one.platform.ai.web.controller.EmbeddingController;
-import studio.one.platform.ai.web.controller.InMemoryChatMemoryStore;
 import studio.one.platform.ai.web.controller.QueryRewriteController;
 import studio.one.platform.ai.web.controller.RagController;
 import studio.one.platform.ai.web.controller.RagContextBuilder;
 import studio.one.platform.ai.web.controller.VectorController;
+import studio.one.platform.ai.web.service.InMemoryChatMemoryStore;
 import studio.one.platform.constant.PropertyKeys;
 
 @Configuration(proxyBeanMethods = false)

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
@@ -1,6 +1,8 @@
 package studio.one.platform.ai.autoconfigure;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Bean;
@@ -9,6 +11,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.lang.Nullable;
 
 import studio.one.platform.ai.autoconfigure.config.AiAdapterProperties;
+import studio.one.platform.ai.core.chat.ChatMemoryStore;
 import studio.one.platform.ai.core.chat.ChatPort;
 import studio.one.platform.ai.core.embedding.EmbeddingPort;
 import studio.one.platform.ai.core.registry.AiProviderRegistry;
@@ -19,6 +22,7 @@ import studio.one.platform.ai.web.controller.AiWebExceptionHandler;
 import studio.one.platform.ai.web.controller.AiInfoController;
 import studio.one.platform.ai.web.controller.ChatController;
 import studio.one.platform.ai.web.controller.EmbeddingController;
+import studio.one.platform.ai.web.controller.InMemoryChatMemoryStore;
 import studio.one.platform.ai.web.controller.QueryRewriteController;
 import studio.one.platform.ai.web.controller.RagController;
 import studio.one.platform.ai.web.controller.RagContextBuilder;
@@ -28,7 +32,7 @@ import studio.one.platform.constant.PropertyKeys;
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(ChatPort.class)
 @Conditional(AiWebEndpointCondition.class)
-@EnableConfigurationProperties(AiWebRagProperties.class)
+@EnableConfigurationProperties({AiWebRagProperties.class, AiWebChatProperties.class})
 public class AiWebAutoConfiguration {
 
     @Bean
@@ -37,13 +41,24 @@ public class AiWebAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean(ChatMemoryStore.class)
+    @ConditionalOnProperty(prefix = PropertyKeys.AI.Endpoints.PREFIX + ".chat.memory", name = "enabled", havingValue = "true")
+    ChatMemoryStore chatMemoryStore(AiWebChatProperties properties) {
+        return new InMemoryChatMemoryStore(properties.getMemory());
+    }
+
+    @Bean
     ChatController chatController(
             AiProviderRegistry providerRegistry,
             RagPipelineService ragPipelineService,
             RagContextBuilder ragContextBuilder,
-            AiWebRagProperties properties) {
+            AiWebRagProperties ragProperties,
+            AiWebChatProperties chatProperties,
+            @Nullable ChatMemoryStore chatMemoryStore) {
         return new ChatController(providerRegistry, ragPipelineService, ragContextBuilder,
-                properties.getDiagnostics().isAllowClientDebug());
+                ragProperties.getDiagnostics().isAllowClientDebug(),
+                chatMemoryStore,
+                chatProperties.getMemory().isEnabled());
     }
 
     @Bean

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebChatProperties.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebChatProperties.java
@@ -1,0 +1,56 @@
+package studio.one.platform.ai.autoconfigure;
+
+import java.time.Duration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import studio.one.platform.constant.PropertyKeys;
+
+@ConfigurationProperties(prefix = PropertyKeys.AI.Endpoints.PREFIX + ".chat")
+public class AiWebChatProperties {
+
+    private final MemoryProperties memory = new MemoryProperties();
+
+    public MemoryProperties getMemory() {
+        return memory;
+    }
+
+    public static class MemoryProperties {
+        private boolean enabled = false;
+        private int maxMessages = 20;
+        private long maxConversations = 1_000;
+        private Duration ttl = Duration.ofMinutes(30);
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public int getMaxMessages() {
+            return maxMessages;
+        }
+
+        public void setMaxMessages(int maxMessages) {
+            this.maxMessages = maxMessages;
+        }
+
+        public long getMaxConversations() {
+            return maxConversations;
+        }
+
+        public void setMaxConversations(long maxConversations) {
+            this.maxConversations = maxConversations;
+        }
+
+        public Duration getTtl() {
+            return ttl;
+        }
+
+        public void setTtl(Duration ttl) {
+            this.ttl = ttl;
+        }
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebChatProperties.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebChatProperties.java
@@ -34,6 +34,9 @@ public class AiWebChatProperties {
         }
 
         public void setMaxMessages(int maxMessages) {
+            if (maxMessages <= 0) {
+                throw new IllegalArgumentException("maxMessages must be greater than 0");
+            }
             this.maxMessages = maxMessages;
         }
 
@@ -42,6 +45,9 @@ public class AiWebChatProperties {
         }
 
         public void setMaxConversations(long maxConversations) {
+            if (maxConversations <= 0) {
+                throw new IllegalArgumentException("maxConversations must be greater than 0");
+            }
             this.maxConversations = maxConversations;
         }
 
@@ -50,6 +56,9 @@ public class AiWebChatProperties {
         }
 
         public void setTtl(Duration ttl) {
+            if (ttl == null || ttl.isNegative() || ttl.isZero()) {
+                throw new IllegalArgumentException("ttl must be greater than 0");
+            }
             this.ttl = ttl;
         }
     }

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.security.Principal;
 
 import jakarta.validation.Valid;
 
@@ -147,8 +148,18 @@ public class ChatController {
      */
     @PostMapping
     @PreAuthorize("@endpointAuthz.can('services:ai_chat','write')")
-    public ResponseEntity<ApiResponse<ChatResponseDto>> chat(@Valid @RequestBody ChatRequestDto request) {
-        ChatMemoryContext memory = resolveMemory(request);
+    public ResponseEntity<ApiResponse<ChatResponseDto>> chat(
+            @Valid @RequestBody ChatRequestDto request,
+            Principal principal) {
+        return chatInternal(request, principal);
+    }
+
+    ResponseEntity<ApiResponse<ChatResponseDto>> chat(ChatRequestDto request) {
+        return chatInternal(request, null);
+    }
+
+    private ResponseEntity<ApiResponse<ChatResponseDto>> chatInternal(ChatRequestDto request, Principal principal) {
+        ChatMemoryContext memory = resolveMemory(request, principal);
         ChatResponse response = chatPort(request.provider()).chat(toDomainChatRequest(request, toDomainMessages(request, memory.history())));
         int memoryMessageCount = appendMemory(memory, request.messages(), response);
         return ResponseEntity.ok(ApiResponse.ok(toDto(response, null, false, memoryMetadata(memory, memoryMessageCount))));
@@ -161,7 +172,19 @@ public class ChatController {
     @PreAuthorize("@endpointAuthz.can('services:ai_chat','write') and "
             + "(#request.objectType() == null or !#request.objectType().trim().equalsIgnoreCase('attachment') "
             + "or @endpointAuthz.can('features:attachment','read'))")
-    public ResponseEntity<ApiResponse<ChatResponseDto>> chatWithRag(@Valid @RequestBody ChatRagRequestDto request) {
+    public ResponseEntity<ApiResponse<ChatResponseDto>> chatWithRag(
+            @Valid @RequestBody ChatRagRequestDto request,
+            Principal principal) {
+        return chatWithRagInternal(request, principal);
+    }
+
+    ResponseEntity<ApiResponse<ChatResponseDto>> chatWithRag(ChatRagRequestDto request) {
+        return chatWithRagInternal(request, null);
+    }
+
+    private ResponseEntity<ApiResponse<ChatResponseDto>> chatWithRagInternal(
+            ChatRagRequestDto request,
+            Principal principal) {
         ChatRequestDto chat = request.chat();
         int ragTopK = request.ragTopK() != null ? request.ragTopK() : 3;
         ObjectScope objectScope = resolveObjectScope(request.objectType(), request.objectId());
@@ -195,7 +218,7 @@ public class ChatController {
         if (chat.systemPrompt() != null && !chat.systemPrompt().isBlank()) {
             augmentedMessages.add(new ChatMessageDto("system", chat.systemPrompt()));
         }
-        ChatMemoryContext memory = resolveMemory(chat);
+        ChatMemoryContext memory = resolveMemory(chat, principal);
         augmentedMessages.addAll(toDtoMessages(memory.history()));
         augmentedMessages.addAll(chat.messages());
 
@@ -312,10 +335,6 @@ public class ChatController {
         return new ChatMessage(role, dto.content());
     }
 
-    private ChatResponseDto toDto(ChatResponse response) {
-        return toDto(response, null, false, Map.of("memoryEnabled", false));
-    }
-
     private ChatResponseDto toDto(
             ChatResponse response,
             RagRetrievalDiagnostics diagnostics,
@@ -350,21 +369,22 @@ public class ChatController {
         throw new IllegalArgumentException("RAG query is empty");
     }
 
-    private ChatMemoryContext resolveMemory(ChatRequestDto request) {
+    private ChatMemoryContext resolveMemory(ChatRequestDto request, Principal principal) {
         ChatMemoryOptionsDto memory = request.memory();
         if (memory == null || !Boolean.TRUE.equals(memory.enabled())) {
             return ChatMemoryContext.disabled();
+        }
+        if (!chatMemoryEnabled || chatMemoryStore == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Chat memory is not enabled on this server");
         }
         String conversationId = normalizeText(memory.conversationId());
         if (conversationId == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
                     "conversationId is required when chat memory is enabled");
         }
-        if (!chatMemoryEnabled || chatMemoryStore == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-                    "Chat memory is not enabled on this server");
-        }
-        return new ChatMemoryContext(true, conversationId, chatMemoryStore.get(conversationId));
+        String scopedConversationId = currentPrincipalScope(principal) + ":" + conversationId;
+        return new ChatMemoryContext(true, conversationId, scopedConversationId, chatMemoryStore.get(scopedConversationId));
     }
 
     private int appendMemory(ChatMemoryContext memory, List<ChatMessageDto> requestMessages, ChatResponse response) {
@@ -379,7 +399,7 @@ public class ChatController {
         response.messages().stream()
                 .filter(message -> message.role() == ChatMessageRole.ASSISTANT)
                 .forEach(messagesToStore::add);
-        return chatMemoryStore.append(memory.conversationId(), messagesToStore);
+        return chatMemoryStore.append(memory.storageKey(), messagesToStore);
     }
 
     private Map<String, Object> memoryMetadata(ChatMemoryContext memory, int memoryMessageCount) {
@@ -403,10 +423,22 @@ public class ChatController {
         }
     }
 
-    private record ChatMemoryContext(boolean enabled, String conversationId, List<ChatMessage> history) {
+    private String currentPrincipalScope(Principal principal) {
+        if (principal != null) {
+            String name = normalizeText(principal.getName());
+            if (name != null) {
+                return "principal:" + name;
+            }
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Principal name is required when chat memory is enabled");
+        }
+        return "anonymous";
+    }
+
+    private record ChatMemoryContext(boolean enabled, String conversationId, String storageKey, List<ChatMessage> history) {
 
         static ChatMemoryContext disabled() {
-            return new ChatMemoryContext(false, null, List.of());
+            return new ChatMemoryContext(false, null, null, List.of());
         }
     }
 }

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
@@ -41,6 +41,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
 import studio.one.platform.ai.core.chat.ChatMessage;
+import studio.one.platform.ai.core.chat.ChatMemoryStore;
 import studio.one.platform.ai.core.chat.ChatMessageRole;
 import studio.one.platform.ai.core.chat.ChatPort;
 import studio.one.platform.ai.core.chat.ChatRequest;
@@ -50,6 +51,7 @@ import studio.one.platform.ai.core.rag.RagRetrievalDiagnostics;
 import studio.one.platform.ai.core.rag.RagSearchRequest;
 import studio.one.platform.ai.core.rag.RagSearchResult;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
+import studio.one.platform.ai.web.dto.ChatMemoryOptionsDto;
 import studio.one.platform.ai.web.dto.ChatMessageDto;
 import studio.one.platform.ai.web.dto.ChatRagRequestDto;
 import studio.one.platform.ai.web.dto.ChatRequestDto;
@@ -75,6 +77,8 @@ public class ChatController {
     private final RagPipelineService ragPipelineService;
     private final RagContextBuilder ragContextBuilder;
     private final boolean allowClientDebug;
+    private final ChatMemoryStore chatMemoryStore;
+    private final boolean chatMemoryEnabled;
 
     public ChatController(AiProviderRegistry providerRegistry, RagPipelineService ragPipelineService) {
         this(providerRegistry, ragPipelineService, RagContextBuilder.defaults());
@@ -92,10 +96,22 @@ public class ChatController {
             RagPipelineService ragPipelineService,
             RagContextBuilder ragContextBuilder,
             boolean allowClientDebug) {
+        this(providerRegistry, ragPipelineService, ragContextBuilder, allowClientDebug, null, false);
+    }
+
+    public ChatController(
+            AiProviderRegistry providerRegistry,
+            RagPipelineService ragPipelineService,
+            RagContextBuilder ragContextBuilder,
+            boolean allowClientDebug,
+            ChatMemoryStore chatMemoryStore,
+            boolean chatMemoryEnabled) {
         this.providerRegistry = Objects.requireNonNull(providerRegistry, "providerRegistry");
         this.ragPipelineService = Objects.requireNonNull(ragPipelineService, "ragPipelineService");
         this.ragContextBuilder = Objects.requireNonNull(ragContextBuilder, "ragContextBuilder");
         this.allowClientDebug = allowClientDebug;
+        this.chatMemoryStore = chatMemoryStore;
+        this.chatMemoryEnabled = chatMemoryEnabled;
     }
 
     /**
@@ -132,8 +148,10 @@ public class ChatController {
     @PostMapping
     @PreAuthorize("@endpointAuthz.can('services:ai_chat','write')")
     public ResponseEntity<ApiResponse<ChatResponseDto>> chat(@Valid @RequestBody ChatRequestDto request) {
-        ChatResponse response = chatPort(request.provider()).chat(toDomainChatRequest(request));
-        return ResponseEntity.ok(ApiResponse.ok(toDto(response)));
+        ChatMemoryContext memory = resolveMemory(request);
+        ChatResponse response = chatPort(request.provider()).chat(toDomainChatRequest(request, toDomainMessages(request, memory.history())));
+        int memoryMessageCount = appendMemory(memory, request.messages(), response);
+        return ResponseEntity.ok(ApiResponse.ok(toDto(response, null, false, memoryMetadata(memory, memoryMessageCount))));
     }
 
     /**
@@ -177,6 +195,8 @@ public class ChatController {
         if (chat.systemPrompt() != null && !chat.systemPrompt().isBlank()) {
             augmentedMessages.add(new ChatMessageDto("system", chat.systemPrompt()));
         }
+        ChatMemoryContext memory = resolveMemory(chat);
+        augmentedMessages.addAll(toDtoMessages(memory.history()));
         augmentedMessages.addAll(chat.messages());
 
         ChatRequestDto augmented = new ChatRequestDto(
@@ -188,14 +208,24 @@ public class ChatController {
                 chat.topP(),
                 chat.topK(),
                 chat.maxOutputTokens(),
-                chat.stopSequences());
+                chat.stopSequences(),
+                chat.memory());
 
         ChatResponse response = chatPort(chat.provider()).chat(toDomainChatRequest(augmented));
-        return ResponseEntity.ok(ApiResponse.ok(toDto(response, diagnostics, shouldExposeDiagnostics(request))));
+        int memoryMessageCount = appendMemory(memory, chat.messages(), response);
+        return ResponseEntity.ok(ApiResponse.ok(toDto(
+                response,
+                diagnostics,
+                shouldExposeDiagnostics(request),
+                memoryMetadata(memory, memoryMessageCount))));
     }
 
     private ChatRequest toDomainChatRequest(ChatRequestDto request) {
-        ChatRequest.Builder builder = ChatRequest.builder().messages(toDomainMessages(request));
+        return toDomainChatRequest(request, toDomainMessages(request));
+    }
+
+    private ChatRequest toDomainChatRequest(ChatRequestDto request, List<ChatMessage> messages) {
+        ChatRequest.Builder builder = ChatRequest.builder().messages(messages);
         if (request.model() != null) {
             builder.model(request.model());
         }
@@ -252,13 +282,28 @@ public class ChatController {
     }
 
     private List<ChatMessage> toDomainMessages(ChatRequestDto request) {
+        return toDomainMessages(request, List.of());
+    }
+
+    private List<ChatMessage> toDomainMessages(ChatRequestDto request, List<ChatMessage> history) {
         List<ChatMessageDto> messages = new ArrayList<>();
         if (request.systemPrompt() != null && !request.systemPrompt().isBlank()) {
             messages.add(new ChatMessageDto("system", request.systemPrompt()));
         }
-        messages.addAll(request.messages());
-        return messages.stream()
+        List<ChatMessage> domainMessages = new ArrayList<>();
+        domainMessages.addAll(messages.stream()
                 .map(this::toDomainMessage)
+                .toList());
+        domainMessages.addAll(history);
+        domainMessages.addAll(request.messages().stream()
+                .map(this::toDomainMessage)
+                .toList());
+        return domainMessages;
+    }
+
+    private List<ChatMessageDto> toDtoMessages(List<ChatMessage> messages) {
+        return messages.stream()
+                .map(message -> new ChatMessageDto(message.role().name().toLowerCase(Locale.ROOT), message.content()))
                 .toList();
     }
 
@@ -268,17 +313,19 @@ public class ChatController {
     }
 
     private ChatResponseDto toDto(ChatResponse response) {
-        return toDto(response, null, false);
+        return toDto(response, null, false, Map.of("memoryEnabled", false));
     }
 
     private ChatResponseDto toDto(
             ChatResponse response,
             RagRetrievalDiagnostics diagnostics,
-            boolean exposeDiagnostics) {
+            boolean exposeDiagnostics,
+            Map<String, Object> extraMetadata) {
         List<ChatMessageDto> messages = response.messages().stream()
                 .map(message -> new ChatMessageDto(message.role().name().toLowerCase(Locale.ROOT), message.content()))
                 .toList();
         Map<String, Object> metadata = new HashMap<>(response.metadata());
+        metadata.putAll(extraMetadata);
         if (exposeDiagnostics && diagnostics != null) {
             metadata.put("ragDiagnostics", diagnostics.toMetadata());
         }
@@ -303,6 +350,48 @@ public class ChatController {
         throw new IllegalArgumentException("RAG query is empty");
     }
 
+    private ChatMemoryContext resolveMemory(ChatRequestDto request) {
+        ChatMemoryOptionsDto memory = request.memory();
+        if (memory == null || !Boolean.TRUE.equals(memory.enabled())) {
+            return ChatMemoryContext.disabled();
+        }
+        String conversationId = normalizeText(memory.conversationId());
+        if (conversationId == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "conversationId is required when chat memory is enabled");
+        }
+        if (!chatMemoryEnabled || chatMemoryStore == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Chat memory is not enabled on this server");
+        }
+        return new ChatMemoryContext(true, conversationId, chatMemoryStore.get(conversationId));
+    }
+
+    private int appendMemory(ChatMemoryContext memory, List<ChatMessageDto> requestMessages, ChatResponse response) {
+        if (!memory.enabled()) {
+            return 0;
+        }
+        List<ChatMessage> messagesToStore = new ArrayList<>();
+        requestMessages.stream()
+                .map(this::toDomainMessage)
+                .filter(message -> message.role() != ChatMessageRole.SYSTEM)
+                .forEach(messagesToStore::add);
+        response.messages().stream()
+                .filter(message -> message.role() == ChatMessageRole.ASSISTANT)
+                .forEach(messagesToStore::add);
+        return chatMemoryStore.append(memory.conversationId(), messagesToStore);
+    }
+
+    private Map<String, Object> memoryMetadata(ChatMemoryContext memory, int memoryMessageCount) {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("memoryEnabled", memory.enabled());
+        if (memory.enabled()) {
+            metadata.put("conversationId", memory.conversationId());
+            metadata.put("memoryMessageCount", memoryMessageCount);
+        }
+        return metadata;
+    }
+
     private record ObjectScope(String objectType, String objectId) {
 
         static ObjectScope none() {
@@ -311,6 +400,13 @@ public class ChatController {
 
         boolean hasFilter() {
             return objectType != null || objectId != null;
+        }
+    }
+
+    private record ChatMemoryContext(boolean enabled, String conversationId, List<ChatMessage> history) {
+
+        static ChatMemoryContext disabled() {
+            return new ChatMemoryContext(false, null, List.of());
         }
     }
 }

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/InMemoryChatMemoryStore.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/InMemoryChatMemoryStore.java
@@ -1,0 +1,61 @@
+package studio.one.platform.ai.web.controller;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import studio.one.platform.ai.autoconfigure.AiWebChatProperties;
+import studio.one.platform.ai.core.chat.ChatMemoryStore;
+import studio.one.platform.ai.core.chat.ChatMessage;
+
+/**
+ * Bounded in-memory chat memory for a single application instance.
+ */
+public class InMemoryChatMemoryStore implements ChatMemoryStore {
+
+    private final Cache<String, List<ChatMessage>> conversations;
+    private final int maxMessages;
+
+    public InMemoryChatMemoryStore(AiWebChatProperties.MemoryProperties properties) {
+        if (properties.getMaxMessages() <= 0) {
+            throw new IllegalArgumentException("maxMessages must be greater than 0");
+        }
+        if (properties.getMaxConversations() <= 0) {
+            throw new IllegalArgumentException("maxConversations must be greater than 0");
+        }
+        if (properties.getTtl() == null || properties.getTtl().isNegative() || properties.getTtl().isZero()) {
+            throw new IllegalArgumentException("ttl must be greater than 0");
+        }
+        this.maxMessages = properties.getMaxMessages();
+        this.conversations = Caffeine.newBuilder()
+                .maximumSize(properties.getMaxConversations())
+                .expireAfterAccess(properties.getTtl())
+                .build();
+    }
+
+    @Override
+    public List<ChatMessage> get(String conversationId) {
+        List<ChatMessage> messages = conversations.getIfPresent(conversationId);
+        return messages == null ? Collections.emptyList() : List.copyOf(messages);
+    }
+
+    @Override
+    public int append(String conversationId, List<ChatMessage> messages) {
+        if (messages == null || messages.isEmpty()) {
+            return get(conversationId).size();
+        }
+        List<ChatMessage> updated = conversations.asMap().compute(conversationId, (key, existing) -> {
+            List<ChatMessage> merged = new ArrayList<>();
+            if (existing != null) {
+                merged.addAll(existing);
+            }
+            merged.addAll(messages);
+            int fromIndex = Math.max(0, merged.size() - maxMessages);
+            return List.copyOf(merged.subList(fromIndex, merged.size()));
+        });
+        return updated == null ? 0 : updated.size();
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/ChatMemoryOptionsDto.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/ChatMemoryOptionsDto.java
@@ -1,0 +1,10 @@
+package studio.one.platform.ai.web.dto;
+
+/**
+ * Optional per-request chat memory settings.
+ */
+public record ChatMemoryOptionsDto(
+        Boolean enabled,
+        String conversationId
+) {
+}

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/ChatRequestDto.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/ChatRequestDto.java
@@ -17,6 +17,19 @@ public record ChatRequestDto(
         Double topP,
         Integer topK,
         Integer maxOutputTokens,
-        List<String> stopSequences
+        List<String> stopSequences,
+        @Valid ChatMemoryOptionsDto memory
 ) {
+    public ChatRequestDto(
+            String provider,
+            String systemPrompt,
+            List<ChatMessageDto> messages,
+            String model,
+            Double temperature,
+            Double topP,
+            Integer topK,
+            Integer maxOutputTokens,
+            List<String> stopSequences) {
+        this(provider, systemPrompt, messages, model, temperature, topP, topK, maxOutputTokens, stopSequences, null);
+    }
 }

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/ChatRequestDto.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/ChatRequestDto.java
@@ -18,7 +18,7 @@ public record ChatRequestDto(
         Integer topK,
         Integer maxOutputTokens,
         List<String> stopSequences,
-        @Valid ChatMemoryOptionsDto memory
+        ChatMemoryOptionsDto memory
 ) {
     public ChatRequestDto(
             String provider,

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/service/InMemoryChatMemoryStore.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/service/InMemoryChatMemoryStore.java
@@ -1,4 +1,4 @@
-package studio.one.platform.ai.web.controller;
+package studio.one.platform.ai.web.service;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -56,6 +56,6 @@ public class InMemoryChatMemoryStore implements ChatMemoryStore {
             int fromIndex = Math.max(0, merged.size() - maxMessages);
             return List.copyOf(merged.subList(fromIndex, merged.size()));
         });
-        return updated == null ? 0 : updated.size();
+        return updated.size();
     }
 }

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/AiWebRagPropertiesTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/AiWebRagPropertiesTest.java
@@ -14,6 +14,35 @@ import org.springframework.core.env.StandardEnvironment;
 class AiWebRagPropertiesTest {
 
     @Test
+    void shouldExposeChatMemoryDefaults() {
+        AiWebChatProperties properties = new AiWebChatProperties();
+
+        assertThat(properties.getMemory().isEnabled()).isFalse();
+        assertThat(properties.getMemory().getMaxMessages()).isEqualTo(20);
+        assertThat(properties.getMemory().getMaxConversations()).isEqualTo(1_000);
+        assertThat(properties.getMemory().getTtl()).isEqualTo(java.time.Duration.ofMinutes(30));
+    }
+
+    @Test
+    void shouldBindChatMemoryOverrides() {
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().addFirst(new MapPropertySource("test", Map.of(
+                "studio.ai.endpoints.chat.memory.enabled", "true",
+                "studio.ai.endpoints.chat.memory.max-messages", "12",
+                "studio.ai.endpoints.chat.memory.max-conversations", "200",
+                "studio.ai.endpoints.chat.memory.ttl", "5m")));
+
+        AiWebChatProperties properties = new Binder(ConfigurationPropertySources.get(environment))
+                .bind("studio.ai.endpoints.chat", Bindable.of(AiWebChatProperties.class))
+                .orElseThrow(() -> new AssertionError("AiWebChatProperties binding failed"));
+
+        assertThat(properties.getMemory().isEnabled()).isTrue();
+        assertThat(properties.getMemory().getMaxMessages()).isEqualTo(12);
+        assertThat(properties.getMemory().getMaxConversations()).isEqualTo(200);
+        assertThat(properties.getMemory().getTtl()).isEqualTo(java.time.Duration.ofMinutes(5));
+    }
+
+    @Test
     void shouldExposeDiagnosticsDefaults() {
         AiWebRagProperties properties = new AiWebRagProperties();
 

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
@@ -116,7 +116,7 @@ class OpenAiProviderAutoConfigurationTest {
                     null,
                     null,
                     null,
-                    null));
+                    null), null);
 
             assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
             assertThat(response.getBody().getData().model()).isEqualTo("gpt-4.1-mini");

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
@@ -20,6 +20,7 @@ import org.springframework.http.ResponseEntity;
 
 import studio.one.platform.ai.autoconfigure.AiWebAutoConfiguration;
 import studio.one.platform.ai.autoconfigure.AiSecretPresenceGuard;
+import studio.one.platform.ai.core.chat.ChatMemoryStore;
 import studio.one.platform.ai.core.chat.ChatPort;
 import studio.one.platform.ai.core.embedding.EmbeddingPort;
 import studio.one.platform.ai.core.registry.AiProviderRegistry;
@@ -78,6 +79,7 @@ class OpenAiProviderAutoConfigurationTest {
             assertThat(context).hasSingleBean(ChatController.class);
             assertThat(context).hasSingleBean(EmbeddingController.class);
             assertThat(context).hasSingleBean(AiInfoController.class);
+            assertThat(context).doesNotHaveBean(ChatMemoryStore.class);
 
             AiProviderRegistry registry = context.getBean(AiProviderRegistry.class);
             assertThat(registry.defaultProvider()).isEqualTo("openai");
@@ -146,6 +148,17 @@ class OpenAiProviderAutoConfigurationTest {
             assertThat(response.getBody().getData().vectors().get(0).referenceId()).isEqualTo("first");
             assertThat(response.getBody().getData().vectors().get(0).values()).containsExactly(1.0, 2.0);
         });
+    }
+
+    @Test
+    void registersInMemoryChatMemoryStoreWhenChatMemoryIsEnabled() {
+        contextRunner
+                .withPropertyValues("studio.ai.endpoints.chat.memory.enabled=true")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).hasSingleBean(ChatMemoryStore.class);
+                    assertThat(context).hasSingleBean(ChatController.class);
+                });
     }
 
     @Test

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
@@ -36,6 +36,7 @@ import studio.one.platform.ai.web.dto.ChatMessageDto;
 import studio.one.platform.ai.web.dto.ChatRagRequestDto;
 import studio.one.platform.ai.web.dto.ChatRequestDto;
 import studio.one.platform.ai.web.dto.ChatResponseDto;
+import studio.one.platform.ai.web.service.InMemoryChatMemoryStore;
 import studio.one.platform.web.dto.ApiResponse;
 
 class ChatControllerTest {
@@ -245,7 +246,34 @@ class ChatControllerTest {
 
         assertThrows(IllegalStateException.class, () -> controller.chat(memoryChat("chat-1", "hello")));
 
-        assertThat(memoryStore.get("chat-1")).isEmpty();
+        assertThat(memoryStore.get("anonymous:chat-1")).isEmpty();
+    }
+
+    @Test
+    void chatRejectsBlankPrincipalNameWhenMemoryIsEnabled() {
+        controller = memoryController();
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> controller.chat(memoryChat("chat-1", "hello"), () -> "  "));
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(ex.getReason()).contains("Principal name");
+        verifyNoInteractions(defaultChatPort);
+    }
+
+    @Test
+    void differentPrincipalsDoNotShareConversationMemory() {
+        controller = memoryController();
+        ArgumentCaptor<ChatRequest> captor = ArgumentCaptor.forClass(ChatRequest.class);
+
+        controller.chat(memoryChat("chat-1", "hello from user a"), () -> "user-a");
+        controller.chat(memoryChat("chat-1", "hello from user b"), () -> "user-b");
+
+        verify(defaultChatPort, times(2)).chat(captor.capture());
+        List<studio.one.platform.ai.core.chat.ChatMessage> userBMessages = captor.getAllValues().get(1).messages();
+        assertThat(userBMessages)
+                .extracting(message -> message.role().name() + ":" + message.content())
+                .containsExactly("USER:hello from user b");
     }
 
     @Test

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
@@ -3,6 +3,7 @@ package studio.one.platform.ai.web.controller;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -20,6 +21,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
+import studio.one.platform.ai.autoconfigure.AiWebChatProperties;
+import studio.one.platform.ai.core.chat.ChatMemoryStore;
 import studio.one.platform.ai.core.chat.ChatPort;
 import studio.one.platform.ai.core.chat.ChatRequest;
 import studio.one.platform.ai.core.chat.ChatResponse;
@@ -28,6 +31,7 @@ import studio.one.platform.ai.core.rag.RagRetrievalDiagnostics;
 import studio.one.platform.ai.core.rag.RagSearchRequest;
 import studio.one.platform.ai.core.rag.RagSearchResult;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
+import studio.one.platform.ai.web.dto.ChatMemoryOptionsDto;
 import studio.one.platform.ai.web.dto.ChatMessageDto;
 import studio.one.platform.ai.web.dto.ChatRagRequestDto;
 import studio.one.platform.ai.web.dto.ChatRequestDto;
@@ -169,6 +173,115 @@ class ChatControllerTest {
         assertThat(captor.getValue().messages().get(0).role().name()).isEqualTo("SYSTEM");
         assertThat(captor.getValue().messages().get(0).content()).isEqualTo("answer briefly");
         assertThat(captor.getValue().messages().get(1).role().name()).isEqualTo("USER");
+    }
+
+    @Test
+    void chatRejectsMemoryRequestWhenServerMemoryIsDisabled() {
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> controller.chat(new ChatRequestDto(
+                        null,
+                        null,
+                        List.of(new ChatMessageDto("user", "hello")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        new ChatMemoryOptionsDto(true, "chat-1"))));
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(ex.getReason()).contains("not enabled");
+        verifyNoInteractions(defaultChatPort);
+    }
+
+    @Test
+    void chatRejectsBlankConversationIdWhenMemoryIsEnabled() {
+        controller = memoryController();
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> controller.chat(new ChatRequestDto(
+                        null,
+                        null,
+                        List.of(new ChatMessageDto("user", "hello")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        new ChatMemoryOptionsDto(true, "  "))));
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(ex.getReason()).contains("conversationId");
+        verifyNoInteractions(defaultChatPort);
+    }
+
+    @Test
+    void chatAddsPreviousConversationMessagesWhenMemoryIsEnabled() {
+        controller = memoryController();
+        ArgumentCaptor<ChatRequest> captor = ArgumentCaptor.forClass(ChatRequest.class);
+
+        controller.chat(memoryChat("chat-1", "hello"));
+        ChatResponseDto response = controller.chat(memoryChat("chat-1", "next")).getBody().getData();
+
+        verify(defaultChatPort, times(2)).chat(captor.capture());
+        List<studio.one.platform.ai.core.chat.ChatMessage> secondMessages = captor.getAllValues().get(1).messages();
+        assertThat(secondMessages)
+                .extracting(message -> message.role().name() + ":" + message.content())
+                .containsExactly("USER:hello", "ASSISTANT:default", "USER:next");
+        assertThat(response.metadata())
+                .containsEntry("memoryEnabled", true)
+                .containsEntry("conversationId", "chat-1")
+                .containsEntry("memoryMessageCount", 4);
+    }
+
+    @Test
+    void chatDoesNotAppendMemoryWhenProviderFails() {
+        ChatMemoryStore memoryStore = memoryStore();
+        controller = new ChatController(providerRegistry, ragPipelineService, RagContextBuilder.defaults(),
+                false, memoryStore, true);
+        when(defaultChatPort.chat(any())).thenThrow(new IllegalStateException("provider failed"));
+
+        assertThrows(IllegalStateException.class, () -> controller.chat(memoryChat("chat-1", "hello")));
+
+        assertThat(memoryStore.get("chat-1")).isEmpty();
+    }
+
+    @Test
+    void ragChatStoresOnlyConversationMessagesWhenMemoryIsEnabled() {
+        controller = memoryController();
+        ArgumentCaptor<ChatRequest> captor = ArgumentCaptor.forClass(ChatRequest.class);
+        when(ragPipelineService.searchByObject(any(RagSearchRequest.class), any(), any()))
+                .thenReturn(List.of(new RagSearchResult("doc-1", "file text", Map.of(), 0.9d)));
+
+        controller.chatWithRag(new ChatRagRequestDto(
+                new ChatRequestDto(
+                        null,
+                        "answer from file",
+                        List.of(new ChatMessageDto("user", "summarize")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        new ChatMemoryOptionsDto(true, "chat-1")),
+                "summary",
+                3,
+                "attachment",
+                "123"));
+        controller.chat(memoryChat("chat-1", "follow up"));
+
+        verify(defaultChatPort, times(2)).chat(captor.capture());
+        List<studio.one.platform.ai.core.chat.ChatMessage> secondMessages = captor.getAllValues().get(1).messages();
+        assertThat(secondMessages)
+                .extracting(message -> message.role().name() + ":" + message.content())
+                .containsExactly("USER:summarize", "ASSISTANT:default", "USER:follow up");
+        assertThat(secondMessages)
+                .extracting(studio.one.platform.ai.core.chat.ChatMessage::content)
+                .doesNotContain("answer from file")
+                .noneMatch(content -> content.contains("file text"));
     }
 
     @Test
@@ -484,6 +597,31 @@ class ChatControllerTest {
     private ChatResponse response(String content) {
         return new ChatResponse(List.of(studio.one.platform.ai.core.chat.ChatMessage.assistant(content)), "model",
                 Map.of());
+    }
+
+    private ChatController memoryController() {
+        return new ChatController(providerRegistry, ragPipelineService, RagContextBuilder.defaults(), false,
+                memoryStore(), true);
+    }
+
+    private ChatMemoryStore memoryStore() {
+        AiWebChatProperties.MemoryProperties properties = new AiWebChatProperties.MemoryProperties();
+        properties.setMaxMessages(20);
+        return new InMemoryChatMemoryStore(properties);
+    }
+
+    private ChatRequestDto memoryChat(String conversationId, String message) {
+        return new ChatRequestDto(
+                null,
+                null,
+                List.of(new ChatMessageDto("user", message)),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                new ChatMemoryOptionsDto(true, conversationId));
     }
 
     private RagRetrievalDiagnostics diagnostics() {

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ChatMemoryStore.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ChatMemoryStore.java
@@ -1,0 +1,13 @@
+package studio.one.platform.ai.core.chat;
+
+import java.util.List;
+
+/**
+ * Stores recent chat messages for a client-managed conversation.
+ */
+public interface ChatMemoryStore {
+
+    List<ChatMessage> get(String conversationId);
+
+    int append(String conversationId, List<ChatMessage> messages);
+}


### PR DESCRIPTION
## Why

- 기존 `POST /api/ai/chat`와 `POST /api/ai/chat/rag`는 서버가 이전 대화를 기억하지 않아 클라이언트가 전체 `messages`를 매번 재전송해야 했다.
- 기본 stateless 동작은 유지하면서 필요한 요청에서만 `conversationId` 기반 최근 대화 기억을 사용할 수 있어야 한다.

## What

- `ChatMemoryStore` 계약과 Caffeine 기반 in-memory 구현을 추가했다.
- `ChatRequestDto.memory` 옵션과 `studio.ai.endpoints.chat.memory.*` 설정을 추가했다.
- `/chat`, `/chat/rag`에서 memory opt-in 요청일 때만 저장된 history를 합치고, provider 성공 후에만 user/assistant 메시지를 append하도록 했다.
- RAG context와 client `systemPrompt`는 memory에 저장하지 않도록 했다.
- 응답 metadata에 `memoryEnabled`, `conversationId`, `memoryMessageCount`를 추가했다.
- README와 CHANGELOG에 기본 stateless 동작, opt-in 예시, in-memory 제약을 기록했다.

## Related Issues

- Issue 없음: 별도 issue 생성 요청과 식별자가 없어 commit body와 PR 본문에 예외 사유를 기록한다.

## Validation

- Command: `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-ai-web:test`
- Result: `BUILD SUCCESSFUL`
- Command: `git diff --check --cached`
- Result: passed

## Risk / Rollback

- Risk: in-memory conversation cache는 단일 인스턴스 범위이므로 재시작 또는 다중 인스턴스 환경에서 대화가 이어지지 않는다. 기본값은 disabled라 기존 endpoint 동작은 유지된다.
- Rollback: 이 커밋을 revert하면 기존 stateless chat endpoint 동작으로 복구된다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: 로컬 Gradle test와 staged diff whitespace check를 수행했다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included