### PR TITLE
[textract] warning 구조를 code 기반으로 개선

### DIFF
--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/HwpHwpxFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/HwpHwpxFileParser.java
@@ -99,7 +99,11 @@ public class HwpHwpxFileParser extends AbstractFileParser implements StructuredF
                 String sectionPath = resolvePackagePath(entries, packageInfo.sectionFiles().get(i));
                 byte[] sectionBytes = entries.get(sectionPath);
                 if (sectionBytes == null) {
-                    warnings.add(new ParseWarning("hwpx.section.missing", "Missing section file", sectionPath, Map.of()));
+                    warnings.add(ParseWarning.partial(
+                            "hwpx.section.missing",
+                            "Missing section file",
+                            sectionPath,
+                            Map.of()));
                     continue;
                 }
                 Document section = parseXml(sectionBytes);
@@ -285,11 +289,18 @@ public class HwpHwpxFileParser extends AbstractFileParser implements StructuredF
             HwpFlags flags = parseHwpFlags(header);
             List<ParseWarning> warnings = new ArrayList<>();
             if (flags.encrypted()) {
-                warnings.add(new ParseWarning("hwp.encrypted", "Encrypted HWP is not supported", "FileHeader", Map.of()));
+                warnings.add(ParseWarning.error(
+                        "hwp.encrypted",
+                        "Encrypted HWP is not supported",
+                        "FileHeader",
+                        Map.of()));
             }
             if (flags.distribution()) {
-                warnings.add(new ParseWarning("hwp.distribution", "Distribution HWP ViewText decryption is not supported",
-                        "FileHeader", Map.of()));
+                warnings.add(ParseWarning.partial(
+                        "hwp.distribution",
+                        "Distribution HWP ViewText decryption is not supported",
+                        "FileHeader",
+                        Map.of()));
             }
 
             List<BinDataRef> binDataRefs = readHwpBinDataRefs(root, flags.compressed(), warnings);
@@ -422,8 +433,11 @@ public class HwpHwpxFileParser extends AbstractFileParser implements StructuredF
             }
             return refs;
         } catch (RuntimeException | IOException e) {
-            warnings.add(new ParseWarning("hwp.docinfo.parse", "Failed to parse DocInfo BinData",
-                    "DocInfo", Map.of("error", e.getMessage())));
+            warnings.add(ParseWarning.partial(
+                    "hwp.docinfo.parse",
+                    "Failed to parse DocInfo BinData",
+                    "DocInfo",
+                    Map.of("error", e.getMessage())));
             return List.of();
         }
     }
@@ -518,14 +532,21 @@ public class HwpHwpxFileParser extends AbstractFileParser implements StructuredF
             int size = (header >>> 20) & 0xFFF;
             if (size == 0xFFF) {
                 if (pos + 4 > data.length) {
-                    warnings.add(new ParseWarning("hwp.record.eof", "Record extended size is truncated", "", Map.of()));
+                    warnings.add(ParseWarning.partial(
+                            "hwp.record.eof",
+                            "Record extended size is truncated",
+                            "",
+                            Map.of()));
                     break;
                 }
                 size = i32(data, pos);
                 pos += 4;
             }
             if (size < 0 || pos + size > data.length) {
-                warnings.add(new ParseWarning("hwp.record.eof", "Record data is truncated", "",
+                warnings.add(ParseWarning.partial(
+                        "hwp.record.eof",
+                        "Record data is truncated",
+                        "",
                         Map.of("tagId", tagId, "size", size)));
                 break;
             }

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ParseWarning.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ParseWarning.java
@@ -1,5 +1,6 @@
 package studio.one.platform.textract.model;
 
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -43,6 +44,7 @@ public record ParseWarning(
             String sourceRef,
             String blockRef,
             Map<String, Object> metadata) {
+        // blockRef is an optional logical block pointer inside the same sourceRef scope.
         return structured(code, message, sourceRef, sourceRef, blockRef, true, ParseWarningSeverity.WARNING, metadata);
     }
 
@@ -59,9 +61,6 @@ public record ParseWarning(
 
     public ParseWarningSeverity severity() {
         Object value = metadata.get(KEY_SEVERITY);
-        if (value instanceof ParseWarningSeverity severityValue) {
-            return severityValue;
-        }
         if (value instanceof String stringValue) {
             try {
                 return ParseWarningSeverity.valueOf(stringValue);
@@ -100,7 +99,7 @@ public record ParseWarning(
             boolean partialParse,
             ParseWarningSeverity severity,
             Map<String, Object> metadata) {
-        Map<String, Object> merged = new java.util.LinkedHashMap<>();
+        Map<String, Object> merged = new LinkedHashMap<>();
         if (metadata != null) {
             merged.putAll(metadata);
         }

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ParseWarning.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ParseWarning.java
@@ -1,16 +1,126 @@
 package studio.one.platform.textract.model;
 
+import java.util.Locale;
 import java.util.Map;
 
 /**
  * Non-fatal warning emitted during parsing.
  */
-public record ParseWarning(String code, String message, String path, Map<String, Object> metadata) {
+public record ParseWarning(
+        String code,
+        String message,
+        String path,
+        Map<String, Object> metadata) {
+
+    public static final String KEY_CANONICAL_CODE = "canonicalCode";
+    public static final String KEY_SEVERITY = "severity";
+    public static final String KEY_SOURCE_REF = "sourceRef";
+    public static final String KEY_BLOCK_REF = "blockRef";
+    public static final String KEY_PARTIAL_PARSE = "partialParse";
 
     public ParseWarning {
         code = code == null ? "unknown" : code;
         message = message == null ? "" : message;
         path = path == null ? "" : path;
         metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+    }
+
+    public static ParseWarning warning(String code, String message, String sourceRef) {
+        return warning(code, message, sourceRef, Map.of());
+    }
+
+    public static ParseWarning warning(String code, String message, String sourceRef, Map<String, Object> metadata) {
+        return structured(code, message, sourceRef, sourceRef, "", false, ParseWarningSeverity.WARNING, metadata);
+    }
+
+    public static ParseWarning partial(String code, String message, String sourceRef, Map<String, Object> metadata) {
+        return structured(code, message, sourceRef, sourceRef, "", true, ParseWarningSeverity.WARNING, metadata);
+    }
+
+    public static ParseWarning partial(
+            String code,
+            String message,
+            String sourceRef,
+            String blockRef,
+            Map<String, Object> metadata) {
+        return structured(code, message, sourceRef, sourceRef, blockRef, true, ParseWarningSeverity.WARNING, metadata);
+    }
+
+    public static ParseWarning error(String code, String message, String sourceRef, Map<String, Object> metadata) {
+        return structured(code, message, sourceRef, sourceRef, "", false, ParseWarningSeverity.ERROR, metadata);
+    }
+
+    public String canonicalCode() {
+        Object value = metadata.get(KEY_CANONICAL_CODE);
+        return value instanceof String stringValue && !stringValue.isBlank()
+                ? stringValue
+                : normalizeCode(code);
+    }
+
+    public ParseWarningSeverity severity() {
+        Object value = metadata.get(KEY_SEVERITY);
+        if (value instanceof ParseWarningSeverity severityValue) {
+            return severityValue;
+        }
+        if (value instanceof String stringValue) {
+            try {
+                return ParseWarningSeverity.valueOf(stringValue);
+            } catch (IllegalArgumentException ignored) {
+                return ParseWarningSeverity.WARNING;
+            }
+        }
+        return ParseWarningSeverity.WARNING;
+    }
+
+    public String sourceRef() {
+        Object value = metadata.get(KEY_SOURCE_REF);
+        return value instanceof String stringValue && !stringValue.isBlank() ? stringValue : path;
+    }
+
+    public String blockRef() {
+        Object value = metadata.get(KEY_BLOCK_REF);
+        return value instanceof String stringValue ? stringValue : "";
+    }
+
+    public boolean partialParse() {
+        Object value = metadata.get(KEY_PARTIAL_PARSE);
+        return value instanceof Boolean booleanValue && booleanValue;
+    }
+
+    public boolean isError() {
+        return severity() == ParseWarningSeverity.ERROR;
+    }
+
+    private static ParseWarning structured(
+            String code,
+            String message,
+            String path,
+            String sourceRef,
+            String blockRef,
+            boolean partialParse,
+            ParseWarningSeverity severity,
+            Map<String, Object> metadata) {
+        Map<String, Object> merged = new java.util.LinkedHashMap<>();
+        if (metadata != null) {
+            merged.putAll(metadata);
+        }
+        merged.putIfAbsent(KEY_CANONICAL_CODE, normalizeCode(code));
+        merged.putIfAbsent(KEY_SEVERITY, severity.name());
+        merged.putIfAbsent(KEY_SOURCE_REF, sourceRef == null || sourceRef.isBlank() ? path : sourceRef);
+        merged.putIfAbsent(KEY_BLOCK_REF, blockRef == null ? "" : blockRef);
+        merged.putIfAbsent(KEY_PARTIAL_PARSE, partialParse);
+        return new ParseWarning(code, message, path, merged);
+    }
+
+    private static String normalizeCode(String code) {
+        if (code == null || code.isBlank()) {
+            return "UNKNOWN";
+        }
+        return code
+                .trim()
+                .replace('.', '_')
+                .replace('-', '_')
+                .replace(' ', '_')
+                .toUpperCase(Locale.ROOT);
     }
 }

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ParseWarningSeverity.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ParseWarningSeverity.java
@@ -4,7 +4,6 @@ package studio.one.platform.textract.model;
  * Severity for structured parse warnings.
  */
 public enum ParseWarningSeverity {
-    INFO,
     WARNING,
     ERROR
 }

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ParseWarningSeverity.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ParseWarningSeverity.java
@@ -1,0 +1,10 @@
+package studio.one.platform.textract.model;
+
+/**
+ * Severity for structured parse warnings.
+ */
+public enum ParseWarningSeverity {
+    INFO,
+    WARNING,
+    ERROR
+}

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/HwpHwpxFileParserTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/HwpHwpxFileParserTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import studio.one.platform.textract.extractor.DocumentFormat;
 import studio.one.platform.textract.model.BlockType;
+import studio.one.platform.textract.model.ParseWarningSeverity;
 import studio.one.platform.textract.model.ParsedFile;
 
 class HwpHwpxFileParserTest {
@@ -46,6 +47,27 @@ class HwpHwpxFileParserTest {
         assertFalse(result.blocks().isEmpty());
         assertEquals(1, result.images().size());
         assertEquals("image/png", result.images().get(0).contentType());
+    }
+
+    @Test
+    void parseStructuredEmitsCodeBasedWarningsForMissingHwpxSection() throws Exception {
+        ParsedFile result = parser.parseStructured(hwpxBytesWithMissingSection(), "application/hwpx", "missing.hwpx");
+
+        assertEquals(1, result.warnings().size());
+        assertEquals("hwpx.section.missing", result.warnings().get(0).code());
+        assertEquals("HWPX_SECTION_MISSING", result.warnings().get(0).canonicalCode());
+        assertTrue(result.warnings().get(0).partialParse());
+    }
+
+    @Test
+    void parseStructuredMarksEncryptedHwpAsErrorWarning() throws Exception {
+        ParsedFile result = parser.parseStructured(hwpBytesWithFlags(0x02), "application/x-hwp", "encrypted.hwp");
+
+        assertEquals(1, result.warnings().size());
+        assertEquals("hwp.encrypted", result.warnings().get(0).code());
+        assertEquals("HWP_ENCRYPTED", result.warnings().get(0).canonicalCode());
+        assertEquals(ParseWarningSeverity.ERROR, result.warnings().get(0).severity());
+        assertFalse(result.warnings().get(0).partialParse());
     }
 
     private byte[] hwpxBytes() throws Exception {
@@ -90,10 +112,35 @@ class HwpHwpxFileParserTest {
         return out.toByteArray();
     }
 
+    private byte[] hwpxBytesWithMissingSection() throws Exception {
+        Map<String, byte[]> entries = Map.of(
+                "Contents/content.hpf", """
+                        <opf:package xmlns:opf="http://www.idpf.org/2007/opf">
+                          <opf:manifest>
+                            <opf:item id="section0" href="section0.xml" media-type="application/xml"/>
+                          </opf:manifest>
+                          <opf:spine><opf:itemref idref="section0"/></opf:spine>
+                        </opf:package>
+                        """.getBytes(UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (ZipOutputStream zip = new ZipOutputStream(out)) {
+            for (Map.Entry<String, byte[]> entry : entries.entrySet()) {
+                zip.putNextEntry(new ZipEntry(entry.getKey()));
+                zip.write(entry.getValue());
+                zip.closeEntry();
+            }
+        }
+        return out.toByteArray();
+    }
+
     private byte[] hwpBytes() throws Exception {
+        return hwpBytesWithFlags(0);
+    }
+
+    private byte[] hwpBytesWithFlags(int flags) throws Exception {
         try (POIFSFileSystem fs = new POIFSFileSystem();
                 ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-            fs.getRoot().createDocument("FileHeader", new ByteArrayInputStream(fileHeader()));
+            fs.getRoot().createDocument("FileHeader", new ByteArrayInputStream(fileHeader(flags)));
             DirectoryEntry bodyText = fs.getRoot().createDirectory("BodyText");
             bodyText.createDocument("Section0", new ByteArrayInputStream(section("한글 본문")));
             DirectoryEntry binData = fs.getRoot().createDirectory("BinData");
@@ -103,11 +150,15 @@ class HwpHwpxFileParserTest {
         }
     }
 
-    private byte[] fileHeader() {
+    private byte[] fileHeader(int flags) {
         byte[] header = new byte[256];
         byte[] signature = "HWP Document File".getBytes(UTF_8);
         System.arraycopy(signature, 0, header, 0, signature.length);
         header[35] = 5;
+        header[36] = (byte) flags;
+        header[37] = (byte) (flags >>> 8);
+        header[38] = (byte) (flags >>> 16);
+        header[39] = (byte) (flags >>> 24);
         return header;
     }
 

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/model/ParseWarningTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/model/ParseWarningTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 class ParseWarningTest {
 
     @Test
-    void constructorNormalizesCodeAndKeepsLegacyFields() {
+    void constructorFallsBackToNormalizedCanonicalCodeAndKeepsLegacyFields() {
         ParseWarning warning = new ParseWarning("hwp.encrypted", "Encrypted HWP is not supported", "FileHeader", Map.of());
 
         assertEquals("hwp.encrypted", warning.code());
@@ -39,5 +39,35 @@ class ParseWarningTest {
         assertEquals("section[0]", warning.sourceRef());
         assertEquals("section[0]/paragraph[1]", warning.blockRef());
         assertTrue(warning.partialParse());
+    }
+
+    @Test
+    void warningFactoryKeepsWarningSeverityAndNonPartialState() {
+        ParseWarning warning = ParseWarning.warning("hwpx.section.missing", "Missing section file", "section[0]");
+
+        assertEquals(ParseWarningSeverity.WARNING, warning.severity());
+        assertFalse(warning.partialParse());
+        assertFalse(warning.isError());
+    }
+
+    @Test
+    void errorFactoryMarksWarningAsError() {
+        ParseWarning warning = ParseWarning.error("hwp.encrypted", "Encrypted HWP is not supported", "FileHeader", Map.of());
+
+        assertEquals(ParseWarningSeverity.ERROR, warning.severity());
+        assertFalse(warning.partialParse());
+        assertTrue(warning.isError());
+    }
+
+    @Test
+    void severityFallsBackToWarningForInvalidMetadataValue() {
+        ParseWarning warning = new ParseWarning(
+                "custom.warning",
+                "Custom warning",
+                "document",
+                Map.of(ParseWarning.KEY_SEVERITY, "BROKEN"));
+
+        assertEquals(ParseWarningSeverity.WARNING, warning.severity());
+        assertFalse(warning.isError());
     }
 }

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/model/ParseWarningTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/model/ParseWarningTest.java
@@ -1,0 +1,43 @@
+package studio.one.platform.textract.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class ParseWarningTest {
+
+    @Test
+    void constructorNormalizesCodeAndKeepsLegacyFields() {
+        ParseWarning warning = new ParseWarning("hwp.encrypted", "Encrypted HWP is not supported", "FileHeader", Map.of());
+
+        assertEquals("hwp.encrypted", warning.code());
+        assertEquals("HWP_ENCRYPTED", warning.canonicalCode());
+        assertEquals(ParseWarningSeverity.WARNING, warning.severity());
+        assertEquals("FileHeader", warning.path());
+        assertEquals("FileHeader", warning.sourceRef());
+        assertEquals("", warning.blockRef());
+        assertFalse(warning.partialParse());
+    }
+
+    @Test
+    void partialFactoryMarksPartialParseAndCarriesRefs() {
+        ParseWarning warning = ParseWarning.partial(
+                "hwp.record.eof",
+                "Section parsing fell back to plain text",
+                "section[0]",
+                "section[0]/paragraph[1]",
+                Map.of("detailCode", "SECTION_FALLBACK"));
+
+        assertEquals("hwp.record.eof", warning.code());
+        assertEquals("HWP_RECORD_EOF", warning.canonicalCode());
+        assertEquals(ParseWarningSeverity.WARNING, warning.severity());
+        assertEquals("section[0]", warning.path());
+        assertEquals("section[0]", warning.sourceRef());
+        assertEquals("section[0]/paragraph[1]", warning.blockRef());
+        assertTrue(warning.partialParse());
+    }
+}


### PR DESCRIPTION
## Why
- `ParseWarning`를 문자열 메시지 중심이 아니라 code 중심으로 다루기 위한 구조가 필요했다.
- 다만 기존 `ParseWarning` 공개 계약과 legacy `warning.code()` 소비 흐름은 최대한 유지해야 했다.
- HWP/HWPX warning에서 partial parse와 error를 구분할 수 있어야 했다.

## What
- `ParseWarning`에 `canonicalCode()`, `severity()`, `sourceRef()`, `blockRef()`, `partialParse()` helper를 추가했다.
- `ParseWarningSeverity`를 도입하고 metadata 기반으로 구조화 warning 정보를 담도록 정리했다.
- HWP/HWPX parser warning 생성부를 `warning/error/partial` factory로 정리했다.
- HWP encrypted, HWPX missing section, truncated record 등에 대한 테스트를 추가했다.

## Related Issues
- #232
- Parent: #231

## Validation
- `./gradlew :studio-platform-textract:test`
- 결과: PASS

## Risk / Rollback
- Risk: warning metadata를 새로 읽는 소비 코드가 없더라도 기존 `code/message/path/metadata` 계약은 유지되지만, 새 helper 동작을 전제로 한 후속 구현과의 정합성은 계속 확인이 필요하다.
- Rollback: 이 PR의 commit `5b31011`를 revert하면 warning 구조 변경을 이전 상태로 되돌릴 수 있다.

## AI / Subagent Usage
- AI-Assisted: Yes
- Main agent usage: 구현, 테스트, 커밋/PR 준비
- Subagent used: Yes
- Delegated scope: `code-reviewer` subagent로 변경분 리뷰 수행
- Review result: 초기 리뷰에서 공개 계약 호환성 이슈 1건이 보고되어 반영 후 수정했다.

## Checklist
- [x] commit message follows policy
- [x] issue template was used or exception was recorded
- [x] AI-Assisted value is correct
- [x] validation is recorded
- [x] subagent usage is recorded
- [x] CI or repository verification passed
- [x] human review is required before merge
- [x] unrelated changes are excluded
