### PR TITLE
[textract] ParsedBlock 구조 개선 (blockType 및 metadata 확장)

### DIFF
--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/DocxFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/DocxFileParser.java
@@ -3,6 +3,7 @@ package studio.one.platform.textract.extractor.impl;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -42,13 +43,28 @@ public class DocxFileParser extends AbstractFileParser implements StructuredFile
             StringBuilder sb = new StringBuilder();
             List<ParsedBlock> blocks = new ArrayList<>();
             List<ExtractedTable> tables = new ArrayList<>();
+            int order = 0;
 
-            appendBodyElements(doc.getBodyElements(), sb, blocks, tables, "body");
+            order = appendBodyElements(doc.getBodyElements(), sb, blocks, tables, "body", null, order);
             for (int i = 0; i < doc.getHeaderList().size(); i++) {
-                appendBodyElements(doc.getHeaderList().get(i).getBodyElements(), sb, blocks, tables, "header[" + i + "]");
+                order = appendBodyElements(
+                        doc.getHeaderList().get(i).getBodyElements(),
+                        sb,
+                        blocks,
+                        tables,
+                        "header[" + i + "]",
+                        BlockType.HEADER,
+                        order);
             }
             for (int i = 0; i < doc.getFooterList().size(); i++) {
-                appendBodyElements(doc.getFooterList().get(i).getBodyElements(), sb, blocks, tables, "footer[" + i + "]");
+                order = appendBodyElements(
+                        doc.getFooterList().get(i).getBodyElements(),
+                        sb,
+                        blocks,
+                        tables,
+                        "footer[" + i + "]",
+                        BlockType.FOOTER,
+                        order);
             }
 
             String text = cleanText(sb.toString());
@@ -73,38 +89,51 @@ public class DocxFileParser extends AbstractFileParser implements StructuredFile
         return parseStructured(bytes, contentType, filename).plainText();
     }
 
-    private void appendBodyElements(
+    private int appendBodyElements(
             List<IBodyElement> elements,
             StringBuilder sb,
             List<ParsedBlock> blocks,
             List<ExtractedTable> tables,
-            String parentPath) {
+            String parentPath,
+            BlockType containerType,
+            int startOrder) {
+        int order = startOrder;
         for (int i = 0; i < elements.size(); i++) {
             IBodyElement element = elements.get(i);
             String path = parentPath + "/element[" + i + "]";
             switch (element.getElementType()) {
-                case PARAGRAPH -> appendParagraph((XWPFParagraph) element, sb, blocks, path);
-                case TABLE -> appendTable((XWPFTable) element, sb, blocks, tables, path);
+                case PARAGRAPH -> order += appendParagraph((XWPFParagraph) element, sb, blocks, path, containerType, order);
+                case TABLE -> order += appendTable((XWPFTable) element, sb, blocks, tables, path, order);
                 default -> { /* ignore other elements */ }
             }
         }
+        return order;
     }
 
-    private void appendParagraph(XWPFParagraph p, StringBuilder sb, List<ParsedBlock> blocks, String path) {
+    private int appendParagraph(
+            XWPFParagraph p,
+            StringBuilder sb,
+            List<ParsedBlock> blocks,
+            String path,
+            BlockType containerType,
+            int order) {
         String text = p.getText();
         if (text != null && !text.isBlank()) {
             String trimmed = text.trim();
             sb.append(trimmed).append("\n");
-            blocks.add(ParsedBlock.text(path, BlockType.PARAGRAPH, trimmed));
+            blocks.add(ParsedBlock.text(path, resolveParagraphType(p, containerType), trimmed, null, order, blockMetadata(path)));
+            return 1;
         }
+        return 0;
     }
 
-    private void appendTable(
+    private int appendTable(
             XWPFTable table,
             StringBuilder sb,
             List<ParsedBlock> blocks,
             List<ExtractedTable> tables,
-            String path) {
+            String path,
+            int order) {
         List<ExtractedTableCell> cells = new ArrayList<>();
         List<String> markdownRows = new ArrayList<>();
         for (int rowIndex = 0; rowIndex < table.getRows().size(); rowIndex++) {
@@ -126,7 +155,45 @@ public class DocxFileParser extends AbstractFileParser implements StructuredFile
         }
         String markdown = String.join("\n", markdownRows);
         tables.add(new ExtractedTable(path, markdown, cells, Map.of()));
-        blocks.add(new ParsedBlock(path, BlockType.TABLE, path, markdown, null, List.of(), Map.of()));
+        blocks.add(new ParsedBlock(path, BlockType.TABLE, path, markdown, null, List.of(), blockMetadata(path, order)));
+        return 1;
+    }
+
+    private BlockType resolveParagraphType(XWPFParagraph paragraph, BlockType containerType) {
+        if (containerType == BlockType.HEADER || containerType == BlockType.FOOTER) {
+            return containerType;
+        }
+        String style = paragraph.getStyle();
+        if (style == null) {
+            return BlockType.PARAGRAPH;
+        }
+        String normalized = style.trim().toLowerCase();
+        if (normalized.contains("title")) {
+            return BlockType.TITLE;
+        }
+        if (normalized.startsWith("heading") || normalized.startsWith("header")) {
+            return BlockType.HEADING;
+        }
+        if (normalized.contains("footnote")) {
+            return BlockType.FOOTNOTE;
+        }
+        if (normalized.contains("list")) {
+            return BlockType.LIST_ITEM;
+        }
+        return BlockType.PARAGRAPH;
+    }
+
+    private Map<String, Object> blockMetadata(String path) {
+        return blockMetadata(path, null);
+    }
+
+    private Map<String, Object> blockMetadata(String path, Integer order) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put(ParsedBlock.KEY_SOURCE_REF, path);
+        if (order != null) {
+            metadata.put(ParsedBlock.KEY_ORDER, order);
+        }
+        return metadata;
     }
 
     private Map<String, Object> metadata(String contentType, String filename) {

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/HwpHwpxFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/HwpHwpxFileParser.java
@@ -181,7 +181,7 @@ public class HwpHwpxFileParser extends AbstractFileParser implements StructuredF
                 ExtractedTable table = parseHwpxTable((Element) child, path + "/tbl[" + i + "]");
                 tables.add(table);
                 blocks.add(new ParsedBlock(table.path(), BlockType.TABLE, table.path(), table.markdown(),
-                        null, List.of(), table.metadata()));
+                        null, List.of(), ParsedBlock.metadata(table.path(), blocks.size(), null, null, table.metadata())));
                 if (!table.markdown().isBlank()) {
                     paragraphText.append('\n').append(table.markdown()).append('\n');
                 }
@@ -199,7 +199,7 @@ public class HwpHwpxFileParser extends AbstractFileParser implements StructuredF
                 plain.append('\n');
             }
             plain.append(text);
-            blocks.add(ParsedBlock.text(path, BlockType.PARAGRAPH, text));
+            blocks.add(ParsedBlock.text(path, BlockType.PARAGRAPH, text, null, blocks.size(), Map.of()));
         }
     }
 
@@ -360,7 +360,7 @@ public class HwpHwpxFileParser extends AbstractFileParser implements StructuredF
                     plain.append('\n');
                 }
                 plain.append(text);
-                blocks.add(ParsedBlock.text(path, BlockType.PARAGRAPH, text));
+                blocks.add(ParsedBlock.text(path, BlockType.PARAGRAPH, text, null, blocks.size(), Map.of()));
                 paragraphOrder++;
             }
         }

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/ImageFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/ImageFileParser.java
@@ -48,7 +48,13 @@ public class ImageFileParser extends AbstractFileParser implements StructuredFil
             String text = cleanText(tesseract.doOCR(image));
             List<ParsedBlock> blocks = text == null || text.isBlank()
                     ? List.of()
-                    : List.of(ParsedBlock.text("image/ocr", BlockType.OCR_TEXT, text));
+                    : List.of(ParsedBlock.text(
+                            "image/ocr",
+                            BlockType.OCR_TEXT,
+                            text,
+                            null,
+                            0,
+                            Map.of()));
             ExtractedImage extractedImage = new ExtractedImage(
                     "image",
                     contentType,

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/model/BlockType.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/model/BlockType.java
@@ -4,8 +4,11 @@ package studio.one.platform.textract.model;
  * Logical block types used by structured file parsing.
  */
 public enum BlockType {
+    TITLE,
     DOCUMENT,
     PAGE,
+    HEADER,
+    FOOTER,
     PARAGRAPH,
     HEADING,
     LIST_ITEM,
@@ -13,6 +16,8 @@ public enum BlockType {
     TABLE_ROW,
     TABLE_CELL,
     IMAGE,
+    IMAGE_CAPTION,
+    FOOTNOTE,
     OCR_TEXT,
     METADATA,
     UNKNOWN

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ParsedBlock.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ParsedBlock.java
@@ -1,5 +1,6 @@
 package studio.one.platform.textract.model;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -15,6 +16,12 @@ public record ParsedBlock(
         List<ParsedBlock> children,
         Map<String, Object> metadata) {
 
+    public static final String KEY_ORDER = "order";
+    public static final String KEY_SOURCE_REF = "sourceRef";
+    public static final String KEY_PARENT_BLOCK_ID = "parentBlockId";
+    public static final String KEY_CONFIDENCE = "confidence";
+    public static final String KEY_SLIDE = "slide";
+
     public ParsedBlock {
         id = id == null ? path : id;
         type = type == null ? BlockType.UNKNOWN : type;
@@ -25,6 +32,76 @@ public record ParsedBlock(
     }
 
     public static ParsedBlock text(String path, BlockType type, String text) {
-        return new ParsedBlock(path, type, path, text, null, List.of(), Map.of());
+        return text(path, type, text, null, null, Map.of());
+    }
+
+    public static ParsedBlock text(
+            String path,
+            BlockType type,
+            String text,
+            Integer page,
+            Integer order,
+            Map<String, Object> metadata) {
+        return new ParsedBlock(path, type, path, text, page, List.of(), metadata(path, order, null, null, metadata));
+    }
+
+    public BlockType blockType() {
+        return type;
+    }
+
+    public Integer order() {
+        Object value = metadata.get(KEY_ORDER);
+        return value instanceof Integer integerValue ? integerValue : null;
+    }
+
+    public String sourceRef() {
+        Object value = metadata.get(KEY_SOURCE_REF);
+        return value instanceof String stringValue && !stringValue.isBlank() ? stringValue : path;
+    }
+
+    public String parentBlockId() {
+        Object value = metadata.get(KEY_PARENT_BLOCK_ID);
+        return value instanceof String stringValue ? stringValue : "";
+    }
+
+    public Double confidence() {
+        Object value = metadata.get(KEY_CONFIDENCE);
+        if (value instanceof Double doubleValue) {
+            return doubleValue;
+        }
+        if (value instanceof Number numberValue) {
+            return numberValue.doubleValue();
+        }
+        return null;
+    }
+
+    public Integer slide() {
+        Object value = metadata.get(KEY_SLIDE);
+        return value instanceof Integer integerValue ? integerValue : null;
+    }
+
+    public static Map<String, Object> metadata(
+            String sourceRef,
+            Integer order,
+            String parentBlockId,
+            Double confidence,
+            Map<String, Object> metadata) {
+        Map<String, Object> merged = new LinkedHashMap<>();
+        if (metadata != null) {
+            merged.putAll(metadata);
+        }
+        if (sourceRef != null && !sourceRef.isBlank()) {
+            merged.putIfAbsent(KEY_SOURCE_REF, sourceRef);
+        }
+        if (order != null) {
+            merged.putIfAbsent(KEY_ORDER, order);
+        }
+        if (parentBlockId != null && !parentBlockId.isBlank()) {
+            merged.putIfAbsent(KEY_PARENT_BLOCK_ID, parentBlockId);
+        }
+        if (confidence != null) {
+            merged.putIfAbsent(KEY_CONFIDENCE, confidence);
+        }
+        return merged;
     }
 }

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ParsedFile.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ParsedFile.java
@@ -36,7 +36,7 @@ public record ParsedFile(
                 : Map.of("filename", filename);
         List<ParsedBlock> blocks = plainText == null || plainText.isBlank()
                 ? List.of()
-                : List.of(ParsedBlock.text("document", BlockType.DOCUMENT, plainText));
+                : List.of(ParsedBlock.text("document", BlockType.DOCUMENT, plainText, null, 0, Map.of()));
         return new ParsedFile(format, plainText, blocks, metadata, List.of(), List.of(), List.of(), List.of(), false);
     }
 }

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/DocxFileParserTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/DocxFileParserTest.java
@@ -1,16 +1,19 @@
 package studio.one.platform.textract.extractor.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.apache.poi.xwpf.usermodel.XWPFHeader;
 import org.apache.poi.xwpf.usermodel.XWPFTable;
 import org.junit.jupiter.api.Test;
 
 import studio.one.platform.textract.extractor.DocumentFormat;
 import studio.one.platform.textract.model.BlockType;
+import studio.one.platform.textract.model.ParsedBlock;
 import studio.one.platform.textract.model.ParsedFile;
 
 class DocxFileParserTest {
@@ -30,6 +33,37 @@ class DocxFileParserTest {
         assertEquals(4, result.tables().get(0).cells().size());
         assertEquals("A1", result.tables().get(0).cells().get(0).text());
         assertEquals("| A1 | B1 |", result.tables().get(0).markdown().split("\\n")[0]);
+        assertEquals("body/element[0]", result.blocks().get(0).sourceRef());
+        assertEquals(0, result.blocks().get(0).order());
+        assertEquals(1, result.blocks().get(1).order());
+    }
+
+    @Test
+    void parseStructuredAssignsHeaderBlockTypeAndProvenance() throws Exception {
+        byte[] bytes = docxWithHeader();
+
+        ParsedFile result = new DocxFileParser()
+                .parseStructured(bytes, "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "header.docx");
+
+        assertTrue(result.blocks().stream().anyMatch(block -> block.blockType() == BlockType.HEADER));
+        ParsedBlock headerBlock = result.blocks().stream()
+                .filter(block -> block.blockType() == BlockType.HEADER)
+                .findFirst()
+                .orElseThrow();
+        assertTrue(headerBlock.sourceRef().startsWith("header[0]/element[0]"));
+        assertTrue(headerBlock.order() != null && headerBlock.order() >= 0);
+    }
+
+    @Test
+    void parseStructuredSkipsBlankParagraphsWithoutLeavingOrderGaps() throws Exception {
+        byte[] bytes = docxWithBlankParagraph();
+
+        ParsedFile result = new DocxFileParser()
+                .parseStructured(bytes, "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "blank.docx");
+
+        assertEquals(2, result.blocks().size());
+        assertEquals(0, result.blocks().get(0).order());
+        assertEquals(1, result.blocks().get(1).order());
     }
 
     private byte[] docxWithParagraphAndTable() throws Exception {
@@ -41,6 +75,28 @@ class DocxFileParserTest {
             table.getRow(0).getCell(1).setText("B1");
             table.getRow(1).getCell(0).setText("A2");
             table.getRow(1).getCell(1).setText("B2");
+            document.write(out);
+            return out.toByteArray();
+        }
+    }
+
+    private byte[] docxWithHeader() throws Exception {
+        try (XWPFDocument document = new XWPFDocument();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            XWPFHeader header = document.createHeader(org.apache.poi.wp.usermodel.HeaderFooterType.DEFAULT);
+            header.createParagraph().createRun().setText("문서 헤더");
+            document.createParagraph().createRun().setText("본문 문단");
+            document.write(out);
+            return out.toByteArray();
+        }
+    }
+
+    private byte[] docxWithBlankParagraph() throws Exception {
+        try (XWPFDocument document = new XWPFDocument();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            document.createParagraph().createRun().setText("첫 문단");
+            document.createParagraph();
+            document.createParagraph().createRun().setText("둘째 문단");
             document.write(out);
             return out.toByteArray();
         }

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/model/ParsedBlockTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/model/ParsedBlockTest.java
@@ -1,0 +1,54 @@
+package studio.one.platform.textract.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class ParsedBlockTest {
+
+    @Test
+    void textFactoryAddsProvenanceMetadata() {
+        ParsedBlock block = ParsedBlock.text("body/element[0]", BlockType.PARAGRAPH, "본문", null, 3, Map.of());
+
+        assertEquals(BlockType.PARAGRAPH, block.blockType());
+        assertEquals(3, block.order());
+        assertEquals("body/element[0]", block.sourceRef());
+        assertEquals("", block.parentBlockId());
+        assertNull(block.confidence());
+        assertNull(block.slide());
+    }
+
+    @Test
+    void confidenceRemainsNullWhenMetadataDoesNotProvideIt() {
+        ParsedBlock block = ParsedBlock.text("image/ocr", BlockType.OCR_TEXT, "텍스트", null, 0, Map.of());
+
+        assertNull(block.confidence());
+    }
+
+    @Test
+    void helperAccessorsReadMetadataBack() {
+        ParsedBlock block = new ParsedBlock(
+                "block-1",
+                BlockType.IMAGE,
+                "slides/0/image[0]",
+                "diagram",
+                2,
+                java.util.List.of(),
+                Map.of(
+                        ParsedBlock.KEY_SOURCE_REF, "slides/0",
+                        ParsedBlock.KEY_ORDER, 7,
+                        ParsedBlock.KEY_PARENT_BLOCK_ID, "slide-0",
+                        ParsedBlock.KEY_CONFIDENCE, 0.82d,
+                        ParsedBlock.KEY_SLIDE, 1));
+
+        assertEquals(BlockType.IMAGE, block.blockType());
+        assertEquals(7, block.order());
+        assertEquals("slides/0", block.sourceRef());
+        assertEquals("slide-0", block.parentBlockId());
+        assertEquals(0.82d, block.confidence());
+        assertEquals(1, block.slide());
+    }
+}


### PR DESCRIPTION
## Why
- `ParsedBlock`에 blockType과 provenance helper가 필요했다.
- downstream 소비 코드가 기존 record shape를 유지한 채 `order`, `sourceRef`, `confidence` 같은 구조 정보를 읽을 수 있어야 했다.
- DOCX/HWP/HWPX/Image parser에서 block metadata를 더 일관되게 제공할 필요가 있었다.

## What
- `BlockType`에 `TITLE`, `HEADER`, `FOOTER`, `IMAGE_CAPTION`, `FOOTNOTE`를 추가했다.
- `ParsedBlock`에 `blockType()`, `order()`, `sourceRef()`, `parentBlockId()`, `confidence()`, `slide()` helper와 metadata builder를 추가했다.
- `ParsedFile.textOnly(...)`와 DOCX/HWP/HWPX/Image parser가 block provenance metadata를 채우도록 수정했다.
- DOCX header block type, blank paragraph order 처리, `ParsedBlock` provenance 테스트를 추가했다.

## Related Issues
- #233
- Parent: #231

## Validation
- `./gradlew :studio-platform-textract:test --tests 'studio.one.platform.textract.model.ParsedBlockTest' --tests 'studio.one.platform.textract.extractor.impl.DocxFileParserTest' --tests 'studio.one.platform.textract.extractor.impl.HwpHwpxFileParserTest' --tests 'studio.one.platform.textract.extractor.FileParserFactoryTest'`
- 결과: PASS
- `./gradlew :studio-platform-textract:test`
- 결과: PASS

## Risk / Rollback
- Risk: `BlockType` 확장과 DOCX 분류 규칙 추가로 downstream block 소비 코드가 새 타입을 예상하지 못할 수 있다.
- Rollback: 이 PR의 commit `7222418`를 revert하면 `ParsedBlock` helper와 parser metadata 변경을 이전 상태로 되돌릴 수 있다.

## AI / Subagent Usage
- AI-Assisted: Yes
- Main agent usage: 구현, 로컬 리뷰, 테스트, 커밋/PR 준비
- Subagent used: Yes
- Delegated scope: `code-reviewer` subagent로 현재 diff에 대한 로컬 리뷰 수행
- Review result: PR 코멘트는 아직 없었고, 로컬 리뷰에서 `order` gap과 OCR confidence 0.0 강제 설정 이슈가 보고되어 반영 후 수정했다.

## Checklist
- [x] commit message follows policy
- [x] issue template was used or exception was recorded
- [x] AI-Assisted value is correct
- [x] validation is recorded
- [x] subagent usage is recorded
- [x] CI or repository verification passed
- [x] human review is required before merge
- [x] unrelated changes are excluded
