### PR TITLE
[textract] README 및 OCR 설치 문서 개선

### DIFF
--- a/studio-platform-textract/README.md
+++ b/studio-platform-textract/README.md
@@ -72,6 +72,40 @@ HWP/HWPX parser는 `rhwp`의 파싱 흐름을 Java 서비스용 경량 추출기
 자동설정은 `starter/studio-platform-textract-starter`가 제공한다.
 설정 prefix는 기존과 같은 `studio.features.text`를 사용한다.
 
+## OCR 설정
+
+이미지 OCR은 `net.sourceforge.tess4j:tess4j` 의존성만으로 바로 동작하지 않는다.
+`tess4j`는 Java wrapper이고, 실제 OCR 엔진은 외부 `Tesseract` 바이너리와 `tessdata` 언어 데이터가 담당한다.
+
+OCR을 사용하려면 다음이 모두 준비되어야 한다.
+
+- `Tesseract` 엔진 설치
+- `tessdata` 언어 데이터 설치
+- `studio.features.text.tesseract.datapath`가 `tessdata` 디렉터리를 가리키도록 설정
+- 필요 시 native library 검색 경로(`jna.library.path`) 설정
+
+### macOS (Homebrew) 설치 예시
+
+```bash
+brew install tesseract
+brew install tesseract-lang
+```
+
+Apple Silicon(macOS on arm64) 환경에서는 Homebrew 기본 경로가 `/opt/homebrew` 이므로,
+JNA가 native library를 찾지 못하면 다음 JVM 옵션이 필요할 수 있다.
+
+```bash
+-Djna.library.path=/opt/homebrew/lib
+```
+
+예를 들어 shell 환경 변수로는 다음처럼 줄 수 있다.
+
+```bash
+export JAVA_TOOL_OPTIONS="-Djna.library.path=/opt/homebrew/lib"
+```
+
+### application.yml 예시
+
 ```yaml
 studio:
   features:
@@ -79,30 +113,36 @@ studio:
       enabled: true
       max-extract-bytes: 10485760
       tesseract:
-        datapath: /usr/share/tesseract-ocr/4.00/tessdata
+        datapath: /opt/homebrew/share/tessdata
         language: kor+eng
 ```
 
-조금 더 짧고 README 친화적으로 줄인 버전도 가능합니다. 예를 들면:
+설정 값 설명:
 
-```md
-> [!NOTE]
-> 이미지 OCR은 `tess4j` 의존성만으로 동작하지 않는다.  
-> macOS / Linux / Windows 환경에 **Tesseract OCR 엔진**과 **언어 데이터(tessdata)** 가
-> 별도로 설치되어 있어야 한다.
->
-> macOS(Homebrew) 예시:
->
-> ```bash
-> brew install tesseract
-> brew install tesseract-lang
-> ```
->
-> Apple Silicon 환경에서는 필요 시:
->
-> ```bash
-> JAVA_TOOL_OPTIONS=-Djna.library.path=/opt/homebrew/lib
-> ```
+- `datapath`: `kor.traineddata`, `eng.traineddata` 같은 언어 파일이 들어 있는 `tessdata` 디렉터리 경로
+- `language`: Tesseract 언어 코드. 여러 언어는 `kor+eng`처럼 `+`로 연결
+
+Linux 계열에서는 `datapath`가 `/usr/share/tesseract-ocr/4.00/tessdata` 또는 `/usr/share/tessdata`일 수 있다.
+설치 배포판에 따라 실제 경로를 확인해서 맞춰야 한다.
+
+### 자주 발생하는 오류
+
+`Unable to load library 'tesseract'`
+
+- `Tesseract` 엔진이 설치되지 않았거나
+- JNA가 native library 경로를 찾지 못했거나
+- Apple Silicon에서 `/opt/homebrew/lib`가 `jna.library.path`에 포함되지 않은 경우다.
+
+우선 `tesseract --version`으로 설치 여부를 확인하고, 필요하면 `-Djna.library.path=/opt/homebrew/lib`를 추가한다.
+
+`language data not found`
+
+- `tessdata`가 설치되지 않았거나
+- `datapath`가 `tessdata` 상위 또는 잘못된 디렉터리를 가리키는 경우다.
+
+`datapath`에는 언어 파일이 직접 들어 있는 `tessdata` 경로를 넣어야 한다.
+예를 들어 `kor.traineddata`가 `/opt/homebrew/share/tessdata/kor.traineddata`에 있으면
+`datapath`는 `/opt/homebrew/share/tessdata`여야 한다.
 
 포맷별 parser는 관련 라이브러리가 classpath에 있을 때만 등록된다.
 예를 들어 HWP parser는 `org.apache.poi.poifs.filesystem.POIFSFileSystem`이 있어야 자동 구성된다.

--- a/studio-platform-textract/README.md
+++ b/studio-platform-textract/README.md
@@ -104,6 +104,10 @@ JNA가 native library를 찾지 못하면 다음 JVM 옵션이 필요할 수 있
 export JAVA_TOOL_OPTIONS="-Djna.library.path=/opt/homebrew/lib"
 ```
 
+`JAVA_TOOL_OPTIONS`는 해당 shell에서 실행되는 모든 JVM 프로세스에 적용된다.
+Gradle, Maven, IDE 실행에도 영향을 줄 수 있으므로 운영 환경에서는 애플리케이션 기동 스크립트나 서비스 설정에
+`-Djna.library.path=/opt/homebrew/lib`를 직접 추가하는 방식을 우선 검토한다.
+
 ### application.yml 예시
 
 ```yaml
@@ -113,6 +117,9 @@ studio:
       enabled: true
       max-extract-bytes: 10485760
       tesseract:
+        # macOS(Apple Silicon): /opt/homebrew/share/tessdata
+        # Linux: /usr/share/tessdata 또는 /usr/share/tesseract-ocr/4.00/tessdata
+        # Windows: C:\Program Files\Tesseract-OCR\tessdata
         datapath: /opt/homebrew/share/tessdata
         language: kor+eng
 ```
@@ -125,9 +132,16 @@ studio:
 Linux 계열에서는 `datapath`가 `/usr/share/tesseract-ocr/4.00/tessdata` 또는 `/usr/share/tessdata`일 수 있다.
 설치 배포판에 따라 실제 경로를 확인해서 맞춰야 한다.
 
+Windows에서는 Tesseract 설치 경로에 따라 `datapath`가
+`C:\Program Files\Tesseract-OCR\tessdata`일 수 있다.
+native library 로딩 오류가 나면 `tesseract.exe`가 있는 디렉터리를 `PATH`에 추가하거나,
+애플리케이션 JVM 옵션에 `-Djna.library.path=C:\Program Files\Tesseract-OCR`를 지정한다.
+
 ### 자주 발생하는 오류
 
-`Unable to load library 'tesseract'`
+```text
+Unable to load library 'tesseract'
+```
 
 - `Tesseract` 엔진이 설치되지 않았거나
 - JNA가 native library 경로를 찾지 못했거나
@@ -135,7 +149,9 @@ Linux 계열에서는 `datapath`가 `/usr/share/tesseract-ocr/4.00/tessdata` 또
 
 우선 `tesseract --version`으로 설치 여부를 확인하고, 필요하면 `-Djna.library.path=/opt/homebrew/lib`를 추가한다.
 
-`language data not found`
+```text
+language data not found
+```
 
 - `tessdata`가 설치되지 않았거나
 - `datapath`가 `tessdata` 상위 또는 잘못된 디렉터리를 가리키는 경우다.


### PR DESCRIPTION
## Why
- README만 보고 OCR 설치와 설정을 끝낼 수 있도록 문서를 보강할 필요가 있었다.
- `tess4j` wrapper와 실제 `Tesseract` 엔진, `tessdata`, native library 경로 이슈를 OS별로 분명히 안내해야 했다.

## What
- `studio-platform-textract/README.md`에 OCR 설정 섹션을 추가했다.
- Homebrew 설치 예시, `application.yml` 예시, `datapath`/`language` 설명을 추가했다.
- `application.yml` 예시에 macOS/Linux/Windows tessdata 경로 주석을 추가했다.
- Apple Silicon에서 `-Djna.library.path=/opt/homebrew/lib`가 필요한 경우를 문서화했다.
- `JAVA_TOOL_OPTIONS`가 모든 JVM 프로세스에 적용되는 주의 사항과 애플리케이션 기동 옵션 사용 방식을 병기했다.
- Windows Tesseract 설치 경로와 `jna.library.path` 예시를 추가했다.
- `Unable to load library 'tesseract'`, `language data not found` 오류 대응을 code block 중심으로 정리했다.

## Related Issues
- Closes #236
- Parent: #231

## Validation
- Command: `git diff --check`
- Result: `passed`
- 문서 변경만 포함되어 실행 테스트는 생략했다.

## Risk / Rollback
- Risk: OS/배포판별 Tesseract 설치 경로는 환경마다 다를 수 있으므로 실제 설치 경로 확인이 필요하다.
- Rollback: 이 PR을 revert하면 README 변경을 이전 상태로 되돌릴 수 있다.

## AI / Subagent Usage
- AI-assisted: Yes
- Subagent used: No
- Delegated scope: 없음
- Main author validation: README diff와 `git diff --check` 결과를 확인했다.

## Checklist
- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
