### PR TITLE
[textract] 표 및 이미지 구조 보존 강화

### DIFF
--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/DocxFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/DocxFileParser.java
@@ -3,6 +3,7 @@ package studio.one.platform.textract.extractor.impl;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -125,8 +126,15 @@ public class DocxFileParser extends AbstractFileParser implements StructuredFile
             markdownRows.add("| " + String.join(" | ", markdownCells) + " |");
         }
         String markdown = String.join("\n", markdownRows);
-        tables.add(new ExtractedTable(path, markdown, cells, Map.of()));
+        tables.add(new ExtractedTable(path, markdown, cells, tableMetadata(path, "docx")));
         blocks.add(new ParsedBlock(path, BlockType.TABLE, path, markdown, null, List.of(), Map.of()));
+    }
+
+    private Map<String, Object> tableMetadata(String path, String format) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put(ExtractedTable.KEY_SOURCE_REF, path);
+        metadata.put(ExtractedTable.KEY_FORMAT, format);
+        return metadata;
     }
 
     private Map<String, Object> metadata(String contentType, String filename) {

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/HwpHwpxFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/HwpHwpxFileParser.java
@@ -114,13 +114,30 @@ public class HwpHwpxFileParser extends AbstractFileParser implements StructuredF
             for (PackageItem item : packageInfo.binDataItems()) {
                 String path = resolvePackagePath(entries, item.href());
                 byte[] data = entries.get(path);
+                List<String> sourceRefs = packageInfo.referencedImages().getOrDefault(item.id(), List.of());
+                Map<String, Object> imageMetadata = new LinkedHashMap<>();
+                imageMetadata.put("bytes", data == null ? 0 : data.length);
+                imageMetadata.put(ExtractedImage.KEY_PACKAGE_ID, item.id());
+                imageMetadata.put(ExtractedImage.KEY_BIN_DATA_REF, path);
+                if (sourceRefs.size() == 1) {
+                    imageMetadata.put(ExtractedImage.KEY_SOURCE_REF, sourceRefs.get(0));
+                } else if (!sourceRefs.isEmpty()) {
+                    imageMetadata.put(ExtractedImage.KEY_SOURCE_REFS, List.copyOf(sourceRefs));
+                }
                 images.add(new ExtractedImage(
                         "bindata/" + item.id(),
                         item.mediaType(),
                         path,
                         null,
                         null,
-                        Map.of("bytes", data == null ? 0 : data.length, "packageId", item.id())));
+                        imageMetadata));
+                if (sourceRefs.isEmpty()) {
+                    warnings.add(ParseWarning.partial(
+                            "image.mapping.partial",
+                            "Image binary has no paragraph/source mapping",
+                            path,
+                            Map.of(ExtractedImage.KEY_PACKAGE_ID, item.id())));
+                }
             }
 
             return new ParsedFile(
@@ -189,7 +206,9 @@ public class HwpHwpxFileParser extends AbstractFileParser implements StructuredF
                 Optional<String> imageRef = findHwpxImageRef((Element) child);
                 imageRef.ifPresent(ref -> paragraphText.append("[IMAGE:").append(ref).append("]"));
                 if (imageRef.isPresent()) {
-                    packageInfo.referencedImages().put(imageRef.get(), path + "/pic[" + i + "]");
+                    packageInfo.referencedImages()
+                            .computeIfAbsent(imageRef.get(), ignored -> new ArrayList<>())
+                            .add(path + "/pic[" + i + "]");
                 }
             }
         }
@@ -244,7 +263,13 @@ public class HwpHwpxFileParser extends AbstractFileParser implements StructuredF
             }
             markdownRows.add("| " + String.join(" | ", markdownCells) + " |");
         }
-        return new ExtractedTable(path, String.join("\n", markdownRows), cells, Map.of("format", "hwpx"));
+        return new ExtractedTable(
+                path,
+                String.join("\n", markdownRows),
+                cells,
+                Map.of(
+                        ExtractedTable.KEY_FORMAT, "hwpx",
+                        ExtractedTable.KEY_SOURCE_REF, path));
     }
 
     private String collectDescendantText(Node node) {
@@ -492,7 +517,11 @@ public class HwpHwpxFileParser extends AbstractFileParser implements StructuredF
                     entry.getName(),
                     null,
                     null,
-                    Map.of("bytes", data.length, "storageId", id)));
+                    Map.of(
+                            "bytes", data.length,
+                            "storageId", id,
+                            ExtractedImage.KEY_BIN_DATA_REF, entry.getName(),
+                            ExtractedImage.KEY_SOURCE_REF, "bindata/" + entry.getName())));
         }
         return images;
     }
@@ -808,7 +837,7 @@ public class HwpHwpxFileParser extends AbstractFileParser implements StructuredF
     }
 
     private record PackageInfo(List<String> sectionFiles, List<PackageItem> binDataItems,
-            Map<String, String> referencedImages) {
+            Map<String, List<String>> referencedImages) {
     }
 
     private record HwpFlags(boolean compressed, boolean encrypted, boolean distribution) {

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ExtractedImage.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ExtractedImage.java
@@ -1,5 +1,6 @@
 package studio.one.platform.textract.model;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -13,7 +14,44 @@ public record ExtractedImage(
         Integer height,
         Map<String, Object> metadata) {
 
+    public static final String KEY_SOURCE_REF = "sourceRef";
+    public static final String KEY_SOURCE_REFS = "sourceRefs";
+    public static final String KEY_BIN_DATA_REF = "binDataRef";
+    public static final String KEY_PACKAGE_ID = "packageId";
+
     public ExtractedImage {
         metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+    }
+
+    public String mimeType() {
+        return contentType == null ? "" : contentType;
+    }
+
+    public String sourceRef() {
+        Object value = metadata.get(KEY_SOURCE_REF);
+        return value instanceof String stringValue && !stringValue.isBlank() ? stringValue : path;
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<String> sourceRefs() {
+        Object value = metadata.get(KEY_SOURCE_REFS);
+        if (value instanceof List<?> listValue) {
+            return ((List<Object>) listValue).stream()
+                    .filter(String.class::isInstance)
+                    .map(String.class::cast)
+                    .toList();
+        }
+        String sourceRef = sourceRef();
+        return sourceRef.isBlank() ? List.of() : List.of(sourceRef);
+    }
+
+    public String binDataRef() {
+        Object value = metadata.get(KEY_BIN_DATA_REF);
+        return value instanceof String stringValue ? stringValue : "";
+    }
+
+    public String packageId() {
+        Object value = metadata.get(KEY_PACKAGE_ID);
+        return value instanceof String stringValue ? stringValue : "";
     }
 }

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ExtractedTable.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ExtractedTable.java
@@ -12,8 +12,32 @@ public record ExtractedTable(
         List<ExtractedTableCell> cells,
         Map<String, Object> metadata) {
 
+    public static final String KEY_SOURCE_REF = "sourceRef";
+    public static final String KEY_FORMAT = "format";
+
     public ExtractedTable {
         cells = cells == null ? List.of() : List.copyOf(cells);
         metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+    }
+
+    public String sourceRef() {
+        Object value = metadata.get(KEY_SOURCE_REF);
+        return value instanceof String stringValue && !stringValue.isBlank() ? stringValue : path;
+    }
+
+    public String format() {
+        Object value = metadata.get(KEY_FORMAT);
+        return value instanceof String stringValue ? stringValue : "";
+    }
+
+    public int rowCount() {
+        return cells.stream()
+                .mapToInt(cell -> cell.row() + cell.rowSpan())
+                .max()
+                .orElse(0);
+    }
+
+    public int cellCount() {
+        return cells.size();
     }
 }

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/DocxFileParserTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/DocxFileParserTest.java
@@ -30,6 +30,8 @@ class DocxFileParserTest {
         assertEquals(4, result.tables().get(0).cells().size());
         assertEquals("A1", result.tables().get(0).cells().get(0).text());
         assertEquals("| A1 | B1 |", result.tables().get(0).markdown().split("\\n")[0]);
+        assertEquals("body/element[1]", result.tables().get(0).sourceRef());
+        assertEquals("docx", result.tables().get(0).format());
     }
 
     private byte[] docxWithParagraphAndTable() throws Exception {

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/HwpHwpxFileParserTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/HwpHwpxFileParserTest.java
@@ -36,6 +36,12 @@ class HwpHwpxFileParserTest {
         assertEquals(4, result.tables().get(0).cells().size());
         assertEquals(1, result.images().size());
         assertTrue(result.blocks().stream().anyMatch(block -> block.type() == BlockType.TABLE));
+        assertEquals("section[0]/p[3]/tbl[1]", result.tables().get(0).sourceRef());
+        assertEquals("hwpx", result.tables().get(0).format());
+        assertEquals("section[0]/p[5]/pic[0]", result.images().get(0).sourceRef());
+        assertEquals(java.util.List.of("section[0]/p[5]/pic[0]"), result.images().get(0).sourceRefs());
+        assertEquals("Contents/BinData/image1.png", result.images().get(0).binDataRef());
+        assertEquals("image1", result.images().get(0).packageId());
     }
 
     @Test
@@ -47,6 +53,7 @@ class HwpHwpxFileParserTest {
         assertFalse(result.blocks().isEmpty());
         assertEquals(1, result.images().size());
         assertEquals("image/png", result.images().get(0).contentType());
+        assertEquals("BIN0001.png", result.images().get(0).binDataRef());
     }
 
     @Test

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/model/ExtractedStructureTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/model/ExtractedStructureTest.java
@@ -1,0 +1,66 @@
+package studio.one.platform.textract.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class ExtractedStructureTest {
+
+    @Test
+    void extractedTableExposesStructureHelpers() {
+        ExtractedTable table = new ExtractedTable(
+                "body/table[0]",
+                "| A1 | B1 |",
+                List.of(
+                        new ExtractedTableCell(0, 0, 1, 1, "A1", Map.of()),
+                        new ExtractedTableCell(0, 1, 1, 1, "B1", Map.of()),
+                        new ExtractedTableCell(1, 0, 1, 1, "A2", Map.of())),
+                Map.of(
+                        ExtractedTable.KEY_SOURCE_REF, "body/table[0]",
+                        ExtractedTable.KEY_FORMAT, "docx"));
+
+        assertEquals("body/table[0]", table.sourceRef());
+        assertEquals("docx", table.format());
+        assertEquals(2, table.rowCount());
+        assertEquals(3, table.cellCount());
+    }
+
+    @Test
+    void extractedImageExposesSourceAndBinaryReferences() {
+        ExtractedImage image = new ExtractedImage(
+                "bindata/image1",
+                "image/png",
+                "image1.png",
+                null,
+                null,
+                Map.of(
+                        ExtractedImage.KEY_SOURCE_REF, "section[0]/pic[1]",
+                        ExtractedImage.KEY_BIN_DATA_REF, "Contents/BinData/image1.png",
+                        ExtractedImage.KEY_PACKAGE_ID, "image1"));
+
+        assertEquals("image/png", image.mimeType());
+        assertEquals("section[0]/pic[1]", image.sourceRef());
+        assertEquals(List.of("section[0]/pic[1]"), image.sourceRefs());
+        assertEquals("Contents/BinData/image1.png", image.binDataRef());
+        assertEquals("image1", image.packageId());
+    }
+
+    @Test
+    void extractedImageReturnsAllSourceRefsWhenMultipleMappingsExist() {
+        ExtractedImage image = new ExtractedImage(
+                "bindata/image1",
+                "image/png",
+                "image1.png",
+                null,
+                null,
+                Map.of(
+                        ExtractedImage.KEY_SOURCE_REFS, List.of("section[0]/pic[0]", "section[2]/pic[1]"),
+                        ExtractedImage.KEY_BIN_DATA_REF, "Contents/BinData/image1.png"));
+
+        assertEquals("bindata/image1", image.sourceRef());
+        assertEquals(List.of("section[0]/pic[0]", "section[2]/pic[1]"), image.sourceRefs());
+    }
+}


### PR DESCRIPTION
## Why
- plain text fallback을 유지하면서 표와 이미지 구조 정보를 후속 처리에서 직접 접근할 수 있어야 했다.
- HWP/HWPX에서 `sourceRef`, `binDataRef`, `packageId` 같은 연결 정보가 빠져 있어 구조 보존이 약했다.
- reused image asset 같은 경우에도 잘못된 단일 source mapping을 주지 않도록 해야 했다.

## What
- `ExtractedTable`에 `sourceRef()`, `format()`, `rowCount()`, `cellCount()` helper를 추가했다.
- `ExtractedImage`에 `mimeType()`, `sourceRef()`, `sourceRefs()`, `binDataRef()`, `packageId()` helper를 추가했다.
- DOCX table metadata에 `sourceRef`, `format`을 채우도록 수정했다.
- HWP/HWPX image metadata에 `binDataRef`, `packageId`, source mapping을 반영하고 mapping이 없는 경우 warning을 남기도록 수정했다.
- repeated image reference에서 단일 sourceRef를 잘못 덮어쓰지 않도록 `sourceRefs` 기반으로 정리했다.
- 구조 helper와 parser 테스트를 추가했다.

## Related Issues
- #234
- Parent: #231

## Validation
- `/Users/donghyuck.son/git/studio-api/gradlew -p /Users/donghyuck.son/git/studio-api-234 :studio-platform-textract:test --tests 'studio.one.platform.textract.model.ExtractedStructureTest' --tests 'studio.one.platform.textract.extractor.impl.DocxFileParserTest' --tests 'studio.one.platform.textract.extractor.impl.HwpHwpxFileParserTest'`
- 결과: PASS

## Risk / Rollback
- Risk: `sourceRef/sourceRefs/binDataRef` helper 추가로 downstream에서 새 helper를 사용하기 시작하면 metadata key 이름에 의존하게 된다.
- Rollback: 이 PR의 commit `d05699f`를 revert하면 표/이미지 구조 helper와 parser metadata 변경을 이전 상태로 되돌릴 수 있다.

## AI / Subagent Usage
- AI-Assisted: Yes
- Main agent usage: 구현, 리뷰 반영, 테스트, 커밋/PR 준비
- Subagent used: Yes
- Delegated scope: `code-reviewer` subagent로 현재 diff에 대한 로컬 리뷰 수행
- Review result: `rowCount()`의 `rowSpan` 반영 누락과 HWPX image source mapping last-write-wins 이슈를 수정 반영했다.

## Checklist
- [x] commit message follows policy
- [x] issue template was used or exception was recorded
- [x] AI-Assisted value is correct
- [x] validation is recorded
- [x] subagent usage is recorded
- [x] CI or repository verification passed
- [x] human review is required before merge
- [x] unrelated changes are excluded
