### PR TITLE
[textract] 포맷별 추출 품질 개선 (PDF/DOCX/PPTX/HTML/OCR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-04-24
+
+### 변경됨
+- 이슈 #235 대응으로 `HtmlFileParser.parse()`가 기존 `Jsoup.text()` 기반 plain text 전용 추출에서 `parseStructured(...).plainText()` 경로를 사용하도록 변경됐다.
+- HTML 추출은 `script`, `style`, `nav`, `aside`, `footer`, `form` 등 boilerplate 후보를 제거하고 `h1`-`h6`, `p`, `li`, `table`, `img` 기반 semantic block을 구성한다.
+- PDF/PPTX/HTML 파서에 구조화 block/provenance 추출을 추가하고, DOCX footnote/list 및 OCR line block metadata를 보강했다.
+
+### 검증
+- `./gradlew :studio-platform-textract:test`
+- `./gradlew :studio-platform-textract:build`
+
 ## 2026-04-20
 
 ### 변경됨

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/AbstractFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/AbstractFileParser.java
@@ -1,10 +1,14 @@
 package studio.one.platform.textract.extractor.impl;
 
 import java.util.Locale;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import lombok.extern.slf4j.Slf4j;
 import studio.one.platform.textract.extractor.FileParser;
+import studio.one.platform.textract.model.ExtractedTable;
+import studio.one.platform.textract.model.ParsedBlock;
 
 @Slf4j
 public abstract class AbstractFileParser implements FileParser {
@@ -58,6 +62,38 @@ public abstract class AbstractFileParser implements FileParser {
         normalized = CONTROL_CHARS.matcher(normalized).replaceAll("");
         normalized = MULTI_BLANK_LINES.matcher(normalized).replaceAll("\n\n");
         return normalized.trim();
+    }
+
+    protected Map<String, Object> fileMetadata(String contentType, String filename) {
+        if (filename == null || filename.isBlank()) {
+            return contentType == null || contentType.isBlank()
+                    ? Map.of()
+                    : Map.of("contentType", contentType);
+        }
+        if (contentType == null || contentType.isBlank()) {
+            return Map.of("filename", filename);
+        }
+        return Map.of("filename", filename, "contentType", contentType);
+    }
+
+    protected Map<String, Object> blockMetadata(String sourceRef) {
+        return blockMetadata(sourceRef, null);
+    }
+
+    protected Map<String, Object> blockMetadata(String sourceRef, Integer order) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put(ParsedBlock.KEY_SOURCE_REF, sourceRef);
+        if (order != null) {
+            metadata.put(ParsedBlock.KEY_ORDER, order);
+        }
+        return metadata;
+    }
+
+    protected Map<String, Object> tableMetadata(String sourceRef, String format) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put(ExtractedTable.KEY_SOURCE_REF, sourceRef);
+        metadata.put(ExtractedTable.KEY_FORMAT, format);
+        return metadata;
     }
 
     /**

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/DocxFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/DocxFileParser.java
@@ -3,7 +3,6 @@ package studio.one.platform.textract.extractor.impl;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -74,7 +73,7 @@ public class DocxFileParser extends AbstractFileParser implements StructuredFile
                     DocumentFormat.DOCX,
                     text,
                     blocks,
-                    metadata(contentType, filename),
+                    fileMetadata(contentType, filename),
                     List.of(),
                     List.of(),
                     tables,
@@ -205,35 +204,4 @@ public class DocxFileParser extends AbstractFileParser implements StructuredFile
         return BlockType.PARAGRAPH;
     }
 
-    private Map<String, Object> blockMetadata(String path) {
-        return blockMetadata(path, null);
-    }
-
-    private Map<String, Object> blockMetadata(String path, Integer order) {
-        Map<String, Object> metadata = new LinkedHashMap<>();
-        metadata.put(ParsedBlock.KEY_SOURCE_REF, path);
-        if (order != null) {
-            metadata.put(ParsedBlock.KEY_ORDER, order);
-        }
-        return metadata;
-    }
-
-    private Map<String, Object> tableMetadata(String path, String format) {
-        Map<String, Object> metadata = new LinkedHashMap<>();
-        metadata.put(ExtractedTable.KEY_SOURCE_REF, path);
-        metadata.put(ExtractedTable.KEY_FORMAT, format);
-        return metadata;
-    }
-
-    private Map<String, Object> metadata(String contentType, String filename) {
-        if (filename == null || filename.isBlank()) {
-            return contentType == null || contentType.isBlank()
-                    ? Map.of()
-                    : Map.of("contentType", contentType);
-        }
-        if (contentType == null || contentType.isBlank()) {
-            return Map.of("filename", filename);
-        }
-        return Map.of("filename", filename, "contentType", contentType);
-    }
 }

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/DocxFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/DocxFileParser.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 
 import org.apache.poi.xwpf.usermodel.IBodyElement;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.apache.poi.xwpf.usermodel.XWPFFootnote;
 import org.apache.poi.xwpf.usermodel.XWPFParagraph;
 import org.apache.poi.xwpf.usermodel.XWPFTable;
 import org.apache.poi.xwpf.usermodel.XWPFTableCell;
@@ -66,6 +67,7 @@ public class DocxFileParser extends AbstractFileParser implements StructuredFile
                         BlockType.FOOTER,
                         order);
             }
+            order = appendFootnotes(doc.getFootnotes(), sb, blocks, order);
 
             String text = cleanText(sb.toString());
             return new ParsedFile(
@@ -105,6 +107,23 @@ public class DocxFileParser extends AbstractFileParser implements StructuredFile
                 case PARAGRAPH -> order += appendParagraph((XWPFParagraph) element, sb, blocks, path, containerType, order);
                 case TABLE -> order += appendTable((XWPFTable) element, sb, blocks, tables, path, order);
                 default -> { /* ignore other elements */ }
+            }
+        }
+        return order;
+    }
+
+    private int appendFootnotes(
+            List<XWPFFootnote> footnotes,
+            StringBuilder sb,
+            List<ParsedBlock> blocks,
+            int startOrder) {
+        int order = startOrder;
+        for (int footnoteIndex = 0; footnoteIndex < footnotes.size(); footnoteIndex++) {
+            XWPFFootnote footnote = footnotes.get(footnoteIndex);
+            List<XWPFParagraph> paragraphs = footnote.getParagraphs();
+            for (int paragraphIndex = 0; paragraphIndex < paragraphs.size(); paragraphIndex++) {
+                String path = "footnote[" + footnoteIndex + "]/paragraph[" + paragraphIndex + "]";
+                order += appendParagraph(paragraphs.get(paragraphIndex), sb, blocks, path, BlockType.FOOTNOTE, order);
             }
         }
         return order;
@@ -160,8 +179,11 @@ public class DocxFileParser extends AbstractFileParser implements StructuredFile
     }
 
     private BlockType resolveParagraphType(XWPFParagraph paragraph, BlockType containerType) {
-        if (containerType == BlockType.HEADER || containerType == BlockType.FOOTER) {
+        if (containerType == BlockType.HEADER || containerType == BlockType.FOOTER || containerType == BlockType.FOOTNOTE) {
             return containerType;
+        }
+        if (paragraph.getNumID() != null) {
+            return BlockType.LIST_ITEM;
         }
         String style = paragraph.getStyle();
         if (style == null) {

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/HtmlFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/HtmlFileParser.java
@@ -85,7 +85,7 @@ public class HtmlFileParser extends AbstractFileParser implements StructuredFile
                     DocumentFormat.HTML,
                     text,
                     blocks,
-                    metadata(contentType, filename),
+                    fileMetadata(contentType, filename),
                     List.of(),
                     List.of(),
                     tables,
@@ -169,22 +169,4 @@ public class HtmlFileParser extends AbstractFileParser implements StructuredFile
         return element.tagName() + "[" + order + "]";
     }
 
-    private Map<String, Object> blockMetadata(String path, int order) {
-        Map<String, Object> metadata = new LinkedHashMap<>();
-        metadata.put(ParsedBlock.KEY_SOURCE_REF, path);
-        metadata.put(ParsedBlock.KEY_ORDER, order);
-        return metadata;
-    }
-
-    private Map<String, Object> metadata(String contentType, String filename) {
-        if (filename == null || filename.isBlank()) {
-            return contentType == null || contentType.isBlank()
-                    ? Map.of()
-                    : Map.of("contentType", contentType);
-        }
-        if (contentType == null || contentType.isBlank()) {
-            return Map.of("filename", filename);
-        }
-        return Map.of("filename", filename, "contentType", contentType);
-    }
 }

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/HtmlFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/HtmlFileParser.java
@@ -3,12 +3,27 @@ package studio.one.platform.textract.extractor.impl;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
 
+import studio.one.platform.textract.extractor.DocumentFormat;
 import studio.one.platform.textract.extractor.FileParseException;
+import studio.one.platform.textract.extractor.StructuredFileParser;
+import studio.one.platform.textract.model.BlockType;
+import studio.one.platform.textract.model.ExtractedImage;
+import studio.one.platform.textract.model.ExtractedTable;
+import studio.one.platform.textract.model.ExtractedTableCell;
+import studio.one.platform.textract.model.ParsedBlock;
+import studio.one.platform.textract.model.ParsedFile;
 
-public class HtmlFileParser extends AbstractFileParser {
+public class HtmlFileParser extends AbstractFileParser implements StructuredFileParser {
 
     @Override
     public boolean supports(String contentType, String filename) {
@@ -18,14 +33,158 @@ public class HtmlFileParser extends AbstractFileParser {
     }
 
     @Override
-    public String parse(byte[] bytes, String contentType, String filename) throws FileParseException {
+    public ParsedFile parseStructured(byte[] bytes, String contentType, String filename) throws FileParseException {
         try (ByteArrayInputStream in = new ByteArrayInputStream(bytes)) {
-            String text = Jsoup
-                    .parse(in, StandardCharsets.UTF_8.name(), "")
-                    .text();
-            return cleanText(text);
+            Document document = Jsoup.parse(in, StandardCharsets.UTF_8.name(), "");
+            document.select("script, style, noscript, template, nav, aside, footer, form").remove();
+            Element root = semanticRoot(document);
+            List<ParsedBlock> blocks = new ArrayList<>();
+            List<ExtractedTable> tables = new ArrayList<>();
+            List<ExtractedImage> images = new ArrayList<>();
+            StringBuilder sb = new StringBuilder();
+            int order = 0;
+
+            for (Element element : root.select("h1, h2, h3, h4, h5, h6, p, li, table, img")) {
+                String path = cssPath(element, order);
+                if ("table".equals(element.tagName())) {
+                    ExtractedTable table = extractTable(element, path);
+                    if (!table.markdown().isBlank()) {
+                        tables.add(table);
+                        blocks.add(ParsedBlock.text(path, BlockType.TABLE, table.markdown(), null, order, blockMetadata(path, order)));
+                        sb.append(table.markdown()).append("\n");
+                        order++;
+                    }
+                    continue;
+                }
+                if ("img".equals(element.tagName())) {
+                    ExtractedImage image = extractImage(element, path);
+                    images.add(image);
+                    String alt = cleanText(element.attr("alt"));
+                    if (alt != null && !alt.isBlank()) {
+                        blocks.add(ParsedBlock.text(path, BlockType.IMAGE_CAPTION, alt, null, order, blockMetadata(path, order)));
+                        sb.append(alt).append("\n");
+                        order++;
+                    }
+                    continue;
+                }
+                String text = cleanText(element.text());
+                if (text == null || text.isBlank() || hasTableAncestor(element)) {
+                    continue;
+                }
+                BlockType type = resolveElementType(element);
+                blocks.add(ParsedBlock.text(path, type, text, null, order, blockMetadata(path, order)));
+                sb.append(text).append("\n");
+                order++;
+            }
+
+            String text = cleanText(sb.toString());
+            if ((text == null || text.isBlank()) && root != null) {
+                text = cleanText(root.text());
+            }
+            return new ParsedFile(
+                    DocumentFormat.HTML,
+                    text,
+                    blocks,
+                    metadata(contentType, filename),
+                    List.of(),
+                    List.of(),
+                    tables,
+                    images,
+                    false);
         } catch (IOException e) {
             throw new FileParseException("Failed to parse HTML: " + safeFilename(filename), e);
         }
+    }
+
+    @Override
+    public String parse(byte[] bytes, String contentType, String filename) throws FileParseException {
+        return parseStructured(bytes, contentType, filename).plainText();
+    }
+
+    private Element semanticRoot(Document document) {
+        Elements roots = document.select("main, article");
+        return roots.isEmpty() ? document.body() : roots.first();
+    }
+
+    private BlockType resolveElementType(Element element) {
+        String tag = element.tagName();
+        if ("h1".equals(tag)) {
+            return BlockType.TITLE;
+        }
+        if (tag.matches("h[2-6]")) {
+            return BlockType.HEADING;
+        }
+        if ("li".equals(tag)) {
+            return BlockType.LIST_ITEM;
+        }
+        return BlockType.PARAGRAPH;
+    }
+
+    private ExtractedTable extractTable(Element table, String path) {
+        List<ExtractedTableCell> cells = new ArrayList<>();
+        List<String> markdownRows = new ArrayList<>();
+        Elements rows = table.select("tr");
+        for (int rowIndex = 0; rowIndex < rows.size(); rowIndex++) {
+            Elements rowCells = rows.get(rowIndex).select("th, td");
+            List<String> markdownCells = new ArrayList<>();
+            for (int colIndex = 0; colIndex < rowCells.size(); colIndex++) {
+                Element cell = rowCells.get(colIndex);
+                String text = cleanText(cell.text());
+                cells.add(new ExtractedTableCell(rowIndex, colIndex, 1, 1, text, Map.of()));
+                markdownCells.add(text == null ? "" : text.replace("\n", " "));
+            }
+            if (!markdownCells.isEmpty()) {
+                markdownRows.add("| " + String.join(" | ", markdownCells) + " |");
+            }
+        }
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put(ExtractedTable.KEY_SOURCE_REF, path);
+        metadata.put(ExtractedTable.KEY_FORMAT, "html");
+        return new ExtractedTable(path, String.join("\n", markdownRows), cells, metadata);
+    }
+
+    private ExtractedImage extractImage(Element image, String path) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put(ExtractedImage.KEY_SOURCE_REF, path);
+        String source = image.attr("src");
+        if (source != null && !source.isBlank()) {
+            metadata.put("src", source);
+        }
+        String alt = image.attr("alt");
+        if (alt != null && !alt.isBlank()) {
+            metadata.put("alt", alt);
+        }
+        return new ExtractedImage(path, null, source, null, null, metadata);
+    }
+
+    private boolean hasTableAncestor(Element element) {
+        return element.parents().stream().anyMatch(parent -> "table".equals(parent.tagName()));
+    }
+
+    private String cssPath(Element element, int order) {
+        String id = element.id();
+        if (id != null && !id.isBlank()) {
+            return element.tagName() + "#" + id;
+        }
+        return element.tagName() + "[" + order + "]";
+    }
+
+    private Map<String, Object> blockMetadata(String path, int order) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put(ParsedBlock.KEY_SOURCE_REF, path);
+        metadata.put(ParsedBlock.KEY_ORDER, order);
+        return metadata;
+    }
+
+    private Map<String, Object> metadata(String contentType, String filename) {
+        if (filename == null || filename.isBlank()) {
+            return contentType == null || contentType.isBlank()
+                    ? Map.of()
+                    : Map.of("contentType", contentType);
+        }
+        if (contentType == null || contentType.isBlank()) {
+            return Map.of("filename", filename);
+        }
+        return Map.of("filename", filename, "contentType", contentType);
     }
 }

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/HtmlFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/HtmlFileParser.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -140,7 +141,7 @@ public class HtmlFileParser extends AbstractFileParser implements StructuredFile
     }
 
     private ExtractedImage extractImage(Element image, String path) {
-        Map<String, Object> metadata = blockMetadata(path);
+        Map<String, Object> metadata = new LinkedHashMap<>();
         metadata.put(ExtractedImage.KEY_SOURCE_REF, path);
         String source = image.attr("src");
         if (source != null && !source.isBlank()) {

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/HtmlFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/HtmlFileParser.java
@@ -4,7 +4,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -78,7 +77,7 @@ public class HtmlFileParser extends AbstractFileParser implements StructuredFile
             }
 
             String text = cleanText(sb.toString());
-            if ((text == null || text.isBlank()) && root != null) {
+            if (text == null || text.isBlank()) {
                 text = cleanText(root.text());
             }
             return new ParsedFile(
@@ -137,14 +136,11 @@ public class HtmlFileParser extends AbstractFileParser implements StructuredFile
                 markdownRows.add("| " + String.join(" | ", markdownCells) + " |");
             }
         }
-        Map<String, Object> metadata = new LinkedHashMap<>();
-        metadata.put(ExtractedTable.KEY_SOURCE_REF, path);
-        metadata.put(ExtractedTable.KEY_FORMAT, "html");
-        return new ExtractedTable(path, String.join("\n", markdownRows), cells, metadata);
+        return new ExtractedTable(path, String.join("\n", markdownRows), cells, tableMetadata(path, "html"));
     }
 
     private ExtractedImage extractImage(Element image, String path) {
-        Map<String, Object> metadata = new LinkedHashMap<>();
+        Map<String, Object> metadata = blockMetadata(path);
         metadata.put(ExtractedImage.KEY_SOURCE_REF, path);
         String source = image.attr("src");
         if (source != null && !source.isBlank()) {

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/ImageFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/ImageFileParser.java
@@ -3,6 +3,8 @@ package studio.one.platform.textract.extractor.impl;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -25,7 +27,7 @@ public class ImageFileParser extends AbstractFileParser implements StructuredFil
     private final Tesseract tesseract; // Spring Bean 으로 주입받는 것을 권장
 
     public ImageFileParser(String tesseractDataPath, String language) {
-        this.tesseract = new  Tesseract();
+        this.tesseract = new Tesseract();
         this.tesseract.setDatapath(tesseractDataPath);
         this.tesseract.setLanguage(language);
     }
@@ -46,22 +48,14 @@ public class ImageFileParser extends AbstractFileParser implements StructuredFil
                 throw new FileParseException("Unsupported or corrupt image: " + safeFilename(filename));
             }
             String text = cleanText(tesseract.doOCR(image));
-            List<ParsedBlock> blocks = text == null || text.isBlank()
-                    ? List.of()
-                    : List.of(ParsedBlock.text(
-                            "image/ocr",
-                            BlockType.OCR_TEXT,
-                            text,
-                            null,
-                            0,
-                            Map.of()));
+            List<ParsedBlock> blocks = ocrLineBlocks(text);
             ExtractedImage extractedImage = new ExtractedImage(
                     "image",
                     contentType,
                     filename,
                     image.getWidth(),
                     image.getHeight(),
-                    Map.of("ocr", true));
+                    imageMetadata(blocks.size()));
             return new ParsedFile(
                     DocumentFormat.IMAGE,
                     text,
@@ -80,6 +74,43 @@ public class ImageFileParser extends AbstractFileParser implements StructuredFil
     @Override
     public String parse(byte[] bytes, String contentType, String filename) throws FileParseException {
         return parseStructured(bytes, contentType, filename).plainText();
+    }
+
+    List<ParsedBlock> ocrLineBlocks(String text) {
+        if (text == null || text.isBlank()) {
+            return List.of();
+        }
+        List<ParsedBlock> blocks = new ArrayList<>();
+        String[] lines = text.split("\\n");
+        for (String line : lines) {
+            String cleanedLine = cleanText(line);
+            if (cleanedLine == null || cleanedLine.isBlank()) {
+                continue;
+            }
+            int order = blocks.size();
+            String path = "image/ocr/line[" + order + "]";
+            blocks.add(ParsedBlock.text(path, BlockType.OCR_TEXT, cleanedLine, null, order, ocrBlockMetadata(path, order)));
+        }
+        return blocks;
+    }
+
+    private Map<String, Object> ocrBlockMetadata(String path, int order) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put(ParsedBlock.KEY_SOURCE_REF, path);
+        metadata.put(ParsedBlock.KEY_ORDER, order);
+        metadata.put("ocr", true);
+        metadata.put("ocrUnit", "line");
+        metadata.put("confidenceAvailable", false);
+        return metadata;
+    }
+
+    private Map<String, Object> imageMetadata(int ocrLineCount) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put(ExtractedImage.KEY_SOURCE_REF, "image");
+        metadata.put("ocr", true);
+        metadata.put("ocrLineCount", ocrLineCount);
+        metadata.put("confidenceAvailable", false);
+        return metadata;
     }
 
     private Map<String, Object> metadata(String contentType, String filename) {

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/ImageFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/ImageFileParser.java
@@ -60,7 +60,7 @@ public class ImageFileParser extends AbstractFileParser implements StructuredFil
                     DocumentFormat.IMAGE,
                     text,
                     blocks,
-                    metadata(contentType, filename),
+                    fileMetadata(contentType, filename),
                     List.of(),
                     List.of(),
                     List.of(),
@@ -113,15 +113,4 @@ public class ImageFileParser extends AbstractFileParser implements StructuredFil
         return metadata;
     }
 
-    private Map<String, Object> metadata(String contentType, String filename) {
-        if (filename == null || filename.isBlank()) {
-            return contentType == null || contentType.isBlank()
-                    ? Map.of()
-                    : Map.of("contentType", contentType);
-        }
-        if (contentType == null || contentType.isBlank()) {
-            return Map.of("filename", filename);
-        }
-        return Map.of("filename", filename, "contentType", contentType);
-    }
 }

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PdfFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PdfFileParser.java
@@ -2,7 +2,10 @@ package studio.one.platform.textract.extractor.impl;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -10,10 +13,15 @@ import org.apache.pdfbox.text.PDFTextStripper;
 import org.springframework.http.MediaType;
 
 import lombok.extern.slf4j.Slf4j;
+import studio.one.platform.textract.extractor.DocumentFormat;
 import studio.one.platform.textract.extractor.FileParseException;
+import studio.one.platform.textract.extractor.StructuredFileParser;
+import studio.one.platform.textract.model.BlockType;
+import studio.one.platform.textract.model.ParsedBlock;
+import studio.one.platform.textract.model.ParsedFile;
 
 @Slf4j
-public class PdfFileParser extends AbstractFileParser {
+public class PdfFileParser extends AbstractFileParser implements StructuredFileParser {
 
     @Override
     public boolean supports(String contentType, String filename) {
@@ -31,16 +39,99 @@ public class PdfFileParser extends AbstractFileParser {
     }
 
     @Override
-    public String parse(byte[] bytes, String contentType, String filename) throws FileParseException {
+    public ParsedFile parseStructured(byte[] bytes, String contentType, String filename) throws FileParseException {
         try (PDDocument document = Loader.loadPDF(bytes)) {
             PDFTextStripper stripper = new PDFTextStripper();
             stripper.setSortByPosition(true);
-            stripper.setStartPage(1);
-            stripper.setEndPage(document.getNumberOfPages());
-            return cleanPdfText(stripper.getText(document));
+            List<String> pages = extractPages(document, stripper);
+            List<String> cleanedPages = cleanPdfPages(pages);
+            List<ParsedBlock> pageBlocks = new ArrayList<>();
+            List<ParsedBlock> blocks = new ArrayList<>();
+            int order = 0;
+            for (int pageIndex = 0; pageIndex < cleanedPages.size(); pageIndex++) {
+                String pageText = cleanedPages.get(pageIndex);
+                if (pageText == null || pageText.isBlank()) {
+                    continue;
+                }
+                int pageNumber = pageIndex + 1;
+                String pagePath = "page[" + pageNumber + "]";
+                pageBlocks.add(ParsedBlock.text(
+                        pagePath,
+                        BlockType.PAGE,
+                        pageText,
+                        pageNumber,
+                        order,
+                        blockMetadata(pagePath, order)));
+                List<String> paragraphs = splitParagraphs(pageText);
+                for (int paragraphIndex = 0; paragraphIndex < paragraphs.size(); paragraphIndex++) {
+                    String paragraph = paragraphs.get(paragraphIndex);
+                    String paragraphPath = pagePath + "/paragraph[" + paragraphIndex + "]";
+                    blocks.add(ParsedBlock.text(
+                            paragraphPath,
+                            BlockType.PARAGRAPH,
+                            paragraph,
+                            pageNumber,
+                            order,
+                            blockMetadata(paragraphPath, order)));
+                    order++;
+                }
+            }
+            String text = cleanText(cleanedPages.stream()
+                    .filter(page -> page != null && !page.isBlank())
+                    .collect(Collectors.joining("\n\n")));
+            return new ParsedFile(
+                    DocumentFormat.PDF,
+                    text,
+                    blocks,
+                    metadata(contentType, filename),
+                    List.of(),
+                    pageBlocks,
+                    List.of(),
+                    List.of(),
+                    false);
         } catch (IOException e) {
             throw new FileParseException("Failed to parse PDF file: " + safeFilename(filename), e);
         }
+    }
+
+    @Override
+    public String parse(byte[] bytes, String contentType, String filename) throws FileParseException {
+        return parseStructured(bytes, contentType, filename).plainText();
+    }
+
+    private List<String> extractPages(PDDocument document, PDFTextStripper stripper) throws IOException {
+        List<String> pages = new ArrayList<>();
+        for (int page = 1; page <= document.getNumberOfPages(); page++) {
+            stripper.setStartPage(page);
+            stripper.setEndPage(page);
+            pages.add(stripper.getText(document));
+        }
+        return pages;
+    }
+
+    List<String> cleanPdfPages(List<String> rawPages) {
+        if (rawPages == null || rawPages.isEmpty()) {
+            return List.of();
+        }
+        List<List<String>> pageLines = rawPages.stream()
+                .map(this::contentLines)
+                .toList();
+        Map<String, Integer> boundaryFrequency = new LinkedHashMap<>();
+        for (List<String> lines : pageLines) {
+            for (String boundaryLine : boundaryLines(lines)) {
+                boundaryFrequency.merge(normalizeBoundaryLine(boundaryLine), 1, Integer::sum);
+            }
+        }
+        List<String> repeatedBoundaries = boundaryFrequency.entrySet().stream()
+                .filter(entry -> rawPages.size() > 1 && entry.getValue() >= 2)
+                .map(Map.Entry::getKey)
+                .toList();
+        List<String> cleaned = new ArrayList<>();
+        for (String rawPage : rawPages) {
+            String pageWithoutRepeatedBoundaries = removeRepeatedBoundaries(rawPage, repeatedBoundaries);
+            cleaned.add(cleanPdfText(pageWithoutRepeatedBoundaries));
+        }
+        return cleaned;
     }
 
     String cleanPdfText(String raw) {
@@ -85,6 +176,77 @@ public class PdfFileParser extends AbstractFileParser {
             }
         }
         return contentLineCount >= 8 && (double) shortLineCount / contentLineCount >= 0.35d;
+    }
+
+    private List<String> splitParagraphs(String pageText) {
+        if (pageText == null || pageText.isBlank()) {
+            return List.of();
+        }
+        List<String> paragraphs = new ArrayList<>();
+        for (String paragraph : pageText.split("\\n\\s*\\n")) {
+            String cleaned = cleanText(paragraph);
+            if (cleaned != null && !cleaned.isBlank()) {
+                paragraphs.add(cleaned);
+            }
+        }
+        return paragraphs;
+    }
+
+    private List<String> contentLines(String raw) {
+        String cleaned = cleanText(raw);
+        if (cleaned == null || cleaned.isBlank()) {
+            return List.of();
+        }
+        return cleaned.lines()
+                .map(String::trim)
+                .filter(line -> !line.isBlank())
+                .toList();
+    }
+
+    private List<String> boundaryLines(List<String> lines) {
+        if (lines.isEmpty()) {
+            return List.of();
+        }
+        List<String> boundaries = new ArrayList<>();
+        boundaries.add(lines.get(0));
+        if (lines.size() > 1) {
+            boundaries.add(lines.get(lines.size() - 1));
+        }
+        return boundaries;
+    }
+
+    private String removeRepeatedBoundaries(String raw, List<String> repeatedBoundaries) {
+        if (repeatedBoundaries.isEmpty()) {
+            return raw;
+        }
+        return contentLines(raw).stream()
+                .filter(line -> !repeatedBoundaries.contains(normalizeBoundaryLine(line)))
+                .collect(Collectors.joining("\n"));
+    }
+
+    private String normalizeBoundaryLine(String line) {
+        return line == null ? "" : line.trim().replaceAll("\\s+", " ");
+    }
+
+    private Map<String, Object> blockMetadata(String path, Integer order) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put(ParsedBlock.KEY_SOURCE_REF, path);
+        if (order != null) {
+            metadata.put(ParsedBlock.KEY_ORDER, order);
+        }
+        return metadata;
+    }
+
+    private Map<String, Object> metadata(String contentType, String filename) {
+        if (filename == null || filename.isBlank()) {
+            return contentType == null || contentType.isBlank()
+                    ? Map.of()
+                    : Map.of("contentType", contentType);
+        }
+        if (contentType == null || contentType.isBlank()) {
+            return Map.of("filename", filename);
+        }
+        return Map.of("filename", filename, "contentType", contentType);
     }
 
     private void appendLine(StringBuilder paragraph, String line, int previousLineLength) {

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PdfFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PdfFileParser.java
@@ -23,6 +23,8 @@ import studio.one.platform.textract.model.ParsedFile;
 @Slf4j
 public class PdfFileParser extends AbstractFileParser implements StructuredFileParser {
 
+    private static final double REPEATED_BOUNDARY_RATIO = 0.50d;
+
     @Override
     public boolean supports(String contentType, String filename) {
         try {
@@ -62,6 +64,7 @@ public class PdfFileParser extends AbstractFileParser implements StructuredFileP
                         pageNumber,
                         order,
                         blockMetadata(pagePath, order)));
+                order++;
                 List<String> paragraphs = splitParagraphs(pageText);
                 for (int paragraphIndex = 0; paragraphIndex < paragraphs.size(); paragraphIndex++) {
                     String paragraph = paragraphs.get(paragraphIndex);
@@ -123,7 +126,7 @@ public class PdfFileParser extends AbstractFileParser implements StructuredFileP
             }
         }
         List<String> repeatedBoundaries = boundaryFrequency.entrySet().stream()
-                .filter(entry -> rawPages.size() > 1 && entry.getValue() >= 2)
+                .filter(entry -> isRepeatedBoundary(entry.getValue(), rawPages.size()))
                 .map(Map.Entry::getKey)
                 .toList();
         List<String> cleaned = new ArrayList<>();
@@ -132,6 +135,10 @@ public class PdfFileParser extends AbstractFileParser implements StructuredFileP
             cleaned.add(cleanPdfText(pageWithoutRepeatedBoundaries));
         }
         return cleaned;
+    }
+
+    private boolean isRepeatedBoundary(int count, int pageCount) {
+        return pageCount > 1 && count >= Math.max(2, (int) Math.ceil(pageCount * REPEATED_BOUNDARY_RATIO));
     }
 
     String cleanPdfText(String raw) {

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PdfFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PdfFileParser.java
@@ -83,7 +83,7 @@ public class PdfFileParser extends AbstractFileParser implements StructuredFileP
                     DocumentFormat.PDF,
                     text,
                     blocks,
-                    metadata(contentType, filename),
+                    fileMetadata(contentType, filename),
                     List.of(),
                     pageBlocks,
                     List.of(),
@@ -226,27 +226,6 @@ public class PdfFileParser extends AbstractFileParser implements StructuredFileP
 
     private String normalizeBoundaryLine(String line) {
         return line == null ? "" : line.trim().replaceAll("\\s+", " ");
-    }
-
-    private Map<String, Object> blockMetadata(String path, Integer order) {
-        Map<String, Object> metadata = new LinkedHashMap<>();
-        metadata.put(ParsedBlock.KEY_SOURCE_REF, path);
-        if (order != null) {
-            metadata.put(ParsedBlock.KEY_ORDER, order);
-        }
-        return metadata;
-    }
-
-    private Map<String, Object> metadata(String contentType, String filename) {
-        if (filename == null || filename.isBlank()) {
-            return contentType == null || contentType.isBlank()
-                    ? Map.of()
-                    : Map.of("contentType", contentType);
-        }
-        if (contentType == null || contentType.isBlank()) {
-            return Map.of("filename", filename);
-        }
-        return Map.of("filename", filename, "contentType", contentType);
     }
 
     private void appendLine(StringBuilder paragraph, String line, int previousLineLength) {

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PptxFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PptxFileParser.java
@@ -5,6 +5,7 @@ import java.awt.geom.Rectangle2D;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -112,7 +113,7 @@ public class PptxFileParser extends AbstractFileParser implements StructuredFile
     }
 
     private Map<String, Object> blockMetadata(String path, int slide, int order) {
-        Map<String, Object> metadata = blockMetadata(path, Integer.valueOf(order));
+        Map<String, Object> metadata = new LinkedHashMap<>(blockMetadata(path, Integer.valueOf(order)));
         metadata.put(ParsedBlock.KEY_SLIDE, slide);
         return metadata;
     }

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PptxFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PptxFileParser.java
@@ -5,7 +5,6 @@ import java.awt.geom.Rectangle2D;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -87,7 +86,7 @@ public class PptxFileParser extends AbstractFileParser implements StructuredFile
                     DocumentFormat.PPTX,
                     cleanText(sb.toString()),
                     blocks,
-                    metadata(contentType, filename),
+                    fileMetadata(contentType, filename),
                     List.of(),
                     pages,
                     List.of(),
@@ -113,22 +112,8 @@ public class PptxFileParser extends AbstractFileParser implements StructuredFile
     }
 
     private Map<String, Object> blockMetadata(String path, int slide, int order) {
-        Map<String, Object> metadata = new LinkedHashMap<>();
-        metadata.put(ParsedBlock.KEY_SOURCE_REF, path);
+        Map<String, Object> metadata = blockMetadata(path, Integer.valueOf(order));
         metadata.put(ParsedBlock.KEY_SLIDE, slide);
-        metadata.put(ParsedBlock.KEY_ORDER, order);
         return metadata;
-    }
-
-    private Map<String, Object> metadata(String contentType, String filename) {
-        if (filename == null || filename.isBlank()) {
-            return contentType == null || contentType.isBlank()
-                    ? Map.of()
-                    : Map.of("contentType", contentType);
-        }
-        if (contentType == null || contentType.isBlank()) {
-            return Map.of("filename", filename);
-        }
-        return Map.of("filename", filename, "contentType", contentType);
     }
 }

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PptxFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PptxFileParser.java
@@ -1,15 +1,27 @@
 package studio.one.platform.textract.extractor.impl;
 
+import java.awt.Dimension;
+import java.awt.geom.Rectangle2D;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.poi.xslf.usermodel.XMLSlideShow;
 import org.apache.poi.xslf.usermodel.XSLFShape;
+import org.apache.poi.xslf.usermodel.XSLFSlide;
 import org.apache.poi.xslf.usermodel.XSLFTextShape;
 
+import studio.one.platform.textract.extractor.DocumentFormat;
 import studio.one.platform.textract.extractor.FileParseException;
+import studio.one.platform.textract.extractor.StructuredFileParser;
+import studio.one.platform.textract.model.BlockType;
+import studio.one.platform.textract.model.ParsedBlock;
+import studio.one.platform.textract.model.ParsedFile;
 
-public class PptxFileParser extends AbstractFileParser {
+public class PptxFileParser extends AbstractFileParser implements StructuredFileParser {
 
     @Override
     public boolean supports(String contentType, String filename) {
@@ -20,27 +32,103 @@ public class PptxFileParser extends AbstractFileParser {
     }
 
     @Override
-    public String parse(byte[] bytes, String contentType, String filename) throws FileParseException {
+    public ParsedFile parseStructured(byte[] bytes, String contentType, String filename) throws FileParseException {
         try (ByteArrayInputStream in = new ByteArrayInputStream(bytes);
              XMLSlideShow ppt = new XMLSlideShow(in)) {
 
             StringBuilder sb = new StringBuilder();
+            List<ParsedBlock> blocks = new ArrayList<>();
+            List<ParsedBlock> pages = new ArrayList<>();
+            Dimension pageSize = ppt.getPageSize();
+            int order = 0;
 
-            ppt.getSlides().forEach(slide -> {
+            for (int slideIndex = 0; slideIndex < ppt.getSlides().size(); slideIndex++) {
+                StringBuilder slideText = new StringBuilder();
+                boolean titleSeen = false;
+                XSLFSlide slide = ppt.getSlides().get(slideIndex);
+                int shapeIndex = 0;
                 for (XSLFShape shape : slide.getShapes()) {
                     if (shape instanceof XSLFTextShape textShape) {
-                        String text = textShape.getText();
+                        String text = cleanText(textShape.getText());
                         if (text != null && !text.isBlank()) {
+                            String path = "slide[" + (slideIndex + 1) + "]/shape[" + shapeIndex + "]";
+                            BlockType blockType = resolveTextShapeType(textShape, pageSize, titleSeen);
+                            if (blockType == BlockType.TITLE) {
+                                titleSeen = true;
+                            }
+                            blocks.add(ParsedBlock.text(
+                                    path,
+                                    blockType,
+                                    text,
+                                    null,
+                                    order,
+                                    blockMetadata(path, slideIndex + 1, order)));
                             sb.append(text).append("\n");
+                            slideText.append(text).append("\n");
+                            order++;
                         }
                     }
+                    shapeIndex++;
                 }
-            });
+                String cleanedSlideText = cleanText(slideText.toString());
+                if (cleanedSlideText != null && !cleanedSlideText.isBlank()) {
+                    String path = "slide[" + (slideIndex + 1) + "]";
+                    pages.add(ParsedBlock.text(
+                            path,
+                            BlockType.PAGE,
+                            cleanedSlideText,
+                            null,
+                            pages.size(),
+                            blockMetadata(path, slideIndex + 1, pages.size())));
+                }
+            }
 
-            return cleanText(sb.toString());
+            return new ParsedFile(
+                    DocumentFormat.PPTX,
+                    cleanText(sb.toString()),
+                    blocks,
+                    metadata(contentType, filename),
+                    List.of(),
+                    pages,
+                    List.of(),
+                    List.of(),
+                    false);
 
         } catch (IOException e) {
             throw new FileParseException("Failed to parse PPTX file: " + safeFilename(filename), e);
         }
+    }
+
+    @Override
+    public String parse(byte[] bytes, String contentType, String filename) throws FileParseException {
+        return parseStructured(bytes, contentType, filename).plainText();
+    }
+
+    private BlockType resolveTextShapeType(XSLFTextShape textShape, Dimension pageSize, boolean titleSeen) {
+        Rectangle2D anchor = textShape.getAnchor();
+        if (anchor != null && pageSize != null && anchor.getY() > pageSize.getHeight() * 0.80d) {
+            return BlockType.FOOTER;
+        }
+        return titleSeen ? BlockType.PARAGRAPH : BlockType.TITLE;
+    }
+
+    private Map<String, Object> blockMetadata(String path, int slide, int order) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put(ParsedBlock.KEY_SOURCE_REF, path);
+        metadata.put(ParsedBlock.KEY_SLIDE, slide);
+        metadata.put(ParsedBlock.KEY_ORDER, order);
+        return metadata;
+    }
+
+    private Map<String, Object> metadata(String contentType, String filename) {
+        if (filename == null || filename.isBlank()) {
+            return contentType == null || contentType.isBlank()
+                    ? Map.of()
+                    : Map.of("contentType", contentType);
+        }
+        if (contentType == null || contentType.isBlank()) {
+            return Map.of("filename", filename);
+        }
+        return Map.of("filename", filename, "contentType", contentType);
     }
 }

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/DocxFileParserTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/DocxFileParserTest.java
@@ -1,13 +1,15 @@
 package studio.one.platform.textract.extractor.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
+import java.math.BigInteger;
 
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.apache.poi.xwpf.usermodel.XWPFFootnote;
 import org.apache.poi.xwpf.usermodel.XWPFHeader;
+import org.apache.poi.xwpf.usermodel.XWPFParagraph;
 import org.apache.poi.xwpf.usermodel.XWPFTable;
 import org.junit.jupiter.api.Test;
 
@@ -68,6 +70,37 @@ class DocxFileParserTest {
         assertEquals(1, result.blocks().get(1).order());
     }
 
+    @Test
+    void parseStructuredAssignsListItemBlockTypeFromNumbering() throws Exception {
+        byte[] bytes = docxWithNumberedParagraph();
+
+        ParsedFile result = new DocxFileParser()
+                .parseStructured(bytes, "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "list.docx");
+
+        ParsedBlock listBlock = result.blocks().stream()
+                .filter(block -> block.blockType() == BlockType.LIST_ITEM)
+                .findFirst()
+                .orElseThrow();
+        assertEquals("목록 항목", listBlock.text());
+        assertEquals(0, listBlock.order());
+    }
+
+    @Test
+    void parseStructuredAssignsFootnoteBlockTypeAndProvenance() throws Exception {
+        byte[] bytes = docxWithFootnote();
+
+        ParsedFile result = new DocxFileParser()
+                .parseStructured(bytes, "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "footnote.docx");
+
+        ParsedBlock footnoteBlock = result.blocks().stream()
+                .filter(block -> block.blockType() == BlockType.FOOTNOTE)
+                .findFirst()
+                .orElseThrow();
+        assertEquals("각주 본문", footnoteBlock.text());
+        assertTrue(footnoteBlock.sourceRef().startsWith("footnote["));
+        assertTrue(footnoteBlock.order() != null && footnoteBlock.order() > 0);
+    }
+
     private byte[] docxWithParagraphAndTable() throws Exception {
         try (XWPFDocument document = new XWPFDocument();
                 ByteArrayOutputStream out = new ByteArrayOutputStream()) {
@@ -99,6 +132,28 @@ class DocxFileParserTest {
             document.createParagraph().createRun().setText("첫 문단");
             document.createParagraph();
             document.createParagraph().createRun().setText("둘째 문단");
+            document.write(out);
+            return out.toByteArray();
+        }
+    }
+
+    private byte[] docxWithNumberedParagraph() throws Exception {
+        try (XWPFDocument document = new XWPFDocument();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            XWPFParagraph paragraph = document.createParagraph();
+            paragraph.setNumID(BigInteger.ONE);
+            paragraph.createRun().setText("목록 항목");
+            document.write(out);
+            return out.toByteArray();
+        }
+    }
+
+    private byte[] docxWithFootnote() throws Exception {
+        try (XWPFDocument document = new XWPFDocument();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            document.createParagraph().createRun().setText("본문 문단");
+            XWPFFootnote footnote = document.createFootnote();
+            footnote.createParagraph().createRun().setText("각주 본문");
             document.write(out);
             return out.toByteArray();
         }

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/HtmlFileParserTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/HtmlFileParserTest.java
@@ -1,0 +1,47 @@
+package studio.one.platform.textract.extractor.impl;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.textract.extractor.DocumentFormat;
+import studio.one.platform.textract.model.BlockType;
+import studio.one.platform.textract.model.ParsedFile;
+
+class HtmlFileParserTest {
+
+    @Test
+    void parseStructuredExtractsSemanticBlocksAndSkipsBoilerplate() {
+        String html = """
+                <html>
+                  <body>
+                    <nav>메뉴 링크</nav>
+                    <main>
+                      <h1>문서 제목</h1>
+                      <p>본문 문단</p>
+                      <ul><li>목록 항목</li></ul>
+                      <table><tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr></table>
+                      <img src="hero.png" alt="대표 이미지">
+                    </main>
+                    <footer>푸터</footer>
+                  </body>
+                </html>
+                """;
+
+        ParsedFile result = new HtmlFileParser().parseStructured(html.getBytes(UTF_8), "text/html", "sample.html");
+
+        assertEquals(DocumentFormat.HTML, result.format());
+        assertTrue(result.plainText().contains("문서 제목"));
+        assertTrue(result.blocks().stream().anyMatch(block -> block.blockType() == BlockType.TITLE));
+        assertTrue(result.blocks().stream().anyMatch(block -> block.blockType() == BlockType.LIST_ITEM));
+        assertTrue(result.blocks().stream().anyMatch(block -> block.blockType() == BlockType.TABLE));
+        assertEquals(1, result.tables().size());
+        assertEquals("html", result.tables().get(0).format());
+        assertEquals(1, result.images().size());
+        assertFalse(result.plainText().contains("메뉴 링크"));
+        assertFalse(result.plainText().contains("푸터"));
+    }
+}

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/ImageFileParserTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/ImageFileParserTest.java
@@ -1,0 +1,30 @@
+package studio.one.platform.textract.extractor.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.textract.model.BlockType;
+import studio.one.platform.textract.model.ParsedBlock;
+
+class ImageFileParserTest {
+
+    @Test
+    void ocrLineBlocksSplitTextIntoLineLevelBlocks() {
+        List<ParsedBlock> blocks = new ImageFileParser("/tmp", "kor+eng").ocrLineBlocks("""
+                첫 줄
+                둘째 줄
+
+                셋째 줄
+                """);
+
+        assertEquals(3, blocks.size());
+        assertTrue(blocks.stream().allMatch(block -> block.blockType() == BlockType.OCR_TEXT));
+        assertEquals("image/ocr/line[0]", blocks.get(0).sourceRef());
+        assertEquals("line", blocks.get(0).metadata().get("ocrUnit"));
+        assertEquals(false, blocks.get(0).metadata().get("confidenceAvailable"));
+    }
+}

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/PdfFileParserTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/PdfFileParserTest.java
@@ -1,8 +1,21 @@
 package studio.one.platform.textract.extractor.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
 import org.junit.jupiter.api.Test;
+
+import studio.one.platform.textract.extractor.DocumentFormat;
+import studio.one.platform.textract.model.BlockType;
+import studio.one.platform.textract.model.ParsedFile;
 
 class PdfFileParserTest {
 
@@ -48,5 +61,62 @@ class PdfFileParserTest {
 
                 두 번째 문단입니다.
                 정상적인 줄바꿈은 유지합니다.""", result);
+    }
+
+    @Test
+    void cleanPdfPagesRemovesRepeatedBoundaryLines() {
+        List<String> result = parser.cleanPdfPages(List.of(
+                """
+                공통 헤더
+                첫 페이지 본문
+                공통 푸터
+                """,
+                """
+                공통 헤더
+                둘째 페이지 본문
+                공통 푸터
+                """));
+
+        assertEquals(List.of("첫 페이지 본문", "둘째 페이지 본문"), result);
+    }
+
+    @Test
+    void parseStructuredReturnsParagraphBlocksAndPageProvenance() throws Exception {
+        byte[] bytes = pdfWithTwoPages();
+
+        ParsedFile result = parser.parseStructured(bytes, "application/pdf", "sample.pdf");
+
+        assertEquals(DocumentFormat.PDF, result.format());
+        assertTrue(result.plainText().contains("First page body"));
+        assertEquals(2, result.pages().size());
+        assertTrue(result.blocks().stream().allMatch(block -> block.blockType() == BlockType.PARAGRAPH));
+        assertEquals(1, result.blocks().get(0).page());
+        assertEquals("page[1]/paragraph[0]", result.blocks().get(0).sourceRef());
+    }
+
+    private byte[] pdfWithTwoPages() throws Exception {
+        try (PDDocument document = new PDDocument();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            addPage(document, "Common header", "First page body", "Common footer");
+            addPage(document, "Common header", "Second page body", "Common footer");
+            document.save(out);
+            return out.toByteArray();
+        }
+    }
+
+    private void addPage(PDDocument document, String header, String body, String footer) throws Exception {
+        PDPage page = new PDPage();
+        document.addPage(page);
+        try (PDPageContentStream contentStream = new PDPageContentStream(document, page)) {
+            contentStream.beginText();
+            contentStream.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 12);
+            contentStream.newLineAtOffset(50, 750);
+            contentStream.showText(header);
+            contentStream.newLineAtOffset(0, -40);
+            contentStream.showText(body);
+            contentStream.newLineAtOffset(0, -640);
+            contentStream.showText(footer);
+            contentStream.endText();
+        }
     }
 }

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/PdfFileParserTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/PdfFileParserTest.java
@@ -81,6 +81,39 @@ class PdfFileParserTest {
     }
 
     @Test
+    void cleanPdfPagesKeepsBoundaryLinesBelowRepeatedRatio() {
+        List<String> result = parser.cleanPdfPages(List.of(
+                """
+                우연히 같은 첫 줄
+                첫 페이지 본문
+                끝1
+                """,
+                """
+                우연히 같은 첫 줄
+                둘째 페이지 본문
+                끝2
+                """,
+                """
+                다른 첫 줄
+                셋째 페이지 본문
+                끝3
+                """,
+                """
+                또 다른 첫 줄
+                넷째 페이지 본문
+                끝4
+                """,
+                """
+                마지막 첫 줄
+                다섯째 페이지 본문
+                끝5
+                """));
+
+        assertTrue(result.get(0).contains("우연히 같은 첫 줄"));
+        assertTrue(result.get(1).contains("우연히 같은 첫 줄"));
+    }
+
+    @Test
     void parseStructuredReturnsParagraphBlocksAndPageProvenance() throws Exception {
         byte[] bytes = pdfWithTwoPages();
 
@@ -90,7 +123,9 @@ class PdfFileParserTest {
         assertTrue(result.plainText().contains("First page body"));
         assertEquals(2, result.pages().size());
         assertTrue(result.blocks().stream().allMatch(block -> block.blockType() == BlockType.PARAGRAPH));
+        assertEquals(0, result.pages().get(0).order());
         assertEquals(1, result.blocks().get(0).page());
+        assertEquals(1, result.blocks().get(0).order());
         assertEquals("page[1]/paragraph[0]", result.blocks().get(0).sourceRef());
     }
 

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/PptxFileParserTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/PptxFileParserTest.java
@@ -1,0 +1,57 @@
+package studio.one.platform.textract.extractor.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Rectangle;
+import java.io.ByteArrayOutputStream;
+
+import org.apache.poi.xslf.usermodel.XMLSlideShow;
+import org.apache.poi.xslf.usermodel.XSLFSlide;
+import org.apache.poi.xslf.usermodel.XSLFTextBox;
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.textract.extractor.DocumentFormat;
+import studio.one.platform.textract.model.BlockType;
+import studio.one.platform.textract.model.ParsedFile;
+
+class PptxFileParserTest {
+
+    @Test
+    void parseStructuredClassifiesTitleBodyAndFooterBlocks() throws Exception {
+        byte[] bytes = pptxWithTitleBodyAndFooter();
+
+        ParsedFile result = new PptxFileParser().parseStructured(
+                bytes,
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                "sample.pptx");
+
+        assertEquals(DocumentFormat.PPTX, result.format());
+        assertTrue(result.plainText().contains("슬라이드 제목"));
+        assertEquals(1, result.pages().size());
+        assertTrue(result.blocks().stream().anyMatch(block -> block.blockType() == BlockType.TITLE));
+        assertTrue(result.blocks().stream().anyMatch(block -> block.blockType() == BlockType.PARAGRAPH));
+        assertTrue(result.blocks().stream().anyMatch(block -> block.blockType() == BlockType.FOOTER));
+        assertEquals(1, result.blocks().get(0).slide());
+        assertEquals(0, result.blocks().get(0).order());
+    }
+
+    private byte[] pptxWithTitleBodyAndFooter() throws Exception {
+        try (XMLSlideShow ppt = new XMLSlideShow();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            ppt.setPageSize(new java.awt.Dimension(640, 480));
+            XSLFSlide slide = ppt.createSlide();
+            addTextBox(slide, "슬라이드 제목", new Rectangle(20, 20, 500, 50));
+            addTextBox(slide, "본문 내용", new Rectangle(20, 120, 500, 80));
+            addTextBox(slide, "푸터", new Rectangle(20, 420, 500, 30));
+            ppt.write(out);
+            return out.toByteArray();
+        }
+    }
+
+    private void addTextBox(XSLFSlide slide, String text, Rectangle anchor) {
+        XSLFTextBox textBox = slide.createTextBox();
+        textBox.setText(text);
+        textBox.setAnchor(anchor);
+    }
+}


### PR DESCRIPTION
## Why

- PDF/DOCX/PPTX/HTML/OCR 이미지의 구조화 추출 품질을 개선해 후속 정규화/RAG 전처리 입력의 blockType, provenance, fallback 품질을 높인다.
- 기존 plainText 추출 흐름은 유지하면서 포맷별 semantic block 접근 경로를 추가한다.
- `HtmlFileParser.parse()`가 구조화 추출 기반 plainText 경로로 변경된 사실을 CHANGELOG에 명시한다.

## What

- PDF 파서를 `StructuredFileParser`로 확장하고 page/paragraph block, page provenance, 반복 boundary header/footer 제거를 추가했다.
- PDF `PAGE`/`PARAGRAPH` order 충돌을 제거하고, 반복 boundary 제거 조건을 전체 페이지 수 대비 50% 이상 반복될 때로 제한했다.
- PPTX 파서를 `StructuredFileParser`로 확장하고 slide title/body/footer block 분류 및 slide/order metadata를 추가했다.
- PPTX slide metadata 추가 시 부모 helper 반환 맵을 명시적으로 복사해 변이 안전성을 확보했다.
- HTML 파서를 `StructuredFileParser`로 확장하고 boilerplate 제거, heading/paragraph/list/table/image semantic extraction을 추가했다.
- HTML table metadata는 공통 `tableMetadata` helper를 사용하고, 불필요한 `root != null` 검사를 제거했다.
- DOCX list 번호 기반 `LIST_ITEM` 판별과 footnote block 추출을 보강하고 관련 테스트를 추가했다.
- OCR 이미지 결과를 line 단위 `OCR_TEXT` block으로 분리하고 OCR metadata를 추가했다.
- `fileMetadata`, `blockMetadata`, `tableMetadata` 공통 helper를 `AbstractFileParser`로 이동해 중복 구현을 줄였다.
- PDF/HTML/PPTX/OCR/DOCX block 단위 테스트와 CHANGELOG 기록을 추가했다.

## Related Issues

- Closes #235

## Validation

- Command: `git diff --check`
- Result: `passed`
- Command: `./gradlew :studio-platform-textract:test`
- Result: `BUILD SUCCESSFUL`
- Command: `./gradlew :studio-platform-textract:build`
- Result: `BUILD SUCCESSFUL`

## Risk / Rollback

- Risk: 포맷별 block 분류 heuristic이 일부 문서에서 기대와 다르게 title/footer/header를 판단할 수 있다. HTML은 boilerplate 제거 대상(`nav`, `footer` 등)이 plainText에서 제외되는 동작 변경이 있다.
- Rollback: 이 PR revert 시 기존 plainText 중심 추출 동작으로 복귀한다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: 없음
- Main author validation: `git diff --check`, `:studio-platform-textract:test`, `:studio-platform-textract:build` 결과를 확인했다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included
