### PR TITLE
[textract] 포맷별 테스트 및 golden test 강화

### DIFF
--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/FormatGoldenTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/FormatGoldenTest.java
@@ -1,0 +1,417 @@
+package studio.one.platform.textract.extractor.impl;
+
+import static java.nio.charset.StandardCharsets.UTF_16LE;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Rectangle;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
+import org.apache.poi.poifs.filesystem.DirectoryEntry;
+import org.apache.poi.poifs.filesystem.POIFSFileSystem;
+import org.apache.poi.wp.usermodel.HeaderFooterType;
+import org.apache.poi.xslf.usermodel.XMLSlideShow;
+import org.apache.poi.xslf.usermodel.XSLFSlide;
+import org.apache.poi.xslf.usermodel.XSLFTextBox;
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.apache.poi.xwpf.usermodel.XWPFFooter;
+import org.apache.poi.xwpf.usermodel.XWPFFootnote;
+import org.apache.poi.xwpf.usermodel.XWPFHeader;
+import org.apache.poi.xwpf.usermodel.XWPFParagraph;
+import org.apache.poi.xwpf.usermodel.XWPFTable;
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.textract.extractor.DocumentFormat;
+import studio.one.platform.textract.model.BlockType;
+import studio.one.platform.textract.model.ParsedFile;
+
+class FormatGoldenTest {
+
+    @Test
+    void pdfGoldenKeepsPageAndParagraphProvenance() throws Exception {
+        ParsedFile result = new PdfFileParser().parseStructured(pdfBytes(), "application/pdf", "golden.pdf");
+
+        GoldenSnapshot snapshot = snapshot(result);
+
+        assertEquals(DocumentFormat.PDF.name(), snapshot.format());
+        assertEquals(List.of("PAGE:1:page[1]:0", "PAGE:2:page[2]:2"), snapshot.pages());
+        assertEquals(List.of(
+                "PARAGRAPH:1:page[1]/paragraph[0]:1:First page body Second paragraph",
+                "PARAGRAPH:2:page[2]/paragraph[0]:3:Second page body"), snapshot.blocks());
+        assertTrue(snapshot.plainText().contains("First page body"));
+    }
+
+    @Test
+    void docxGoldenCapturesHeaderFooterTableListAndFootnote() throws Exception {
+        ParsedFile result = new DocxFileParser().parseStructured(
+                docxBytes(),
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "golden.docx");
+
+        GoldenSnapshot snapshot = snapshot(result);
+
+        assertEquals(DocumentFormat.DOCX.name(), snapshot.format());
+        assertTrue(snapshot.blocks().contains("HEADING::body/element[0]:0:문서 제목"));
+        assertTrue(snapshot.blocks().contains("LIST_ITEM::body/element[2]:2:목록 항목"));
+        assertTrue(snapshot.blocks().stream().anyMatch(block -> block.startsWith("TABLE::body/element[3]:3:")));
+        assertTrue(snapshot.blocks().stream().anyMatch(block -> block.startsWith("HEADER::header[0]/element[0]:")));
+        assertTrue(snapshot.blocks().stream().anyMatch(block -> block.startsWith("FOOTER::footer[0]/element[0]:")));
+        assertTrue(snapshot.blocks().stream().anyMatch(block -> block.startsWith("FOOTNOTE::footnote[")));
+        assertEquals(List.of("docx:body/element[3]:2x2:4"), snapshot.tables());
+    }
+
+    @Test
+    void pptxGoldenCapturesTitleBodyFooterAndSlide() throws Exception {
+        ParsedFile result = new PptxFileParser().parseStructured(
+                pptxBytes(),
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                "golden.pptx");
+
+        GoldenSnapshot snapshot = snapshot(result);
+
+        assertEquals(DocumentFormat.PPTX.name(), snapshot.format());
+        assertEquals(List.of("PAGE::slide[1]:0"), snapshot.pages());
+        assertEquals(List.of(
+                "TITLE:1:slide[1]/shape[0]:0:슬라이드 제목",
+                "PARAGRAPH:1:slide[1]/shape[1]:1:본문 내용",
+                "FOOTER:1:slide[1]/shape[2]:2:푸터"), snapshot.blocks());
+    }
+
+    @Test
+    void htmlGoldenRemovesBoilerplateAndCapturesSemanticObjects() {
+        ParsedFile result = new HtmlFileParser().parseStructured(htmlBytes(), "text/html", "golden.html");
+
+        GoldenSnapshot snapshot = snapshot(result);
+
+        assertEquals(DocumentFormat.HTML.name(), snapshot.format());
+        assertEquals(List.of(
+                "TITLE::h1[0]:0:문서 제목",
+                "PARAGRAPH::p[1]:1:본문 문단",
+                "LIST_ITEM::li[2]:2:목록 항목",
+                "TABLE::table[3]:3:| A | B | | 1 | 2 |",
+                "IMAGE_CAPTION::img[4]:4:대표 이미지"), snapshot.blocks());
+        assertEquals(List.of("html:table[3]:2x2:4"), snapshot.tables());
+        assertEquals(List.of(":img[4]:hero.png"), snapshot.images());
+        assertTrue(!snapshot.plainText().contains("메뉴 링크"));
+    }
+
+    @Test
+    void hwpxGoldenCapturesTableImageAndPartialWarning() throws Exception {
+        HwpHwpxFileParser parser = new HwpHwpxFileParser();
+
+        ParsedFile parsed = parser.parseStructured(hwpxBytes(), "application/hwpx", "golden.hwpx");
+        ParsedFile partial = parser.parseStructured(hwpxBytesWithMissingSection(), "application/hwpx", "missing.hwpx");
+
+        GoldenSnapshot snapshot = snapshot(parsed);
+        GoldenSnapshot partialSnapshot = snapshot(partial);
+
+        assertEquals(DocumentFormat.HWPX.name(), snapshot.format());
+        assertEquals(List.of("hwpx:section[0]/p[3]/tbl[1]:2x2:4"), snapshot.tables());
+        assertEquals(List.of("image/png:section[0]/p[5]/pic[0]:Contents/BinData/image1.png"), snapshot.images());
+        assertEquals(List.of("WARNING:HWPX_SECTION_MISSING:true:section0.xml"), partialSnapshot.warnings());
+    }
+
+    @Test
+    void hwpGoldenCapturesBodyTextAndEncryptedWarning() throws Exception {
+        HwpHwpxFileParser parser = new HwpHwpxFileParser();
+
+        ParsedFile parsed = parser.parseStructured(hwpBytesWithFlags(0), "application/x-hwp", "golden.hwp");
+        ParsedFile encrypted = parser.parseStructured(hwpBytesWithFlags(0x02), "application/x-hwp", "encrypted.hwp");
+
+        assertEquals(List.of("PARAGRAPH::section[0]/paragraph[0]:0:한글 본문"), snapshot(parsed).blocks());
+        assertEquals(List.of("ERROR:HWP_ENCRYPTED:false:FileHeader"), snapshot(encrypted).warnings());
+    }
+
+    @Test
+    void ocrGoldenCapturesKoreanLineBlocksWithoutEngineDependency() {
+        List<String> blocks = new ImageFileParser("/tmp", "kor+eng").ocrLineBlocks("""
+                첫 줄
+                둘째 줄
+                """).stream()
+                .map(block -> block.blockType() + ":" + block.sourceRef() + ":" + block.order() + ":" + block.text())
+                .toList();
+
+        assertEquals(List.of(
+                "OCR_TEXT:image/ocr/line[0]:0:첫 줄",
+                "OCR_TEXT:image/ocr/line[1]:1:둘째 줄"), blocks);
+    }
+
+    private GoldenSnapshot snapshot(ParsedFile file) {
+        return new GoldenSnapshot(
+                file.format().name(),
+                file.plainText(),
+                file.blocks().stream()
+                        .map(block -> block.blockType()
+                                + ":" + blockLocation(block.page(), block.slide())
+                                + ":" + block.sourceRef()
+                                + ":" + value(block.order())
+                                + ":" + normalize(block.text()))
+                        .toList(),
+                file.pages().stream()
+                        .map(page -> page.blockType()
+                                + ":" + value(page.page())
+                                + ":" + page.sourceRef()
+                                + ":" + value(page.order()))
+                        .toList(),
+                file.tables().stream()
+                        .map(table -> table.format()
+                                + ":" + table.sourceRef()
+                                + ":" + table.rowCount() + "x" + table.cells().stream()
+                                        .mapToInt(cell -> cell.col() + cell.colSpan())
+                                        .max()
+                                        .orElse(0)
+                                + ":" + table.cellCount())
+                        .toList(),
+                file.images().stream()
+                        .map(image -> image.mimeType()
+                                + ":" + image.sourceRef()
+                                + ":" + imageReference(image.filename(), image.binDataRef()))
+                        .toList(),
+                file.warnings().stream()
+                        .map(warning -> warning.severity()
+                                + ":" + warning.canonicalCode()
+                                + ":" + warning.partialParse()
+                                + ":" + warning.sourceRef())
+                        .toList());
+    }
+
+    private String normalize(String value) {
+        return value.replace('\n', ' ').replaceAll("\\s+", " ").trim();
+    }
+
+    private String value(Object value) {
+        return value == null ? "" : value.toString();
+    }
+
+    private String blockLocation(Integer page, Integer slide) {
+        return slide != null ? slide.toString() : value(page);
+    }
+
+    private String imageReference(String filename, String binDataRef) {
+        return binDataRef == null || binDataRef.isBlank() ? value(filename) : binDataRef;
+    }
+
+    private byte[] pdfBytes() throws Exception {
+        try (PDDocument document = new PDDocument();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            addPdfPage(document, "Common header", "First page body", "Second paragraph", "Common footer");
+            addPdfPage(document, "Common header", "Second page body", null, "Common footer");
+            document.save(out);
+            return out.toByteArray();
+        }
+    }
+
+    private void addPdfPage(PDDocument document, String header, String first, String second, String footer)
+            throws Exception {
+        PDPage page = new PDPage();
+        document.addPage(page);
+        try (PDPageContentStream contentStream = new PDPageContentStream(document, page)) {
+            contentStream.beginText();
+            contentStream.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 12);
+            contentStream.newLineAtOffset(50, 750);
+            contentStream.showText(header);
+            contentStream.newLineAtOffset(0, -40);
+            contentStream.showText(first);
+            if (second != null) {
+                contentStream.newLineAtOffset(0, -40);
+                contentStream.showText(second);
+            }
+            contentStream.newLineAtOffset(0, -600);
+            contentStream.showText(footer);
+            contentStream.endText();
+        }
+    }
+
+    private byte[] docxBytes() throws Exception {
+        try (XWPFDocument document = new XWPFDocument();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            XWPFParagraph title = document.createParagraph();
+            title.setStyle("Heading1");
+            title.createRun().setText("문서 제목");
+            document.createParagraph().createRun().setText("본문 문단");
+            XWPFParagraph list = document.createParagraph();
+            list.setNumID(java.math.BigInteger.ONE);
+            list.createRun().setText("목록 항목");
+            XWPFTable table = document.createTable(2, 2);
+            table.getRow(0).getCell(0).setText("A1");
+            table.getRow(0).getCell(1).setText("B1");
+            table.getRow(1).getCell(0).setText("A2");
+            table.getRow(1).getCell(1).setText("B2");
+            XWPFHeader header = document.createHeader(HeaderFooterType.DEFAULT);
+            header.createParagraph().createRun().setText("문서 헤더");
+            XWPFFooter footer = document.createFooter(HeaderFooterType.DEFAULT);
+            footer.createParagraph().createRun().setText("문서 푸터");
+            XWPFFootnote footnote = document.createFootnote();
+            footnote.createParagraph().createRun().setText("각주 본문");
+            document.write(out);
+            return out.toByteArray();
+        }
+    }
+
+    private byte[] pptxBytes() throws Exception {
+        try (XMLSlideShow ppt = new XMLSlideShow();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            ppt.setPageSize(new java.awt.Dimension(640, 480));
+            XSLFSlide slide = ppt.createSlide();
+            addTextBox(slide, "슬라이드 제목", new Rectangle(20, 20, 500, 50));
+            addTextBox(slide, "본문 내용", new Rectangle(20, 120, 500, 80));
+            addTextBox(slide, "푸터", new Rectangle(20, 420, 500, 30));
+            ppt.write(out);
+            return out.toByteArray();
+        }
+    }
+
+    private void addTextBox(XSLFSlide slide, String text, Rectangle anchor) {
+        XSLFTextBox textBox = slide.createTextBox();
+        textBox.setText(text);
+        textBox.setAnchor(anchor);
+    }
+
+    private byte[] htmlBytes() {
+        return """
+                <html>
+                  <body>
+                    <nav>메뉴 링크</nav>
+                    <main>
+                      <h1>문서 제목</h1>
+                      <p>본문 문단</p>
+                      <ul><li>목록 항목</li></ul>
+                      <table><tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr></table>
+                      <img src="hero.png" alt="대표 이미지">
+                    </main>
+                  </body>
+                </html>
+                """.getBytes(UTF_8);
+    }
+
+    private byte[] hwpxBytes() throws Exception {
+        Map<String, byte[]> entries = Map.of(
+                "Contents/content.hpf", """
+                        <opf:package xmlns:opf="http://www.idpf.org/2007/opf">
+                          <opf:manifest>
+                            <opf:item id="section0" href="section0.xml" media-type="application/xml"/>
+                            <opf:item id="image1" href="BinData/image1.png" media-type="image/png"/>
+                          </opf:manifest>
+                          <opf:spine><opf:itemref idref="section0"/></opf:spine>
+                        </opf:package>
+                        """.getBytes(UTF_8),
+                "Contents/section0.xml", """
+                        <hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+                                xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph">
+                          <hp:p><hp:run><hp:t>본문 문단</hp:t></hp:run></hp:p>
+                          <hp:p>
+                            <hp:tbl>
+                              <hp:tr>
+                                <hp:tc><hp:subList><hp:p><hp:run><hp:t>A1</hp:t></hp:run></hp:p></hp:subList></hp:tc>
+                                <hp:tc><hp:subList><hp:p><hp:run><hp:t>B1</hp:t></hp:run></hp:p></hp:subList></hp:tc>
+                              </hp:tr>
+                              <hp:tr>
+                                <hp:tc><hp:subList><hp:p><hp:run><hp:t>A2</hp:t></hp:run></hp:p></hp:subList></hp:tc>
+                                <hp:tc><hp:subList><hp:p><hp:run><hp:t>B2</hp:t></hp:run></hp:p></hp:subList></hp:tc>
+                              </hp:tr>
+                            </hp:tbl>
+                          </hp:p>
+                          <hp:p><hp:pic><hp:img binaryItemIDRef="image1"/></hp:pic></hp:p>
+                        </hs:sec>
+                        """.getBytes(UTF_8),
+                "Contents/BinData/image1.png", new byte[] { (byte) 0x89, 'P', 'N', 'G' });
+        return zip(entries);
+    }
+
+    private byte[] hwpxBytesWithMissingSection() throws Exception {
+        return zip(Map.of(
+                "Contents/content.hpf", """
+                        <opf:package xmlns:opf="http://www.idpf.org/2007/opf">
+                          <opf:manifest>
+                            <opf:item id="section0" href="section0.xml" media-type="application/xml"/>
+                          </opf:manifest>
+                          <opf:spine><opf:itemref idref="section0"/></opf:spine>
+                        </opf:package>
+                        """.getBytes(UTF_8)));
+    }
+
+    private byte[] zip(Map<String, byte[]> entries) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (ZipOutputStream zip = new ZipOutputStream(out)) {
+            for (Map.Entry<String, byte[]> entry : entries.entrySet()) {
+                zip.putNextEntry(new ZipEntry(entry.getKey()));
+                zip.write(entry.getValue());
+                zip.closeEntry();
+            }
+        }
+        return out.toByteArray();
+    }
+
+    private byte[] hwpBytesWithFlags(int flags) throws Exception {
+        try (POIFSFileSystem fs = new POIFSFileSystem();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            fs.getRoot().createDocument("FileHeader", new ByteArrayInputStream(fileHeader(flags)));
+            DirectoryEntry bodyText = fs.getRoot().createDirectory("BodyText");
+            bodyText.createDocument("Section0", new ByteArrayInputStream(section("한글 본문")));
+            fs.writeFilesystem(out);
+            return out.toByteArray();
+        }
+    }
+
+    private byte[] fileHeader(int flags) {
+        byte[] header = new byte[256];
+        byte[] signature = "HWP Document File".getBytes(UTF_8);
+        System.arraycopy(signature, 0, header, 0, signature.length);
+        header[35] = 5;
+        header[36] = (byte) flags;
+        header[37] = (byte) (flags >>> 8);
+        header[38] = (byte) (flags >>> 16);
+        header[39] = (byte) (flags >>> 24);
+        return header;
+    }
+
+    private byte[] section(String text) throws Exception {
+        byte[] paraHeaderData = new byte[12];
+        byte[] paraTextData = paraText(text);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(record(66, 0, paraHeaderData));
+        out.write(record(67, 1, paraTextData));
+        return out.toByteArray();
+    }
+
+    private byte[] paraText(String text) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(text.getBytes(UTF_16LE));
+        out.write(new byte[] { 0x0D, 0x00 });
+        return out.toByteArray();
+    }
+
+    private byte[] record(int tagId, int level, byte[] data) throws Exception {
+        int header = tagId | (level << 10) | (data.length << 20);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(new byte[] {
+                (byte) header,
+                (byte) (header >>> 8),
+                (byte) (header >>> 16),
+                (byte) (header >>> 24)
+        });
+        out.write(data);
+        return out.toByteArray();
+    }
+
+    private record GoldenSnapshot(
+            String format,
+            String plainText,
+            List<String> blocks,
+            List<String> pages,
+            List<String> tables,
+            List<String> images,
+            List<String> warnings) {
+    }
+}

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/FormatGoldenTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/FormatGoldenTest.java
@@ -38,6 +38,9 @@ import studio.one.platform.textract.model.ParsedFile;
 
 class FormatGoldenTest {
 
+    private static final String FIELD = "|";
+    private static final String ROW = "↵";
+
     @Test
     void pdfGoldenKeepsPageAndParagraphProvenance() throws Exception {
         ParsedFile result = new PdfFileParser().parseStructured(pdfBytes(), "application/pdf", "golden.pdf");
@@ -45,10 +48,10 @@ class FormatGoldenTest {
         GoldenSnapshot snapshot = snapshot(result);
 
         assertEquals(DocumentFormat.PDF.name(), snapshot.format());
-        assertEquals(List.of("PAGE:1:page[1]:0", "PAGE:2:page[2]:2"), snapshot.pages());
+        assertEquals(List.of("PAGE|1|page[1]|0", "PAGE|2|page[2]|2"), snapshot.pages());
         assertEquals(List.of(
-                "PARAGRAPH:1:page[1]/paragraph[0]:1:First page body Second paragraph",
-                "PARAGRAPH:2:page[2]/paragraph[0]:3:Second page body"), snapshot.blocks());
+                "PARAGRAPH|1|page[1]/paragraph[0]|1|First page body↵Second paragraph",
+                "PARAGRAPH|2|page[2]/paragraph[0]|3|Second page body"), snapshot.blocks());
         assertTrue(snapshot.plainText().contains("First page body"));
     }
 
@@ -62,13 +65,13 @@ class FormatGoldenTest {
         GoldenSnapshot snapshot = snapshot(result);
 
         assertEquals(DocumentFormat.DOCX.name(), snapshot.format());
-        assertTrue(snapshot.blocks().contains("HEADING::body/element[0]:0:문서 제목"));
-        assertTrue(snapshot.blocks().contains("LIST_ITEM::body/element[2]:2:목록 항목"));
-        assertTrue(snapshot.blocks().stream().anyMatch(block -> block.startsWith("TABLE::body/element[3]:3:")));
-        assertTrue(snapshot.blocks().stream().anyMatch(block -> block.startsWith("HEADER::header[0]/element[0]:")));
-        assertTrue(snapshot.blocks().stream().anyMatch(block -> block.startsWith("FOOTER::footer[0]/element[0]:")));
-        assertTrue(snapshot.blocks().stream().anyMatch(block -> block.startsWith("FOOTNOTE::footnote[")));
-        assertEquals(List.of("docx:body/element[3]:2x2:4"), snapshot.tables());
+        assertTrue(snapshot.blocks().contains("HEADING||body/element[0]|0|문서 제목"));
+        assertTrue(snapshot.blocks().contains("LIST_ITEM||body/element[2]|2|목록 항목"));
+        assertTrue(snapshot.blocks().stream().anyMatch(block -> block.startsWith("TABLE||body/element[3]|3|")));
+        assertTrue(snapshot.blocks().stream().anyMatch(block -> block.startsWith("HEADER||header[0]/element[0]|")));
+        assertTrue(snapshot.blocks().stream().anyMatch(block -> block.startsWith("FOOTER||footer[0]/element[0]|")));
+        assertTrue(snapshot.blocks().stream().anyMatch(block -> block.startsWith("FOOTNOTE||footnote[")));
+        assertEquals(List.of("docx|body/element[3]|2x2|4"), snapshot.tables());
     }
 
     @Test
@@ -81,11 +84,11 @@ class FormatGoldenTest {
         GoldenSnapshot snapshot = snapshot(result);
 
         assertEquals(DocumentFormat.PPTX.name(), snapshot.format());
-        assertEquals(List.of("PAGE::slide[1]:0"), snapshot.pages());
+        assertEquals(List.of("PAGE||slide[1]|0"), snapshot.pages());
         assertEquals(List.of(
-                "TITLE:1:slide[1]/shape[0]:0:슬라이드 제목",
-                "PARAGRAPH:1:slide[1]/shape[1]:1:본문 내용",
-                "FOOTER:1:slide[1]/shape[2]:2:푸터"), snapshot.blocks());
+                "TITLE|1|slide[1]/shape[0]|0|슬라이드 제목",
+                "PARAGRAPH|1|slide[1]/shape[1]|1|본문 내용",
+                "FOOTER|1|slide[1]/shape[2]|2|푸터"), snapshot.blocks());
     }
 
     @Test
@@ -96,13 +99,13 @@ class FormatGoldenTest {
 
         assertEquals(DocumentFormat.HTML.name(), snapshot.format());
         assertEquals(List.of(
-                "TITLE::h1[0]:0:문서 제목",
-                "PARAGRAPH::p[1]:1:본문 문단",
-                "LIST_ITEM::li[2]:2:목록 항목",
-                "TABLE::table[3]:3:| A | B | | 1 | 2 |",
-                "IMAGE_CAPTION::img[4]:4:대표 이미지"), snapshot.blocks());
-        assertEquals(List.of("html:table[3]:2x2:4"), snapshot.tables());
-        assertEquals(List.of(":img[4]:hero.png"), snapshot.images());
+                "TITLE||h1[0]|0|문서 제목",
+                "PARAGRAPH||p[1]|1|본문 문단",
+                "LIST_ITEM||li[2]|2|목록 항목",
+                "TABLE||table[3]|3|| A | B |↵| 1 | 2 |",
+                "IMAGE_CAPTION||img[4]|4|대표 이미지"), snapshot.blocks());
+        assertEquals(List.of("html|table[3]|2x2|4"), snapshot.tables());
+        assertEquals(List.of("|img[4]|hero.png"), snapshot.images());
         assertTrue(!snapshot.plainText().contains("메뉴 링크"));
     }
 
@@ -117,9 +120,9 @@ class FormatGoldenTest {
         GoldenSnapshot partialSnapshot = snapshot(partial);
 
         assertEquals(DocumentFormat.HWPX.name(), snapshot.format());
-        assertEquals(List.of("hwpx:section[0]/p[3]/tbl[1]:2x2:4"), snapshot.tables());
-        assertEquals(List.of("image/png:section[0]/p[5]/pic[0]:Contents/BinData/image1.png"), snapshot.images());
-        assertEquals(List.of("WARNING:HWPX_SECTION_MISSING:true:section0.xml"), partialSnapshot.warnings());
+        assertEquals(List.of("hwpx|section[0]/p[3]/tbl[1]|2x2|4"), snapshot.tables());
+        assertEquals(List.of("image/png|section[0]/p[5]/pic[0]|Contents/BinData/image1.png"), snapshot.images());
+        assertEquals(List.of("WARNING|HWPX_SECTION_MISSING|true|section0.xml"), partialSnapshot.warnings());
     }
 
     @Test
@@ -129,8 +132,8 @@ class FormatGoldenTest {
         ParsedFile parsed = parser.parseStructured(hwpBytesWithFlags(0), "application/x-hwp", "golden.hwp");
         ParsedFile encrypted = parser.parseStructured(hwpBytesWithFlags(0x02), "application/x-hwp", "encrypted.hwp");
 
-        assertEquals(List.of("PARAGRAPH::section[0]/paragraph[0]:0:한글 본문"), snapshot(parsed).blocks());
-        assertEquals(List.of("ERROR:HWP_ENCRYPTED:false:FileHeader"), snapshot(encrypted).warnings());
+        assertEquals(List.of("PARAGRAPH||section[0]/paragraph[0]|0|한글 본문"), snapshot(parsed).blocks());
+        assertEquals(List.of("ERROR|HWP_ENCRYPTED|false|FileHeader"), snapshot(encrypted).warnings());
     }
 
     @Test
@@ -139,12 +142,12 @@ class FormatGoldenTest {
                 첫 줄
                 둘째 줄
                 """).stream()
-                .map(block -> block.blockType() + ":" + block.sourceRef() + ":" + block.order() + ":" + block.text())
+                .map(block -> block.blockType() + FIELD + block.sourceRef() + FIELD + block.order() + FIELD + block.text())
                 .toList();
 
         assertEquals(List.of(
-                "OCR_TEXT:image/ocr/line[0]:0:첫 줄",
-                "OCR_TEXT:image/ocr/line[1]:1:둘째 줄"), blocks);
+                "OCR_TEXT|image/ocr/line[0]|0|첫 줄",
+                "OCR_TEXT|image/ocr/line[1]|1|둘째 줄"), blocks);
     }
 
     private GoldenSnapshot snapshot(ParsedFile file) {
@@ -153,41 +156,45 @@ class FormatGoldenTest {
                 file.plainText(),
                 file.blocks().stream()
                         .map(block -> block.blockType()
-                                + ":" + blockLocation(block.page(), block.slide())
-                                + ":" + block.sourceRef()
-                                + ":" + value(block.order())
-                                + ":" + normalize(block.text()))
+                                + FIELD + blockLocation(block.page(), block.slide())
+                                + FIELD + block.sourceRef()
+                                + FIELD + value(block.order())
+                                + FIELD + normalize(block.text()))
                         .toList(),
                 file.pages().stream()
                         .map(page -> page.blockType()
-                                + ":" + value(page.page())
-                                + ":" + page.sourceRef()
-                                + ":" + value(page.order()))
+                                + FIELD + value(page.page())
+                                + FIELD + page.sourceRef()
+                                + FIELD + value(page.order()))
                         .toList(),
                 file.tables().stream()
                         .map(table -> table.format()
-                                + ":" + table.sourceRef()
-                                + ":" + table.rowCount() + "x" + table.cells().stream()
+                                + FIELD + table.sourceRef()
+                                + FIELD + table.rowCount() + "x" + table.cells().stream()
                                         .mapToInt(cell -> cell.col() + cell.colSpan())
                                         .max()
                                         .orElse(0)
-                                + ":" + table.cellCount())
+                                + FIELD + table.cellCount())
                         .toList(),
                 file.images().stream()
                         .map(image -> image.mimeType()
-                                + ":" + image.sourceRef()
-                                + ":" + imageReference(image.filename(), image.binDataRef()))
+                                + FIELD + image.sourceRef()
+                                + FIELD + imageReference(image.filename(), image.binDataRef()))
                         .toList(),
                 file.warnings().stream()
                         .map(warning -> warning.severity()
-                                + ":" + warning.canonicalCode()
-                                + ":" + warning.partialParse()
-                                + ":" + warning.sourceRef())
+                                + FIELD + warning.canonicalCode()
+                                + FIELD + warning.partialParse()
+                                + FIELD + warning.sourceRef())
                         .toList());
     }
 
     private String normalize(String value) {
-        return value.replace('\n', ' ').replaceAll("\\s+", " ").trim();
+        return value.replace("\r\n", "\n")
+                .replace('\r', '\n')
+                .replace("\n", ROW)
+                .replaceAll("[ \\t]+", " ")
+                .trim();
     }
 
     private String value(Object value) {
@@ -205,6 +212,7 @@ class FormatGoldenTest {
     private byte[] pdfBytes() throws Exception {
         try (PDDocument document = new PDDocument();
                 ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            // Golden output intentionally omits these repeated boundaries; this guards the PDF boundary heuristic.
             addPdfPage(document, "Common header", "First page body", "Second paragraph", "Common footer");
             addPdfPage(document, "Common header", "Second page body", null, "Common footer");
             document.save(out);

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/service/FileContentExtractionServiceTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/service/FileContentExtractionServiceTest.java
@@ -52,6 +52,19 @@ class FileContentExtractionServiceTest {
     }
 
     @Test
+    void parseStructuredRejectsOversizedInputStreamsBeforeParserDispatch() {
+        RecordingParser parser = new RecordingParser();
+        FileContentExtractionService service = new FileContentExtractionService(
+                new FileParserFactory(List.of(parser)),
+                4);
+        InputStream oversized = new ByteArrayInputStream("abcde".getBytes(UTF_8));
+
+        assertThrows(FileParseException.class,
+                () -> service.parseStructured("text/plain", "large.txt", oversized));
+        assertEquals(0, parser.invocations);
+    }
+
+    @Test
     void extractTextRejectsOversizedFiles() throws Exception {
         FileContentExtractionService service = new FileContentExtractionService(
                 new FileParserFactory(List.of(new RecordingParser())),
@@ -68,6 +81,7 @@ class FileContentExtractionServiceTest {
 
     private static final class RecordingParser implements FileParser {
         private byte[] lastBytes;
+        private int invocations;
 
         @Override
         public boolean supports(String contentType, String filename) {
@@ -76,6 +90,7 @@ class FileContentExtractionServiceTest {
 
         @Override
         public String parse(byte[] bytes, String contentType, String filename) {
+            invocations++;
             lastBytes = bytes;
             return "parsed";
         }


### PR DESCRIPTION
## Why

- 포맷별 구조화 추출 결과가 이후 리팩터링에서 회귀하지 않도록 대표 문서 snapshot 기준의 golden test가 필요하다.
- warning/partial parse와 oversized 입력 실패 경로도 구조화 추출 계약 기준으로 고정할 필요가 있다.

## What

- `FormatGoldenTest`를 추가해 PDF, DOCX, PPTX, HTML, HWPX, HWP, OCR line 결과를 snapshot 형태로 검증했다.
- PDF는 page/paragraph provenance와 plainText를 검증하고, 반복 header/footer boundary 제거 heuristic 의도를 fixture 주석으로 남겼다.
- DOCX는 heading, list, table, header, footer, footnote block을 검증했다.
- PPTX는 title/body/footer와 slide metadata를 검증했다.
- HTML은 boilerplate 제거, semantic block, table, image reference를 검증했다.
- HWPX는 table/image 및 missing section partial warning을 검증했다.
- HWP는 body text와 encrypted error warning을 검증했다.
- OCR은 Tesseract 엔진 의존 없이 한국어 line block 생성을 검증했다.
- Snapshot 문자열은 `|` field delimiter를 사용하고, block text 줄바꿈은 `↵`로 보존해 구분자 충돌과 테이블 row 경계 소실 위험을 줄였다.
- `parseStructured` oversized input stream이 parser dispatch 전에 실패하는지 테스트를 추가했다.

## Related Issues

- Closes #237
- Parent: #231

## Validation

- Command: `./gradlew :studio-platform-textract:test --tests 'studio.one.platform.textract.extractor.impl.FormatGoldenTest'`
- Result: `BUILD SUCCESSFUL`
- Command: `./gradlew :studio-platform-textract:test`
- Result: `BUILD SUCCESSFUL`
- Command: `./gradlew :studio-platform-textract:build`
- Result: `BUILD SUCCESSFUL`
- Command: `git diff --check`
- Result: `passed`

## Risk / Rollback

- Risk: golden snapshot은 현재 파서 heuristic을 고정하므로, 의도적인 파서 품질 변경 시 테스트 기대값 갱신이 필요하다.
- Rollback: 이 PR revert 시 golden/oversized 테스트 추가 전 상태로 복귀한다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: 없음
- Main author validation: golden 단독 테스트, textract 전체 테스트, build, diff check를 확인했다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
