### PR TITLE
[textract] vector-ready 추출 모델 metadata hardening

### DIFF
--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/AbstractFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/AbstractFileParser.java
@@ -7,6 +7,7 @@ import java.util.regex.Pattern;
 
 import lombok.extern.slf4j.Slf4j;
 import studio.one.platform.textract.extractor.FileParser;
+import studio.one.platform.textract.model.ExtractedImage;
 import studio.one.platform.textract.model.ExtractedTable;
 import studio.one.platform.textract.model.ParsedBlock;
 
@@ -93,6 +94,12 @@ public abstract class AbstractFileParser implements FileParser {
         Map<String, Object> metadata = new LinkedHashMap<>();
         metadata.put(ExtractedTable.KEY_SOURCE_REF, sourceRef);
         metadata.put(ExtractedTable.KEY_FORMAT, format);
+        return metadata;
+    }
+
+    protected Map<String, Object> imageMetadata(String sourceRef) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put(ExtractedImage.KEY_SOURCE_REF, sourceRef);
         return metadata;
     }
 

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/HtmlFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/HtmlFileParser.java
@@ -143,7 +143,7 @@ public class HtmlFileParser extends AbstractFileParser implements StructuredFile
         Map<String, Object> metadata = imageMetadata(path);
         String source = image.attr("src");
         if (source != null && !source.isBlank()) {
-            metadata.put("src", source);
+            metadata.put(ExtractedImage.KEY_SRC, source);
         }
         String alt = image.attr("alt");
         if (alt != null && !alt.isBlank()) {

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/HtmlFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/HtmlFileParser.java
@@ -4,7 +4,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -141,15 +140,14 @@ public class HtmlFileParser extends AbstractFileParser implements StructuredFile
     }
 
     private ExtractedImage extractImage(Element image, String path) {
-        Map<String, Object> metadata = new LinkedHashMap<>();
-        metadata.put(ExtractedImage.KEY_SOURCE_REF, path);
+        Map<String, Object> metadata = imageMetadata(path);
         String source = image.attr("src");
         if (source != null && !source.isBlank()) {
             metadata.put("src", source);
         }
         String alt = image.attr("alt");
         if (alt != null && !alt.isBlank()) {
-            metadata.put("alt", alt);
+            metadata.put(ExtractedImage.KEY_ALT_TEXT, alt);
         }
         return new ExtractedImage(path, null, source, null, null, metadata);
     }

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/ImageFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/ImageFileParser.java
@@ -108,7 +108,7 @@ public class ImageFileParser extends AbstractFileParser implements StructuredFil
         Map<String, Object> metadata = new LinkedHashMap<>();
         metadata.put(ExtractedImage.KEY_SOURCE_REF, "image");
         metadata.put(ExtractedImage.KEY_OCR_APPLIED, true);
-        metadata.put("ocrLineCount", ocrLineCount);
+        metadata.put(ExtractedImage.KEY_OCR_LINE_COUNT, ocrLineCount);
         metadata.put(ExtractedImage.KEY_CONFIDENCE_AVAILABLE, false);
         return metadata;
     }

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/ImageFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/ImageFileParser.java
@@ -98,7 +98,7 @@ public class ImageFileParser extends AbstractFileParser implements StructuredFil
         Map<String, Object> metadata = new LinkedHashMap<>();
         metadata.put(ParsedBlock.KEY_SOURCE_REF, path);
         metadata.put(ParsedBlock.KEY_ORDER, order);
-        metadata.put("ocr", true);
+        metadata.put(ExtractedImage.KEY_OCR_APPLIED, true);
         metadata.put("ocrUnit", "line");
         metadata.put("confidenceAvailable", false);
         return metadata;
@@ -107,7 +107,7 @@ public class ImageFileParser extends AbstractFileParser implements StructuredFil
     private Map<String, Object> imageMetadata(int ocrLineCount) {
         Map<String, Object> metadata = new LinkedHashMap<>();
         metadata.put(ExtractedImage.KEY_SOURCE_REF, "image");
-        metadata.put("ocr", true);
+        metadata.put(ExtractedImage.KEY_OCR_APPLIED, true);
         metadata.put("ocrLineCount", ocrLineCount);
         metadata.put("confidenceAvailable", false);
         return metadata;

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/ImageFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/ImageFileParser.java
@@ -99,8 +99,8 @@ public class ImageFileParser extends AbstractFileParser implements StructuredFil
         metadata.put(ParsedBlock.KEY_SOURCE_REF, path);
         metadata.put(ParsedBlock.KEY_ORDER, order);
         metadata.put(ExtractedImage.KEY_OCR_APPLIED, true);
-        metadata.put("ocrUnit", "line");
-        metadata.put("confidenceAvailable", false);
+        metadata.put(ExtractedImage.KEY_OCR_UNIT, "line");
+        metadata.put(ExtractedImage.KEY_CONFIDENCE_AVAILABLE, false);
         return metadata;
     }
 
@@ -109,7 +109,7 @@ public class ImageFileParser extends AbstractFileParser implements StructuredFil
         metadata.put(ExtractedImage.KEY_SOURCE_REF, "image");
         metadata.put(ExtractedImage.KEY_OCR_APPLIED, true);
         metadata.put("ocrLineCount", ocrLineCount);
-        metadata.put("confidenceAvailable", false);
+        metadata.put(ExtractedImage.KEY_CONFIDENCE_AVAILABLE, false);
         return metadata;
     }
 

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ExtractedImage.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ExtractedImage.java
@@ -24,6 +24,7 @@ public record ExtractedImage(
     public static final String KEY_OCR_TEXT = "ocrText";
     public static final String KEY_OCR_APPLIED = "ocrApplied";
     public static final String KEY_OCR_UNIT = "ocrUnit";
+    public static final String KEY_OCR_LINE_COUNT = "ocrLineCount";
     public static final String KEY_CONFIDENCE_AVAILABLE = "confidenceAvailable";
 
     public ExtractedImage {
@@ -89,6 +90,17 @@ public record ExtractedImage(
     public String ocrUnit() {
         Object value = metadata.get(KEY_OCR_UNIT);
         return value instanceof String stringValue ? stringValue : "";
+    }
+
+    public int ocrLineCount() {
+        Object value = metadata.get(KEY_OCR_LINE_COUNT);
+        if (value instanceof Integer integerValue) {
+            return Math.max(0, integerValue);
+        }
+        if (value instanceof Number numberValue) {
+            return Math.max(0, numberValue.intValue());
+        }
+        return 0;
     }
 
     public boolean confidenceAvailable() {

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ExtractedImage.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ExtractedImage.java
@@ -19,9 +19,12 @@ public record ExtractedImage(
     public static final String KEY_BIN_DATA_REF = "binDataRef";
     public static final String KEY_PACKAGE_ID = "packageId";
     public static final String KEY_CAPTION = "caption";
+    public static final String KEY_SRC = "src";
     public static final String KEY_ALT_TEXT = "altText";
     public static final String KEY_OCR_TEXT = "ocrText";
     public static final String KEY_OCR_APPLIED = "ocrApplied";
+    public static final String KEY_OCR_UNIT = "ocrUnit";
+    public static final String KEY_CONFIDENCE_AVAILABLE = "confidenceAvailable";
 
     public ExtractedImage {
         metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
@@ -63,6 +66,11 @@ public record ExtractedImage(
         return value instanceof String stringValue ? stringValue : "";
     }
 
+    public String src() {
+        Object value = metadata.get(KEY_SRC);
+        return value instanceof String stringValue ? stringValue : "";
+    }
+
     public String altText() {
         Object value = metadata.get(KEY_ALT_TEXT);
         return value instanceof String stringValue ? stringValue : "";
@@ -75,6 +83,16 @@ public record ExtractedImage(
 
     public boolean ocrApplied() {
         Object value = metadata.get(KEY_OCR_APPLIED);
+        return value instanceof Boolean booleanValue && booleanValue;
+    }
+
+    public String ocrUnit() {
+        Object value = metadata.get(KEY_OCR_UNIT);
+        return value instanceof String stringValue ? stringValue : "";
+    }
+
+    public boolean confidenceAvailable() {
+        Object value = metadata.get(KEY_CONFIDENCE_AVAILABLE);
         return value instanceof Boolean booleanValue && booleanValue;
     }
 }

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ExtractedImage.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ExtractedImage.java
@@ -18,6 +18,10 @@ public record ExtractedImage(
     public static final String KEY_SOURCE_REFS = "sourceRefs";
     public static final String KEY_BIN_DATA_REF = "binDataRef";
     public static final String KEY_PACKAGE_ID = "packageId";
+    public static final String KEY_CAPTION = "caption";
+    public static final String KEY_ALT_TEXT = "altText";
+    public static final String KEY_OCR_TEXT = "ocrText";
+    public static final String KEY_OCR_APPLIED = "ocrApplied";
 
     public ExtractedImage {
         metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
@@ -32,11 +36,10 @@ public record ExtractedImage(
         return value instanceof String stringValue && !stringValue.isBlank() ? stringValue : path;
     }
 
-    @SuppressWarnings("unchecked")
     public List<String> sourceRefs() {
         Object value = metadata.get(KEY_SOURCE_REFS);
         if (value instanceof List<?> listValue) {
-            return ((List<Object>) listValue).stream()
+            return listValue.stream()
                     .filter(String.class::isInstance)
                     .map(String.class::cast)
                     .toList();
@@ -53,5 +56,25 @@ public record ExtractedImage(
     public String packageId() {
         Object value = metadata.get(KEY_PACKAGE_ID);
         return value instanceof String stringValue ? stringValue : "";
+    }
+
+    public String caption() {
+        Object value = metadata.get(KEY_CAPTION);
+        return value instanceof String stringValue ? stringValue : "";
+    }
+
+    public String altText() {
+        Object value = metadata.get(KEY_ALT_TEXT);
+        return value instanceof String stringValue ? stringValue : "";
+    }
+
+    public String ocrText() {
+        Object value = metadata.get(KEY_OCR_TEXT);
+        return value instanceof String stringValue ? stringValue : "";
+    }
+
+    public boolean ocrApplied() {
+        Object value = metadata.get(KEY_OCR_APPLIED);
+        return value instanceof Boolean booleanValue && booleanValue;
     }
 }

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ExtractedTable.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ExtractedTable.java
@@ -14,6 +14,8 @@ public record ExtractedTable(
 
     public static final String KEY_SOURCE_REF = "sourceRef";
     public static final String KEY_FORMAT = "format";
+    public static final String KEY_VECTOR_TEXT = "vectorText";
+    public static final String KEY_HEADER_ROW_COUNT = "headerRowCount";
 
     public ExtractedTable {
         cells = cells == null ? List.of() : List.copyOf(cells);
@@ -28,6 +30,22 @@ public record ExtractedTable(
     public String format() {
         Object value = metadata.get(KEY_FORMAT);
         return value instanceof String stringValue ? stringValue : "";
+    }
+
+    public String vectorText() {
+        Object value = metadata.get(KEY_VECTOR_TEXT);
+        return value instanceof String stringValue && !stringValue.isBlank() ? stringValue : markdown;
+    }
+
+    public int headerRowCount() {
+        Object value = metadata.get(KEY_HEADER_ROW_COUNT);
+        if (value instanceof Integer integerValue) {
+            return Math.max(0, integerValue);
+        }
+        if (value instanceof Number numberValue) {
+            return Math.max(0, numberValue.intValue());
+        }
+        return 0;
     }
 
     public int rowCount() {

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ExtractedTableCell.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ExtractedTableCell.java
@@ -13,9 +13,22 @@ public record ExtractedTableCell(
         String text,
         Map<String, Object> metadata) {
 
+    public static final String KEY_SOURCE_REF = "sourceRef";
+    public static final String KEY_HEADER = "header";
+
     public ExtractedTableCell {
         rowSpan = Math.max(1, rowSpan);
         colSpan = Math.max(1, colSpan);
         metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+    }
+
+    public String sourceRef() {
+        Object value = metadata.get(KEY_SOURCE_REF);
+        return value instanceof String stringValue ? stringValue : "";
+    }
+
+    public boolean header() {
+        Object value = metadata.get(KEY_HEADER);
+        return value instanceof Boolean booleanValue && booleanValue;
     }
 }

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/HtmlFileParserTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/HtmlFileParserTest.java
@@ -41,6 +41,8 @@ class HtmlFileParserTest {
         assertEquals(1, result.tables().size());
         assertEquals("html", result.tables().get(0).format());
         assertEquals(1, result.images().size());
+        assertEquals("hero.png", result.images().get(0).src());
+        assertEquals("대표 이미지", result.images().get(0).altText());
         assertFalse(result.plainText().contains("메뉴 링크"));
         assertFalse(result.plainText().contains("푸터"));
     }

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/ImageFileParserTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/ImageFileParserTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import studio.one.platform.textract.model.BlockType;
+import studio.one.platform.textract.model.ExtractedImage;
 import studio.one.platform.textract.model.ParsedBlock;
 
 class ImageFileParserTest {
@@ -24,7 +25,7 @@ class ImageFileParserTest {
         assertEquals(3, blocks.size());
         assertTrue(blocks.stream().allMatch(block -> block.blockType() == BlockType.OCR_TEXT));
         assertEquals("image/ocr/line[0]", blocks.get(0).sourceRef());
-        assertEquals("line", blocks.get(0).metadata().get("ocrUnit"));
-        assertEquals(false, blocks.get(0).metadata().get("confidenceAvailable"));
+        assertEquals("line", blocks.get(0).metadata().get(ExtractedImage.KEY_OCR_UNIT));
+        assertEquals(false, blocks.get(0).metadata().get(ExtractedImage.KEY_CONFIDENCE_AVAILABLE));
     }
 }

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/model/ExtractedStructureTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/model/ExtractedStructureTest.java
@@ -61,9 +61,12 @@ class ExtractedStructureTest {
                         ExtractedImage.KEY_BIN_DATA_REF, "Contents/BinData/image1.png",
                         ExtractedImage.KEY_PACKAGE_ID, "image1",
                         ExtractedImage.KEY_CAPTION, "그림 설명",
+                        ExtractedImage.KEY_SRC, "media/image1.png",
                         ExtractedImage.KEY_ALT_TEXT, "대체 텍스트",
                         ExtractedImage.KEY_OCR_TEXT, "OCR 텍스트",
-                        ExtractedImage.KEY_OCR_APPLIED, true));
+                        ExtractedImage.KEY_OCR_APPLIED, true,
+                        ExtractedImage.KEY_OCR_UNIT, "line",
+                        ExtractedImage.KEY_CONFIDENCE_AVAILABLE, false));
 
         assertEquals("image/png", image.mimeType());
         assertEquals("section[0]/pic[1]", image.sourceRef());
@@ -71,9 +74,12 @@ class ExtractedStructureTest {
         assertEquals("Contents/BinData/image1.png", image.binDataRef());
         assertEquals("image1", image.packageId());
         assertEquals("그림 설명", image.caption());
+        assertEquals("media/image1.png", image.src());
         assertEquals("대체 텍스트", image.altText());
         assertEquals("OCR 텍스트", image.ocrText());
         assertEquals(true, image.ocrApplied());
+        assertEquals("line", image.ocrUnit());
+        assertEquals(false, image.confidenceAvailable());
     }
 
     @Test

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/model/ExtractedStructureTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/model/ExtractedStructureTest.java
@@ -15,17 +15,37 @@ class ExtractedStructureTest {
                 "body/table[0]",
                 "| A1 | B1 |",
                 List.of(
-                        new ExtractedTableCell(0, 0, 1, 1, "A1", Map.of()),
+                        new ExtractedTableCell(0, 0, 1, 1, "A1", Map.of(
+                                ExtractedTableCell.KEY_SOURCE_REF, "body/table[0]/row[0]/cell[0]",
+                                ExtractedTableCell.KEY_HEADER, true)),
                         new ExtractedTableCell(0, 1, 1, 1, "B1", Map.of()),
                         new ExtractedTableCell(1, 0, 1, 1, "A2", Map.of())),
                 Map.of(
                         ExtractedTable.KEY_SOURCE_REF, "body/table[0]",
-                        ExtractedTable.KEY_FORMAT, "docx"));
+                        ExtractedTable.KEY_FORMAT, "docx",
+                        ExtractedTable.KEY_VECTOR_TEXT, "A1 B1\nA2",
+                        ExtractedTable.KEY_HEADER_ROW_COUNT, 1));
 
         assertEquals("body/table[0]", table.sourceRef());
         assertEquals("docx", table.format());
+        assertEquals("A1 B1\nA2", table.vectorText());
+        assertEquals(1, table.headerRowCount());
         assertEquals(2, table.rowCount());
         assertEquals(3, table.cellCount());
+        assertEquals("body/table[0]/row[0]/cell[0]", table.cells().get(0).sourceRef());
+        assertEquals(true, table.cells().get(0).header());
+    }
+
+    @Test
+    void extractedTableFallsBackToMarkdownVectorTextAndZeroHeaderRows() {
+        ExtractedTable table = new ExtractedTable(
+                "body/table[0]",
+                "| A1 | B1 |",
+                List.of(),
+                Map.of());
+
+        assertEquals("| A1 | B1 |", table.vectorText());
+        assertEquals(0, table.headerRowCount());
     }
 
     @Test
@@ -39,13 +59,21 @@ class ExtractedStructureTest {
                 Map.of(
                         ExtractedImage.KEY_SOURCE_REF, "section[0]/pic[1]",
                         ExtractedImage.KEY_BIN_DATA_REF, "Contents/BinData/image1.png",
-                        ExtractedImage.KEY_PACKAGE_ID, "image1"));
+                        ExtractedImage.KEY_PACKAGE_ID, "image1",
+                        ExtractedImage.KEY_CAPTION, "그림 설명",
+                        ExtractedImage.KEY_ALT_TEXT, "대체 텍스트",
+                        ExtractedImage.KEY_OCR_TEXT, "OCR 텍스트",
+                        ExtractedImage.KEY_OCR_APPLIED, true));
 
         assertEquals("image/png", image.mimeType());
         assertEquals("section[0]/pic[1]", image.sourceRef());
         assertEquals(List.of("section[0]/pic[1]"), image.sourceRefs());
         assertEquals("Contents/BinData/image1.png", image.binDataRef());
         assertEquals("image1", image.packageId());
+        assertEquals("그림 설명", image.caption());
+        assertEquals("대체 텍스트", image.altText());
+        assertEquals("OCR 텍스트", image.ocrText());
+        assertEquals(true, image.ocrApplied());
     }
 
     @Test
@@ -62,5 +90,18 @@ class ExtractedStructureTest {
 
         assertEquals("bindata/image1", image.sourceRef());
         assertEquals(List.of("section[0]/pic[0]", "section[2]/pic[1]"), image.sourceRefs());
+    }
+
+    @Test
+    void extractedImageIgnoresNonStringSourceRefsWithoutUncheckedCast() {
+        ExtractedImage image = new ExtractedImage(
+                "bindata/image1",
+                "image/png",
+                "image1.png",
+                null,
+                null,
+                Map.of(ExtractedImage.KEY_SOURCE_REFS, List.of("section[0]/pic[0]", 10, true)));
+
+        assertEquals(List.of("section[0]/pic[0]"), image.sourceRefs());
     }
 }

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/model/ExtractedStructureTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/model/ExtractedStructureTest.java
@@ -1,5 +1,6 @@
 package studio.one.platform.textract.model;
 
+import static java.util.Map.entry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
@@ -56,17 +57,18 @@ class ExtractedStructureTest {
                 "image1.png",
                 null,
                 null,
-                Map.of(
-                        ExtractedImage.KEY_SOURCE_REF, "section[0]/pic[1]",
-                        ExtractedImage.KEY_BIN_DATA_REF, "Contents/BinData/image1.png",
-                        ExtractedImage.KEY_PACKAGE_ID, "image1",
-                        ExtractedImage.KEY_CAPTION, "그림 설명",
-                        ExtractedImage.KEY_SRC, "media/image1.png",
-                        ExtractedImage.KEY_ALT_TEXT, "대체 텍스트",
-                        ExtractedImage.KEY_OCR_TEXT, "OCR 텍스트",
-                        ExtractedImage.KEY_OCR_APPLIED, true,
-                        ExtractedImage.KEY_OCR_UNIT, "line",
-                        ExtractedImage.KEY_CONFIDENCE_AVAILABLE, false));
+                Map.ofEntries(
+                        entry(ExtractedImage.KEY_SOURCE_REF, "section[0]/pic[1]"),
+                        entry(ExtractedImage.KEY_BIN_DATA_REF, "Contents/BinData/image1.png"),
+                        entry(ExtractedImage.KEY_PACKAGE_ID, "image1"),
+                        entry(ExtractedImage.KEY_CAPTION, "그림 설명"),
+                        entry(ExtractedImage.KEY_SRC, "media/image1.png"),
+                        entry(ExtractedImage.KEY_ALT_TEXT, "대체 텍스트"),
+                        entry(ExtractedImage.KEY_OCR_TEXT, "OCR 텍스트"),
+                        entry(ExtractedImage.KEY_OCR_APPLIED, true),
+                        entry(ExtractedImage.KEY_OCR_UNIT, "line"),
+                        entry(ExtractedImage.KEY_OCR_LINE_COUNT, 3),
+                        entry(ExtractedImage.KEY_CONFIDENCE_AVAILABLE, false)));
 
         assertEquals("image/png", image.mimeType());
         assertEquals("section[0]/pic[1]", image.sourceRef());
@@ -79,6 +81,7 @@ class ExtractedStructureTest {
         assertEquals("OCR 텍스트", image.ocrText());
         assertEquals(true, image.ocrApplied());
         assertEquals("line", image.ocrUnit());
+        assertEquals(3, image.ocrLineCount());
         assertEquals(false, image.confidenceAvailable());
     }
 


### PR DESCRIPTION
## Why

- 상위 벡터화 파이프라인이 `textract` 결과의 table/image/OCR metadata를 타입 안전하게 소비할 수 있도록 모델 helper 계약을 보강한다.
- 후속 DOCX/PPTX/PDF/OCR/table 개선 이슈가 동일한 metadata key와 accessor를 재사용할 수 있게 한다.

## What

- `ExtractedImage.sourceRefs()`의 unchecked cast를 제거했다.
- `ExtractedImage`에 `caption`, `src`, `altText`, `ocrText`, `ocrApplied`, `ocrUnit`, `ocrLineCount`, `confidenceAvailable` metadata key와 accessor를 추가했다.
- `ExtractedTable`에 `vectorText`, `headerRowCount` helper를 추가했다.
- `ExtractedTableCell`에 `sourceRef`, `header` helper를 추가했다.
- `AbstractFileParser`에 `imageMetadata(sourceRef)` helper를 추가했다.
- HTML image metadata와 OCR image metadata가 새 key/helper를 사용하도록 정리했다.
- HTML parser 경로에서 `src()`와 `altText()`가 채워지는지 테스트를 보강했다.
- 후속 이슈에서 실제 포맷 파서가 채워야 하는 metadata 계획을 #245 코멘트로 기록했다.
- 모델 helper 단위 테스트를 보강했다.

## Related Issues

- Closes #245
- Parent: #244

## Validation

- Command: `git diff --check`
- Result: `passed`
- Command: `./gradlew :studio-platform-textract:test`
- Result: `BUILD SUCCESSFUL`
- Command: `./gradlew :studio-platform-textract:build`
- Result: `BUILD SUCCESSFUL`

## Risk / Rollback

- Risk: metadata key accessor가 추가되지만 record shape는 유지되므로 runtime 호환성 위험은 낮다. OCR metadata key가 `ocr`에서 `ocrApplied`로 정규화되어 해당 raw metadata key를 직접 읽는 외부 코드가 있다면 조정이 필요할 수 있다.
- Rollback: 이 PR revert 시 기존 metadata helper 계약으로 복귀한다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: 없음
- Main author validation: textract test/build와 diff check를 확인했다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included