### PR TITLE
[textract] DOCX/PPTX 내장 이미지 및 caption 추출 강화

### DIFF
--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/DocxFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/DocxFileParser.java
@@ -3,14 +3,20 @@ package studio.one.platform.textract.extractor.impl;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.poi.common.usermodel.PictureType;
+import org.apache.poi.util.Units;
 import org.apache.poi.xwpf.usermodel.IBodyElement;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.apache.poi.xwpf.usermodel.XWPFFootnote;
 import org.apache.poi.xwpf.usermodel.XWPFParagraph;
+import org.apache.poi.xwpf.usermodel.XWPFPicture;
+import org.apache.poi.xwpf.usermodel.XWPFPictureData;
+import org.apache.poi.xwpf.usermodel.XWPFRun;
 import org.apache.poi.xwpf.usermodel.XWPFTable;
 import org.apache.poi.xwpf.usermodel.XWPFTableCell;
 import org.apache.poi.xwpf.usermodel.XWPFTableRow;
@@ -19,6 +25,7 @@ import studio.one.platform.textract.extractor.DocumentFormat;
 import studio.one.platform.textract.extractor.FileParseException;
 import studio.one.platform.textract.extractor.StructuredFileParser;
 import studio.one.platform.textract.model.BlockType;
+import studio.one.platform.textract.model.ExtractedImage;
 import studio.one.platform.textract.model.ExtractedTable;
 import studio.one.platform.textract.model.ExtractedTableCell;
 import studio.one.platform.textract.model.ParsedBlock;
@@ -43,15 +50,17 @@ public class DocxFileParser extends AbstractFileParser implements StructuredFile
             StringBuilder sb = new StringBuilder();
             List<ParsedBlock> blocks = new ArrayList<>();
             List<ExtractedTable> tables = new ArrayList<>();
+            List<ExtractedImage> images = new ArrayList<>();
             int order = 0;
 
-            order = appendBodyElements(doc.getBodyElements(), sb, blocks, tables, "body", null, order);
+            order = appendBodyElements(doc.getBodyElements(), sb, blocks, tables, images, "body", null, order);
             for (int i = 0; i < doc.getHeaderList().size(); i++) {
                 order = appendBodyElements(
                         doc.getHeaderList().get(i).getBodyElements(),
                         sb,
                         blocks,
                         tables,
+                        images,
                         "header[" + i + "]",
                         BlockType.HEADER,
                         order);
@@ -62,11 +71,12 @@ public class DocxFileParser extends AbstractFileParser implements StructuredFile
                         sb,
                         blocks,
                         tables,
+                        images,
                         "footer[" + i + "]",
                         BlockType.FOOTER,
                         order);
             }
-            order = appendFootnotes(doc.getFootnotes(), sb, blocks, order);
+            order = appendFootnotes(doc.getFootnotes(), sb, blocks, images, order);
 
             String text = cleanText(sb.toString());
             return new ParsedFile(
@@ -77,7 +87,7 @@ public class DocxFileParser extends AbstractFileParser implements StructuredFile
                     List.of(),
                     List.of(),
                     tables,
-                    List.of(),
+                    images,
                     false);
 
         } catch (IOException e) {
@@ -95,6 +105,7 @@ public class DocxFileParser extends AbstractFileParser implements StructuredFile
             StringBuilder sb,
             List<ParsedBlock> blocks,
             List<ExtractedTable> tables,
+            List<ExtractedImage> images,
             String parentPath,
             BlockType containerType,
             int startOrder) {
@@ -103,8 +114,9 @@ public class DocxFileParser extends AbstractFileParser implements StructuredFile
             IBodyElement element = elements.get(i);
             String path = parentPath + "/element[" + i + "]";
             switch (element.getElementType()) {
-                case PARAGRAPH -> order += appendParagraph((XWPFParagraph) element, sb, blocks, path, containerType, order);
-                case TABLE -> order += appendTable((XWPFTable) element, sb, blocks, tables, path, order);
+                case PARAGRAPH -> order += appendParagraph(
+                        (XWPFParagraph) element, sb, blocks, images, path, containerType, order);
+                case TABLE -> order += appendTable((XWPFTable) element, sb, blocks, tables, images, path, order);
                 default -> { /* ignore other elements */ }
             }
         }
@@ -115,6 +127,7 @@ public class DocxFileParser extends AbstractFileParser implements StructuredFile
             List<XWPFFootnote> footnotes,
             StringBuilder sb,
             List<ParsedBlock> blocks,
+            List<ExtractedImage> images,
             int startOrder) {
         int order = startOrder;
         for (int footnoteIndex = 0; footnoteIndex < footnotes.size(); footnoteIndex++) {
@@ -122,7 +135,8 @@ public class DocxFileParser extends AbstractFileParser implements StructuredFile
             List<XWPFParagraph> paragraphs = footnote.getParagraphs();
             for (int paragraphIndex = 0; paragraphIndex < paragraphs.size(); paragraphIndex++) {
                 String path = "footnote[" + footnoteIndex + "]/paragraph[" + paragraphIndex + "]";
-                order += appendParagraph(paragraphs.get(paragraphIndex), sb, blocks, path, BlockType.FOOTNOTE, order);
+                order += appendParagraph(
+                        paragraphs.get(paragraphIndex), sb, blocks, images, path, BlockType.FOOTNOTE, order);
             }
         }
         return order;
@@ -132,10 +146,12 @@ public class DocxFileParser extends AbstractFileParser implements StructuredFile
             XWPFParagraph p,
             StringBuilder sb,
             List<ParsedBlock> blocks,
+            List<ExtractedImage> images,
             String path,
             BlockType containerType,
             int order) {
         String text = p.getText();
+        appendParagraphImages(p, images, path, cleanText(text));
         if (text != null && !text.isBlank()) {
             String trimmed = text.trim();
             sb.append(trimmed).append("\n");
@@ -150,6 +166,7 @@ public class DocxFileParser extends AbstractFileParser implements StructuredFile
             StringBuilder sb,
             List<ParsedBlock> blocks,
             List<ExtractedTable> tables,
+            List<ExtractedImage> images,
             String path,
             int order) {
         List<ExtractedTableCell> cells = new ArrayList<>();
@@ -165,7 +182,9 @@ public class DocxFileParser extends AbstractFileParser implements StructuredFile
             List<XWPFTableCell> tableCells = row.getTableCells();
             List<String> markdownCells = new ArrayList<>();
             for (int colIndex = 0; colIndex < tableCells.size(); colIndex++) {
-                String cellText = cleanText(tableCells.get(colIndex).getText());
+                XWPFTableCell cell = tableCells.get(colIndex);
+                String cellText = cleanText(cell.getText());
+                appendCellImages(cell, images, path + "/row[" + rowIndex + "]/cell[" + colIndex + "]", cellText);
                 cells.add(new ExtractedTableCell(rowIndex, colIndex, 1, 1, cellText, Map.of()));
                 markdownCells.add(cellText == null ? "" : cellText.replace("\n", " "));
             }
@@ -175,6 +194,68 @@ public class DocxFileParser extends AbstractFileParser implements StructuredFile
         tables.add(new ExtractedTable(path, markdown, cells, tableMetadata(path, "docx")));
         blocks.add(new ParsedBlock(path, BlockType.TABLE, path, markdown, null, List.of(), blockMetadata(path, order)));
         return 1;
+    }
+
+    private void appendCellImages(XWPFTableCell cell, List<ExtractedImage> images, String path, String caption) {
+        List<XWPFParagraph> paragraphs = cell.getParagraphs();
+        for (int paragraphIndex = 0; paragraphIndex < paragraphs.size(); paragraphIndex++) {
+            appendParagraphImages(
+                    paragraphs.get(paragraphIndex),
+                    images,
+                    path + "/paragraph[" + paragraphIndex + "]",
+                    caption);
+        }
+    }
+
+    private void appendParagraphImages(
+            XWPFParagraph paragraph,
+            List<ExtractedImage> images,
+            String path,
+            String caption) {
+        List<XWPFRun> runs = paragraph.getRuns();
+        for (int runIndex = 0; runIndex < runs.size(); runIndex++) {
+            List<XWPFPicture> pictures = runs.get(runIndex).getEmbeddedPictures();
+            for (int pictureIndex = 0; pictureIndex < pictures.size(); pictureIndex++) {
+                String sourceRef = path + "/run[" + runIndex + "]/picture[" + pictureIndex + "]";
+                images.add(toExtractedImage(pictures.get(pictureIndex), sourceRef, caption));
+            }
+        }
+    }
+
+    private ExtractedImage toExtractedImage(XWPFPicture picture, String sourceRef, String caption) {
+        XWPFPictureData data = picture.getPictureData();
+        String filename = data == null ? "" : data.getFileName();
+        String contentType = null;
+        if (data != null) {
+            PictureType type = data.getPictureTypeEnum();
+            contentType = type == null ? null : type.getContentType();
+        }
+        Map<String, Object> metadata = new LinkedHashMap<>(imageMetadata(sourceRef));
+        if (data != null) {
+            metadata.put(ExtractedImage.KEY_BIN_DATA_REF, filename);
+            metadata.put(ExtractedImage.KEY_PACKAGE_ID, filename);
+        }
+        String description = cleanText(picture.getDescription());
+        if (description != null && !description.isBlank()) {
+            metadata.put(ExtractedImage.KEY_ALT_TEXT, description);
+        }
+        if (caption != null && !caption.isBlank()) {
+            metadata.put(ExtractedImage.KEY_CAPTION, caption);
+        }
+        return new ExtractedImage(
+                sourceRef,
+                contentType,
+                filename,
+                toPixels(picture.getWidth()),
+                toPixels(picture.getDepth()),
+                metadata);
+    }
+
+    private Integer toPixels(double emu) {
+        if (emu <= 0) {
+            return null;
+        }
+        return Math.max(1, (int) Math.round(emu / Units.EMU_PER_PIXEL));
     }
 
     private BlockType resolveParagraphType(XWPFParagraph paragraph, BlockType containerType) {

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/DocxFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/DocxFileParser.java
@@ -233,7 +233,6 @@ public class DocxFileParser extends AbstractFileParser implements StructuredFile
         Map<String, Object> metadata = new LinkedHashMap<>(imageMetadata(sourceRef));
         if (data != null) {
             metadata.put(ExtractedImage.KEY_BIN_DATA_REF, filename);
-            metadata.put(ExtractedImage.KEY_PACKAGE_ID, filename);
         }
         String description = cleanText(picture.getDescription());
         if (description != null && !description.isBlank()) {

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PptxFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PptxFileParser.java
@@ -9,6 +9,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.poi.util.Units;
 import org.apache.poi.xslf.usermodel.XMLSlideShow;
 import org.apache.poi.xslf.usermodel.XSLFPictureData;
 import org.apache.poi.xslf.usermodel.XSLFPictureShape;
@@ -53,12 +54,13 @@ public class PptxFileParser extends AbstractFileParser implements StructuredFile
                 boolean titleSeen = false;
                 XSLFSlide slide = ppt.getSlides().get(slideIndex);
                 List<TextCandidate> textCandidates = new ArrayList<>();
+                List<PictureCandidate> pictureCandidates = new ArrayList<>();
                 int shapeIndex = 0;
                 for (XSLFShape shape : slide.getShapes()) {
+                    String path = "slide[" + (slideIndex + 1) + "]/shape[" + shapeIndex + "]";
                     if (shape instanceof XSLFTextShape textShape) {
                         String text = cleanText(textShape.getText());
                         if (text != null && !text.isBlank()) {
-                            String path = "slide[" + (slideIndex + 1) + "]/shape[" + shapeIndex + "]";
                             BlockType blockType = resolveTextShapeType(textShape, pageSize, titleSeen);
                             if (blockType == BlockType.TITLE) {
                                 titleSeen = true;
@@ -75,10 +77,12 @@ public class PptxFileParser extends AbstractFileParser implements StructuredFile
                             slideText.append(text).append("\n");
                             order++;
                         }
+                    } else if (shape instanceof XSLFPictureShape pictureShape) {
+                        pictureCandidates.add(new PictureCandidate(pictureShape, path));
                     }
                     shapeIndex++;
                 }
-                appendSlideImages(slide, images, warnings, textCandidates, slideIndex + 1);
+                appendSlideImages(pictureCandidates, images, warnings, textCandidates);
                 String cleanedSlideText = cleanText(slideText.toString());
                 if (cleanedSlideText != null && !cleanedSlideText.isBlank()) {
                     String path = "slide[" + (slideIndex + 1) + "]";
@@ -122,25 +126,19 @@ public class PptxFileParser extends AbstractFileParser implements StructuredFile
     }
 
     private void appendSlideImages(
-            XSLFSlide slide,
+            List<PictureCandidate> pictureCandidates,
             List<ExtractedImage> images,
             List<ParseWarning> warnings,
-            List<TextCandidate> textCandidates,
-            int slideNumber) {
-        int shapeIndex = 0;
-        for (XSLFShape shape : slide.getShapes()) {
-            if (shape instanceof XSLFPictureShape pictureShape) {
-                String sourceRef = "slide[" + slideNumber + "]/shape[" + shapeIndex + "]";
-                if (pictureShape.isExternalLinkedPicture()) {
-                    warnings.add(ParseWarning.partial(
-                            "PPTX_LINKED_IMAGE_PARTIAL",
-                            "Linked PPTX image metadata is partially supported.",
-                            sourceRef,
-                            Map.of()));
-                }
-                images.add(toExtractedImage(pictureShape, sourceRef, textCandidates));
+            List<TextCandidate> textCandidates) {
+        for (PictureCandidate candidate : pictureCandidates) {
+            if (candidate.pictureShape().isExternalLinkedPicture()) {
+                warnings.add(ParseWarning.partial(
+                        "PPTX_LINKED_IMAGE_PARTIAL",
+                        "Linked PPTX image metadata is partially supported.",
+                        candidate.sourceRef(),
+                        Map.of()));
             }
-            shapeIndex++;
+            images.add(toExtractedImage(candidate.pictureShape(), candidate.sourceRef(), textCandidates));
         }
     }
 
@@ -156,7 +154,6 @@ public class PptxFileParser extends AbstractFileParser implements StructuredFile
         Map<String, Object> metadata = new LinkedHashMap<>(imageMetadata(sourceRef));
         if (data != null) {
             metadata.put(ExtractedImage.KEY_BIN_DATA_REF, filename);
-            metadata.put(ExtractedImage.KEY_PACKAGE_ID, filename);
         }
         String shapeName = cleanText(pictureShape.getShapeName());
         if (shapeName != null && !shapeName.isBlank()) {
@@ -200,14 +197,14 @@ public class PptxFileParser extends AbstractFileParser implements StructuredFile
         if (dimension != null && dimension.width > 0) {
             return dimension.width;
         }
-        return anchor == null || anchor.getWidth() <= 0 ? null : Math.max(1, (int) Math.round(anchor.getWidth()));
+        return anchor == null || anchor.getWidth() <= 0 ? null : Units.pointsToPixel(anchor.getWidth());
     }
 
     private Integer imageHeight(Dimension dimension, Rectangle2D anchor) {
         if (dimension != null && dimension.height > 0) {
             return dimension.height;
         }
-        return anchor == null || anchor.getHeight() <= 0 ? null : Math.max(1, (int) Math.round(anchor.getHeight()));
+        return anchor == null || anchor.getHeight() <= 0 ? null : Units.pointsToPixel(anchor.getHeight());
     }
 
     private Map<String, Object> blockMetadata(String path, int slide, int order) {
@@ -217,5 +214,8 @@ public class PptxFileParser extends AbstractFileParser implements StructuredFile
     }
 
     private record TextCandidate(String text, Rectangle2D anchor) {
+    }
+
+    private record PictureCandidate(XSLFPictureShape pictureShape, String sourceRef) {
     }
 }

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PptxFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PptxFileParser.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.poi.xslf.usermodel.XMLSlideShow;
+import org.apache.poi.xslf.usermodel.XSLFPictureData;
+import org.apache.poi.xslf.usermodel.XSLFPictureShape;
 import org.apache.poi.xslf.usermodel.XSLFShape;
 import org.apache.poi.xslf.usermodel.XSLFSlide;
 import org.apache.poi.xslf.usermodel.XSLFTextShape;
@@ -18,6 +20,8 @@ import studio.one.platform.textract.extractor.DocumentFormat;
 import studio.one.platform.textract.extractor.FileParseException;
 import studio.one.platform.textract.extractor.StructuredFileParser;
 import studio.one.platform.textract.model.BlockType;
+import studio.one.platform.textract.model.ExtractedImage;
+import studio.one.platform.textract.model.ParseWarning;
 import studio.one.platform.textract.model.ParsedBlock;
 import studio.one.platform.textract.model.ParsedFile;
 
@@ -39,6 +43,8 @@ public class PptxFileParser extends AbstractFileParser implements StructuredFile
             StringBuilder sb = new StringBuilder();
             List<ParsedBlock> blocks = new ArrayList<>();
             List<ParsedBlock> pages = new ArrayList<>();
+            List<ExtractedImage> images = new ArrayList<>();
+            List<ParseWarning> warnings = new ArrayList<>();
             Dimension pageSize = ppt.getPageSize();
             int order = 0;
 
@@ -46,6 +52,7 @@ public class PptxFileParser extends AbstractFileParser implements StructuredFile
                 StringBuilder slideText = new StringBuilder();
                 boolean titleSeen = false;
                 XSLFSlide slide = ppt.getSlides().get(slideIndex);
+                List<TextCandidate> textCandidates = new ArrayList<>();
                 int shapeIndex = 0;
                 for (XSLFShape shape : slide.getShapes()) {
                     if (shape instanceof XSLFTextShape textShape) {
@@ -56,6 +63,7 @@ public class PptxFileParser extends AbstractFileParser implements StructuredFile
                             if (blockType == BlockType.TITLE) {
                                 titleSeen = true;
                             }
+                            textCandidates.add(new TextCandidate(text, textShape.getAnchor()));
                             blocks.add(ParsedBlock.text(
                                     path,
                                     blockType,
@@ -70,6 +78,7 @@ public class PptxFileParser extends AbstractFileParser implements StructuredFile
                     }
                     shapeIndex++;
                 }
+                appendSlideImages(slide, images, warnings, textCandidates, slideIndex + 1);
                 String cleanedSlideText = cleanText(slideText.toString());
                 if (cleanedSlideText != null && !cleanedSlideText.isBlank()) {
                     String path = "slide[" + (slideIndex + 1) + "]";
@@ -88,10 +97,10 @@ public class PptxFileParser extends AbstractFileParser implements StructuredFile
                     cleanText(sb.toString()),
                     blocks,
                     fileMetadata(contentType, filename),
-                    List.of(),
+                    warnings,
                     pages,
                     List.of(),
-                    List.of(),
+                    images,
                     false);
 
         } catch (IOException e) {
@@ -112,9 +121,101 @@ public class PptxFileParser extends AbstractFileParser implements StructuredFile
         return titleSeen ? BlockType.PARAGRAPH : BlockType.TITLE;
     }
 
+    private void appendSlideImages(
+            XSLFSlide slide,
+            List<ExtractedImage> images,
+            List<ParseWarning> warnings,
+            List<TextCandidate> textCandidates,
+            int slideNumber) {
+        int shapeIndex = 0;
+        for (XSLFShape shape : slide.getShapes()) {
+            if (shape instanceof XSLFPictureShape pictureShape) {
+                String sourceRef = "slide[" + slideNumber + "]/shape[" + shapeIndex + "]";
+                if (pictureShape.isExternalLinkedPicture()) {
+                    warnings.add(ParseWarning.partial(
+                            "PPTX_LINKED_IMAGE_PARTIAL",
+                            "Linked PPTX image metadata is partially supported.",
+                            sourceRef,
+                            Map.of()));
+                }
+                images.add(toExtractedImage(pictureShape, sourceRef, textCandidates));
+            }
+            shapeIndex++;
+        }
+    }
+
+    private ExtractedImage toExtractedImage(
+            XSLFPictureShape pictureShape,
+            String sourceRef,
+            List<TextCandidate> textCandidates) {
+        XSLFPictureData data = pictureShape.getPictureData();
+        Rectangle2D anchor = pictureShape.getAnchor();
+        Dimension dimension = data == null ? null : data.getImageDimensionInPixels();
+        String filename = data == null ? "" : data.getFileName();
+        String contentType = data == null ? null : data.getContentType();
+        Map<String, Object> metadata = new LinkedHashMap<>(imageMetadata(sourceRef));
+        if (data != null) {
+            metadata.put(ExtractedImage.KEY_BIN_DATA_REF, filename);
+            metadata.put(ExtractedImage.KEY_PACKAGE_ID, filename);
+        }
+        String shapeName = cleanText(pictureShape.getShapeName());
+        if (shapeName != null && !shapeName.isBlank()) {
+            metadata.put(ExtractedImage.KEY_ALT_TEXT, shapeName);
+        }
+        String caption = nearestLowerText(anchor, textCandidates);
+        if (caption != null && !caption.isBlank()) {
+            metadata.put(ExtractedImage.KEY_CAPTION, caption);
+        }
+        return new ExtractedImage(
+                sourceRef,
+                contentType,
+                filename,
+                imageWidth(dimension, anchor),
+                imageHeight(dimension, anchor),
+                metadata);
+    }
+
+    private String nearestLowerText(Rectangle2D imageAnchor, List<TextCandidate> textCandidates) {
+        if (imageAnchor == null) {
+            return "";
+        }
+        TextCandidate nearest = null;
+        double nearestDistance = Double.MAX_VALUE;
+        double imageBottom = imageAnchor.getMaxY();
+        for (TextCandidate candidate : textCandidates) {
+            Rectangle2D textAnchor = candidate.anchor();
+            if (textAnchor == null || textAnchor.getY() < imageBottom) {
+                continue;
+            }
+            double distance = textAnchor.getY() - imageBottom;
+            if (distance < nearestDistance) {
+                nearest = candidate;
+                nearestDistance = distance;
+            }
+        }
+        return nearest == null ? "" : nearest.text();
+    }
+
+    private Integer imageWidth(Dimension dimension, Rectangle2D anchor) {
+        if (dimension != null && dimension.width > 0) {
+            return dimension.width;
+        }
+        return anchor == null || anchor.getWidth() <= 0 ? null : Math.max(1, (int) Math.round(anchor.getWidth()));
+    }
+
+    private Integer imageHeight(Dimension dimension, Rectangle2D anchor) {
+        if (dimension != null && dimension.height > 0) {
+            return dimension.height;
+        }
+        return anchor == null || anchor.getHeight() <= 0 ? null : Math.max(1, (int) Math.round(anchor.getHeight()));
+    }
+
     private Map<String, Object> blockMetadata(String path, int slide, int order) {
         Map<String, Object> metadata = new LinkedHashMap<>(blockMetadata(path, Integer.valueOf(order)));
         metadata.put(ParsedBlock.KEY_SLIDE, slide);
         return metadata;
+    }
+
+    private record TextCandidate(String text, Rectangle2D anchor) {
     }
 }

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/DocxFileParserTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/DocxFileParserTest.java
@@ -3,22 +3,31 @@ package studio.one.platform.textract.extractor.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.math.BigInteger;
+import java.util.Base64;
 
+import org.apache.poi.util.Units;
+import org.apache.poi.xwpf.usermodel.Document;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.apache.poi.xwpf.usermodel.XWPFFootnote;
 import org.apache.poi.xwpf.usermodel.XWPFHeader;
 import org.apache.poi.xwpf.usermodel.XWPFParagraph;
+import org.apache.poi.xwpf.usermodel.XWPFRun;
 import org.apache.poi.xwpf.usermodel.XWPFTable;
 import org.junit.jupiter.api.Test;
 
 import studio.one.platform.textract.extractor.DocumentFormat;
 import studio.one.platform.textract.model.BlockType;
+import studio.one.platform.textract.model.ExtractedImage;
 import studio.one.platform.textract.model.ParsedBlock;
 import studio.one.platform.textract.model.ParsedFile;
 
 class DocxFileParserTest {
+
+    private static final byte[] PNG_BYTES = Base64.getDecoder().decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==");
 
     @Test
     void parseStructuredReturnsParagraphTextAndTableCells() throws Exception {
@@ -101,6 +110,25 @@ class DocxFileParserTest {
         assertTrue(footnoteBlock.order() != null && footnoteBlock.order() > 0);
     }
 
+    @Test
+    void parseStructuredExtractsEmbeddedImageWithCaptionAndSourceRef() throws Exception {
+        byte[] bytes = docxWithEmbeddedImage();
+
+        ParsedFile result = new DocxFileParser()
+                .parseStructured(bytes, "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "image.docx");
+
+        assertEquals(1, result.images().size());
+        ExtractedImage image = result.images().get(0);
+        assertEquals("image/png", image.mimeType());
+        assertEquals("image1.png", image.filename());
+        assertTrue(image.sourceRef().startsWith("body/element[0]/run[1]/picture[0]"));
+        assertEquals("그림 1 설명", image.caption());
+        assertEquals("image1.png", image.binDataRef());
+        assertEquals(1, image.width());
+        assertEquals(1, image.height());
+        assertTrue(result.plainText().contains("그림 1 설명"));
+    }
+
     private byte[] docxWithParagraphAndTable() throws Exception {
         try (XWPFDocument document = new XWPFDocument();
                 ByteArrayOutputStream out = new ByteArrayOutputStream()) {
@@ -154,6 +182,23 @@ class DocxFileParserTest {
             document.createParagraph().createRun().setText("본문 문단");
             XWPFFootnote footnote = document.createFootnote();
             footnote.createParagraph().createRun().setText("각주 본문");
+            document.write(out);
+            return out.toByteArray();
+        }
+    }
+
+    private byte[] docxWithEmbeddedImage() throws Exception {
+        try (XWPFDocument document = new XWPFDocument();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            XWPFParagraph paragraph = document.createParagraph();
+            paragraph.createRun().setText("그림 1 설명");
+            XWPFRun imageRun = paragraph.createRun();
+            imageRun.addPicture(
+                    new ByteArrayInputStream(PNG_BYTES),
+                    Document.PICTURE_TYPE_PNG,
+                    "inline.png",
+                    Units.pixelToEMU(24),
+                    Units.pixelToEMU(12));
             document.write(out);
             return out.toByteArray();
         }

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/DocxFileParserTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/DocxFileParserTest.java
@@ -121,12 +121,26 @@ class DocxFileParserTest {
         ExtractedImage image = result.images().get(0);
         assertEquals("image/png", image.mimeType());
         assertEquals("image1.png", image.filename());
-        assertTrue(image.sourceRef().startsWith("body/element[0]/run[1]/picture[0]"));
+        assertEquals("body/element[0]/run[1]/picture[0]", image.sourceRef());
         assertEquals("그림 1 설명", image.caption());
         assertEquals("image1.png", image.binDataRef());
         assertEquals(1, image.width());
         assertEquals(1, image.height());
         assertTrue(result.plainText().contains("그림 1 설명"));
+    }
+
+    @Test
+    void parseStructuredExtractsTableCellEmbeddedImageWithCellSourceRef() throws Exception {
+        byte[] bytes = docxWithTableCellImage();
+
+        ParsedFile result = new DocxFileParser()
+                .parseStructured(bytes, "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "cell-image.docx");
+
+        assertEquals(1, result.images().size());
+        ExtractedImage image = result.images().get(0);
+        assertEquals("body/element[0]/row[0]/cell[0]/paragraph[0]/run[1]/picture[0]", image.sourceRef());
+        assertEquals("셀 이미지 설명", image.caption());
+        assertEquals("image1.png", image.binDataRef());
     }
 
     private byte[] docxWithParagraphAndTable() throws Exception {
@@ -199,6 +213,24 @@ class DocxFileParserTest {
                     "inline.png",
                     Units.pixelToEMU(24),
                     Units.pixelToEMU(12));
+            document.write(out);
+            return out.toByteArray();
+        }
+    }
+
+    private byte[] docxWithTableCellImage() throws Exception {
+        try (XWPFDocument document = new XWPFDocument();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            XWPFTable table = document.createTable(1, 1);
+            XWPFParagraph paragraph = table.getRow(0).getCell(0).getParagraphs().get(0);
+            paragraph.createRun().setText("셀 이미지 설명");
+            XWPFRun imageRun = paragraph.createRun();
+            imageRun.addPicture(
+                    new ByteArrayInputStream(PNG_BYTES),
+                    Document.PICTURE_TYPE_PNG,
+                    "cell.png",
+                    Units.pixelToEMU(10),
+                    Units.pixelToEMU(10));
             document.write(out);
             return out.toByteArray();
         }

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/PptxFileParserTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/PptxFileParserTest.java
@@ -59,8 +59,8 @@ class PptxFileParserTest {
         assertEquals("image1.png", image.filename());
         assertEquals("slide[1]/shape[1]", image.sourceRef());
         assertEquals("그림 설명", image.caption());
-        assertEquals(120, image.width());
-        assertEquals(80, image.height());
+        assertEquals(160, image.width());
+        assertEquals(107, image.height());
         assertTrue(result.plainText().contains("그림 설명"));
     }
 

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/PptxFileParserTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/PptxFileParserTest.java
@@ -5,17 +5,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.Rectangle;
 import java.io.ByteArrayOutputStream;
+import java.util.Base64;
 
+import org.apache.poi.sl.usermodel.PictureData;
 import org.apache.poi.xslf.usermodel.XMLSlideShow;
+import org.apache.poi.xslf.usermodel.XSLFPictureData;
+import org.apache.poi.xslf.usermodel.XSLFPictureShape;
 import org.apache.poi.xslf.usermodel.XSLFSlide;
 import org.apache.poi.xslf.usermodel.XSLFTextBox;
 import org.junit.jupiter.api.Test;
 
 import studio.one.platform.textract.extractor.DocumentFormat;
 import studio.one.platform.textract.model.BlockType;
+import studio.one.platform.textract.model.ExtractedImage;
 import studio.one.platform.textract.model.ParsedFile;
 
 class PptxFileParserTest {
+
+    private static final byte[] PNG_BYTES = Base64.getDecoder().decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==");
 
     @Test
     void parseStructuredClassifiesTitleBodyAndFooterBlocks() throws Exception {
@@ -36,6 +44,26 @@ class PptxFileParserTest {
         assertEquals(0, result.blocks().get(0).order());
     }
 
+    @Test
+    void parseStructuredExtractsPictureShapeWithCaptionAndSourceRef() throws Exception {
+        byte[] bytes = pptxWithPictureAndCaption();
+
+        ParsedFile result = new PptxFileParser().parseStructured(
+                bytes,
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                "image.pptx");
+
+        assertEquals(1, result.images().size());
+        ExtractedImage image = result.images().get(0);
+        assertEquals("image/png", image.mimeType());
+        assertEquals("image1.png", image.filename());
+        assertEquals("slide[1]/shape[1]", image.sourceRef());
+        assertEquals("그림 설명", image.caption());
+        assertEquals(120, image.width());
+        assertEquals(80, image.height());
+        assertTrue(result.plainText().contains("그림 설명"));
+    }
+
     private byte[] pptxWithTitleBodyAndFooter() throws Exception {
         try (XMLSlideShow ppt = new XMLSlideShow();
                 ByteArrayOutputStream out = new ByteArrayOutputStream()) {
@@ -44,6 +72,21 @@ class PptxFileParserTest {
             addTextBox(slide, "슬라이드 제목", new Rectangle(20, 20, 500, 50));
             addTextBox(slide, "본문 내용", new Rectangle(20, 120, 500, 80));
             addTextBox(slide, "푸터", new Rectangle(20, 420, 500, 30));
+            ppt.write(out);
+            return out.toByteArray();
+        }
+    }
+
+    private byte[] pptxWithPictureAndCaption() throws Exception {
+        try (XMLSlideShow ppt = new XMLSlideShow();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            ppt.setPageSize(new java.awt.Dimension(640, 480));
+            XSLFSlide slide = ppt.createSlide();
+            addTextBox(slide, "슬라이드 제목", new Rectangle(20, 20, 500, 50));
+            XSLFPictureData pictureData = ppt.addPicture(PNG_BYTES, PictureData.PictureType.PNG);
+            XSLFPictureShape picture = slide.createPicture(pictureData);
+            picture.setAnchor(new Rectangle(20, 100, 120, 80));
+            addTextBox(slide, "그림 설명", new Rectangle(20, 190, 500, 40));
             ppt.write(out);
             return out.toByteArray();
         }

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/PptxFileParserTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/PptxFileParserTest.java
@@ -4,8 +4,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.Rectangle;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
 
 import org.apache.poi.sl.usermodel.PictureData;
 import org.apache.poi.xslf.usermodel.XMLSlideShow;
@@ -18,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import studio.one.platform.textract.extractor.DocumentFormat;
 import studio.one.platform.textract.model.BlockType;
 import studio.one.platform.textract.model.ExtractedImage;
+import studio.one.platform.textract.model.ParseWarningSeverity;
 import studio.one.platform.textract.model.ParsedFile;
 
 class PptxFileParserTest {
@@ -64,6 +72,34 @@ class PptxFileParserTest {
         assertTrue(result.plainText().contains("그림 설명"));
     }
 
+    @Test
+    void parseStructuredUsesNearestLowerTextAsPictureCaption() throws Exception {
+        byte[] bytes = pptxWithPictureAndCompetingText();
+
+        ParsedFile result = new PptxFileParser().parseStructured(
+                bytes,
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                "caption-boundary.pptx");
+
+        assertEquals("가까운 아래 설명", result.images().get(0).caption());
+    }
+
+    @Test
+    void parseStructuredWarnsForLinkedPicture() throws Exception {
+        byte[] bytes = linkedPicturePptx();
+
+        ParsedFile result = new PptxFileParser().parseStructured(
+                bytes,
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                "linked.pptx");
+
+        assertEquals(1, result.images().size());
+        assertEquals(1, result.warnings().size());
+        assertEquals("PPTX_LINKED_IMAGE_PARTIAL", result.warnings().get(0).canonicalCode());
+        assertEquals(ParseWarningSeverity.WARNING, result.warnings().get(0).severity());
+        assertEquals(result.images().get(0).sourceRef(), result.warnings().get(0).sourceRef());
+    }
+
     private byte[] pptxWithTitleBodyAndFooter() throws Exception {
         try (XMLSlideShow ppt = new XMLSlideShow();
                 ByteArrayOutputStream out = new ByteArrayOutputStream()) {
@@ -92,9 +128,70 @@ class PptxFileParserTest {
         }
     }
 
+    private byte[] pptxWithPictureAndCompetingText() throws Exception {
+        try (XMLSlideShow ppt = new XMLSlideShow();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            ppt.setPageSize(new java.awt.Dimension(640, 480));
+            XSLFSlide slide = ppt.createSlide();
+            addTextBox(slide, "위쪽 텍스트", new Rectangle(20, 20, 500, 40));
+            addTextBox(slide, "겹치는 텍스트", new Rectangle(20, 150, 500, 40));
+            XSLFPictureData pictureData = ppt.addPicture(PNG_BYTES, PictureData.PictureType.PNG);
+            XSLFPictureShape picture = slide.createPicture(pictureData);
+            picture.setAnchor(new Rectangle(20, 140, 120, 80));
+            addTextBox(slide, "먼 아래 설명", new Rectangle(20, 320, 500, 40));
+            addTextBox(slide, "가까운 아래 설명", new Rectangle(20, 230, 500, 40));
+            ppt.write(out);
+            return out.toByteArray();
+        }
+    }
+
+    private byte[] linkedPicturePptx() throws Exception {
+        return rewritePictureAsExternalLink(pptxWithPictureAndCaption());
+    }
+
     private void addTextBox(XSLFSlide slide, String text, Rectangle anchor) {
         XSLFTextBox textBox = slide.createTextBox();
         textBox.setText(text);
         textBox.setAnchor(anchor);
+    }
+
+    private byte[] rewritePictureAsExternalLink(byte[] pptxBytes) throws Exception {
+        Map<String, byte[]> entries = unzip(pptxBytes);
+        String slideXml = new String(entries.get("ppt/slides/slide1.xml"), StandardCharsets.UTF_8)
+                .replaceFirst("r:embed=\"rId[0-9]+\"", "r:link=\"rIdLinkedImage\"");
+        String relsPath = "ppt/slides/_rels/slide1.xml.rels";
+        String relsXml = new String(entries.get(relsPath), StandardCharsets.UTF_8)
+                .replace(
+                        "</Relationships>",
+                        "<Relationship Id=\"rIdLinkedImage\" "
+                                + "Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image\" "
+                                + "Target=\"https://example.com/linked.png\" TargetMode=\"External\"/>"
+                                + "</Relationships>");
+        entries.put("ppt/slides/slide1.xml", slideXml.getBytes(StandardCharsets.UTF_8));
+        entries.put(relsPath, relsXml.getBytes(StandardCharsets.UTF_8));
+        return zip(entries);
+    }
+
+    private Map<String, byte[]> unzip(byte[] bytes) throws Exception {
+        Map<String, byte[]> entries = new LinkedHashMap<>();
+        try (ZipInputStream zip = new ZipInputStream(new ByteArrayInputStream(bytes))) {
+            ZipEntry entry;
+            while ((entry = zip.getNextEntry()) != null) {
+                entries.put(entry.getName(), zip.readAllBytes());
+            }
+        }
+        return entries;
+    }
+
+    private byte[] zip(Map<String, byte[]> entries) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (ZipOutputStream zip = new ZipOutputStream(out)) {
+            for (Map.Entry<String, byte[]> entry : entries.entrySet()) {
+                zip.putNextEntry(new ZipEntry(entry.getKey()));
+                zip.write(entry.getValue());
+                zip.closeEntry();
+            }
+        }
+        return out.toByteArray();
     }
 }


### PR DESCRIPTION
## Why

- 벡터화 파이프라인이 DOCX/PPTX 내부 이미지를 텍스트와 별도 구조로 추적할 수 있어야 한다.
- 이미지 주변 문맥을 caption 후보로 기록해 후속 indexing/embedding 단계가 이미지 설명과 provenance를 활용할 수 있게 한다.

## What

- `DocxFileParser`가 paragraph/run embedded picture를 `ExtractedImage`로 노출하도록 추가했다.
- DOCX table cell 내부 picture도 cell provenance 기반 `sourceRef`로 추출한다.
- DOCX image caption은 같은 paragraph/cell 텍스트를 후보로 기록한다. 동일 텍스트가 `ParsedBlock`에도 남는 것은 기존 텍스트 추출 흐름을 유지하면서 이미지 provenance에 주변 문맥을 연결하기 위한 의도적 중복이다.
- `PptxFileParser`가 `XSLFPictureShape`를 `ExtractedImage`로 노출하도록 추가했다.
- PPTX picture shape 아래쪽에 가장 가까운 text shape를 caption 후보로 기록한다.
- PPTX external linked picture는 partial warning code `PPTX_LINKED_IMAGE_PARTIAL`로 표현한다.
- DOCX/PPTX 신규 image metadata에는 HWP/HWPX 전용 의미의 `packageId`를 채우지 않도록 정리했다.
- PPTX picture 후보는 text shape 수집과 같은 shape 순회에서 모아 중복 순회를 제거했다.
- PPTX image size fallback은 shape anchor의 points 값을 pixel로 변환해 기록한다.
- DOCX paragraph image, DOCX table cell image, PPTX caption boundary, PPTX linked image warning 테스트를 추가했다.

## Related Issues

- Closes #246
- Parent: #244

## Validation

- Command: `git diff --check`
- Result: `passed`
- Command: `./gradlew :studio-platform-textract:test`
- Result: `BUILD SUCCESSFUL`
- Command: `./gradlew :studio-platform-textract:build`
- Result: `BUILD SUCCESSFUL`

## Risk / Rollback

- Risk: DOCX/PPTX parseStructured 결과의 `images()`가 새로 채워지므로, 기존에 항상 empty list를 가정한 소비 코드가 있다면 조정이 필요할 수 있다. DOCX caption 후보는 동일 paragraph/cell 텍스트와 중복될 수 있으므로 downstream은 `sourceRef` 기준 dedupe 또는 join 정책을 적용해야 한다. 기존 plainText, blocks, tables 흐름은 유지했다.
- Rollback: 이 PR revert 시 DOCX/PPTX 이미지 추출은 기존 empty image list 동작으로 돌아간다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: 없음
- Main author validation: textract test/build와 diff check를 확인했다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review required before merge
- [x] no unrelated changes included