### PR TITLE
[textract] PDF 표 및 이미지 추출 강화

### DIFF
--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PdfFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PdfFileParser.java
@@ -89,17 +89,17 @@ public class PdfFileParser extends AbstractFileParser implements StructuredFileP
                             blockMetadata(paragraphPath, order)));
                     order++;
                 }
-            }
-            for (ExtractedTable table : tableExtraction.tables()) {
-                blocks.add(new ParsedBlock(
-                        table.sourceRef(),
-                        BlockType.TABLE,
-                        table.sourceRef(),
-                        table.markdown(),
-                        null,
-                        List.of(),
-                        blockMetadata(table.sourceRef(), order)));
-                order++;
+                for (ExtractedTable table : tablesOnPage(tableExtraction.tables(), pagePath)) {
+                    blocks.add(new ParsedBlock(
+                            table.sourceRef(),
+                            BlockType.TABLE,
+                            table.sourceRef(),
+                            table.markdown(),
+                            pageNumber,
+                            List.of(),
+                            blockMetadata(table.sourceRef(), order)));
+                    order++;
+                }
             }
             String text = cleanText(cleanedPages.stream()
                     .filter(page -> page != null && !page.isBlank())
@@ -171,8 +171,14 @@ public class PdfFileParser extends AbstractFileParser implements StructuredFileP
             case "png" -> "image/png";
             case "tif", "tiff" -> "image/tiff";
             case "gif" -> "image/gif";
-            default -> "image/" + suffix.toLowerCase();
+            default -> null;
         };
+    }
+
+    private List<ExtractedTable> tablesOnPage(List<ExtractedTable> tables, String pagePath) {
+        return tables.stream()
+                .filter(table -> table.sourceRef().startsWith(pagePath + "/"))
+                .toList();
     }
 
     private TableExtraction extractTables(List<String> pages) {
@@ -253,6 +259,11 @@ public class PdfFileParser extends AbstractFileParser implements StructuredFileP
                 markdownCells.add(row.get(colIndex));
             }
             markdownRows.add("| " + String.join(" | ", markdownCells) + " |");
+            if (rowIndex == 0) {
+                markdownRows.add("| " + row.stream()
+                        .map(ignored -> "---")
+                        .collect(Collectors.joining(" | ")) + " |");
+            }
         }
         String markdown = String.join("\n", markdownRows);
         Map<String, Object> metadata = new LinkedHashMap<>(tableMetadata(sourceRef, "pdf"));

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PdfFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PdfFileParser.java
@@ -2,13 +2,20 @@ package studio.one.platform.textract.extractor.impl;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDResources;
+import org.apache.pdfbox.pdmodel.graphics.PDXObject;
+import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
+import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.springframework.http.MediaType;
 
@@ -17,6 +24,10 @@ import studio.one.platform.textract.extractor.DocumentFormat;
 import studio.one.platform.textract.extractor.FileParseException;
 import studio.one.platform.textract.extractor.StructuredFileParser;
 import studio.one.platform.textract.model.BlockType;
+import studio.one.platform.textract.model.ExtractedImage;
+import studio.one.platform.textract.model.ExtractedTable;
+import studio.one.platform.textract.model.ExtractedTableCell;
+import studio.one.platform.textract.model.ParseWarning;
 import studio.one.platform.textract.model.ParsedBlock;
 import studio.one.platform.textract.model.ParsedFile;
 
@@ -47,6 +58,8 @@ public class PdfFileParser extends AbstractFileParser implements StructuredFileP
             stripper.setSortByPosition(true);
             List<String> pages = extractPages(document, stripper);
             List<String> cleanedPages = cleanPdfPages(pages);
+            List<ExtractedImage> images = extractImages(document);
+            TableExtraction tableExtraction = extractTables(cleanedPages);
             List<ParsedBlock> pageBlocks = new ArrayList<>();
             List<ParsedBlock> blocks = new ArrayList<>();
             int order = 0;
@@ -79,6 +92,17 @@ public class PdfFileParser extends AbstractFileParser implements StructuredFileP
                     order++;
                 }
             }
+            for (ExtractedTable table : tableExtraction.tables()) {
+                blocks.add(new ParsedBlock(
+                        table.sourceRef(),
+                        BlockType.TABLE,
+                        table.sourceRef(),
+                        table.markdown(),
+                        null,
+                        List.of(),
+                        blockMetadata(table.sourceRef(), order)));
+                order++;
+            }
             String text = cleanText(cleanedPages.stream()
                     .filter(page -> page != null && !page.isBlank())
                     .collect(Collectors.joining("\n\n")));
@@ -87,10 +111,10 @@ public class PdfFileParser extends AbstractFileParser implements StructuredFileP
                     text,
                     blocks,
                     fileMetadata(contentType, filename),
-                    List.of(),
+                    tableExtraction.warnings(),
                     pageBlocks,
-                    List.of(),
-                    List.of(),
+                    tableExtraction.tables(),
+                    images,
                     false);
         } catch (IOException e) {
             throw new FileParseException("Failed to parse PDF file: " + safeFilename(filename), e);
@@ -110,6 +134,165 @@ public class PdfFileParser extends AbstractFileParser implements StructuredFileP
             pages.add(stripper.getText(document));
         }
         return pages;
+    }
+
+    private List<ExtractedImage> extractImages(PDDocument document) throws IOException {
+        List<ExtractedImage> images = new ArrayList<>();
+        for (int pageIndex = 0; pageIndex < document.getNumberOfPages(); pageIndex++) {
+            PDPage page = document.getPage(pageIndex);
+            String pagePath = "page[" + (pageIndex + 1) + "]";
+            appendImages(page.getResources(), images, pagePath, pagePath);
+        }
+        return images;
+    }
+
+    private void appendImages(
+            PDResources resources,
+            List<ExtractedImage> images,
+            String sourceRef,
+            String binDataRefPrefix) throws IOException {
+        if (resources == null) {
+            return;
+        }
+        for (COSName name : resources.getXObjectNames()) {
+            PDXObject xObject = resources.getXObject(name);
+            String objectRef = sourceRef + "/xobject[" + name.getName() + "]";
+            if (xObject instanceof PDImageXObject image) {
+                images.add(toExtractedImage(image, objectRef, binDataRefPrefix + "/" + name.getName()));
+            } else if (xObject instanceof PDFormXObject form) {
+                appendImages(form.getResources(), images, objectRef, binDataRefPrefix + "/" + name.getName());
+            }
+        }
+    }
+
+    private ExtractedImage toExtractedImage(PDImageXObject image, String sourceRef, String binDataRef) {
+        String suffix = image.getSuffix();
+        String filename = suffix == null || suffix.isBlank()
+                ? binDataRef
+                : binDataRef + "." + suffix;
+        Map<String, Object> metadata = new LinkedHashMap<>(imageMetadata(sourceRef));
+        metadata.put(ExtractedImage.KEY_BIN_DATA_REF, binDataRef);
+        return new ExtractedImage(
+                sourceRef,
+                imageContentType(suffix),
+                filename,
+                image.getWidth(),
+                image.getHeight(),
+                metadata);
+    }
+
+    private String imageContentType(String suffix) {
+        if (suffix == null || suffix.isBlank()) {
+            return null;
+        }
+        return switch (suffix.toLowerCase()) {
+            case "jpg", "jpeg" -> "image/jpeg";
+            case "png" -> "image/png";
+            case "tif", "tiff" -> "image/tiff";
+            case "gif" -> "image/gif";
+            default -> "image/" + suffix.toLowerCase();
+        };
+    }
+
+    private TableExtraction extractTables(List<String> pages) {
+        List<ExtractedTable> tables = new ArrayList<>();
+        List<ParseWarning> warnings = new ArrayList<>();
+        int tableIndex = 0;
+        for (int pageIndex = 0; pageIndex < pages.size(); pageIndex++) {
+            String page = pages.get(pageIndex);
+            if (page == null || page.isBlank()) {
+                continue;
+            }
+            List<List<String>> rows = new ArrayList<>();
+            int candidateStartLine = -1;
+            List<String> lines = page.lines().toList();
+            for (int lineIndex = 0; lineIndex <= lines.size(); lineIndex++) {
+                String line = lineIndex < lines.size() ? lines.get(lineIndex) : "";
+                List<String> cells = splitTableCells(line);
+                if (cells.size() >= 2) {
+                    if (rows.isEmpty()) {
+                        candidateStartLine = lineIndex;
+                    }
+                    rows.add(cells);
+                    continue;
+                }
+                tableIndex = flushTableCandidate(
+                        tables,
+                        warnings,
+                        rows,
+                        pageIndex + 1,
+                        tableIndex,
+                        candidateStartLine);
+                rows = new ArrayList<>();
+                candidateStartLine = -1;
+            }
+        }
+        return new TableExtraction(tables, warnings);
+    }
+
+    private int flushTableCandidate(
+            List<ExtractedTable> tables,
+            List<ParseWarning> warnings,
+            List<List<String>> rows,
+            int pageNumber,
+            int tableIndex,
+            int startLine) {
+        if (rows.isEmpty()) {
+            return tableIndex;
+        }
+        int columnCount = rows.get(0).size();
+        boolean rectangular = rows.size() >= 2
+                && columnCount >= 2
+                && rows.stream().allMatch(row -> row.size() == columnCount);
+        String sourceRef = "page[" + pageNumber + "]/table[" + tableIndex + "]";
+        if (!rectangular) {
+            warnings.add(ParseWarning.partial(
+                    "TABLE_RECONSTRUCTION_PARTIAL",
+                    "PDF table candidate could not be reconstructed safely.",
+                    sourceRef,
+                    Map.of("line", Math.max(0, startLine))));
+            return tableIndex + 1;
+        }
+        List<ExtractedTableCell> cells = new ArrayList<>();
+        List<String> markdownRows = new ArrayList<>();
+        for (int rowIndex = 0; rowIndex < rows.size(); rowIndex++) {
+            List<String> row = rows.get(rowIndex);
+            List<String> markdownCells = new ArrayList<>();
+            for (int colIndex = 0; colIndex < row.size(); colIndex++) {
+                String cellSourceRef = sourceRef + "/row[" + rowIndex + "]/cell[" + colIndex + "]";
+                Map<String, Object> metadata = new LinkedHashMap<>();
+                metadata.put(ExtractedTableCell.KEY_SOURCE_REF, cellSourceRef);
+                if (rowIndex == 0) {
+                    metadata.put(ExtractedTableCell.KEY_HEADER, true);
+                }
+                cells.add(new ExtractedTableCell(rowIndex, colIndex, 1, 1, row.get(colIndex), metadata));
+                markdownCells.add(row.get(colIndex));
+            }
+            markdownRows.add("| " + String.join(" | ", markdownCells) + " |");
+        }
+        String markdown = String.join("\n", markdownRows);
+        Map<String, Object> metadata = new LinkedHashMap<>(tableMetadata(sourceRef, "pdf"));
+        metadata.put(ExtractedTable.KEY_HEADER_ROW_COUNT, 1);
+        metadata.put(ExtractedTable.KEY_VECTOR_TEXT, rows.stream()
+                .map(row -> String.join(" ", row))
+                .collect(Collectors.joining("\n")));
+        tables.add(new ExtractedTable(sourceRef, markdown, cells, metadata));
+        return tableIndex + 1;
+    }
+
+    private List<String> splitTableCells(String line) {
+        String cleaned = cleanText(line);
+        if (cleaned == null || cleaned.isBlank()) {
+            return List.of();
+        }
+        String[] cells = cleaned.split("\\s{2,}");
+        if (cells.length < 2) {
+            return List.of();
+        }
+        return Arrays.stream(cells)
+                .map(String::trim)
+                .filter(cell -> !cell.isBlank())
+                .toList();
     }
 
     List<String> cleanPdfPages(List<String> rawPages) {
@@ -267,5 +450,8 @@ public class PdfFileParser extends AbstractFileParser implements StructuredFileP
         }
         paragraphs.add(paragraph.toString());
         paragraph.setLength(0);
+    }
+
+    private record TableExtraction(List<ExtractedTable> tables, List<ParseWarning> warnings) {
     }
 }

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PdfFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PdfFileParser.java
@@ -1,5 +1,6 @@
 package studio.one.platform.textract.extractor.impl;
 
+import java.awt.geom.Point2D;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -8,14 +9,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.contentstream.PDFGraphicsStreamEngine;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
-import org.apache.pdfbox.pdmodel.PDResources;
-import org.apache.pdfbox.pdmodel.graphics.PDXObject;
-import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
-import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
+import org.apache.pdfbox.pdmodel.graphics.image.PDImage;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.springframework.http.MediaType;
 
@@ -141,31 +139,14 @@ public class PdfFileParser extends AbstractFileParser implements StructuredFileP
         for (int pageIndex = 0; pageIndex < document.getNumberOfPages(); pageIndex++) {
             PDPage page = document.getPage(pageIndex);
             String pagePath = "page[" + (pageIndex + 1) + "]";
-            appendImages(page.getResources(), images, pagePath, pagePath);
+            DrawnImageCollector collector = new DrawnImageCollector(page, pagePath);
+            collector.processPage(page);
+            images.addAll(collector.images());
         }
         return images;
     }
 
-    private void appendImages(
-            PDResources resources,
-            List<ExtractedImage> images,
-            String sourceRef,
-            String binDataRefPrefix) throws IOException {
-        if (resources == null) {
-            return;
-        }
-        for (COSName name : resources.getXObjectNames()) {
-            PDXObject xObject = resources.getXObject(name);
-            String objectRef = sourceRef + "/xobject[" + name.getName() + "]";
-            if (xObject instanceof PDImageXObject image) {
-                images.add(toExtractedImage(image, objectRef, binDataRefPrefix + "/" + name.getName()));
-            } else if (xObject instanceof PDFormXObject form) {
-                appendImages(form.getResources(), images, objectRef, binDataRefPrefix + "/" + name.getName());
-            }
-        }
-    }
-
-    private ExtractedImage toExtractedImage(PDImageXObject image, String sourceRef, String binDataRef) {
+    private ExtractedImage toExtractedImage(PDImage image, String sourceRef, String binDataRef) {
         String suffix = image.getSuffix();
         String filename = suffix == null || suffix.isBlank()
                 ? binDataRef
@@ -238,6 +219,9 @@ public class PdfFileParser extends AbstractFileParser implements StructuredFileP
             int tableIndex,
             int startLine) {
         if (rows.isEmpty()) {
+            return tableIndex;
+        }
+        if (rows.size() == 1) {
             return tableIndex;
         }
         int columnCount = rows.get(0).size();
@@ -453,5 +437,88 @@ public class PdfFileParser extends AbstractFileParser implements StructuredFileP
     }
 
     private record TableExtraction(List<ExtractedTable> tables, List<ParseWarning> warnings) {
+    }
+
+    private class DrawnImageCollector extends PDFGraphicsStreamEngine {
+
+        private final String pagePath;
+        private final List<ExtractedImage> images = new ArrayList<>();
+        private int imageIndex;
+
+        DrawnImageCollector(PDPage page, String pagePath) {
+            super(page);
+            this.pagePath = pagePath;
+        }
+
+        List<ExtractedImage> images() {
+            return images;
+        }
+
+        @Override
+        public void drawImage(PDImage image) {
+            String sourceRef = pagePath + "/image[" + imageIndex + "]";
+            images.add(toExtractedImage(image, sourceRef, sourceRef));
+            imageIndex++;
+        }
+
+        @Override
+        public void appendRectangle(Point2D p0, Point2D p1, Point2D p2, Point2D p3) {
+            // Geometry is not needed for image reference extraction.
+        }
+
+        @Override
+        public void clip(int windingRule) {
+            // No-op.
+        }
+
+        @Override
+        public void moveTo(float x, float y) {
+            // No-op.
+        }
+
+        @Override
+        public void lineTo(float x, float y) {
+            // No-op.
+        }
+
+        @Override
+        public void curveTo(float x1, float y1, float x2, float y2, float x3, float y3) {
+            // No-op.
+        }
+
+        @Override
+        public Point2D getCurrentPoint() {
+            return new Point2D.Float(0, 0);
+        }
+
+        @Override
+        public void closePath() {
+            // No-op.
+        }
+
+        @Override
+        public void endPath() {
+            // No-op.
+        }
+
+        @Override
+        public void strokePath() {
+            // No-op.
+        }
+
+        @Override
+        public void fillPath(int windingRule) {
+            // No-op.
+        }
+
+        @Override
+        public void fillAndStrokePath(int windingRule) {
+            // No-op.
+        }
+
+        @Override
+        public void shadingFill(org.apache.pdfbox.cos.COSName shadingName) {
+            // No-op.
+        }
     }
 }

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/PdfFileParserTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/PdfFileParserTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
+import java.util.Base64;
 import java.util.List;
 
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -11,15 +12,20 @@ import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
 import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
+import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
 import org.junit.jupiter.api.Test;
 
 import studio.one.platform.textract.extractor.DocumentFormat;
 import studio.one.platform.textract.model.BlockType;
+import studio.one.platform.textract.model.ExtractedImage;
+import studio.one.platform.textract.model.ExtractedTable;
 import studio.one.platform.textract.model.ParsedFile;
 
 class PdfFileParserTest {
 
     private final PdfFileParser parser = new PdfFileParser();
+    private static final byte[] PNG_BYTES = Base64.getDecoder().decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==");
 
     @Test
     void cleanPdfTextCompactsFragmentedShortLines() {
@@ -129,11 +135,127 @@ class PdfFileParserTest {
         assertEquals("page[1]/paragraph[0]", result.blocks().get(0).sourceRef());
     }
 
+    @Test
+    void parseStructuredExtractsImageXObjectWithPageSourceRef() throws Exception {
+        byte[] bytes = pdfWithImage();
+
+        ParsedFile result = parser.parseStructured(bytes, "application/pdf", "image.pdf");
+
+        assertEquals(1, result.images().size());
+        ExtractedImage image = result.images().get(0);
+        assertEquals("image/png", image.mimeType());
+        assertEquals(1, image.width());
+        assertEquals(1, image.height());
+        assertTrue(image.sourceRef().startsWith("page[1]/xobject["));
+        assertTrue(image.binDataRef().startsWith("page[1]/"));
+    }
+
+    @Test
+    void parseStructuredReconstructsSimpleAlignedTableCandidate() throws Exception {
+        byte[] bytes = pdfWithTableText();
+
+        ParsedFile result = parser.parseStructured(bytes, "application/pdf", "table.pdf");
+
+        assertEquals(1, result.tables().size());
+        ExtractedTable table = result.tables().get(0);
+        assertEquals("pdf", table.format());
+        assertEquals("page[1]/table[0]", table.sourceRef());
+        assertEquals(4, table.cellCount());
+        assertEquals("| Name | Score |", table.markdown().split("\\n")[0]);
+        assertEquals("Name", table.cells().get(0).text());
+        assertTrue(table.cells().get(0).header());
+        assertTrue(result.blocks().stream().anyMatch(block -> block.blockType() == BlockType.TABLE));
+    }
+
+    @Test
+    void parseStructuredWarnsForAmbiguousTableCandidateWithoutFalseTable() throws Exception {
+        byte[] bytes = pdfWithAmbiguousTableText();
+
+        ParsedFile result = parser.parseStructured(bytes, "application/pdf", "ambiguous-table.pdf");
+
+        assertEquals(0, result.tables().size());
+        assertEquals(1, result.warnings().size());
+        assertEquals("TABLE_RECONSTRUCTION_PARTIAL", result.warnings().get(0).canonicalCode());
+        assertTrue(result.warnings().get(0).partialParse());
+    }
+
+    @Test
+    void parseStructuredDoesNotCreateTableForNormalParagraphSpacing() throws Exception {
+        byte[] bytes = pdfWithNormalParagraph();
+
+        ParsedFile result = parser.parseStructured(bytes, "application/pdf", "normal.pdf");
+
+        assertEquals(0, result.tables().size());
+        assertEquals(0, result.warnings().size());
+        assertTrue(result.plainText().contains("This is a normal paragraph"));
+    }
+
     private byte[] pdfWithTwoPages() throws Exception {
         try (PDDocument document = new PDDocument();
                 ByteArrayOutputStream out = new ByteArrayOutputStream()) {
             addPage(document, "Common header", "First page body", "Common footer");
             addPage(document, "Common header", "Second page body", "Common footer");
+            document.save(out);
+            return out.toByteArray();
+        }
+    }
+
+    private byte[] pdfWithImage() throws Exception {
+        try (PDDocument document = new PDDocument();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            PDPage page = new PDPage();
+            document.addPage(page);
+            PDImageXObject image = PDImageXObject.createFromByteArray(document, PNG_BYTES, "inline.png");
+            try (PDPageContentStream contentStream = new PDPageContentStream(document, page)) {
+                contentStream.drawImage(image, 50, 700, 20, 20);
+            }
+            document.save(out);
+            return out.toByteArray();
+        }
+    }
+
+    private byte[] pdfWithTableText() throws Exception {
+        try (PDDocument document = new PDDocument();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            PDPage page = new PDPage();
+            document.addPage(page);
+            try (PDPageContentStream contentStream = new PDPageContentStream(document, page)) {
+                contentStream.beginText();
+                contentStream.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 12);
+                contentStream.newLineAtOffset(50, 750);
+                contentStream.showText("Name    Score");
+                contentStream.newLineAtOffset(0, -20);
+                contentStream.showText("Alice   90");
+                contentStream.endText();
+            }
+            document.save(out);
+            return out.toByteArray();
+        }
+    }
+
+    private byte[] pdfWithAmbiguousTableText() throws Exception {
+        try (PDDocument document = new PDDocument();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            PDPage page = new PDPage();
+            document.addPage(page);
+            try (PDPageContentStream contentStream = new PDPageContentStream(document, page)) {
+                contentStream.beginText();
+                contentStream.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 12);
+                contentStream.newLineAtOffset(50, 750);
+                contentStream.showText("Name    Score");
+                contentStream.newLineAtOffset(0, -20);
+                contentStream.showText("Alice   90    Passed");
+                contentStream.endText();
+            }
+            document.save(out);
+            return out.toByteArray();
+        }
+    }
+
+    private byte[] pdfWithNormalParagraph() throws Exception {
+        try (PDDocument document = new PDDocument();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            addPage(document, "This is a normal paragraph", "with regular spacing", "and no table");
             document.save(out);
             return out.toByteArray();
         }

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/PdfFileParserTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/PdfFileParserTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.PDResources;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
 import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
 import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
@@ -146,8 +147,17 @@ class PdfFileParserTest {
         assertEquals("image/png", image.mimeType());
         assertEquals(1, image.width());
         assertEquals(1, image.height());
-        assertTrue(image.sourceRef().startsWith("page[1]/xobject["));
-        assertTrue(image.binDataRef().startsWith("page[1]/"));
+        assertEquals("page[1]/image[0]", image.sourceRef());
+        assertEquals("page[1]/image[0]", image.binDataRef());
+    }
+
+    @Test
+    void parseStructuredIgnoresUnusedImageXObjectResources() throws Exception {
+        byte[] bytes = pdfWithUnusedImageResource();
+
+        ParsedFile result = parser.parseStructured(bytes, "application/pdf", "unused-image.pdf");
+
+        assertEquals(0, result.images().size());
     }
 
     @Test
@@ -190,6 +200,17 @@ class PdfFileParserTest {
         assertTrue(result.plainText().contains("This is a normal paragraph"));
     }
 
+    @Test
+    void parseStructuredIgnoresSingleAlignedLineWithoutTableWarning() throws Exception {
+        byte[] bytes = pdfWithSingleAlignedLine();
+
+        ParsedFile result = parser.parseStructured(bytes, "application/pdf", "single-aligned.pdf");
+
+        assertEquals(0, result.tables().size());
+        assertEquals(0, result.warnings().size());
+        assertTrue(result.plainText().contains("Total"));
+    }
+
     private byte[] pdfWithTwoPages() throws Exception {
         try (PDDocument document = new PDDocument();
                 ByteArrayOutputStream out = new ByteArrayOutputStream()) {
@@ -209,6 +230,19 @@ class PdfFileParserTest {
             try (PDPageContentStream contentStream = new PDPageContentStream(document, page)) {
                 contentStream.drawImage(image, 50, 700, 20, 20);
             }
+            document.save(out);
+            return out.toByteArray();
+        }
+    }
+
+    private byte[] pdfWithUnusedImageResource() throws Exception {
+        try (PDDocument document = new PDDocument();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            PDPage page = new PDPage();
+            document.addPage(page);
+            PDResources resources = new PDResources();
+            resources.add(PDImageXObject.createFromByteArray(document, PNG_BYTES, "unused.png"));
+            page.setResources(resources);
             document.save(out);
             return out.toByteArray();
         }
@@ -256,6 +290,23 @@ class PdfFileParserTest {
         try (PDDocument document = new PDDocument();
                 ByteArrayOutputStream out = new ByteArrayOutputStream()) {
             addPage(document, "This is a normal paragraph", "with regular spacing", "and no table");
+            document.save(out);
+            return out.toByteArray();
+        }
+    }
+
+    private byte[] pdfWithSingleAlignedLine() throws Exception {
+        try (PDDocument document = new PDDocument();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            PDPage page = new PDPage();
+            document.addPage(page);
+            try (PDPageContentStream contentStream = new PDPageContentStream(document, page)) {
+                contentStream.beginText();
+                contentStream.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 12);
+                contentStream.newLineAtOffset(50, 750);
+                contentStream.showText("Total    100");
+                contentStream.endText();
+            }
             document.save(out);
             return out.toByteArray();
         }

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/PdfFileParserTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/PdfFileParserTest.java
@@ -171,15 +171,20 @@ class PdfFileParserTest {
         assertEquals("pdf", table.format());
         assertEquals("page[1]/table[0]", table.sourceRef());
         assertEquals(4, table.cellCount());
-        assertEquals("| Name | Score |", table.markdown().split("\\n")[0]);
+        assertEquals("""
+                | Name | Score |
+                | --- | --- |
+                | Alice | 90 |""", table.markdown());
         assertEquals("Name", table.cells().get(0).text());
         assertTrue(table.cells().get(0).header());
-        assertTrue(result.blocks().stream().anyMatch(block -> block.blockType() == BlockType.TABLE));
+        int tableBlockIndex = blockIndex(result, BlockType.TABLE);
+        assertTrue(tableBlockIndex > 0);
+        assertEquals(2, result.blocks().get(tableBlockIndex).order());
     }
 
     @Test
     void parseStructuredWarnsForAmbiguousTableCandidateWithoutFalseTable() throws Exception {
-        byte[] bytes = pdfWithAmbiguousTableText();
+        byte[] bytes = pdfWithUnevenColumnTableCandidate();
 
         ParsedFile result = parser.parseStructured(bytes, "application/pdf", "ambiguous-table.pdf");
 
@@ -267,7 +272,7 @@ class PdfFileParserTest {
         }
     }
 
-    private byte[] pdfWithAmbiguousTableText() throws Exception {
+    private byte[] pdfWithUnevenColumnTableCandidate() throws Exception {
         try (PDDocument document = new PDDocument();
                 ByteArrayOutputStream out = new ByteArrayOutputStream()) {
             PDPage page = new PDPage();
@@ -326,5 +331,14 @@ class PdfFileParserTest {
             contentStream.showText(footer);
             contentStream.endText();
         }
+    }
+
+    private int blockIndex(ParsedFile result, BlockType blockType) {
+        for (int index = 0; index < result.blocks().size(); index++) {
+            if (result.blocks().get(index).blockType() == blockType) {
+                return index;
+            }
+        }
+        return -1;
     }
 }


### PR DESCRIPTION
## Why

- 벡터화 파이프라인이 PDF의 이미지 참조와 표 후보를 `page/sourceRef` provenance와 함께 소비할 수 있어야 한다.
- PDF 표 재구성은 오탐 위험이 높으므로 명확한 후보만 구조화하고 불확실한 후보는 warning으로 표현해야 한다.

## What

- `PdfFileParser`가 실제 content stream에서 `drawImage`로 그려진 PDF image를 `ExtractedImage`로 노출하도록 추가했다.
- image metadata에는 `sourceRef`, `binDataRef`, content type, width, height를 기록한다.
- unused page resource image는 추출하지 않도록 content stream 기반 수집으로 정리했다.
- 정렬 텍스트에서 2열 이상이고 2행 이상인 rectangular candidate만 `ExtractedTable`로 재구성한다.
- PDF table markdown은 GFM/CommonMark 호환 separator 행을 포함한다.
- TABLE block은 해당 page 처리 중 추가해 page-local order를 유지한다.
- 불확실한 다중 행 표 후보는 `TABLE_RECONSTRUCTION_PARTIAL` partial warning으로 표현한다.
- 1행짜리 aligned text candidate는 table warning 없이 무시해 normal text 오탐을 줄였다.
- 알 수 없는 image suffix는 임의 MIME을 만들지 않고 null로 둔다.
- PDF 이미지 추출, unused image resource 무시, 표 후보 재구성, markdown separator, TABLE block order, ambiguous warning, single-line aligned text 오탐 방지, normal paragraph 오탐 방지 테스트를 추가했다.

## Related Issues

- Closes #247
- Parent: #244

## Validation

- Command: `git diff --check`
- Result: `passed`
- Command: `./gradlew :studio-platform-textract:test`
- Result: `BUILD SUCCESSFUL`
- Command: `./gradlew :studio-platform-textract:build`
- Result: `BUILD SUCCESSFUL`

## Risk / Rollback

- Risk: PDF image extraction now follows rendered content stream events, so images only registered as resources but never drawn are intentionally excluded. 표 재구성은 보수적 휴리스틱이므로 복잡한 PDF table은 warning 또는 plainText fallback으로 남을 수 있다.
- Rollback: 이 PR revert 시 PDF는 기존 page/paragraph 중심 구조화로 돌아간다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: 없음
- Main author validation: textract test/build와 diff check를 확인했다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review required before merge
- [x] no unrelated changes included