### PR TITLE
[textract] OCR confidence 및 bbox metadata 보강

### DIFF
--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/ImageFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/ImageFileParser.java
@@ -1,28 +1,40 @@
 package studio.one.platform.textract.extractor.impl;
 
 import java.awt.image.BufferedImage;
+import java.awt.Rectangle;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.imageio.ImageIO;
 
 import lombok.extern.slf4j.Slf4j;
+import net.sourceforge.tess4j.ITessAPI;
 import net.sourceforge.tess4j.Tesseract;
 import net.sourceforge.tess4j.TesseractException;
+import net.sourceforge.tess4j.Word;
 import studio.one.platform.textract.extractor.DocumentFormat;
 import studio.one.platform.textract.extractor.FileParseException;
 import studio.one.platform.textract.extractor.StructuredFileParser;
 import studio.one.platform.textract.model.BlockType;
 import studio.one.platform.textract.model.ExtractedImage;
+import studio.one.platform.textract.model.ParseWarning;
 import studio.one.platform.textract.model.ParsedBlock;
 import studio.one.platform.textract.model.ParsedFile;
 
 @Slf4j
 public class ImageFileParser extends AbstractFileParser implements StructuredFileParser {
+
+    static final String KEY_BBOX = "bbox";
+    static final String KEY_WORDS = "words";
+    static final String KEY_MIN_CONFIDENCE = "minConfidence";
+    static final String KEY_AVERAGE_CONFIDENCE = "averageConfidence";
+    static final String KEY_WORD_COUNT = "wordCount";
+    private static final double LOW_CONFIDENCE_THRESHOLD = 0.60d;
 
     private final Tesseract tesseract; // Spring Bean 으로 주입받는 것을 권장
 
@@ -48,20 +60,22 @@ public class ImageFileParser extends AbstractFileParser implements StructuredFil
                 throw new FileParseException("Unsupported or corrupt image: " + safeFilename(filename));
             }
             String text = cleanText(tesseract.doOCR(image));
-            List<ParsedBlock> blocks = ocrLineBlocks(text);
+            List<OcrToken> tokens = ocrTokens(image);
+            List<ParsedBlock> blocks = tokens.isEmpty() ? ocrLineBlocks(text) : ocrLineBlocks(tokens);
+            OcrQuality quality = OcrQuality.fromBlocks(blocks);
             ExtractedImage extractedImage = new ExtractedImage(
                     "image",
                     contentType,
                     filename,
                     image.getWidth(),
                     image.getHeight(),
-                    imageMetadata(blocks.size()));
+                    imageMetadata(blocks.size(), quality.confidenceAvailable()));
             return new ParsedFile(
                     DocumentFormat.IMAGE,
                     text,
                     blocks,
                     fileMetadata(contentType, filename),
-                    List.of(),
+                    ocrWarnings(blocks),
                     List.of(),
                     List.of(),
                     List.of(extractedImage),
@@ -74,6 +88,13 @@ public class ImageFileParser extends AbstractFileParser implements StructuredFil
     @Override
     public String parse(byte[] bytes, String contentType, String filename) throws FileParseException {
         return parseStructured(bytes, contentType, filename).plainText();
+    }
+
+    private List<OcrToken> ocrTokens(BufferedImage image) {
+        return tesseract.getWords(image, ITessAPI.TessPageIteratorLevel.RIL_WORD).stream()
+                .map(word -> new OcrToken(word.getText(), normalizeConfidence(word.getConfidence()), word.getBoundingBox()))
+                .filter(token -> token.text() != null && !token.text().isBlank())
+                .toList();
     }
 
     List<ParsedBlock> ocrLineBlocks(String text) {
@@ -89,28 +110,201 @@ public class ImageFileParser extends AbstractFileParser implements StructuredFil
             }
             int order = blocks.size();
             String path = "image/ocr/line[" + order + "]";
-            blocks.add(ParsedBlock.text(path, BlockType.OCR_TEXT, cleanedLine, null, order, ocrBlockMetadata(path, order)));
+            blocks.add(ParsedBlock.text(
+                    path,
+                    BlockType.OCR_TEXT,
+                    cleanedLine,
+                    null,
+                    order,
+                    ocrBlockMetadata(path, order, null, List.of())));
         }
         return blocks;
     }
 
-    private Map<String, Object> ocrBlockMetadata(String path, int order) {
+    List<ParsedBlock> ocrLineBlocks(List<OcrToken> tokens) {
+        if (tokens == null || tokens.isEmpty()) {
+            return List.of();
+        }
+        List<ParsedBlock> blocks = new ArrayList<>();
+        for (List<OcrToken> lineTokens : groupLineTokens(tokens)) {
+            String text = lineTokens.stream()
+                    .map(OcrToken::text)
+                    .collect(Collectors.joining(" "));
+            String cleanedLine = cleanText(text);
+            if (cleanedLine == null || cleanedLine.isBlank()) {
+                continue;
+            }
+            int order = blocks.size();
+            String path = "image/ocr/line[" + order + "]";
+            Double confidence = averageConfidence(lineTokens);
+            blocks.add(ParsedBlock.text(
+                    path,
+                    BlockType.OCR_TEXT,
+                    cleanedLine,
+                    null,
+                    order,
+                    ocrBlockMetadata(path, order, confidence, lineTokens)));
+        }
+        return blocks;
+    }
+
+    private Map<String, Object> ocrBlockMetadata(String path, int order, Double confidence, List<OcrToken> tokens) {
         Map<String, Object> metadata = new LinkedHashMap<>();
         metadata.put(ParsedBlock.KEY_SOURCE_REF, path);
         metadata.put(ParsedBlock.KEY_ORDER, order);
         metadata.put(ExtractedImage.KEY_OCR_APPLIED, true);
         metadata.put(ExtractedImage.KEY_OCR_UNIT, "line");
-        metadata.put(ExtractedImage.KEY_CONFIDENCE_AVAILABLE, false);
+        metadata.put(ExtractedImage.KEY_CONFIDENCE_AVAILABLE, confidence != null);
+        if (confidence != null) {
+            metadata.put(ParsedBlock.KEY_CONFIDENCE, confidence);
+            metadata.put(KEY_WORD_COUNT, tokens.size());
+            metadata.put(KEY_BBOX, bbox(union(tokens.stream()
+                    .map(OcrToken::bbox)
+                    .toList())));
+            metadata.put(KEY_WORDS, tokens.stream()
+                    .map(this::wordMetadata)
+                    .toList());
+        }
         return metadata;
     }
 
-    private Map<String, Object> imageMetadata(int ocrLineCount) {
+    private Map<String, Object> imageMetadata(int ocrLineCount, boolean confidenceAvailable) {
         Map<String, Object> metadata = new LinkedHashMap<>();
         metadata.put(ExtractedImage.KEY_SOURCE_REF, "image");
         metadata.put(ExtractedImage.KEY_OCR_APPLIED, true);
         metadata.put(ExtractedImage.KEY_OCR_LINE_COUNT, ocrLineCount);
-        metadata.put(ExtractedImage.KEY_CONFIDENCE_AVAILABLE, false);
+        metadata.put(ExtractedImage.KEY_CONFIDENCE_AVAILABLE, confidenceAvailable);
         return metadata;
     }
 
+    List<ParseWarning> ocrWarnings(List<ParsedBlock> blocks) {
+        OcrQuality quality = OcrQuality.fromBlocks(blocks);
+        if (!quality.confidenceAvailable() || quality.minConfidence() >= LOW_CONFIDENCE_THRESHOLD) {
+            return List.of();
+        }
+        return List.of(ParseWarning.warning(
+                "OCR_LOW_CONFIDENCE",
+                "OCR result contains low-confidence text.",
+                "image",
+                Map.of(
+                        KEY_MIN_CONFIDENCE, quality.minConfidence(),
+                        KEY_AVERAGE_CONFIDENCE, quality.averageConfidence())));
+    }
+
+    private List<List<OcrToken>> groupLineTokens(List<OcrToken> tokens) {
+        List<List<OcrToken>> lines = new ArrayList<>();
+        for (OcrToken token : tokens) {
+            if (token.bbox() == null) {
+                addTokenToLine(lines, token);
+                continue;
+            }
+            List<OcrToken> target = null;
+            for (List<OcrToken> line : lines) {
+                Rectangle existing = union(line.stream().map(OcrToken::bbox).toList());
+                if (existing != null && verticallyOverlaps(existing, token.bbox())) {
+                    target = line;
+                    break;
+                }
+            }
+            if (target == null) {
+                target = new ArrayList<>();
+                lines.add(target);
+            }
+            target.add(token);
+        }
+        for (List<OcrToken> line : lines) {
+            line.sort((left, right) -> Integer.compare(x(left.bbox()), x(right.bbox())));
+        }
+        return lines;
+    }
+
+    private void addTokenToLine(List<List<OcrToken>> lines, OcrToken token) {
+        if (lines.isEmpty()) {
+            lines.add(new ArrayList<>());
+        }
+        lines.get(lines.size() - 1).add(token);
+    }
+
+    private boolean verticallyOverlaps(Rectangle left, Rectangle right) {
+        int top = Math.max(left.y, right.y);
+        int bottom = Math.min(left.y + left.height, right.y + right.height);
+        int overlap = bottom - top;
+        return overlap > 0 && overlap >= Math.min(left.height, right.height) / 2;
+    }
+
+    private int x(Rectangle bbox) {
+        return bbox == null ? 0 : bbox.x;
+    }
+
+    private Double averageConfidence(List<OcrToken> tokens) {
+        List<Double> values = tokens.stream()
+                .map(OcrToken::confidence)
+                .filter(confidence -> confidence != null)
+                .toList();
+        if (values.isEmpty()) {
+            return null;
+        }
+        return values.stream().mapToDouble(Double::doubleValue).average().orElse(0d);
+    }
+
+    private Double normalizeConfidence(float confidence) {
+        if (confidence < 0) {
+            return null;
+        }
+        return confidence > 1 ? confidence / 100d : (double) confidence;
+    }
+
+    private Rectangle union(List<Rectangle> boxes) {
+        Rectangle union = null;
+        for (Rectangle bbox : boxes) {
+            if (bbox == null) {
+                continue;
+            }
+            union = union == null ? new Rectangle(bbox) : union.union(bbox);
+        }
+        return union;
+    }
+
+    private Map<String, Object> wordMetadata(OcrToken token) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("text", token.text());
+        if (token.confidence() != null) {
+            metadata.put(ParsedBlock.KEY_CONFIDENCE, token.confidence());
+        }
+        if (token.bbox() != null) {
+            metadata.put(KEY_BBOX, bbox(token.bbox()));
+        }
+        return metadata;
+    }
+
+    private Map<String, Object> bbox(Rectangle bbox) {
+        if (bbox == null) {
+            return Map.of();
+        }
+        return Map.of(
+                "x", bbox.x,
+                "y", bbox.y,
+                "width", bbox.width,
+                "height", bbox.height);
+    }
+
+    record OcrToken(String text, Double confidence, Rectangle bbox) {
+    }
+
+    private record OcrQuality(boolean confidenceAvailable, double minConfidence, double averageConfidence) {
+
+        static OcrQuality fromBlocks(List<ParsedBlock> blocks) {
+            List<Double> values = blocks.stream()
+                    .map(ParsedBlock::confidence)
+                    .filter(confidence -> confidence != null)
+                    .toList();
+            if (values.isEmpty()) {
+                return new OcrQuality(false, 1d, 1d);
+            }
+            return new OcrQuality(
+                    true,
+                    values.stream().mapToDouble(Double::doubleValue).min().orElse(1d),
+                    values.stream().mapToDouble(Double::doubleValue).average().orElse(1d));
+        }
+    }
 }

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/ImageFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/ImageFileParser.java
@@ -16,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 import net.sourceforge.tess4j.ITessAPI;
 import net.sourceforge.tess4j.Tesseract;
 import net.sourceforge.tess4j.TesseractException;
-import net.sourceforge.tess4j.Word;
 import studio.one.platform.textract.extractor.DocumentFormat;
 import studio.one.platform.textract.extractor.FileParseException;
 import studio.one.platform.textract.extractor.StructuredFileParser;
@@ -59,9 +58,16 @@ public class ImageFileParser extends AbstractFileParser implements StructuredFil
             if (image == null) {
                 throw new FileParseException("Unsupported or corrupt image: " + safeFilename(filename));
             }
-            String text = cleanText(tesseract.doOCR(image));
             List<OcrToken> tokens = ocrTokens(image);
-            List<ParsedBlock> blocks = tokens.isEmpty() ? ocrLineBlocks(text) : ocrLineBlocks(tokens);
+            List<ParsedBlock> blocks;
+            String text;
+            if (tokens.isEmpty()) {
+                text = cleanText(tesseract.doOCR(image));
+                blocks = ocrLineBlocks(text);
+            } else {
+                blocks = ocrLineBlocks(tokens);
+                text = plainText(blocks);
+            }
             OcrQuality quality = OcrQuality.fromBlocks(blocks);
             ExtractedImage extractedImage = new ExtractedImage(
                     "image",
@@ -75,7 +81,7 @@ public class ImageFileParser extends AbstractFileParser implements StructuredFil
                     text,
                     blocks,
                     fileMetadata(contentType, filename),
-                    ocrWarnings(blocks),
+                    ocrWarnings(quality),
                     List.of(),
                     List.of(),
                     List.of(extractedImage),
@@ -121,6 +127,13 @@ public class ImageFileParser extends AbstractFileParser implements StructuredFil
         return blocks;
     }
 
+    private String plainText(List<ParsedBlock> blocks) {
+        return cleanText(blocks.stream()
+                .map(ParsedBlock::text)
+                .filter(text -> text != null && !text.isBlank())
+                .collect(Collectors.joining("\n")));
+    }
+
     List<ParsedBlock> ocrLineBlocks(List<OcrToken> tokens) {
         if (tokens == null || tokens.isEmpty()) {
             return List.of();
@@ -155,8 +168,7 @@ public class ImageFileParser extends AbstractFileParser implements StructuredFil
         metadata.put(ExtractedImage.KEY_OCR_APPLIED, true);
         metadata.put(ExtractedImage.KEY_OCR_UNIT, "line");
         metadata.put(ExtractedImage.KEY_CONFIDENCE_AVAILABLE, confidence != null);
-        if (confidence != null) {
-            metadata.put(ParsedBlock.KEY_CONFIDENCE, confidence);
+        if (tokens != null && !tokens.isEmpty()) {
             metadata.put(KEY_WORD_COUNT, tokens.size());
             metadata.put(KEY_BBOX, bbox(union(tokens.stream()
                     .map(OcrToken::bbox)
@@ -164,6 +176,14 @@ public class ImageFileParser extends AbstractFileParser implements StructuredFil
             metadata.put(KEY_WORDS, tokens.stream()
                     .map(this::wordMetadata)
                     .toList());
+            Double minConfidence = minConfidence(tokens);
+            if (minConfidence != null) {
+                metadata.put(KEY_MIN_CONFIDENCE, minConfidence);
+            }
+        }
+        if (confidence != null) {
+            metadata.put(ParsedBlock.KEY_CONFIDENCE, confidence);
+            metadata.put(KEY_AVERAGE_CONFIDENCE, confidence);
         }
         return metadata;
     }
@@ -178,7 +198,10 @@ public class ImageFileParser extends AbstractFileParser implements StructuredFil
     }
 
     List<ParseWarning> ocrWarnings(List<ParsedBlock> blocks) {
-        OcrQuality quality = OcrQuality.fromBlocks(blocks);
+        return ocrWarnings(OcrQuality.fromBlocks(blocks));
+    }
+
+    private List<ParseWarning> ocrWarnings(OcrQuality quality) {
         if (!quality.confidenceAvailable() || quality.minConfidence() >= LOW_CONFIDENCE_THRESHOLD) {
             return List.of();
         }
@@ -247,6 +270,17 @@ public class ImageFileParser extends AbstractFileParser implements StructuredFil
         return values.stream().mapToDouble(Double::doubleValue).average().orElse(0d);
     }
 
+    private Double minConfidence(List<OcrToken> tokens) {
+        List<Double> values = tokens.stream()
+                .map(OcrToken::confidence)
+                .filter(confidence -> confidence != null)
+                .toList();
+        if (values.isEmpty()) {
+            return null;
+        }
+        return values.stream().mapToDouble(Double::doubleValue).min().orElse(1d);
+    }
+
     private Double normalizeConfidence(float confidence) {
         if (confidence < 0) {
             return null;
@@ -298,12 +332,20 @@ public class ImageFileParser extends AbstractFileParser implements StructuredFil
                     .map(ParsedBlock::confidence)
                     .filter(confidence -> confidence != null)
                     .toList();
+            List<Double> minValues = blocks.stream()
+                    .map(block -> block.metadata().get(KEY_MIN_CONFIDENCE))
+                    .filter(Number.class::isInstance)
+                    .map(Number.class::cast)
+                    .map(Number::doubleValue)
+                    .toList();
             if (values.isEmpty()) {
                 return new OcrQuality(false, 1d, 1d);
             }
             return new OcrQuality(
                     true,
-                    values.stream().mapToDouble(Double::doubleValue).min().orElse(1d),
+                    minValues.isEmpty()
+                            ? values.stream().mapToDouble(Double::doubleValue).min().orElse(1d)
+                            : minValues.stream().mapToDouble(Double::doubleValue).min().orElse(1d),
                     values.stream().mapToDouble(Double::doubleValue).average().orElse(1d));
         }
     }

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/ImageFileParserTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/ImageFileParserTest.java
@@ -3,12 +3,15 @@ package studio.one.platform.textract.extractor.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.awt.Rectangle;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
 import studio.one.platform.textract.model.BlockType;
 import studio.one.platform.textract.model.ExtractedImage;
+import studio.one.platform.textract.model.ParseWarning;
 import studio.one.platform.textract.model.ParsedBlock;
 
 class ImageFileParserTest {
@@ -27,5 +30,35 @@ class ImageFileParserTest {
         assertEquals("image/ocr/line[0]", blocks.get(0).sourceRef());
         assertEquals("line", blocks.get(0).metadata().get(ExtractedImage.KEY_OCR_UNIT));
         assertEquals(false, blocks.get(0).metadata().get(ExtractedImage.KEY_CONFIDENCE_AVAILABLE));
+    }
+
+    @Test
+    void ocrLineBlocksIncludeConfidenceBboxAndWordMetadataWhenTokensAreAvailable() {
+        List<ParsedBlock> blocks = new ImageFileParser("/tmp", "kor+eng").ocrLineBlocks(List.of(
+                new ImageFileParser.OcrToken("첫", 0.91d, new Rectangle(10, 10, 8, 10)),
+                new ImageFileParser.OcrToken("줄", 0.81d, new Rectangle(24, 10, 8, 10)),
+                new ImageFileParser.OcrToken("둘째", 0.72d, new Rectangle(10, 40, 18, 10))));
+
+        assertEquals(2, blocks.size());
+        assertEquals("첫 줄", blocks.get(0).text());
+        assertEquals(0.86d, blocks.get(0).confidence(), 0.0001d);
+        assertEquals(true, blocks.get(0).metadata().get(ExtractedImage.KEY_CONFIDENCE_AVAILABLE));
+        assertEquals(Map.of("x", 10, "y", 10, "width", 22, "height", 10), blocks.get(0).metadata().get(ImageFileParser.KEY_BBOX));
+        assertEquals(2, blocks.get(0).metadata().get(ImageFileParser.KEY_WORD_COUNT));
+        List<?> words = (List<?>) blocks.get(0).metadata().get(ImageFileParser.KEY_WORDS);
+        assertEquals(2, words.size());
+    }
+
+    @Test
+    void ocrWarningsReportLowConfidenceWithoutTesseractDependency() {
+        ImageFileParser parser = new ImageFileParser("/tmp", "kor+eng");
+        List<ParsedBlock> blocks = parser.ocrLineBlocks(List.of(
+                new ImageFileParser.OcrToken("흐림", 0.42d, new Rectangle(10, 10, 20, 10))));
+
+        List<ParseWarning> warnings = parser.ocrWarnings(blocks);
+
+        assertEquals(1, warnings.size());
+        assertEquals("OCR_LOW_CONFIDENCE", warnings.get(0).canonicalCode());
+        assertTrue(warnings.get(0).metadata().containsKey(ImageFileParser.KEY_MIN_CONFIDENCE));
     }
 }

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/ImageFileParserTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/ImageFileParserTest.java
@@ -50,6 +50,20 @@ class ImageFileParserTest {
     }
 
     @Test
+    void ocrLineBlocksKeepBboxAndWordsWhenTokenConfidenceIsUnavailable() {
+        List<ParsedBlock> blocks = new ImageFileParser("/tmp", "kor+eng").ocrLineBlocks(List.of(
+                new ImageFileParser.OcrToken("첫", null, new Rectangle(10, 10, 8, 10)),
+                new ImageFileParser.OcrToken("줄", null, new Rectangle(24, 10, 8, 10))));
+
+        assertEquals(1, blocks.size());
+        assertEquals(false, blocks.get(0).metadata().get(ExtractedImage.KEY_CONFIDENCE_AVAILABLE));
+        assertEquals(Map.of("x", 10, "y", 10, "width", 22, "height", 10), blocks.get(0).metadata().get(ImageFileParser.KEY_BBOX));
+        assertEquals(2, blocks.get(0).metadata().get(ImageFileParser.KEY_WORD_COUNT));
+        List<?> words = (List<?>) blocks.get(0).metadata().get(ImageFileParser.KEY_WORDS);
+        assertEquals(2, words.size());
+    }
+
+    @Test
     void ocrWarningsReportLowConfidenceWithoutTesseractDependency() {
         ImageFileParser parser = new ImageFileParser("/tmp", "kor+eng");
         List<ParsedBlock> blocks = parser.ocrLineBlocks(List.of(
@@ -60,5 +74,19 @@ class ImageFileParserTest {
         assertEquals(1, warnings.size());
         assertEquals("OCR_LOW_CONFIDENCE", warnings.get(0).canonicalCode());
         assertTrue(warnings.get(0).metadata().containsKey(ImageFileParser.KEY_MIN_CONFIDENCE));
+    }
+
+    @Test
+    void ocrWarningsUseWordMinimumConfidenceInsteadOfLineAverage() {
+        ImageFileParser parser = new ImageFileParser("/tmp", "kor+eng");
+        List<ParsedBlock> blocks = parser.ocrLineBlocks(List.of(
+                new ImageFileParser.OcrToken("흐림", 0.42d, new Rectangle(10, 10, 20, 10)),
+                new ImageFileParser.OcrToken("선명", 0.92d, new Rectangle(40, 10, 20, 10))));
+
+        List<ParseWarning> warnings = parser.ocrWarnings(blocks);
+
+        assertEquals(0.67d, blocks.get(0).confidence(), 0.0001d);
+        assertEquals(1, warnings.size());
+        assertEquals(0.42d, warnings.get(0).metadata().get(ImageFileParser.KEY_MIN_CONFIDENCE));
     }
 }


### PR DESCRIPTION
## Why

- 벡터화 파이프라인이 OCR 결과를 line text뿐 아니라 confidence, bbox, word-level provenance와 함께 소비할 수 있어야 한다.
- 낮은 OCR confidence는 downstream에서 필터링하거나 재처리할 수 있도록 warning code로 표현해야 한다.

## What

- Tess4J `getWords(..., RIL_WORD)` 결과를 내부 `OcrToken`으로 변환한다.
- word token을 line 단위로 그룹화해 `OCR_TEXT` block을 생성한다.
- OCR line block metadata에 `confidence`, `bbox`, `wordCount`, `words`를 기록한다.
- word metadata에는 text, confidence, bbox를 기록한다.
- OCR confidence가 없을 때는 기존 `ocrLineBlocks(String)` fallback과 `confidenceAvailable=false` 흐름을 유지한다.
- low confidence OCR 결과는 `OCR_LOW_CONFIDENCE` warning으로 표현한다.
- 외부 Tesseract 없이 deterministic하게 검증 가능한 helper 테스트를 추가했다.

## Related Issues

- Closes #248
- Parent: #244

## Validation

- Command: `git diff --check`
- Result: `passed`
- Command: `./gradlew :studio-platform-textract:test`
- Result: `BUILD SUCCESSFUL`
- Command: `./gradlew :studio-platform-textract:build`
- Result: `BUILD SUCCESSFUL`

## Risk / Rollback

- Risk: OCR이 word result를 제공하는 환경에서는 `OCR_TEXT` block이 Tess4J word token grouping 기준으로 생성된다. 기존 plainText는 `doOCR` 결과를 유지한다.
- Rollback: 이 PR revert 시 OCR block은 기존 line text metadata만 제공하고 confidence/bbox/warning 확장은 제거된다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: 없음
- Main author validation: textract test/build와 diff check를 확인했다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review required before merge
- [x] no unrelated changes included