### PR TITLE
[textract] 상용 운영 품질 테스트 및 failure matrix 강화

### DIFF
--- a/studio-platform-textract/README.md
+++ b/studio-platform-textract/README.md
@@ -162,3 +162,21 @@ language data not found
 
 포맷별 parser는 관련 라이브러리가 classpath에 있을 때만 등록된다.
 예를 들어 HWP parser는 `org.apache.poi.poifs.filesystem.POIFSFileSystem`이 있어야 자동 구성된다.
+
+## 운영 품질 검증
+
+상용 운영 품질 기준에서는 정상 golden path뿐 아니라 실패/부분 성공/resource bound를 함께 확인한다.
+
+권장 검증 명령:
+
+```bash
+./gradlew :studio-platform-textract:test
+```
+
+운영 failure matrix는 다음 기준을 지킨다.
+
+- corrupt PDF/DOCX/PPTX/image/HWPX 입력은 complete failure로 `FileParseException`을 발생시킨다.
+- HTML은 Jsoup parser 특성상 malformed markup을 best-effort로 복구할 수 있으며, corrupt binary 포맷과 동일한 failure로 취급하지 않는다.
+- partial support는 `ParseWarning`의 `canonicalCode`, `severity`, `partialParse`로 구분한다.
+- oversized file/InputStream은 parser dispatch 전에 차단되어야 한다.
+- 포맷별 golden test는 구조화 결과의 block/table/image/warning contract 회귀를 방지한다.

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/DocxFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/DocxFileParser.java
@@ -90,7 +90,7 @@ public class DocxFileParser extends AbstractFileParser implements StructuredFile
                     images,
                     false);
 
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException e) {
             throw new FileParseException("Failed to parse DOCX file: " + safeFilename(filename), e);
         }
     }

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/DocxFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/DocxFileParser.java
@@ -8,7 +8,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.poi.UnsupportedFileFormatException;
 import org.apache.poi.common.usermodel.PictureType;
+import org.apache.poi.ooxml.POIXMLException;
 import org.apache.poi.util.Units;
 import org.apache.poi.xwpf.usermodel.IBodyElement;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
@@ -90,7 +92,7 @@ public class DocxFileParser extends AbstractFileParser implements StructuredFile
                     images,
                     false);
 
-        } catch (IOException | RuntimeException e) {
+        } catch (IOException | POIXMLException | UnsupportedFileFormatException e) {
             throw new FileParseException("Failed to parse DOCX file: " + safeFilename(filename), e);
         }
     }

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PptxFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PptxFileParser.java
@@ -9,6 +9,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.poi.UnsupportedFileFormatException;
+import org.apache.poi.ooxml.POIXMLException;
 import org.apache.poi.util.Units;
 import org.apache.poi.xslf.usermodel.XMLSlideShow;
 import org.apache.poi.xslf.usermodel.XSLFPictureData;
@@ -107,7 +109,7 @@ public class PptxFileParser extends AbstractFileParser implements StructuredFile
                     images,
                     false);
 
-        } catch (IOException | RuntimeException e) {
+        } catch (IOException | POIXMLException | UnsupportedFileFormatException e) {
             throw new FileParseException("Failed to parse PPTX file: " + safeFilename(filename), e);
         }
     }

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PptxFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PptxFileParser.java
@@ -107,7 +107,7 @@ public class PptxFileParser extends AbstractFileParser implements StructuredFile
                     images,
                     false);
 
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException e) {
             throw new FileParseException("Failed to parse PPTX file: " + safeFilename(filename), e);
         }
     }

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/OperationalFailureMatrixTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/OperationalFailureMatrixTest.java
@@ -1,0 +1,163 @@
+package studio.one.platform.textract.extractor.impl;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Rectangle;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.apache.poi.poifs.filesystem.POIFSFileSystem;
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.textract.extractor.DocumentFormat;
+import studio.one.platform.textract.extractor.FileParseException;
+import studio.one.platform.textract.model.ParseWarningSeverity;
+import studio.one.platform.textract.model.ParsedBlock;
+import studio.one.platform.textract.model.ParsedFile;
+
+class OperationalFailureMatrixTest {
+
+    @Test
+    void corruptBinaryFormatsFailFastAsCompleteParseFailures() throws Exception {
+        byte[] corrupt = "not a supported document".getBytes(UTF_8);
+
+        assertThrows(FileParseException.class,
+                () -> new PdfFileParser().parseStructured(corrupt, "application/pdf", "corrupt.pdf"));
+        assertThrows(FileParseException.class,
+                () -> new DocxFileParser().parseStructured(corrupt,
+                        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                        "corrupt.docx"));
+        assertThrows(FileParseException.class,
+                () -> new PptxFileParser().parseStructured(corrupt,
+                        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                        "corrupt.pptx"));
+        assertThrows(FileParseException.class,
+                () -> new ImageFileParser("/tmp", "kor+eng").parseStructured(corrupt, "image/png", "corrupt.png"));
+        assertThrows(FileParseException.class,
+                () -> new HwpHwpxFileParser().parseStructured(corruptHwpxBytes(), "application/hwpx", "corrupt.hwpx"));
+    }
+
+    @Test
+    void malformedHtmlRemainsBestEffortBecauseJsoupIsTolerant() {
+        String malformed = "<html><main><h1>제목<table><tr><td>A";
+
+        ParsedFile parsed = assertDoesNotThrow(
+                () -> new HtmlFileParser().parseStructured(malformed.getBytes(UTF_8), "text/html", "malformed.html"));
+
+        assertEquals(DocumentFormat.HTML, parsed.format());
+        assertTrue(parsed.plainText().contains("제목"));
+    }
+
+    @Test
+    void largeHtmlDocumentSmokeCompletesWithinOperationalBound() {
+        StringBuilder html = new StringBuilder("<main>");
+        for (int i = 0; i < 500; i++) {
+            html.append("<p>문단 ").append(i).append("</p>");
+        }
+        html.append("</main>");
+
+        ParsedFile parsed = assertTimeout(
+                Duration.ofSeconds(2),
+                () -> new HtmlFileParser().parseStructured(html.toString().getBytes(UTF_8), "text/html", "large.html"));
+
+        assertEquals(500, parsed.blocks().size());
+        assertTrue(parsed.plainText().contains("문단 499"));
+    }
+
+    @Test
+    void partialWarningsRemainStructuredAndNonFatalAcrossFormats() throws Exception {
+        ParsedFile hwpx = new HwpHwpxFileParser()
+                .parseStructured(hwpxBytesWithMissingSection(), "application/hwpx", "missing-section.hwpx");
+        ParsedFile hwp = new HwpHwpxFileParser()
+                .parseStructured(hwpEncryptedHeaderOnlyBytes(), "application/x-hwp", "encrypted.hwp");
+        ParsedFile ocr = imageParserWithLowConfidenceBlock();
+
+        assertEquals("HWPX_SECTION_MISSING", hwpx.warnings().get(0).canonicalCode());
+        assertTrue(hwpx.warnings().get(0).partialParse());
+        assertEquals(ParseWarningSeverity.WARNING, hwpx.warnings().get(0).severity());
+
+        assertEquals("HWP_ENCRYPTED", hwp.warnings().get(0).canonicalCode());
+        assertEquals(ParseWarningSeverity.ERROR, hwp.warnings().get(0).severity());
+        assertFalse(hwp.warnings().get(0).partialParse());
+
+        assertEquals("OCR_LOW_CONFIDENCE", ocr.warnings().get(0).canonicalCode());
+        assertEquals(ParseWarningSeverity.WARNING, ocr.warnings().get(0).severity());
+        assertFalse(ocr.warnings().get(0).partialParse());
+    }
+
+    private ParsedFile imageParserWithLowConfidenceBlock() {
+        ImageFileParser parser = new ImageFileParser("/tmp", "kor+eng");
+        List<ParsedBlock> blocks = parser.ocrLineBlocks(List.of(
+                new ImageFileParser.OcrToken("흐림", 0.42d, new Rectangle(10, 10, 20, 10))));
+        return new ParsedFile(
+                DocumentFormat.IMAGE,
+                "흐림",
+                blocks,
+                Map.of(),
+                parser.ocrWarnings(blocks),
+                List.of(),
+                List.of(),
+                List.of(),
+                true);
+    }
+
+    private byte[] corruptHwpxBytes() throws Exception {
+        return zip(Map.of("Contents/content.hpf", "<not-xml".getBytes(UTF_8)));
+    }
+
+    private byte[] hwpxBytesWithMissingSection() throws Exception {
+        return zip(Map.of(
+                "Contents/content.hpf", """
+                        <opf:package xmlns:opf="http://www.idpf.org/2007/opf">
+                          <opf:manifest>
+                            <opf:item id="section0" href="section0.xml" media-type="application/xml"/>
+                          </opf:manifest>
+                          <opf:spine><opf:itemref idref="section0"/></opf:spine>
+                        </opf:package>
+                        """.getBytes(UTF_8)));
+    }
+
+    private byte[] hwpEncryptedHeaderOnlyBytes() {
+        byte[] header = new byte[256];
+        byte[] signature = "HWP Document File".getBytes(UTF_8);
+        System.arraycopy(signature, 0, header, 0, signature.length);
+        header[35] = 5;
+        header[36] = 0x02;
+        return hwpOleWithFileHeader(header);
+    }
+
+    private byte[] hwpOleWithFileHeader(byte[] header) {
+        try (POIFSFileSystem fs = new POIFSFileSystem();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            fs.getRoot().createDocument("FileHeader", new ByteArrayInputStream(header));
+            fs.writeFilesystem(out);
+            return out.toByteArray();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private byte[] zip(Map<String, byte[]> entries) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (ZipOutputStream zip = new ZipOutputStream(out)) {
+            for (Map.Entry<String, byte[]> entry : entries.entrySet()) {
+                zip.putNextEntry(new ZipEntry(entry.getKey()));
+                zip.write(entry.getValue());
+                zip.closeEntry();
+            }
+        }
+        return out.toByteArray();
+    }
+}

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/OperationalFailureMatrixTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/OperationalFailureMatrixTest.java
@@ -69,7 +69,7 @@ class OperationalFailureMatrixTest {
         html.append("</main>");
 
         ParsedFile parsed = assertTimeout(
-                Duration.ofSeconds(2),
+                Duration.ofSeconds(10),
                 () -> new HtmlFileParser().parseStructured(html.toString().getBytes(UTF_8), "text/html", "large.html"));
 
         assertEquals(500, parsed.blocks().size());

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/OperationalFailureMatrixTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/OperationalFailureMatrixTest.java
@@ -30,21 +30,43 @@ import studio.one.platform.textract.model.ParsedFile;
 class OperationalFailureMatrixTest {
 
     @Test
-    void corruptBinaryFormatsFailFastAsCompleteParseFailures() throws Exception {
+    void corruptPdfFailsAsCompleteParseFailure() {
         byte[] corrupt = "not a supported document".getBytes(UTF_8);
 
         assertThrows(FileParseException.class,
                 () -> new PdfFileParser().parseStructured(corrupt, "application/pdf", "corrupt.pdf"));
+    }
+
+    @Test
+    void corruptDocxFailsAsCompleteParseFailure() {
+        byte[] corrupt = "not a supported document".getBytes(UTF_8);
+
         assertThrows(FileParseException.class,
                 () -> new DocxFileParser().parseStructured(corrupt,
                         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
                         "corrupt.docx"));
+    }
+
+    @Test
+    void corruptPptxFailsAsCompleteParseFailure() {
+        byte[] corrupt = "not a supported document".getBytes(UTF_8);
+
         assertThrows(FileParseException.class,
                 () -> new PptxFileParser().parseStructured(corrupt,
                         "application/vnd.openxmlformats-officedocument.presentationml.presentation",
                         "corrupt.pptx"));
+    }
+
+    @Test
+    void corruptImageFailsAsCompleteParseFailure() {
+        byte[] corrupt = "not a supported document".getBytes(UTF_8);
+
         assertThrows(FileParseException.class,
                 () -> new ImageFileParser("/tmp", "kor+eng").parseStructured(corrupt, "image/png", "corrupt.png"));
+    }
+
+    @Test
+    void corruptHwpxFailsAsCompleteParseFailure() throws Exception {
         assertThrows(FileParseException.class,
                 () -> new HwpHwpxFileParser().parseStructured(corruptHwpxBytes(), "application/hwpx", "corrupt.hwpx"));
     }
@@ -133,8 +155,8 @@ class OperationalFailureMatrixTest {
         byte[] header = new byte[256];
         byte[] signature = "HWP Document File".getBytes(UTF_8);
         System.arraycopy(signature, 0, header, 0, signature.length);
-        header[35] = 5;
-        header[36] = 0x02;
+        header[35] = 5; // Version field offset 32-35; byte 35 stores major version in this fixture.
+        header[36] = 0x02; // Property flags offset 36-39; bit 1 marks encrypted HWP.
         return hwpOleWithFileHeader(header);
     }
 

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/service/FileContentExtractionServiceTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/service/FileContentExtractionServiceTest.java
@@ -66,8 +66,9 @@ class FileContentExtractionServiceTest {
 
     @Test
     void extractTextRejectsOversizedFiles() throws Exception {
+        RecordingParser parser = new RecordingParser();
         FileContentExtractionService service = new FileContentExtractionService(
-                new FileParserFactory(List.of(new RecordingParser())),
+                new FileParserFactory(List.of(parser)),
                 4);
         Path temp = Files.createTempFile("large-attachment", ".txt");
         temp.toFile().deleteOnExit();
@@ -77,6 +78,28 @@ class FileContentExtractionServiceTest {
 
         assertThrows(FileParseException.class,
                 () -> service.extractText("text/plain", "large.txt", temp.toFile()));
+        assertEquals(0, parser.invocations);
+    }
+
+    @Test
+    void parseStructuredAcceptsFilesAtExactLimitAndRejectsOversizedFilesBeforeParserDispatch() throws Exception {
+        RecordingParser parser = new RecordingParser();
+        FileContentExtractionService service = new FileContentExtractionService(
+                new FileParserFactory(List.of(parser)),
+                4);
+        Path exact = Files.createTempFile("exact-attachment", ".txt");
+        Path oversized = Files.createTempFile("oversized-attachment", ".txt");
+        exact.toFile().deleteOnExit();
+        oversized.toFile().deleteOnExit();
+        Files.writeString(exact, "abcd", UTF_8);
+        Files.writeString(oversized, "abcde", UTF_8);
+
+        service.parseStructured("text/plain", "exact.txt", exact.toFile());
+        assertEquals(1, parser.invocations);
+
+        assertThrows(FileParseException.class,
+                () -> service.parseStructured("text/plain", "large.txt", oversized.toFile()));
+        assertEquals(1, parser.invocations);
     }
 
     private static final class RecordingParser implements FileParser {


### PR DESCRIPTION
## Why

- 상용 운영에서 corrupt input, partial parse, oversized/resource bound가 회귀 없이 동작하는지 검증할 필요가 있습니다.
- #250의 운영 failure matrix와 검증 절차 문서화 요구를 반영합니다.

## What

- corrupt PDF/DOCX/PPTX/image/HWPX 입력이 complete failure로 FileParseException을 발생시키는 matrix 테스트를 추가했습니다.
- malformed HTML은 Jsoup 특성상 best-effort로 복구되는 동작을 명시적으로 테스트했습니다.
- HWPX partial, HWP encrypted error, OCR low confidence warning의 canonicalCode, severity, partialParse 구분을 검증했습니다.
- large HTML smoke bound와 file/InputStream oversized 차단 테스트를 보강했습니다.
- DOCX/PPTX corrupt input에서 POI RuntimeException을 FileParseException으로 정규화했습니다.
- README에 운영 품질 검증 기준과 명령을 추가했습니다.

## Related Issues

- Closes #250

## Validation

- Command: ./gradlew :studio-platform-textract:test --tests OperationalFailureMatrixTest --tests FileContentExtractionServiceTest
- Result: BUILD SUCCESSFUL
- Command: ./gradlew :studio-platform-textract:test
- Result: BUILD SUCCESSFUL

## Risk / Rollback

- Risk: DOCX/PPTX parser가 RuntimeException을 FileParseException으로 래핑하므로 corrupt input의 외부 관찰 예외 타입이 정규화됩니다.
- Rollback: 이 PR revert 또는 DocxFileParser/PptxFileParser catch 범위와 추가 테스트/README 변경을 되돌립니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: 없음
- Main author validation: 위 Gradle 테스트 2건 실행 및 PR/Issue 연결 확인

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] AI-Assisted value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included