### PR TITLE
[chunking] 구조화 입력 기반 RAG chunking 지원

### DIFF
--- a/starter/studio-platform-starter-chunking/README.md
+++ b/starter/studio-platform-starter-chunking/README.md
@@ -15,10 +15,10 @@ Phase 1 supports:
 
 - `recursive` (default)
 - `fixed-size`
+- `structure-based`
 
 Planned Phase 2 strategies:
 
-- `structure-based`
 - `semantic` (AI-linked, not in this pure starter)
 - `llm-based` (AI-linked, not in this pure starter)
 
@@ -36,7 +36,7 @@ studio:
 | Property | Default | Description |
 | --- | --- | --- |
 | `studio.chunking.enabled` | `true` | Registers default chunking beans when enabled. |
-| `studio.chunking.strategy` | `recursive` | Phase 1 strategy. Supported values: `recursive`, `fixed-size`. |
+| `studio.chunking.strategy` | `recursive` | Pure chunking strategy. Supported values: `recursive`, `fixed-size`, `structure-based`. |
 | `studio.chunking.max-size` | `800` | Maximum chunk size in characters. |
 | `studio.chunking.overlap` | `100` | Character overlap carried from the previous chunk. |
 
@@ -49,8 +49,9 @@ Applications can override the default behavior by registering custom beans:
 - `ChunkingOrchestrator`
 - `FixedSizeChunker`
 - `RecursiveChunker`
+- `StructureBasedChunker`
 
-`DefaultChunkingOrchestrator` receives all `Chunker` beans, but Phase 1 only executes `FIXED_SIZE` and `RECURSIVE`.
+`DefaultChunkingOrchestrator` receives all `Chunker` beans and executes `FIXED_SIZE`, `RECURSIVE`, and `STRUCTURE_BASED`.
 
 ## Recursive Strategy
 
@@ -69,3 +70,30 @@ Chunk ids are deterministic:
 ```
 
 `chunkOrder` starts at `0`.
+
+## Structure-Based Strategy
+
+`StructureBasedChunker` consumes `NormalizedDocument` and preserves parser provenance in `ChunkMetadata`.
+It keeps heading boundaries as `section` / `headingPath`, packs paragraph-like blocks by configured size, and emits table, OCR text, and image-caption blocks as standalone chunks.
+
+The strategy does not parse files, run OCR, call embedding APIs, call LLMs, or write vector stores.
+
+When `studio-platform-textract` is available, `TextractNormalizedDocumentAdapter` can convert `ParsedFile` into `NormalizedDocument`:
+
+```java
+ParsedFile parsedFile = fileContentExtractionService.parseStructured(...);
+NormalizedDocument document = new TextractNormalizedDocumentAdapter()
+        .adapt("doc-1", parsedFile);
+List<Chunk> chunks = chunkingOrchestrator.chunk(document);
+```
+
+The adapter maps:
+
+- `ParsedBlock` to normalized heading, paragraph, list, footnote, OCR, and other logical blocks.
+- `ExtractedTable.vectorText()` to table chunks.
+- `ExtractedImage.caption()`, `altText()`, or `ocrText()` to image-caption/OCR chunks.
+
+## Size Policy
+
+Character size remains the default policy. `ChunkUnit.TOKEN` uses a deterministic estimate based on compacted character length and does not call an external tokenizer.
+Structure-based overlap is conservative: heading, table, OCR, and image-caption boundaries are not carried as overlap tails.

--- a/starter/studio-platform-starter-chunking/README.md
+++ b/starter/studio-platform-starter-chunking/README.md
@@ -93,6 +93,11 @@ The adapter maps:
 - `ExtractedTable.vectorText()` to table chunks.
 - `ExtractedImage.caption()`, `altText()`, or `ocrText()` to image-caption/OCR chunks.
 
+When a parsed table block and an `ExtractedTable` share the same `sourceRef`, the adapter keeps one table block based on
+`ExtractedTable.vectorText()` and carries over the parsed table block order/provenance. `ExtractedImage` does not currently
+carry an independent order value, so image-caption/OCR chunks are sorted after ordered parsed blocks unless the source
+metadata provides a future ordering field.
+
 ## Size Policy
 
 Character size remains the default policy. `ChunkUnit.TOKEN` uses a deterministic estimate based on compacted character length and does not call an external tokenizer.

--- a/starter/studio-platform-starter-chunking/build.gradle.kts
+++ b/starter/studio-platform-starter-chunking/build.gradle.kts
@@ -18,6 +18,7 @@ tasks.named<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {
 
 dependencies {
     api(project(":studio-platform-chunking"))
+    compileOnly(project(":studio-platform-textract"))
     compileOnly(project(":studio-platform-autoconfigure"))
     compileOnly(project(":starter:studio-platform-starter"))
     compileOnly("org.springframework.boot:spring-boot-autoconfigure")
@@ -25,6 +26,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("org.assertj:assertj-core")
+    testImplementation(project(":studio-platform-textract"))
     testImplementation("org.springframework.boot:spring-boot-autoconfigure")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/autoconfigure/ChunkingAutoConfiguration.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/autoconfigure/ChunkingAutoConfiguration.java
@@ -13,6 +13,7 @@ import studio.one.platform.chunking.core.ChunkingOrchestrator;
 import studio.one.platform.chunking.service.DefaultChunkingOrchestrator;
 import studio.one.platform.chunking.service.FixedSizeChunker;
 import studio.one.platform.chunking.service.RecursiveChunker;
+import studio.one.platform.chunking.service.StructureBasedChunker;
 
 @AutoConfiguration
 @EnableConfigurationProperties(ChunkingProperties.class)
@@ -29,6 +30,14 @@ public class ChunkingAutoConfiguration {
     @ConditionalOnMissingBean
     public RecursiveChunker recursiveChunker(ChunkingProperties properties) {
         return new RecursiveChunker(properties.getMaxSize(), properties.getOverlap());
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public StructureBasedChunker structureBasedChunker(
+            ChunkingProperties properties,
+            RecursiveChunker recursiveChunker) {
+        return new StructureBasedChunker(properties.getMaxSize(), properties.getOverlap(), recursiveChunker);
     }
 
     @Bean

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/ChunkSizing.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/ChunkSizing.java
@@ -1,0 +1,35 @@
+package studio.one.platform.chunking.service;
+
+import studio.one.platform.chunking.core.ChunkUnit;
+
+final class ChunkSizing {
+
+    private static final int AVERAGE_TOKEN_CHARS = 4;
+
+    private ChunkSizing() {
+    }
+
+    static int effectiveMaxSize(int requestedMaxSize, int defaultMaxSize) {
+        return requestedMaxSize <= 0 ? defaultMaxSize : requestedMaxSize;
+    }
+
+    static int effectiveOverlap(int requestedOverlap, int defaultOverlap, int maxSize) {
+        int overlap = requestedOverlap < 0 ? defaultOverlap : requestedOverlap;
+        return Math.min(overlap, maxSize - 1);
+    }
+
+    static int sizeOf(String text, ChunkUnit unit) {
+        if (text == null || text.isBlank()) {
+            return 0;
+        }
+        return unit == ChunkUnit.TOKEN ? estimateTokens(text) : text.length();
+    }
+
+    static int estimateTokens(String text) {
+        if (text == null || text.isBlank()) {
+            return 0;
+        }
+        int compactLength = text.replaceAll("\\s+", " ").trim().length();
+        return Math.max(1, (int) Math.ceil((double) compactLength / AVERAGE_TOKEN_CHARS));
+    }
+}

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/DefaultChunkingOrchestrator.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/DefaultChunkingOrchestrator.java
@@ -10,6 +10,8 @@ import studio.one.platform.chunking.core.Chunker;
 import studio.one.platform.chunking.core.ChunkingContext;
 import studio.one.platform.chunking.core.ChunkingOrchestrator;
 import studio.one.platform.chunking.core.ChunkingStrategyType;
+import studio.one.platform.chunking.core.NormalizedDocument;
+import studio.one.platform.chunking.core.NormalizedDocumentChunker;
 
 public class DefaultChunkingOrchestrator implements ChunkingOrchestrator {
 
@@ -30,11 +32,31 @@ public class DefaultChunkingOrchestrator implements ChunkingOrchestrator {
         return selectChunker(effectiveContext).chunk(effectiveContext);
     }
 
+    @Override
+    public List<Chunk> chunk(NormalizedDocument document) {
+        if (document.chunkableText().isBlank()) {
+            return List.of();
+        }
+        ChunkingContext context = document.toContextBuilder()
+                .strategy(ChunkingStrategyType.STRUCTURE_BASED)
+                .maxSize(properties.getMaxSize())
+                .overlap(properties.getOverlap())
+                .build();
+        Chunker chunker = selectChunker(context);
+        if (chunker instanceof NormalizedDocumentChunker normalizedDocumentChunker) {
+            return normalizedDocumentChunker.chunk(document, context);
+        }
+        return chunker.chunk(context);
+    }
+
     private Chunker selectChunker(ChunkingContext context) {
         ChunkingStrategyType strategy = context.strategy() == null ? properties.strategyType() : context.strategy();
-        if (strategy != ChunkingStrategyType.FIXED_SIZE && strategy != ChunkingStrategyType.RECURSIVE) {
+        if (strategy != ChunkingStrategyType.FIXED_SIZE
+                && strategy != ChunkingStrategyType.RECURSIVE
+                && strategy != ChunkingStrategyType.STRUCTURE_BASED) {
             throw new IllegalArgumentException(
-                    "Unsupported Phase 1 chunking strategy: " + strategy + ". Supported values are FIXED_SIZE and RECURSIVE.");
+                    "Unsupported pure chunking strategy: " + strategy
+                            + ". Supported values are FIXED_SIZE, RECURSIVE, and STRUCTURE_BASED.");
         }
         Chunker chunker = chunkers.get(strategy);
         if (chunker == null) {

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/DefaultChunkingOrchestrator.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/DefaultChunkingOrchestrator.java
@@ -34,7 +34,7 @@ public class DefaultChunkingOrchestrator implements ChunkingOrchestrator {
 
     @Override
     public List<Chunk> chunk(NormalizedDocument document) {
-        if (document.chunkableText().isBlank()) {
+        if (document == null || document.chunkableText().isBlank()) {
             return List.of();
         }
         ChunkingContext context = document.toContextBuilder()

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/StructureBasedChunker.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/StructureBasedChunker.java
@@ -46,18 +46,7 @@ public class StructureBasedChunker implements NormalizedDocumentChunker {
         if (context.text() == null || context.text().isBlank()) {
             return List.of();
         }
-        NormalizedDocument document = NormalizedDocument.builder(context.sourceDocumentId())
-                .plainText(context.text())
-                .sourceFormat(context.contentType())
-                .filename(context.filename())
-                .blocks(List.of(NormalizedBlock.builder(NormalizedBlockType.PARAGRAPH, context.text())
-                        .sourceRef("document")
-                        .order(0)
-                        .metadata(context.metadata())
-                        .build()))
-                .metadata(context.metadata())
-                .build();
-        return chunk(document, context);
+        return fallbackChunker.chunk(context);
     }
 
     @Override
@@ -147,23 +136,33 @@ public class StructureBasedChunker implements NormalizedDocumentChunker {
             ChunkUnit unit) {
         Map<String, Object> attributes = new LinkedHashMap<>(document.metadata());
         NormalizedBlock first = blocks.get(0);
-        attributes.put(ChunkMetadata.KEY_SOURCE_FORMAT, document.sourceFormat());
-        attributes.put(ChunkMetadata.KEY_SOURCE_REF, first.effectiveSourceRef());
-        attributes.put(ChunkMetadata.KEY_BLOCK_TYPE, first.type().name());
-        attributes.put(ChunkMetadata.KEY_PAGE, first.page());
-        attributes.put(ChunkMetadata.KEY_SLIDE, first.slide());
-        attributes.put(ChunkMetadata.KEY_PARENT_BLOCK_ID, first.parentBlockId());
-        attributes.put(ChunkMetadata.KEY_HEADING_PATH, headingPath);
-        attributes.put(ChunkMetadata.KEY_TOKEN_ESTIMATE, ChunkSizing.estimateTokens(content(blocks)));
-        attributes.put(ChunkMetadata.KEY_CHUNK_UNIT, unit.value());
-        attributes.put(ChunkMetadata.KEY_MAX_SIZE, maxSize);
-        attributes.put(ChunkMetadata.KEY_OVERLAP, overlap);
-        attributes.put(ChunkMetadata.KEY_SOURCE_REFS, blocks.stream()
+        putIfPresent(attributes, ChunkMetadata.KEY_SOURCE_FORMAT, document.sourceFormat());
+        putIfPresent(attributes, ChunkMetadata.KEY_SOURCE_REF, first.effectiveSourceRef());
+        putIfPresent(attributes, ChunkMetadata.KEY_BLOCK_TYPE, first.type().name());
+        putIfPresent(attributes, ChunkMetadata.KEY_PAGE, first.page());
+        putIfPresent(attributes, ChunkMetadata.KEY_SLIDE, first.slide());
+        putIfPresent(attributes, ChunkMetadata.KEY_PARENT_BLOCK_ID, first.parentBlockId());
+        putIfPresent(attributes, ChunkMetadata.KEY_HEADING_PATH, headingPath);
+        putIfPresent(attributes, ChunkMetadata.KEY_TOKEN_ESTIMATE, ChunkSizing.estimateTokens(content(blocks)));
+        putIfPresent(attributes, ChunkMetadata.KEY_CHUNK_UNIT, unit.value());
+        putIfPresent(attributes, ChunkMetadata.KEY_MAX_SIZE, maxSize);
+        putIfPresent(attributes, ChunkMetadata.KEY_OVERLAP, overlap);
+        putIfPresent(attributes, ChunkMetadata.KEY_SOURCE_REFS, blocks.stream()
                 .map(NormalizedBlock::effectiveSourceRef)
                 .filter(ref -> ref != null && !ref.isBlank())
                 .distinct()
                 .toList());
         return attributes;
+    }
+
+    private void putIfPresent(Map<String, Object> attributes, String key, Object value) {
+        if (value == null) {
+            return;
+        }
+        if (value instanceof String text && text.isBlank()) {
+            return;
+        }
+        attributes.put(key, value);
     }
 
     private String content(List<NormalizedBlock> blocks) {

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/StructureBasedChunker.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/StructureBasedChunker.java
@@ -1,0 +1,229 @@
+package studio.one.platform.chunking.service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import studio.one.platform.chunking.core.Chunk;
+import studio.one.platform.chunking.core.ChunkMetadata;
+import studio.one.platform.chunking.core.ChunkUnit;
+import studio.one.platform.chunking.core.Chunker;
+import studio.one.platform.chunking.core.ChunkingContext;
+import studio.one.platform.chunking.core.ChunkingStrategyType;
+import studio.one.platform.chunking.core.NormalizedBlock;
+import studio.one.platform.chunking.core.NormalizedBlockType;
+import studio.one.platform.chunking.core.NormalizedDocument;
+import studio.one.platform.chunking.core.NormalizedDocumentChunker;
+
+public class StructureBasedChunker implements NormalizedDocumentChunker {
+
+    private final int defaultMaxSize;
+
+    private final int defaultOverlap;
+
+    private final Chunker fallbackChunker;
+
+    public StructureBasedChunker(int defaultMaxSize, int defaultOverlap, Chunker fallbackChunker) {
+        if (defaultMaxSize <= 0) {
+            throw new IllegalArgumentException("defaultMaxSize must be positive");
+        }
+        if (defaultOverlap < 0) {
+            throw new IllegalArgumentException("defaultOverlap cannot be negative");
+        }
+        this.defaultMaxSize = defaultMaxSize;
+        this.defaultOverlap = Math.min(defaultOverlap, defaultMaxSize - 1);
+        this.fallbackChunker = fallbackChunker;
+    }
+
+    @Override
+    public ChunkingStrategyType strategy() {
+        return ChunkingStrategyType.STRUCTURE_BASED;
+    }
+
+    @Override
+    public List<Chunk> chunk(ChunkingContext context) {
+        if (context.text() == null || context.text().isBlank()) {
+            return List.of();
+        }
+        NormalizedDocument document = NormalizedDocument.builder(context.sourceDocumentId())
+                .plainText(context.text())
+                .sourceFormat(context.contentType())
+                .filename(context.filename())
+                .blocks(List.of(NormalizedBlock.builder(NormalizedBlockType.PARAGRAPH, context.text())
+                        .sourceRef("document")
+                        .order(0)
+                        .metadata(context.metadata())
+                        .build()))
+                .metadata(context.metadata())
+                .build();
+        return chunk(document, context);
+    }
+
+    @Override
+    public List<Chunk> chunk(NormalizedDocument document, ChunkingContext context) {
+        if (document.blocks().isEmpty()) {
+            return fallbackChunker.chunk(context);
+        }
+
+        int maxSize = ChunkSizing.effectiveMaxSize(context.maxSize(), defaultMaxSize);
+        int overlap = ChunkSizing.effectiveOverlap(context.overlap(), defaultOverlap, maxSize);
+        ChunkUnit unit = context.unit();
+        List<Chunk> chunks = new ArrayList<>();
+        List<NormalizedBlock> current = new ArrayList<>();
+        String headingPath = "";
+
+        for (NormalizedBlock block : document.blocks()) {
+            if (isHeading(block)) {
+                flush(document, context, chunks, current, headingPath, maxSize, overlap, unit);
+                headingPath = block.text();
+                current.clear();
+                current.add(block);
+                continue;
+            }
+
+            if (isStandalone(block)) {
+                flush(document, context, chunks, current, headingPath, maxSize, overlap, unit);
+                current.clear();
+                chunks.add(toChunk(document, context, List.of(block), chunks.size(), headingPath, maxSize, overlap, unit));
+                continue;
+            }
+
+            if (!current.isEmpty() && sizeOf(current, block, unit) > maxSize) {
+                flush(document, context, chunks, current, headingPath, maxSize, overlap, unit);
+                current = overlapTail(current, overlap, unit);
+            }
+            current.add(block);
+        }
+
+        flush(document, context, chunks, current, headingPath, maxSize, overlap, unit);
+        return chunks;
+    }
+
+    private void flush(
+            NormalizedDocument document,
+            ChunkingContext context,
+            List<Chunk> chunks,
+            List<NormalizedBlock> current,
+            String headingPath,
+            int maxSize,
+            int overlap,
+            ChunkUnit unit) {
+        if (current.isEmpty()) {
+            return;
+        }
+        chunks.add(toChunk(document, context, current, chunks.size(), headingPath, maxSize, overlap, unit));
+    }
+
+    private Chunk toChunk(
+            NormalizedDocument document,
+            ChunkingContext context,
+            List<NormalizedBlock> blocks,
+            int order,
+            String headingPath,
+            int maxSize,
+            int overlap,
+            ChunkUnit unit) {
+        String content = content(blocks);
+        Map<String, Object> attributes = attributes(document, blocks, headingPath, maxSize, overlap, unit);
+        ChunkMetadata metadata = ChunkMetadata.builder(strategy(), order)
+                .sourceDocumentId(effectiveSourceDocumentId(document, context))
+                .section(headingPath)
+                .objectType(context.objectType())
+                .objectId(context.objectId())
+                .charCount(content.length())
+                .tokenCount(ChunkSizing.estimateTokens(content))
+                .attributes(attributes)
+                .build();
+        return Chunk.of(chunkId(effectiveSourceDocumentId(document, context), order), content, metadata);
+    }
+
+    private Map<String, Object> attributes(
+            NormalizedDocument document,
+            List<NormalizedBlock> blocks,
+            String headingPath,
+            int maxSize,
+            int overlap,
+            ChunkUnit unit) {
+        Map<String, Object> attributes = new LinkedHashMap<>(document.metadata());
+        NormalizedBlock first = blocks.get(0);
+        attributes.put(ChunkMetadata.KEY_SOURCE_FORMAT, document.sourceFormat());
+        attributes.put(ChunkMetadata.KEY_SOURCE_REF, first.effectiveSourceRef());
+        attributes.put(ChunkMetadata.KEY_BLOCK_TYPE, first.type().name());
+        attributes.put(ChunkMetadata.KEY_PAGE, first.page());
+        attributes.put(ChunkMetadata.KEY_SLIDE, first.slide());
+        attributes.put(ChunkMetadata.KEY_PARENT_BLOCK_ID, first.parentBlockId());
+        attributes.put(ChunkMetadata.KEY_HEADING_PATH, headingPath);
+        attributes.put(ChunkMetadata.KEY_TOKEN_ESTIMATE, ChunkSizing.estimateTokens(content(blocks)));
+        attributes.put(ChunkMetadata.KEY_CHUNK_UNIT, unit.value());
+        attributes.put(ChunkMetadata.KEY_MAX_SIZE, maxSize);
+        attributes.put(ChunkMetadata.KEY_OVERLAP, overlap);
+        attributes.put(ChunkMetadata.KEY_SOURCE_REFS, blocks.stream()
+                .map(NormalizedBlock::effectiveSourceRef)
+                .filter(ref -> ref != null && !ref.isBlank())
+                .distinct()
+                .toList());
+        return attributes;
+    }
+
+    private String content(List<NormalizedBlock> blocks) {
+        return blocks.stream()
+                .map(NormalizedBlock::text)
+                .filter(text -> text != null && !text.isBlank())
+                .reduce((left, right) -> left + "\n\n" + right)
+                .orElse("");
+    }
+
+    private int sizeOf(List<NormalizedBlock> current, NormalizedBlock next, ChunkUnit unit) {
+        int size = ChunkSizing.sizeOf(content(current), unit);
+        if (size > 0) {
+            size += unit == ChunkUnit.TOKEN ? 1 : 2;
+        }
+        return size + ChunkSizing.sizeOf(next.text(), unit);
+    }
+
+    private List<NormalizedBlock> overlapTail(List<NormalizedBlock> blocks, int overlap, ChunkUnit unit) {
+        if (overlap <= 0 || blocks.isEmpty()) {
+            return new ArrayList<>();
+        }
+        List<NormalizedBlock> tail = new ArrayList<>();
+        int size = 0;
+        for (int i = blocks.size() - 1; i >= 0; i--) {
+            NormalizedBlock block = blocks.get(i);
+            int blockSize = ChunkSizing.sizeOf(block.text(), unit);
+            if (isBoundary(block) || size + blockSize > overlap) {
+                break;
+            }
+            tail.add(0, block);
+            size += blockSize;
+        }
+        return tail;
+    }
+
+    private boolean isHeading(NormalizedBlock block) {
+        return block.type() == NormalizedBlockType.TITLE || block.type() == NormalizedBlockType.HEADING;
+    }
+
+    private boolean isStandalone(NormalizedBlock block) {
+        return block.type() == NormalizedBlockType.TABLE
+                || block.type() == NormalizedBlockType.IMAGE
+                || block.type() == NormalizedBlockType.IMAGE_CAPTION
+                || block.type() == NormalizedBlockType.OCR_TEXT;
+    }
+
+    private boolean isBoundary(NormalizedBlock block) {
+        return isHeading(block) || isStandalone(block);
+    }
+
+    private String effectiveSourceDocumentId(NormalizedDocument document, ChunkingContext context) {
+        if (!document.sourceDocumentId().isBlank()) {
+            return document.sourceDocumentId();
+        }
+        return context.sourceDocumentId();
+    }
+
+    private String chunkId(String sourceDocumentId, int order) {
+        String prefix = sourceDocumentId == null || sourceDocumentId.isBlank() ? "document" : sourceDocumentId;
+        return prefix + "-" + order;
+    }
+}

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/TextractNormalizedDocumentAdapter.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/TextractNormalizedDocumentAdapter.java
@@ -1,13 +1,17 @@
 package studio.one.platform.chunking.service;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import studio.one.platform.chunking.core.NormalizedBlock;
 import studio.one.platform.chunking.core.NormalizedBlockType;
 import studio.one.platform.chunking.core.NormalizedDocument;
+import studio.one.platform.textract.model.BlockType;
 import studio.one.platform.textract.model.ExtractedImage;
 import studio.one.platform.textract.model.ExtractedTable;
 import studio.one.platform.textract.model.ParsedBlock;
@@ -21,11 +25,17 @@ public class TextractNormalizedDocumentAdapter {
         }
 
         List<NormalizedBlock> blocks = new ArrayList<>();
+        Map<String, ParsedBlock> tableBlocks = tableBlocks(parsedFile.blocks());
+        List<String> tableRefs = parsedFile.tables().stream()
+                .map(ExtractedTable::sourceRef)
+                .filter(ref -> ref != null && !ref.isBlank())
+                .toList();
         parsedFile.blocks().stream()
+                .filter(block -> !isExtractedTableBlock(block, tableRefs))
                 .map(this::fromBlock)
                 .forEach(blocks::add);
         parsedFile.tables().stream()
-                .map(this::fromTable)
+                .map(table -> fromTable(table, tableBlocks.get(table.sourceRef())))
                 .forEach(blocks::add);
         parsedFile.images().stream()
                 .map(this::fromImage)
@@ -41,6 +51,28 @@ public class TextractNormalizedDocumentAdapter {
                 .build();
     }
 
+    private Map<String, ParsedBlock> tableBlocks(List<ParsedBlock> blocks) {
+        return blocks.stream()
+                .filter(block -> block.blockType() == BlockType.TABLE)
+                .filter(block -> block.sourceRef() != null && !block.sourceRef().isBlank())
+                .collect(Collectors.toMap(
+                        ParsedBlock::sourceRef,
+                        Function.identity(),
+                        this::firstByOrder,
+                        LinkedHashMap::new));
+    }
+
+    private ParsedBlock firstByOrder(ParsedBlock left, ParsedBlock right) {
+        return Comparator.comparing(
+                ParsedBlock::order,
+                Comparator.nullsLast(Integer::compareTo))
+                .compare(left, right) <= 0 ? left : right;
+    }
+
+    private boolean isExtractedTableBlock(ParsedBlock block, List<String> tableRefs) {
+        return block.blockType() == BlockType.TABLE && tableRefs.contains(block.sourceRef());
+    }
+
     private NormalizedBlock fromBlock(ParsedBlock block) {
         return NormalizedBlock.builder(NormalizedBlockType.from(block.blockType().name()), block.text())
                 .id(block.id())
@@ -53,14 +85,18 @@ public class TextractNormalizedDocumentAdapter {
                 .build();
     }
 
-    private NormalizedBlock fromTable(ExtractedTable table) {
+    private NormalizedBlock fromTable(ExtractedTable table, ParsedBlock tableBlock) {
         Map<String, Object> metadata = new LinkedHashMap<>(table.metadata());
-        metadata.put("rowCount", table.rowCount());
-        metadata.put("cellCount", table.cellCount());
-        metadata.put("headerRowCount", table.headerRowCount());
+        metadata.put(NormalizedBlock.KEY_ROW_COUNT, table.rowCount());
+        metadata.put(NormalizedBlock.KEY_CELL_COUNT, table.cellCount());
+        metadata.put(ExtractedTable.KEY_HEADER_ROW_COUNT, table.headerRowCount());
         return NormalizedBlock.builder(NormalizedBlockType.TABLE, table.vectorText())
                 .id(table.path())
                 .sourceRef(table.sourceRef())
+                .page(tableBlock == null ? null : tableBlock.page())
+                .slide(tableBlock == null ? null : tableBlock.slide())
+                .order(tableBlock == null ? null : tableBlock.order())
+                .parentBlockId(tableBlock == null ? null : tableBlock.parentBlockId())
                 .metadata(metadata)
                 .build();
     }

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/TextractNormalizedDocumentAdapter.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/TextractNormalizedDocumentAdapter.java
@@ -1,0 +1,95 @@
+package studio.one.platform.chunking.service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import studio.one.platform.chunking.core.NormalizedBlock;
+import studio.one.platform.chunking.core.NormalizedBlockType;
+import studio.one.platform.chunking.core.NormalizedDocument;
+import studio.one.platform.textract.model.ExtractedImage;
+import studio.one.platform.textract.model.ExtractedTable;
+import studio.one.platform.textract.model.ParsedBlock;
+import studio.one.platform.textract.model.ParsedFile;
+
+public class TextractNormalizedDocumentAdapter {
+
+    public NormalizedDocument adapt(String sourceDocumentId, ParsedFile parsedFile) {
+        if (parsedFile == null) {
+            return NormalizedDocument.builder(sourceDocumentId).build();
+        }
+
+        List<NormalizedBlock> blocks = new ArrayList<>();
+        parsedFile.blocks().stream()
+                .map(this::fromBlock)
+                .forEach(blocks::add);
+        parsedFile.tables().stream()
+                .map(this::fromTable)
+                .forEach(blocks::add);
+        parsedFile.images().stream()
+                .map(this::fromImage)
+                .filter(NormalizedBlock::hasText)
+                .forEach(blocks::add);
+
+        return NormalizedDocument.builder(sourceDocumentId)
+                .plainText(parsedFile.plainText())
+                .sourceFormat(parsedFile.format().name())
+                .filename(filename(parsedFile.metadata()))
+                .blocks(blocks)
+                .metadata(parsedFile.metadata())
+                .build();
+    }
+
+    private NormalizedBlock fromBlock(ParsedBlock block) {
+        return NormalizedBlock.builder(NormalizedBlockType.from(block.blockType().name()), block.text())
+                .id(block.id())
+                .sourceRef(block.sourceRef())
+                .page(block.page())
+                .slide(block.slide())
+                .order(block.order())
+                .parentBlockId(block.parentBlockId())
+                .metadata(block.metadata())
+                .build();
+    }
+
+    private NormalizedBlock fromTable(ExtractedTable table) {
+        Map<String, Object> metadata = new LinkedHashMap<>(table.metadata());
+        metadata.put("rowCount", table.rowCount());
+        metadata.put("cellCount", table.cellCount());
+        metadata.put("headerRowCount", table.headerRowCount());
+        return NormalizedBlock.builder(NormalizedBlockType.TABLE, table.vectorText())
+                .id(table.path())
+                .sourceRef(table.sourceRef())
+                .metadata(metadata)
+                .build();
+    }
+
+    private NormalizedBlock fromImage(ExtractedImage image) {
+        String text = firstNonBlank(image.caption(), image.altText(), image.ocrText());
+        Map<String, Object> metadata = new LinkedHashMap<>(image.metadata());
+        metadata.put("mimeType", image.mimeType());
+        metadata.put("filename", image.filename());
+        metadata.put("width", image.width());
+        metadata.put("height", image.height());
+        return NormalizedBlock.builder(image.ocrApplied() ? NormalizedBlockType.OCR_TEXT : NormalizedBlockType.IMAGE_CAPTION, text)
+                .id(image.path())
+                .sourceRef(image.sourceRef())
+                .metadata(metadata)
+                .build();
+    }
+
+    private String filename(Map<String, Object> metadata) {
+        Object value = metadata.get("filename");
+        return value instanceof String stringValue ? stringValue : "";
+    }
+
+    private String firstNonBlank(String... values) {
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return "";
+    }
+}

--- a/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/autoconfigure/ChunkingAutoConfigurationTest.java
+++ b/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/autoconfigure/ChunkingAutoConfigurationTest.java
@@ -7,6 +7,7 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import studio.one.platform.chunking.core.ChunkingOrchestrator;
+import studio.one.platform.chunking.service.StructureBasedChunker;
 import studio.one.platform.chunking.service.FixedSizeChunker;
 import studio.one.platform.chunking.service.RecursiveChunker;
 import studio.one.platform.chunking.core.ChunkingContext;
@@ -22,6 +23,7 @@ class ChunkingAutoConfigurationTest {
                 .hasSingleBean(ChunkingProperties.class)
                 .hasSingleBean(FixedSizeChunker.class)
                 .hasSingleBean(RecursiveChunker.class)
+                .hasSingleBean(StructureBasedChunker.class)
                 .hasSingleBean(ChunkingOrchestrator.class));
     }
 
@@ -31,6 +33,7 @@ class ChunkingAutoConfigurationTest {
                 .run(context -> assertThat(context)
                         .doesNotHaveBean(FixedSizeChunker.class)
                         .doesNotHaveBean(RecursiveChunker.class)
+                        .doesNotHaveBean(StructureBasedChunker.class)
                         .doesNotHaveBean(ChunkingOrchestrator.class));
     }
 

--- a/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/DefaultChunkingOrchestratorTest.java
+++ b/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/DefaultChunkingOrchestratorTest.java
@@ -10,6 +10,9 @@ import org.junit.jupiter.api.Test;
 import studio.one.platform.chunking.autoconfigure.ChunkingProperties;
 import studio.one.platform.chunking.core.ChunkingContext;
 import studio.one.platform.chunking.core.ChunkingStrategyType;
+import studio.one.platform.chunking.core.NormalizedBlock;
+import studio.one.platform.chunking.core.NormalizedBlockType;
+import studio.one.platform.chunking.core.NormalizedDocument;
 
 class DefaultChunkingOrchestratorTest {
 
@@ -21,7 +24,8 @@ class DefaultChunkingOrchestratorTest {
         properties.setOverlap(1);
         DefaultChunkingOrchestrator orchestrator = new DefaultChunkingOrchestrator(
                 properties,
-                List.of(new FixedSizeChunker(10, 0), new RecursiveChunker(10, 0)));
+                List.of(new FixedSizeChunker(10, 0), new RecursiveChunker(10, 0),
+                        new StructureBasedChunker(10, 0, new RecursiveChunker(10, 0))));
 
         var chunks = orchestrator.chunk(ChunkingContext.configuredDefaults("abcdefghij")
                 .sourceDocumentId("doc")
@@ -38,7 +42,8 @@ class DefaultChunkingOrchestratorTest {
         properties.setOverlap(0);
         DefaultChunkingOrchestrator orchestrator = new DefaultChunkingOrchestrator(
                 properties,
-                List.of(new FixedSizeChunker(5, 0), new RecursiveChunker(5, 0)));
+                List.of(new FixedSizeChunker(5, 0), new RecursiveChunker(5, 0),
+                        new StructureBasedChunker(5, 0, new RecursiveChunker(5, 0))));
 
         var chunks = orchestrator.chunk(ChunkingContext.configuredDefaults("alpha beta")
                 .sourceDocumentId("doc")
@@ -53,14 +58,15 @@ class DefaultChunkingOrchestratorTest {
         ChunkingProperties properties = new ChunkingProperties();
         DefaultChunkingOrchestrator orchestrator = new DefaultChunkingOrchestrator(
                 properties,
-                List.of(new FixedSizeChunker(10, 0), new RecursiveChunker(10, 0)));
+                List.of(new FixedSizeChunker(10, 0), new RecursiveChunker(10, 0),
+                        new StructureBasedChunker(10, 0, new RecursiveChunker(10, 0))));
 
         assertThatThrownBy(() -> orchestrator.chunk(ChunkingContext.builder("hello")
                 .sourceDocumentId("doc")
                 .strategy(ChunkingStrategyType.SEMANTIC)
                 .build()))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Unsupported Phase 1 chunking strategy");
+                .hasMessageContaining("Unsupported pure chunking strategy");
     }
 
     @Test
@@ -76,5 +82,27 @@ class DefaultChunkingOrchestratorTest {
                 .build()))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Chunker bean for strategy FIXED_SIZE is not registered");
+    }
+
+    @Test
+    void chunksNormalizedDocumentWithStructureStrategy() {
+        ChunkingProperties properties = new ChunkingProperties();
+        properties.setMaxSize(80);
+        properties.setOverlap(0);
+        RecursiveChunker recursiveChunker = new RecursiveChunker(80, 0);
+        DefaultChunkingOrchestrator orchestrator = new DefaultChunkingOrchestrator(
+                properties,
+                List.of(new FixedSizeChunker(80, 0), recursiveChunker,
+                        new StructureBasedChunker(80, 0, recursiveChunker)));
+        NormalizedDocument document = NormalizedDocument.builder("doc")
+                .blocks(List.of(
+                        NormalizedBlock.builder(NormalizedBlockType.HEADING, "Title").order(0).build(),
+                        NormalizedBlock.builder(NormalizedBlockType.PARAGRAPH, "Body").order(1).build()))
+                .build();
+
+        var chunks = orchestrator.chunk(document);
+
+        assertThat(chunks).hasSize(1);
+        assertThat(chunks.get(0).metadata().strategy()).isEqualTo(ChunkingStrategyType.STRUCTURE_BASED);
     }
 }

--- a/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/DefaultChunkingOrchestratorTest.java
+++ b/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/DefaultChunkingOrchestratorTest.java
@@ -105,4 +105,17 @@ class DefaultChunkingOrchestratorTest {
         assertThat(chunks).hasSize(1);
         assertThat(chunks.get(0).metadata().strategy()).isEqualTo(ChunkingStrategyType.STRUCTURE_BASED);
     }
+
+    @Test
+    void returnsEmptyChunksForBlankNormalizedDocument() {
+        ChunkingProperties properties = new ChunkingProperties();
+        RecursiveChunker recursiveChunker = new RecursiveChunker(80, 0);
+        DefaultChunkingOrchestrator orchestrator = new DefaultChunkingOrchestrator(
+                properties,
+                List.of(new FixedSizeChunker(80, 0), recursiveChunker,
+                        new StructureBasedChunker(80, 0, recursiveChunker)));
+
+        assertThat(orchestrator.chunk(NormalizedDocument.builder("doc").build())).isEmpty();
+        assertThat(orchestrator.chunk((NormalizedDocument) null)).isEmpty();
+    }
 }

--- a/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/StructureBasedChunkerTest.java
+++ b/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/StructureBasedChunkerTest.java
@@ -1,0 +1,120 @@
+package studio.one.platform.chunking.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.chunking.core.Chunk;
+import studio.one.platform.chunking.core.ChunkMetadata;
+import studio.one.platform.chunking.core.ChunkUnit;
+import studio.one.platform.chunking.core.ChunkingContext;
+import studio.one.platform.chunking.core.ChunkingStrategyType;
+import studio.one.platform.chunking.core.NormalizedBlock;
+import studio.one.platform.chunking.core.NormalizedBlockType;
+import studio.one.platform.chunking.core.NormalizedDocument;
+
+class StructureBasedChunkerTest {
+
+    @Test
+    void keepsHeadingAndParagraphProvenance() {
+        StructureBasedChunker chunker = new StructureBasedChunker(120, 0, new RecursiveChunker(120, 0));
+        NormalizedDocument document = NormalizedDocument.builder("doc")
+                .sourceFormat("PDF")
+                .blocks(List.of(
+                        block(NormalizedBlockType.HEADING, "Install", "page[1]/h[0]", 0),
+                        block(NormalizedBlockType.PARAGRAPH, "Install the engine.", "page[1]/p[1]", 1),
+                        block(NormalizedBlockType.PARAGRAPH, "Configure tessdata.", "page[1]/p[2]", 2)))
+                .build();
+
+        List<Chunk> chunks = chunker.chunk(document, context(document, 120, 0));
+
+        assertThat(chunks).hasSize(1);
+        assertThat(chunks.get(0).content()).contains("Install", "Install the engine.", "Configure tessdata.");
+        assertThat(chunks.get(0).metadata().section()).isEqualTo("Install");
+        assertThat(chunks.get(0).metadata().toMap())
+                .containsEntry(ChunkMetadata.KEY_BLOCK_TYPE, "HEADING")
+                .containsEntry(ChunkMetadata.KEY_SOURCE_FORMAT, "PDF")
+                .containsEntry(ChunkMetadata.KEY_HEADING_PATH, "Install")
+                .containsEntry(ChunkMetadata.KEY_CHUNK_UNIT, "character")
+                .containsEntry(ChunkMetadata.KEY_MAX_SIZE, 120)
+                .containsEntry(ChunkMetadata.KEY_OVERLAP, 0)
+                .containsKey(ChunkMetadata.KEY_SOURCE_REFS);
+    }
+
+    @Test
+    void emitsTableAndOcrBlocksAsStandaloneChunks() {
+        StructureBasedChunker chunker = new StructureBasedChunker(120, 10, new RecursiveChunker(120, 10));
+        NormalizedDocument document = NormalizedDocument.builder("doc")
+                .sourceFormat("HTML")
+                .blocks(List.of(
+                        block(NormalizedBlockType.HEADING, "Metrics", "h1", 0),
+                        block(NormalizedBlockType.TABLE, "Name: Alice\nScore: 90", "table[0]", 1),
+                        block(NormalizedBlockType.OCR_TEXT, "scanned caption", "image[0]/ocr", 2)))
+                .build();
+
+        List<Chunk> chunks = chunker.chunk(document, context(document, 120, 10));
+
+        assertThat(chunks).extracting(Chunk::content)
+                .containsExactly("Metrics", "Name: Alice\nScore: 90", "scanned caption");
+        assertThat(chunks.get(1).metadata().toMap())
+                .containsEntry(ChunkMetadata.KEY_BLOCK_TYPE, "TABLE")
+                .containsEntry(ChunkMetadata.KEY_SOURCE_REF, "table[0]");
+        assertThat(chunks.get(2).metadata().toMap())
+                .containsEntry(ChunkMetadata.KEY_BLOCK_TYPE, "OCR_TEXT")
+                .containsEntry(ChunkMetadata.KEY_SOURCE_REF, "image[0]/ocr");
+    }
+
+    @Test
+    void tokenUnitUsesDeterministicEstimateWithoutTokenizer() {
+        StructureBasedChunker chunker = new StructureBasedChunker(8, 0, new RecursiveChunker(8, 0));
+        NormalizedDocument document = NormalizedDocument.builder("doc")
+                .blocks(List.of(
+                        block(NormalizedBlockType.PARAGRAPH, "alpha beta gamma delta", "p1", 0),
+                        block(NormalizedBlockType.PARAGRAPH, "epsilon zeta eta theta", "p2", 1)))
+                .build();
+
+        List<Chunk> chunks = chunker.chunk(document, document.toContextBuilder()
+                .unit(ChunkUnit.TOKEN)
+                .maxSize(8)
+                .overlap(0)
+                .build());
+
+        assertThat(chunks).hasSize(2);
+        assertThat(chunks.get(0).metadata().toMap())
+                .containsEntry(ChunkMetadata.KEY_CHUNK_UNIT, "token")
+                .containsKey(ChunkMetadata.KEY_TOKEN_ESTIMATE);
+    }
+
+    @Test
+    void textContextStillReportsStructureBasedStrategy() {
+        StructureBasedChunker chunker = new StructureBasedChunker(120, 0, new RecursiveChunker(120, 0));
+
+        List<Chunk> chunks = chunker.chunk(ChunkingContext.builder("plain text")
+                .sourceDocumentId("doc")
+                .strategy(ChunkingStrategyType.STRUCTURE_BASED)
+                .build());
+
+        assertThat(chunks).hasSize(1);
+        assertThat(chunks.get(0).metadata().strategy())
+                .isEqualTo(ChunkingStrategyType.STRUCTURE_BASED);
+    }
+
+    private NormalizedBlock block(NormalizedBlockType type, String text, String sourceRef, int order) {
+        return NormalizedBlock.builder(type, text)
+                .id(sourceRef)
+                .sourceRef(sourceRef)
+                .order(order)
+                .metadata(Map.of("format", "test"))
+                .build();
+    }
+
+    private ChunkingContext context(NormalizedDocument document, int maxSize, int overlap) {
+        return document.toContextBuilder()
+                .maxSize(maxSize)
+                .overlap(overlap)
+                .build();
+    }
+}

--- a/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/StructureBasedChunkerTest.java
+++ b/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/StructureBasedChunkerTest.java
@@ -89,17 +89,19 @@ class StructureBasedChunkerTest {
     }
 
     @Test
-    void textContextStillReportsStructureBasedStrategy() {
-        StructureBasedChunker chunker = new StructureBasedChunker(120, 0, new RecursiveChunker(120, 0));
+    void textContextFallsBackToRecursiveChunkingForOversizedPlainText() {
+        StructureBasedChunker chunker = new StructureBasedChunker(10, 0, new RecursiveChunker(10, 0));
 
-        List<Chunk> chunks = chunker.chunk(ChunkingContext.builder("plain text")
+        List<Chunk> chunks = chunker.chunk(ChunkingContext.builder("alpha beta gamma")
                 .sourceDocumentId("doc")
                 .strategy(ChunkingStrategyType.STRUCTURE_BASED)
+                .maxSize(10)
+                .overlap(0)
                 .build());
 
-        assertThat(chunks).hasSize(1);
+        assertThat(chunks).extracting(Chunk::content).containsExactly("alpha beta", "gamma");
         assertThat(chunks.get(0).metadata().strategy())
-                .isEqualTo(ChunkingStrategyType.STRUCTURE_BASED);
+                .isEqualTo(ChunkingStrategyType.RECURSIVE);
     }
 
     private NormalizedBlock block(NormalizedBlockType type, String text, String sourceRef, int order) {

--- a/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/TextractNormalizedDocumentAdapterTest.java
+++ b/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/TextractNormalizedDocumentAdapterTest.java
@@ -1,0 +1,55 @@
+package studio.one.platform.chunking.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.chunking.core.NormalizedBlockType;
+import studio.one.platform.chunking.core.NormalizedDocument;
+import studio.one.platform.textract.extractor.DocumentFormat;
+import studio.one.platform.textract.model.BlockType;
+import studio.one.platform.textract.model.ExtractedImage;
+import studio.one.platform.textract.model.ExtractedTable;
+import studio.one.platform.textract.model.ExtractedTableCell;
+import studio.one.platform.textract.model.ParsedBlock;
+import studio.one.platform.textract.model.ParsedFile;
+
+class TextractNormalizedDocumentAdapterTest {
+
+    @Test
+    void adaptsParsedBlocksTablesAndImagesWithoutParsingAgain() {
+        ParsedFile parsedFile = new ParsedFile(
+                DocumentFormat.HTML,
+                "plain",
+                List.of(ParsedBlock.text("body/h1", BlockType.HEADING, "Title", 1, 0, Map.of())),
+                Map.of("filename", "sample.html"),
+                List.of(),
+                List.of(),
+                List.of(new ExtractedTable(
+                        "body/table[0]",
+                        "| A |\n| --- |\n| 1 |",
+                        List.of(new ExtractedTableCell(0, 0, 1, 1, "A", Map.of())),
+                        Map.of(ExtractedTable.KEY_VECTOR_TEXT, "A: 1", ExtractedTable.KEY_SOURCE_REF, "body/table[0]"))),
+                List.of(new ExtractedImage(
+                        "body/img[0]",
+                        "image/png",
+                        "image.png",
+                        10,
+                        20,
+                        Map.of(ExtractedImage.KEY_ALT_TEXT, "architecture diagram",
+                                ExtractedImage.KEY_SOURCE_REF, "body/img[0]"))),
+                false);
+
+        NormalizedDocument document = new TextractNormalizedDocumentAdapter().adapt("doc", parsedFile);
+
+        assertThat(document.sourceFormat()).isEqualTo("HTML");
+        assertThat(document.filename()).isEqualTo("sample.html");
+        assertThat(document.blocks()).extracting(block -> block.type())
+                .containsExactly(NormalizedBlockType.HEADING, NormalizedBlockType.TABLE, NormalizedBlockType.IMAGE_CAPTION);
+        assertThat(document.blocks()).extracting(block -> block.text())
+                .contains("Title", "A: 1", "architecture diagram");
+    }
+}

--- a/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/TextractNormalizedDocumentAdapterTest.java
+++ b/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/TextractNormalizedDocumentAdapterTest.java
@@ -24,7 +24,10 @@ class TextractNormalizedDocumentAdapterTest {
         ParsedFile parsedFile = new ParsedFile(
                 DocumentFormat.HTML,
                 "plain",
-                List.of(ParsedBlock.text("body/h1", BlockType.HEADING, "Title", 1, 0, Map.of())),
+                List.of(
+                        ParsedBlock.text("body/h1", BlockType.HEADING, "Title", 1, 0, Map.of()),
+                        ParsedBlock.text("body/table[0]", BlockType.TABLE, "| A |\n| --- |\n| 1 |", 1, 1, Map.of()),
+                        ParsedBlock.text("body/p[1]", BlockType.PARAGRAPH, "After table", 1, 2, Map.of())),
                 Map.of("filename", "sample.html"),
                 List.of(),
                 List.of(),
@@ -48,8 +51,14 @@ class TextractNormalizedDocumentAdapterTest {
         assertThat(document.sourceFormat()).isEqualTo("HTML");
         assertThat(document.filename()).isEqualTo("sample.html");
         assertThat(document.blocks()).extracting(block -> block.type())
-                .containsExactly(NormalizedBlockType.HEADING, NormalizedBlockType.TABLE, NormalizedBlockType.IMAGE_CAPTION);
+                .containsExactly(
+                        NormalizedBlockType.HEADING,
+                        NormalizedBlockType.TABLE,
+                        NormalizedBlockType.PARAGRAPH,
+                        NormalizedBlockType.IMAGE_CAPTION);
         assertThat(document.blocks()).extracting(block -> block.text())
-                .contains("Title", "A: 1", "architecture diagram");
+                .contains("Title", "A: 1", "After table", "architecture diagram")
+                .doesNotContain("| A |\n| --- |\n| 1 |");
+        assertThat(document.blocks().get(1).order()).isEqualTo(1);
     }
 }

--- a/studio-platform-chunking/README.md
+++ b/studio-platform-chunking/README.md
@@ -17,6 +17,9 @@
 - `ChunkMetadata`: standard metadata for vector indexing.
 - `ChunkingStrategyType`: supported strategy identifiers.
 - `ChunkUnit`: size unit for character-based or token-based chunking.
+- `NormalizedDocument`: parser-neutral structured input for structure-aware chunking.
+- `NormalizedBlock`: parser-neutral logical block with source provenance.
+- `NormalizedDocumentChunker`: chunker extension for normalized documents.
 
 ## Metadata Rules
 
@@ -24,7 +27,34 @@
 - Null keys, blank keys, null values, and blank string values are omitted.
 - `chunkOrder` remains the canonical persisted order key for Phase 1 compatibility.
 - `ChunkMetadata.order` is intended to map to the same value as `chunkOrder` when persisted by downstream modules.
+- Structured provenance keys are standardized for downstream consumers:
+  - `sourceRef`, `sourceRefs`, `blockType`, `page`, `slide`
+  - `parentBlockId`, `headingPath`, `sourceFormat`
+  - `tokenEstimate`, `chunkUnit`, `maxSize`, `overlap`
+
+## Structured Input
+
+`NormalizedDocument` and `NormalizedBlock` allow chunking to consume structured extraction results without depending on a parser implementation.
+The text-based API remains the compatibility baseline:
+
+```java
+ChunkingContext context = ChunkingContext.builder("plain text")
+        .sourceDocumentId("doc-1")
+        .build();
+```
+
+Structured chunking should use normalized blocks:
+
+```java
+NormalizedDocument document = NormalizedDocument.builder("doc-1")
+        .sourceFormat("PDF")
+        .blocks(List.of(
+                NormalizedBlock.builder(NormalizedBlockType.HEADING, "Install").order(0).build(),
+                NormalizedBlock.builder(NormalizedBlockType.PARAGRAPH, "Install the engine.").order(1).build()))
+        .build();
+```
 
 ## Dependency Boundary
 
 This module must not depend on Spring, Spring AI, JDBC, pgvector, or web modules. Strategy implementations and auto-configuration belong in a starter module.
+This module also does not call embedding APIs, vector stores, LLMs, OCR engines, or file parsers.

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkMetadata.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkMetadata.java
@@ -32,6 +32,18 @@ public record ChunkMetadata(
     public static final String KEY_END_OFFSET = "endOffset";
     public static final String KEY_TOKEN_COUNT = "tokenCount";
     public static final String KEY_CHAR_COUNT = "charCount";
+    public static final String KEY_SOURCE_REF = "sourceRef";
+    public static final String KEY_SOURCE_REFS = "sourceRefs";
+    public static final String KEY_BLOCK_TYPE = "blockType";
+    public static final String KEY_PAGE = "page";
+    public static final String KEY_SLIDE = "slide";
+    public static final String KEY_PARENT_BLOCK_ID = "parentBlockId";
+    public static final String KEY_HEADING_PATH = "headingPath";
+    public static final String KEY_SOURCE_FORMAT = "sourceFormat";
+    public static final String KEY_TOKEN_ESTIMATE = "tokenEstimate";
+    public static final String KEY_CHUNK_UNIT = "chunkUnit";
+    public static final String KEY_MAX_SIZE = "maxSize";
+    public static final String KEY_OVERLAP = "overlap";
 
     public ChunkMetadata {
         if (order < 0) {
@@ -159,6 +171,13 @@ public record ChunkMetadata(
 
         public Builder attributes(Map<String, Object> attributes) {
             this.attributes = attributes;
+            return this;
+        }
+
+        public Builder attribute(String key, Object value) {
+            Map<String, Object> merged = new LinkedHashMap<>(attributes);
+            merged.put(key, value);
+            this.attributes = merged;
             return this;
         }
 

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkingOrchestrator.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkingOrchestrator.java
@@ -10,6 +10,9 @@ public interface ChunkingOrchestrator {
     List<Chunk> chunk(ChunkingContext context);
 
     default List<Chunk> chunk(NormalizedDocument document) {
+        if (document == null || document.chunkableText().isBlank()) {
+            return List.of();
+        }
         return chunk(document.toContextBuilder().build());
     }
 }

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkingOrchestrator.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkingOrchestrator.java
@@ -8,4 +8,8 @@ import java.util.List;
 public interface ChunkingOrchestrator {
 
     List<Chunk> chunk(ChunkingContext context);
+
+    default List<Chunk> chunk(NormalizedDocument document) {
+        return chunk(document.toContextBuilder().build());
+    }
 }

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkingStrategyType.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkingStrategyType.java
@@ -32,6 +32,6 @@ public enum ChunkingStrategyType {
         }
         throw new IllegalArgumentException("Unsupported chunking strategy: " + value
                 + ". Known values are: fixed-size, recursive, structure-based, semantic, llm-based. "
-                + "Phase 1 starter support is limited to fixed-size and recursive.");
+                + "Pure chunking starter support is limited to fixed-size, recursive, and structure-based.");
     }
 }

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/NormalizedBlock.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/NormalizedBlock.java
@@ -1,0 +1,120 @@
+package studio.one.platform.chunking.core;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Parser-neutral logical block prepared for chunking.
+ */
+public record NormalizedBlock(
+        String id,
+        NormalizedBlockType type,
+        String text,
+        String sourceRef,
+        Integer page,
+        Integer slide,
+        Integer order,
+        String parentBlockId,
+        Map<String, Object> metadata) {
+
+    public NormalizedBlock {
+        id = normalize(id);
+        type = type == null ? NormalizedBlockType.UNKNOWN : type;
+        text = text == null ? "" : text.trim();
+        sourceRef = normalize(sourceRef);
+        parentBlockId = normalize(parentBlockId);
+        metadata = sanitize(metadata);
+    }
+
+    public boolean hasText() {
+        return !text.isBlank();
+    }
+
+    public String effectiveSourceRef() {
+        if (!sourceRef.isBlank()) {
+            return sourceRef;
+        }
+        return id;
+    }
+
+    public static Builder builder(NormalizedBlockType type, String text) {
+        return new Builder(type, text);
+    }
+
+    private static Map<String, Object> sanitize(Map<String, Object> values) {
+        if (values == null || values.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, Object> sanitized = new LinkedHashMap<>();
+        values.forEach((key, value) -> {
+            if (key == null || key.isBlank() || value == null) {
+                return;
+            }
+            if (value instanceof String stringValue && stringValue.isBlank()) {
+                return;
+            }
+            sanitized.put(key, value);
+        });
+        return Map.copyOf(sanitized);
+    }
+
+    private static String normalize(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    public static final class Builder {
+        private String id;
+        private final NormalizedBlockType type;
+        private final String text;
+        private String sourceRef;
+        private Integer page;
+        private Integer slide;
+        private Integer order;
+        private String parentBlockId;
+        private Map<String, Object> metadata = Map.of();
+
+        private Builder(NormalizedBlockType type, String text) {
+            this.type = type;
+            this.text = text;
+        }
+
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder sourceRef(String sourceRef) {
+            this.sourceRef = sourceRef;
+            return this;
+        }
+
+        public Builder page(Integer page) {
+            this.page = page;
+            return this;
+        }
+
+        public Builder slide(Integer slide) {
+            this.slide = slide;
+            return this;
+        }
+
+        public Builder order(Integer order) {
+            this.order = order;
+            return this;
+        }
+
+        public Builder parentBlockId(String parentBlockId) {
+            this.parentBlockId = parentBlockId;
+            return this;
+        }
+
+        public Builder metadata(Map<String, Object> metadata) {
+            this.metadata = metadata;
+            return this;
+        }
+
+        public NormalizedBlock build() {
+            return new NormalizedBlock(id, type, text, sourceRef, page, slide, order, parentBlockId, metadata);
+        }
+    }
+}

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/NormalizedBlock.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/NormalizedBlock.java
@@ -17,6 +17,9 @@ public record NormalizedBlock(
         String parentBlockId,
         Map<String, Object> metadata) {
 
+    public static final String KEY_ROW_COUNT = "rowCount";
+    public static final String KEY_CELL_COUNT = "cellCount";
+
     public NormalizedBlock {
         id = normalize(id);
         type = type == null ? NormalizedBlockType.UNKNOWN : type;

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/NormalizedBlockType.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/NormalizedBlockType.java
@@ -1,0 +1,37 @@
+package studio.one.platform.chunking.core;
+
+/**
+ * Parser-neutral logical block type used by structure-aware chunking.
+ */
+public enum NormalizedBlockType {
+    TITLE,
+    DOCUMENT,
+    PAGE,
+    HEADER,
+    FOOTER,
+    PARAGRAPH,
+    HEADING,
+    LIST_ITEM,
+    TABLE,
+    TABLE_ROW,
+    TABLE_CELL,
+    IMAGE,
+    IMAGE_CAPTION,
+    FOOTNOTE,
+    OCR_TEXT,
+    METADATA,
+    UNKNOWN;
+
+    public static NormalizedBlockType from(String value) {
+        if (value == null || value.isBlank()) {
+            return UNKNOWN;
+        }
+        String normalized = value.trim().replace('-', '_').toUpperCase();
+        for (NormalizedBlockType type : values()) {
+            if (type.name().equals(normalized)) {
+                return type;
+            }
+        }
+        return UNKNOWN;
+    }
+}

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/NormalizedDocument.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/NormalizedDocument.java
@@ -1,0 +1,119 @@
+package studio.one.platform.chunking.core;
+
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Parser-neutral structured document input for chunking.
+ */
+public record NormalizedDocument(
+        String sourceDocumentId,
+        String plainText,
+        String sourceFormat,
+        String filename,
+        List<NormalizedBlock> blocks,
+        Map<String, Object> metadata) {
+
+    public NormalizedDocument {
+        sourceDocumentId = normalize(sourceDocumentId);
+        plainText = plainText == null ? "" : plainText.trim();
+        sourceFormat = normalize(sourceFormat);
+        filename = normalize(filename);
+        blocks = blocks == null ? List.of() : blocks.stream()
+                .filter(block -> block != null)
+                .filter(NormalizedBlock::hasText)
+                .sorted(Comparator.comparing(
+                        NormalizedBlock::order,
+                        Comparator.nullsLast(Integer::compareTo)))
+                .toList();
+        metadata = sanitize(metadata);
+    }
+
+    public String chunkableText() {
+        if (!plainText.isBlank()) {
+            return plainText;
+        }
+        return blocks.stream()
+                .map(NormalizedBlock::text)
+                .filter(text -> text != null && !text.isBlank())
+                .reduce((left, right) -> left + "\n\n" + right)
+                .orElse("");
+    }
+
+    public ChunkingContext.Builder toContextBuilder() {
+        return ChunkingContext.builder(chunkableText())
+                .sourceDocumentId(sourceDocumentId)
+                .filename(filename)
+                .contentType(sourceFormat)
+                .metadata(metadata);
+    }
+
+    public static Builder builder(String sourceDocumentId) {
+        return new Builder(sourceDocumentId);
+    }
+
+    private static Map<String, Object> sanitize(Map<String, Object> values) {
+        if (values == null || values.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, Object> sanitized = new LinkedHashMap<>();
+        values.forEach((key, value) -> {
+            if (key == null || key.isBlank() || value == null) {
+                return;
+            }
+            if (value instanceof String stringValue && stringValue.isBlank()) {
+                return;
+            }
+            sanitized.put(key, value);
+        });
+        return Map.copyOf(sanitized);
+    }
+
+    private static String normalize(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    public static final class Builder {
+        private final String sourceDocumentId;
+        private String plainText;
+        private String sourceFormat;
+        private String filename;
+        private List<NormalizedBlock> blocks = List.of();
+        private Map<String, Object> metadata = Map.of();
+
+        private Builder(String sourceDocumentId) {
+            this.sourceDocumentId = sourceDocumentId;
+        }
+
+        public Builder plainText(String plainText) {
+            this.plainText = plainText;
+            return this;
+        }
+
+        public Builder sourceFormat(String sourceFormat) {
+            this.sourceFormat = sourceFormat;
+            return this;
+        }
+
+        public Builder filename(String filename) {
+            this.filename = filename;
+            return this;
+        }
+
+        public Builder blocks(List<NormalizedBlock> blocks) {
+            this.blocks = blocks;
+            return this;
+        }
+
+        public Builder metadata(Map<String, Object> metadata) {
+            this.metadata = metadata;
+            return this;
+        }
+
+        public NormalizedDocument build() {
+            return new NormalizedDocument(sourceDocumentId, plainText, sourceFormat, filename, blocks, metadata);
+        }
+    }
+}

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/NormalizedDocumentChunker.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/NormalizedDocumentChunker.java
@@ -10,7 +10,7 @@ public interface NormalizedDocumentChunker extends Chunker {
     List<Chunk> chunk(NormalizedDocument document, ChunkingContext context);
 
     default List<Chunk> chunk(NormalizedDocument document) {
-        if (document.chunkableText().isBlank()) {
+        if (document == null || document.chunkableText().isBlank()) {
             return List.of();
         }
         return chunk(document, document.toContextBuilder()

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/NormalizedDocumentChunker.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/NormalizedDocumentChunker.java
@@ -1,0 +1,20 @@
+package studio.one.platform.chunking.core;
+
+import java.util.List;
+
+/**
+ * Chunker extension for structure-aware normalized documents.
+ */
+public interface NormalizedDocumentChunker extends Chunker {
+
+    List<Chunk> chunk(NormalizedDocument document, ChunkingContext context);
+
+    default List<Chunk> chunk(NormalizedDocument document) {
+        if (document.chunkableText().isBlank()) {
+            return List.of();
+        }
+        return chunk(document, document.toContextBuilder()
+                .strategy(strategy())
+                .build());
+    }
+}

--- a/studio-platform-chunking/src/test/java/studio/one/platform/chunking/core/NormalizedDocumentTest.java
+++ b/studio-platform-chunking/src/test/java/studio/one/platform/chunking/core/NormalizedDocumentTest.java
@@ -1,0 +1,51 @@
+package studio.one.platform.chunking.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class NormalizedDocumentTest {
+
+    @Test
+    void keepsParserNeutralBlocksSortedByOrder() {
+        NormalizedBlock second = NormalizedBlock.builder(NormalizedBlockType.PARAGRAPH, "second")
+                .sourceRef("page[1]/p[1]")
+                .order(2)
+                .metadata(Map.of("blank", " "))
+                .build();
+        NormalizedBlock first = NormalizedBlock.builder(NormalizedBlockType.HEADING, "first")
+                .sourceRef("page[1]/h[0]")
+                .order(1)
+                .page(1)
+                .build();
+
+        NormalizedDocument document = NormalizedDocument.builder("doc")
+                .sourceFormat("PDF")
+                .blocks(List.of(second, first))
+                .build();
+
+        assertThat(document.blocks()).extracting(NormalizedBlock::text).containsExactly("first", "second");
+        assertThat(document.chunkableText()).isEqualTo("first\n\nsecond");
+        assertThat(document.blocks().get(0).effectiveSourceRef()).isEqualTo("page[1]/h[0]");
+    }
+
+    @Test
+    void exposesStructuredMetadataKeysWithoutChangingLegacyMapContract() {
+        ChunkMetadata metadata = ChunkMetadata.builder(ChunkingStrategyType.STRUCTURE_BASED, 1)
+                .sourceDocumentId("doc")
+                .attribute(ChunkMetadata.KEY_SOURCE_REF, "page[1]/table[0]")
+                .attribute(ChunkMetadata.KEY_BLOCK_TYPE, "TABLE")
+                .attribute(ChunkMetadata.KEY_TOKEN_ESTIMATE, 12)
+                .build();
+
+        assertThat(metadata.toMap())
+                .containsEntry(ChunkMetadata.KEY_CHUNK_ORDER, 1)
+                .containsEntry(ChunkMetadata.KEY_STRATEGY, "structure-based")
+                .containsEntry(ChunkMetadata.KEY_SOURCE_REF, "page[1]/table[0]")
+                .containsEntry(ChunkMetadata.KEY_BLOCK_TYPE, "TABLE")
+                .containsEntry(ChunkMetadata.KEY_TOKEN_ESTIMATE, 12);
+    }
+}


### PR DESCRIPTION
## Why

studio-platform-chunking이 기존 text-only chunking 계약은 유지하면서 textract의 구조화 추출 결과를 RAG 전처리 입력으로 사용할 수 있어야 한다.
embedding 호출, vector store 저장, LLM 호출 책임은 추가하지 않고, chunking 단계에서 provenance와 block-aware chunk 품질만 강화한다.

## What

- `ChunkMetadata`에 구조화 provenance 표준 key를 추가했다.
- `NormalizedDocument`, `NormalizedBlock`, `NormalizedBlockType`, `NormalizedDocumentChunker`를 추가했다.
- `starter-chunking`에 `StructureBasedChunker`를 추가하고 `STRUCTURE_BASED` 전략 실행을 지원했다.
- `TextractNormalizedDocumentAdapter`를 추가해 `ParsedFile`을 parser-neutral normalized input으로 변환한다.
- heading/paragraph/table/OCR/image-caption chunking 테스트와 README를 보강했다.

## Related Issues

- Closes #262
- Related #263
- Related #264
- Related #265
- Related #266
- Related #267
- Related #268
- Related #269

## Validation

- Command: `./gradlew :studio-platform-chunking:test :starter:studio-platform-starter-chunking:test :starter:studio-platform-starter-ai:test`
- Result: SUCCESS
- Command: `git diff --check`
- Result: SUCCESS

## Risk / Rollback

- Risk: `ChunkingOrchestrator.chunk(NormalizedDocument)`는 normalized 입력에 대해 `STRUCTURE_BASED`를 기본 적용하므로, 호출자가 text-only 전략을 기대하는 경우 명시적으로 `ChunkingContext` 경로를 사용해야 한다.
- Rollback: PR revert로 신규 normalized input 및 structure-based strategy 변경을 되돌릴 수 있다. 기존 text-based API는 변경하지 않았다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: gradle 테스트, diff check, 자체 코드 리뷰 완료

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
