### PR TITLE
[ai] Chat Platform 계약 확장

### DIFF
--- a/studio-platform-ai/README.md
+++ b/studio-platform-ai/README.md
@@ -97,6 +97,8 @@ stream event type:
 - `truncate`, `fork`, `compact`, `cancel` 최소 연산
 
 `ChatConversationSummary`는 목록 API에서 필요한 `conversationId`, `ownerId`, `title`, `summary`, `messageCount`, `lastUpdatedAt`, `status`를 표현한다.
+message 조회는 장기 conversation을 고려해 `offset`/`limit` 기반 페이지네이션을 계약에 포함한다.
+`fork`는 호출자가 새 conversation id를 제공하는 방식이며, 구현체는 중복 `newConversationId`를 거부해야 한다.
 
 ## RAG diagnostics
 `studio-platform-starter-ai`의 기본 RAG 구현은 diagnostics가 활성화된 경우 마지막 RAG 검색의 strategy,

--- a/studio-platform-ai/README.md
+++ b/studio-platform-ai/README.md
@@ -10,6 +10,9 @@ RAG indexing용 chunking 계약과 구현은 `studio-platform-chunking`과 `stud
 
 ## 설계
 - `ChatPort` / `EmbeddingPort` / `VectorStorePort`: 공급자 중립 포트 인터페이스
+- `ChatResponseMetadata` / `TokenUsage`: provider 응답 metadata의 typed view
+- `ChatStreamEvent`: provider-neutral streaming event 계약 (`delta`, `usage`, `complete`, `error`)
+- `ConversationRepositoryPort`: conversation 저장소 구현을 위한 포트
 - `AiProviderRegistry`: 공급자 이름을 키로 ChatPort/EmbeddingPort를 관리하는 레지스트리
 - `TextChunker`: 긴 문서를 임베딩에 적합한 크기로 분할하는 전략 인터페이스
 - `RagPipelineService`: 인덱싱(`index`)과 검색(`search`, `searchByObject`, `listByObject`)을 정의하는 RAG facade 계약
@@ -21,6 +24,10 @@ RAG indexing용 chunking 계약과 구현은 `studio-platform-chunking`과 `stud
 | 타입 | 패키지 | 설명 |
 |---|---|---|
 | `ChatPort` | `core.chat` | 챗 완성 요청/응답 계약 |
+| `ChatResponseMetadata` | `core.chat` | token usage, latency, provider, resolved model, memory, conversation metadata typed view |
+| `ChatStreamEvent` | `core.chat` | streaming chat event 계약 |
+| `ConversationRepositoryPort` | `core.chat` | conversation/message 저장소 포트 |
+| `ChatConversation` / `ChatConversationMessage` / `ChatConversationSummary` | `core.chat` | conversation API 구현을 위한 provider-neutral 모델 |
 | `EmbeddingPort` | `core.embedding` | 텍스트 임베딩 벡터 생성 계약 |
 | `VectorStorePort` | `core.vector` | 벡터 저장/검색/하이브리드 검색 계약 |
 | `AiProviderRegistry` | `core.registry` | 공급자별 ChatPort/EmbeddingPort 룩업 |
@@ -55,6 +62,42 @@ Keyword metadata는 trim, blank 제거, case-insensitive 중복 제거를 거친
 `scope=chunk` 또는 `both`는 chunk별 keyword를 추가해 긴 파일에서 chunk 의미가 희석되는 문제를 줄이는 기반을 제공한다.
 현재 PostgreSQL hybrid SQL ranking은 기존 `simple` text search config 동작을 유지한다.
 
+## Chat metadata
+`ChatResponse.metadata()` map은 기존 호환성을 위해 유지한다. 신규 코드는 `ChatResponse.typedMetadata()`로 표준 metadata를 타입 안전하게 읽을 수 있다.
+
+| key | 타입 | 설명 |
+|---|---|---|
+| `tokenUsage` | `TokenUsage` 또는 map | 입력/출력/전체 token 사용량 |
+| `latencyMs` | `Long` | provider 호출 latency |
+| `provider` | `String` | 실제 사용 provider |
+| `resolvedModel` | `String` | 최종 선택된 model 이름 |
+| `memoryUsed` | `Boolean` | conversation memory 사용 여부 |
+| `conversationId` | `String` | 연결된 conversation 식별자 |
+
+기존 `modelName`, `tokenUsage` map 등 legacy metadata key는 제거하지 않는다. `resolvedModel`이 없으면 typed view는 `modelName`을 fallback으로 사용할 수 있다.
+
+## Chat streaming
+`ChatPort.stream(ChatRequest)`는 provider-neutral stream 계약이다. 기본 구현은 기존 `chat(ChatRequest)` 결과를 `delta`, `usage`, `complete` event sequence로 변환하는 fallback이다. native streaming provider는 이 메서드를 override하면 된다.
+
+stream event type:
+
+- `delta`: assistant text 조각
+- `usage`: token/latency/provider metadata
+- `complete`: stream 완료
+- `error`: provider 호출 실패
+
+이 계약은 Reactor, Spring Web, SSE 구현체에 의존하지 않는다. HTTP `text/event-stream` 변환은 web starter 책임이다.
+
+## Conversation contracts
+`ConversationRepositoryPort`는 conversation platform 구현을 위한 저장소 포트다. 이 모듈은 JPA/JDBC/InMemory 구현을 제공하지 않고, 아래 동작에 필요한 중립 계약만 제공한다.
+
+- conversation 목록/상세/삭제
+- message 저장과 조회
+- assistant 응답 regenerate를 위한 replacement
+- `truncate`, `fork`, `compact`, `cancel` 최소 연산
+
+`ChatConversationSummary`는 목록 API에서 필요한 `conversationId`, `ownerId`, `title`, `summary`, `messageCount`, `lastUpdatedAt`, `status`를 표현한다.
+
 ## RAG diagnostics
 `studio-platform-starter-ai`의 기본 RAG 구현은 diagnostics가 활성화된 경우 마지막 RAG 검색의 strategy,
 result count, score threshold, hybrid weight, object scope, topK를 `RagRetrievalDiagnostics`로 기록한다.
@@ -82,7 +125,10 @@ dependencies {
 ```java
 // 레지스트리에서 포트 조회
 ChatPort chat = aiProviderRegistry.chatPort("openai");
-ChatResponse response = chat.chat(new ChatRequest(messages));
+ChatResponse response = chat.chat(ChatRequest.builder()
+    .messages(messages)
+    .build());
+ChatResponseMetadata metadata = response.typedMetadata();
 
 // RAG 인덱싱
 ragPipelineService.index(RagIndexRequest.builder()

--- a/studio-platform-ai/build.gradle.kts
+++ b/studio-platform-ai/build.gradle.kts
@@ -19,4 +19,7 @@ tasks.named<org.gradle.jvm.tasks.Jar>("jar").configure {
 dependencies {
     implementation(project(":studio-platform")) 
 
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testImplementation("org.assertj:assertj-core")
+
 }

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ChatConversation.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ChatConversation.java
@@ -1,0 +1,46 @@
+package studio.one.platform.ai.core.chat;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Provider-neutral conversation aggregate metadata.
+ */
+public record ChatConversation(
+        String conversationId,
+        String ownerId,
+        String title,
+        String summary,
+        ConversationStatus status,
+        String parentConversationId,
+        String forkedFromMessageId,
+        int messageCount,
+        Instant createdAt,
+        Instant lastUpdatedAt,
+        Map<String, Object> metadata) {
+
+    public ChatConversation {
+        conversationId = required(conversationId, "conversationId");
+        ownerId = normalize(ownerId);
+        title = normalize(title);
+        summary = normalize(summary);
+        status = status == null ? ConversationStatus.ACTIVE : status;
+        parentConversationId = normalize(parentConversationId);
+        forkedFromMessageId = normalize(forkedFromMessageId);
+        messageCount = Math.max(0, messageCount);
+        createdAt = createdAt == null ? Instant.EPOCH : createdAt;
+        lastUpdatedAt = lastUpdatedAt == null ? createdAt : lastUpdatedAt;
+        metadata = ChatMetadataMaps.compact(metadata);
+    }
+
+    private static String required(String value, String name) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " must not be blank");
+        }
+        return value.trim();
+    }
+
+    private static String normalize(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ChatConversationMessage.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ChatConversationMessage.java
@@ -1,0 +1,39 @@
+package studio.one.platform.ai.core.chat;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Message persisted as part of a chat conversation.
+ */
+public record ChatConversationMessage(
+        String messageId,
+        String conversationId,
+        ChatMessage message,
+        String parentMessageId,
+        boolean active,
+        Instant createdAt,
+        Map<String, Object> metadata) {
+
+    public ChatConversationMessage {
+        messageId = required(messageId, "messageId");
+        conversationId = required(conversationId, "conversationId");
+        if (message == null) {
+            throw new IllegalArgumentException("message must not be null");
+        }
+        parentMessageId = normalize(parentMessageId);
+        createdAt = createdAt == null ? Instant.EPOCH : createdAt;
+        metadata = ChatMetadataMaps.compact(metadata);
+    }
+
+    private static String required(String value, String name) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " must not be blank");
+        }
+        return value.trim();
+    }
+
+    private static String normalize(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ChatConversationSummary.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ChatConversationSummary.java
@@ -1,0 +1,40 @@
+package studio.one.platform.ai.core.chat;
+
+import java.time.Instant;
+
+/**
+ * Lightweight conversation list item.
+ */
+public record ChatConversationSummary(
+        String conversationId,
+        String ownerId,
+        String title,
+        String summary,
+        int messageCount,
+        Instant lastUpdatedAt,
+        ConversationStatus status) {
+
+    public ChatConversationSummary {
+        if (conversationId == null || conversationId.isBlank()) {
+            throw new IllegalArgumentException("conversationId must not be blank");
+        }
+        conversationId = conversationId.trim();
+        ownerId = ownerId == null ? "" : ownerId.trim();
+        title = title == null ? "" : title.trim();
+        summary = summary == null ? "" : summary.trim();
+        messageCount = Math.max(0, messageCount);
+        lastUpdatedAt = lastUpdatedAt == null ? Instant.EPOCH : lastUpdatedAt;
+        status = status == null ? ConversationStatus.ACTIVE : status;
+    }
+
+    public static ChatConversationSummary from(ChatConversation conversation) {
+        return new ChatConversationSummary(
+                conversation.conversationId(),
+                conversation.ownerId(),
+                conversation.title(),
+                conversation.summary(),
+                conversation.messageCount(),
+                conversation.lastUpdatedAt(),
+                conversation.status());
+    }
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ChatMetadataMaps.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ChatMetadataMaps.java
@@ -1,0 +1,30 @@
+package studio.one.platform.ai.core.chat;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+final class ChatMetadataMaps {
+
+    private ChatMetadataMaps() {
+    }
+
+    static Map<String, Object> compact(Map<String, Object> values) {
+        if (values == null || values.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, Object> compact = new LinkedHashMap<>();
+        values.forEach((key, value) -> {
+            if (key == null || key.isBlank() || value == null) {
+                return;
+            }
+            if (value instanceof String stringValue && stringValue.isBlank()) {
+                return;
+            }
+            if (value instanceof Map<?, ?> mapValue && mapValue.isEmpty()) {
+                return;
+            }
+            compact.put(key, value);
+        });
+        return Map.copyOf(compact);
+    }
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ChatPort.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ChatPort.java
@@ -19,7 +19,12 @@ public interface ChatPort {
                     ChatStreamEvent.usage(response.typedMetadata()),
                     ChatStreamEvent.complete(response.model(), response.typedMetadata())));
         } catch (RuntimeException e) {
-            return Stream.of(ChatStreamEvent.error(e.getMessage(), ChatResponseMetadata.empty()));
+            return Stream.of(ChatStreamEvent.error(errorMessage(e), ChatResponseMetadata.empty()));
         }
+    }
+
+    private static String errorMessage(RuntimeException e) {
+        String message = e.getMessage();
+        return message == null || message.isBlank() ? e.getClass().getSimpleName() : message;
     }
 }

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ChatPort.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ChatPort.java
@@ -1,9 +1,25 @@
 package studio.one.platform.ai.core.chat;
 
+import java.util.stream.Stream;
+
 /**
  * Contract for interacting with a chat-capable AI provider.
  */
 public interface ChatPort {
 
     ChatResponse chat(ChatRequest request);
+
+    default Stream<ChatStreamEvent> stream(ChatRequest request) {
+        try {
+            ChatResponse response = chat(request);
+            Stream<ChatStreamEvent> deltas = response.messages().stream()
+                    .filter(message -> message.role() == ChatMessageRole.ASSISTANT)
+                    .map(message -> ChatStreamEvent.delta(message.content(), response.model(), response.typedMetadata()));
+            return Stream.concat(deltas, Stream.of(
+                    ChatStreamEvent.usage(response.typedMetadata()),
+                    ChatStreamEvent.complete(response.model(), response.typedMetadata())));
+        } catch (RuntimeException e) {
+            return Stream.of(ChatStreamEvent.error(e.getMessage(), ChatResponseMetadata.empty()));
+        }
+    }
 }

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ChatResponse.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ChatResponse.java
@@ -36,6 +36,10 @@ public final class ChatResponse {
         return Collections.unmodifiableMap(metadata);
     }
 
+    public ChatResponseMetadata typedMetadata() {
+        return ChatResponseMetadata.from(metadata);
+    }
+
     @Override
     public String toString() {
         return "ChatResponse{" +

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ChatResponseMetadata.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ChatResponseMetadata.java
@@ -1,0 +1,112 @@
+package studio.one.platform.ai.core.chat;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Typed view over provider-neutral chat response metadata.
+ */
+public record ChatResponseMetadata(
+        TokenUsage tokenUsage,
+        Long latencyMs,
+        String provider,
+        String resolvedModel,
+        Boolean memoryUsed,
+        String conversationId,
+        Map<String, Object> attributes) {
+
+    public static final String KEY_TOKEN_USAGE = "tokenUsage";
+    public static final String KEY_LATENCY_MS = "latencyMs";
+    public static final String KEY_PROVIDER = "provider";
+    public static final String KEY_RESOLVED_MODEL = "resolvedModel";
+    public static final String KEY_MEMORY_USED = "memoryUsed";
+    public static final String KEY_CONVERSATION_ID = "conversationId";
+
+    public ChatResponseMetadata {
+        tokenUsage = tokenUsage == null ? TokenUsage.empty() : tokenUsage;
+        provider = normalize(provider);
+        resolvedModel = normalize(resolvedModel);
+        conversationId = normalize(conversationId);
+        attributes = ChatMetadataMaps.compact(attributes);
+    }
+
+    public static ChatResponseMetadata empty() {
+        return new ChatResponseMetadata(TokenUsage.empty(), null, "", "", null, "", Map.of());
+    }
+
+    public static ChatResponseMetadata from(Map<String, Object> metadata) {
+        if (metadata == null || metadata.isEmpty()) {
+            return empty();
+        }
+        return new ChatResponseMetadata(
+                TokenUsage.from(metadata.get(KEY_TOKEN_USAGE)),
+                longValue(metadata.get(KEY_LATENCY_MS)),
+                stringValue(metadata.get(KEY_PROVIDER)),
+                firstNonBlank(stringValue(metadata.get(KEY_RESOLVED_MODEL)), stringValue(metadata.get("modelName"))),
+                booleanValue(metadata.get(KEY_MEMORY_USED)),
+                stringValue(metadata.get(KEY_CONVERSATION_ID)),
+                metadata);
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> metadata = new LinkedHashMap<>(attributes);
+        if (!tokenUsage.toMap().isEmpty()) {
+            metadata.putIfAbsent(KEY_TOKEN_USAGE, tokenUsage.toMap());
+        }
+        putIfAbsent(metadata, KEY_LATENCY_MS, latencyMs);
+        putIfAbsent(metadata, KEY_PROVIDER, provider);
+        putIfAbsent(metadata, KEY_RESOLVED_MODEL, resolvedModel);
+        putIfAbsent(metadata, KEY_MEMORY_USED, memoryUsed);
+        putIfAbsent(metadata, KEY_CONVERSATION_ID, conversationId);
+        return ChatMetadataMaps.compact(metadata);
+    }
+
+    private static void putIfAbsent(Map<String, Object> metadata, String key, Object value) {
+        if (value == null) {
+            return;
+        }
+        if (value instanceof String stringValue && stringValue.isBlank()) {
+            return;
+        }
+        metadata.putIfAbsent(key, value);
+    }
+
+    private static String normalize(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    private static String stringValue(Object value) {
+        return value == null ? "" : value.toString();
+    }
+
+    private static String firstNonBlank(String primary, String fallback) {
+        return primary == null || primary.isBlank() ? fallback : primary;
+    }
+
+    private static Long longValue(Object value) {
+        if (value instanceof Long longValue) {
+            return longValue;
+        }
+        if (value instanceof Number numberValue) {
+            return numberValue.longValue();
+        }
+        if (value instanceof String stringValue && !stringValue.isBlank()) {
+            try {
+                return Long.parseLong(stringValue);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static Boolean booleanValue(Object value) {
+        if (value instanceof Boolean booleanValue) {
+            return booleanValue;
+        }
+        if (value instanceof String stringValue && !stringValue.isBlank()) {
+            return Boolean.parseBoolean(stringValue);
+        }
+        return null;
+    }
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ChatStreamEvent.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ChatStreamEvent.java
@@ -1,0 +1,49 @@
+package studio.one.platform.ai.core.chat;
+
+import java.util.Map;
+import java.util.LinkedHashMap;
+
+/**
+ * Provider-neutral chat streaming event.
+ */
+public record ChatStreamEvent(
+        ChatStreamEventType type,
+        String delta,
+        String model,
+        ChatResponseMetadata metadata,
+        String errorMessage) {
+
+    public ChatStreamEvent {
+        type = type == null ? ChatStreamEventType.DELTA : type;
+        delta = delta == null ? "" : delta;
+        model = model == null ? "" : model;
+        metadata = metadata == null ? ChatResponseMetadata.empty() : metadata;
+        errorMessage = errorMessage == null ? "" : errorMessage;
+    }
+
+    public static ChatStreamEvent delta(String delta, String model, ChatResponseMetadata metadata) {
+        return new ChatStreamEvent(ChatStreamEventType.DELTA, delta, model, metadata, "");
+    }
+
+    public static ChatStreamEvent usage(ChatResponseMetadata metadata) {
+        return new ChatStreamEvent(ChatStreamEventType.USAGE, "", "", metadata, "");
+    }
+
+    public static ChatStreamEvent complete(String model, ChatResponseMetadata metadata) {
+        return new ChatStreamEvent(ChatStreamEventType.COMPLETE, "", model, metadata, "");
+    }
+
+    public static ChatStreamEvent error(String errorMessage, ChatResponseMetadata metadata) {
+        return new ChatStreamEvent(ChatStreamEventType.ERROR, "", "", metadata, errorMessage);
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> event = new LinkedHashMap<>();
+        event.put("type", type.value());
+        event.put("delta", delta);
+        event.put("model", model);
+        event.put("metadata", metadata.toMap());
+        event.put("errorMessage", errorMessage);
+        return ChatMetadataMaps.compact(event);
+    }
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ChatStreamEventType.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ChatStreamEventType.java
@@ -1,0 +1,21 @@
+package studio.one.platform.ai.core.chat;
+
+/**
+ * Provider-neutral chat stream event type.
+ */
+public enum ChatStreamEventType {
+    DELTA("delta"),
+    USAGE("usage"),
+    COMPLETE("complete"),
+    ERROR("error");
+
+    private final String value;
+
+    ChatStreamEventType(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ConversationRepositoryPort.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ConversationRepositoryPort.java
@@ -18,12 +18,16 @@ public interface ConversationRepositoryPort {
 
     ChatConversationMessage saveMessage(ChatConversationMessage message);
 
-    List<ChatConversationMessage> listMessages(String conversationId);
+    List<ChatConversationMessage> listMessages(String conversationId, int offset, int limit);
 
     boolean replaceAssistantResponse(String conversationId, String assistantMessageId, ChatConversationMessage replacement);
 
     boolean truncateAfter(String conversationId, String messageId);
 
+    /**
+     * Creates a new conversation id supplied by the caller.
+     * Implementations must reject duplicate {@code newConversationId} values.
+     */
     ChatConversation fork(String conversationId, String fromMessageId, String newConversationId);
 
     ChatConversation compact(String conversationId, String summary);

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ConversationRepositoryPort.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ConversationRepositoryPort.java
@@ -1,0 +1,32 @@
+package studio.one.platform.ai.core.chat;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Provider-neutral persistence port for chat conversations.
+ */
+public interface ConversationRepositoryPort {
+
+    ChatConversation saveConversation(ChatConversation conversation);
+
+    Optional<ChatConversation> findConversation(String conversationId);
+
+    List<ChatConversationSummary> listConversations(String ownerId, int offset, int limit);
+
+    boolean deleteConversation(String conversationId);
+
+    ChatConversationMessage saveMessage(ChatConversationMessage message);
+
+    List<ChatConversationMessage> listMessages(String conversationId);
+
+    boolean replaceAssistantResponse(String conversationId, String assistantMessageId, ChatConversationMessage replacement);
+
+    boolean truncateAfter(String conversationId, String messageId);
+
+    ChatConversation fork(String conversationId, String fromMessageId, String newConversationId);
+
+    ChatConversation compact(String conversationId, String summary);
+
+    boolean cancel(String conversationId);
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ConversationStatus.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/ConversationStatus.java
@@ -1,0 +1,11 @@
+package studio.one.platform.ai.core.chat;
+
+/**
+ * Lifecycle status for a chat conversation.
+ */
+public enum ConversationStatus {
+    ACTIVE,
+    COMPACTED,
+    CANCELLED,
+    DELETED
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/TokenUsage.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/TokenUsage.java
@@ -1,0 +1,71 @@
+package studio.one.platform.ai.core.chat;
+
+import java.util.Map;
+import java.util.LinkedHashMap;
+
+/**
+ * Provider-neutral token usage metadata.
+ */
+public record TokenUsage(Integer inputTokens, Integer outputTokens, Integer totalTokens) {
+
+    public static final String KEY_INPUT_TOKENS = "inputTokens";
+    public static final String KEY_OUTPUT_TOKENS = "outputTokens";
+    public static final String KEY_TOTAL_TOKENS = "totalTokens";
+
+    public TokenUsage {
+        inputTokens = nonNegative(inputTokens);
+        outputTokens = nonNegative(outputTokens);
+        totalTokens = nonNegative(totalTokens);
+    }
+
+    public static TokenUsage empty() {
+        return new TokenUsage(null, null, null);
+    }
+
+    public static TokenUsage of(Integer inputTokens, Integer outputTokens, Integer totalTokens) {
+        return new TokenUsage(inputTokens, outputTokens, totalTokens);
+    }
+
+    public static TokenUsage from(Object value) {
+        if (value instanceof TokenUsage tokenUsage) {
+            return tokenUsage;
+        }
+        if (value instanceof Map<?, ?> map) {
+            return new TokenUsage(
+                    integerValue(map.get(KEY_INPUT_TOKENS), map.get("promptTokens")),
+                    integerValue(map.get(KEY_OUTPUT_TOKENS), map.get("completionTokens")),
+                    integerValue(map.get(KEY_TOTAL_TOKENS), map.get("totalTokens")));
+        }
+        return empty();
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put(KEY_INPUT_TOKENS, inputTokens);
+        metadata.put(KEY_OUTPUT_TOKENS, outputTokens);
+        metadata.put(KEY_TOTAL_TOKENS, totalTokens);
+        return ChatMetadataMaps.compact(metadata);
+    }
+
+    private static Integer integerValue(Object primary, Object fallback) {
+        Object value = primary == null ? fallback : primary;
+        if (value instanceof Integer integerValue) {
+            return integerValue;
+        }
+        if (value instanceof Number numberValue) {
+            return numberValue.intValue();
+        }
+        if (value instanceof String stringValue && !stringValue.isBlank()) {
+            try {
+                return Integer.parseInt(stringValue);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static Integer nonNegative(Integer value) {
+        return value == null ? null : Math.max(0, value);
+    }
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/TokenUsage.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chat/TokenUsage.java
@@ -11,6 +11,9 @@ public record TokenUsage(Integer inputTokens, Integer outputTokens, Integer tota
     public static final String KEY_INPUT_TOKENS = "inputTokens";
     public static final String KEY_OUTPUT_TOKENS = "outputTokens";
     public static final String KEY_TOTAL_TOKENS = "totalTokens";
+    public static final String LEGACY_PROMPT_TOKENS = "promptTokens";
+    public static final String LEGACY_COMPLETION_TOKENS = "completionTokens";
+    public static final String LEGACY_TOTAL_TOKENS_SNAKE_CASE = "total_tokens";
 
     public TokenUsage {
         inputTokens = nonNegative(inputTokens);
@@ -32,9 +35,9 @@ public record TokenUsage(Integer inputTokens, Integer outputTokens, Integer tota
         }
         if (value instanceof Map<?, ?> map) {
             return new TokenUsage(
-                    integerValue(map.get(KEY_INPUT_TOKENS), map.get("promptTokens")),
-                    integerValue(map.get(KEY_OUTPUT_TOKENS), map.get("completionTokens")),
-                    integerValue(map.get(KEY_TOTAL_TOKENS), map.get("totalTokens")));
+                    integerValue(map.get(KEY_INPUT_TOKENS), map.get(LEGACY_PROMPT_TOKENS)),
+                    integerValue(map.get(KEY_OUTPUT_TOKENS), map.get(LEGACY_COMPLETION_TOKENS)),
+                    integerValue(map.get(KEY_TOTAL_TOKENS), map.get(LEGACY_TOTAL_TOKENS_SNAKE_CASE)));
         }
         return empty();
     }

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/core/chat/ChatResponseMetadataTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/core/chat/ChatResponseMetadataTest.java
@@ -41,6 +41,18 @@ class ChatResponseMetadataTest {
     }
 
     @Test
+    void tokenUsageSupportsLegacyKeys() {
+        TokenUsage usage = TokenUsage.from(Map.of(
+                TokenUsage.LEGACY_PROMPT_TOKENS, "11",
+                TokenUsage.LEGACY_COMPLETION_TOKENS, 7,
+                TokenUsage.LEGACY_TOTAL_TOKENS_SNAKE_CASE, 18L));
+
+        assertThat(usage.inputTokens()).isEqualTo(11);
+        assertThat(usage.outputTokens()).isEqualTo(7);
+        assertThat(usage.totalTokens()).isEqualTo(18);
+    }
+
+    @Test
     void chatPortDefaultStreamFallsBackToChatResponseEvents() {
         ChatPort port = request -> new ChatResponse(
                 List.of(ChatMessage.assistant("delta")),
@@ -56,5 +68,21 @@ class ChatResponseMetadataTest {
                 .containsExactly(ChatStreamEventType.DELTA, ChatStreamEventType.USAGE, ChatStreamEventType.COMPLETE);
         assertThat(events.get(0).delta()).isEqualTo("delta");
         assertThat(events.get(0).metadata().provider()).isEqualTo("test");
+    }
+
+    @Test
+    void chatPortDefaultStreamKeepsExceptionTypeWhenMessageIsMissing() {
+        ChatPort port = request -> {
+            throw new NullPointerException();
+        };
+        ChatRequest request = ChatRequest.builder()
+                .messages(List.of(ChatMessage.user("hi")))
+                .build();
+
+        List<ChatStreamEvent> events = port.stream(request).toList();
+
+        assertThat(events).hasSize(1);
+        assertThat(events.get(0).type()).isEqualTo(ChatStreamEventType.ERROR);
+        assertThat(events.get(0).errorMessage()).isEqualTo("NullPointerException");
     }
 }

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/core/chat/ChatResponseMetadataTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/core/chat/ChatResponseMetadataTest.java
@@ -1,0 +1,60 @@
+package studio.one.platform.ai.core.chat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class ChatResponseMetadataTest {
+
+    @Test
+    void typedMetadataKeepsMapCompatibility() {
+        ChatResponse response = new ChatResponse(
+                List.of(ChatMessage.assistant("hello")),
+                "gpt-4.1-mini",
+                Map.of(
+                        ChatResponseMetadata.KEY_TOKEN_USAGE, Map.of(
+                                TokenUsage.KEY_INPUT_TOKENS, 10,
+                                TokenUsage.KEY_OUTPUT_TOKENS, 5,
+                                TokenUsage.KEY_TOTAL_TOKENS, 15),
+                        ChatResponseMetadata.KEY_LATENCY_MS, 123L,
+                        ChatResponseMetadata.KEY_PROVIDER, "openai",
+                        ChatResponseMetadata.KEY_RESOLVED_MODEL, "gpt-4.1-mini",
+                        ChatResponseMetadata.KEY_MEMORY_USED, true,
+                        ChatResponseMetadata.KEY_CONVERSATION_ID, "conv-1"));
+
+        assertThat(response.metadata()).containsEntry(ChatResponseMetadata.KEY_PROVIDER, "openai");
+        assertThat(response.typedMetadata().tokenUsage().totalTokens()).isEqualTo(15);
+        assertThat(response.typedMetadata().latencyMs()).isEqualTo(123L);
+        assertThat(response.typedMetadata().memoryUsed()).isTrue();
+        assertThat(response.typedMetadata().conversationId()).isEqualTo("conv-1");
+    }
+
+    @Test
+    void typedMetadataFallsBackToLegacyModelName() {
+        ChatResponseMetadata metadata = ChatResponseMetadata.from(Map.of("modelName", "legacy-model"));
+
+        assertThat(metadata.resolvedModel()).isEqualTo("legacy-model");
+        assertThat(metadata.toMap()).containsEntry(ChatResponseMetadata.KEY_RESOLVED_MODEL, "legacy-model");
+    }
+
+    @Test
+    void chatPortDefaultStreamFallsBackToChatResponseEvents() {
+        ChatPort port = request -> new ChatResponse(
+                List.of(ChatMessage.assistant("delta")),
+                "model",
+                Map.of(ChatResponseMetadata.KEY_PROVIDER, "test"));
+        ChatRequest request = ChatRequest.builder()
+                .messages(List.of(ChatMessage.user("hi")))
+                .build();
+
+        List<ChatStreamEvent> events = port.stream(request).toList();
+
+        assertThat(events).extracting(ChatStreamEvent::type)
+                .containsExactly(ChatStreamEventType.DELTA, ChatStreamEventType.USAGE, ChatStreamEventType.COMPLETE);
+        assertThat(events.get(0).delta()).isEqualTo("delta");
+        assertThat(events.get(0).metadata().provider()).isEqualTo("test");
+    }
+}

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/core/chat/ConversationContractTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/core/chat/ConversationContractTest.java
@@ -48,4 +48,22 @@ class ConversationContractTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("messageId");
     }
+
+    @Test
+    void conversationRequiresStableId() {
+        assertThatThrownBy(() -> new ChatConversation(
+                "",
+                "user-1",
+                "Title",
+                "",
+                ConversationStatus.ACTIVE,
+                "",
+                "",
+                0,
+                Instant.now(),
+                Instant.now(),
+                Map.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("conversationId");
+    }
 }

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/core/chat/ConversationContractTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/core/chat/ConversationContractTest.java
@@ -1,0 +1,51 @@
+package studio.one.platform.ai.core.chat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class ConversationContractTest {
+
+    @Test
+    void conversationSummaryUsesStableListShape() {
+        ChatConversation conversation = new ChatConversation(
+                "conv-1",
+                "user-1",
+                "Title",
+                "Summary",
+                ConversationStatus.ACTIVE,
+                "",
+                "",
+                3,
+                Instant.parse("2026-04-24T00:00:00Z"),
+                Instant.parse("2026-04-24T00:01:00Z"),
+                Map.of("ownerId", "user-1"));
+
+        ChatConversationSummary summary = ChatConversationSummary.from(conversation);
+
+        assertThat(summary.conversationId()).isEqualTo("conv-1");
+        assertThat(summary.ownerId()).isEqualTo("user-1");
+        assertThat(summary.title()).isEqualTo("Title");
+        assertThat(summary.summary()).isEqualTo("Summary");
+        assertThat(summary.messageCount()).isEqualTo(3);
+        assertThat(summary.status()).isEqualTo(ConversationStatus.ACTIVE);
+    }
+
+    @Test
+    void conversationMessageRequiresStableIdsAndMessage() {
+        assertThatThrownBy(() -> new ChatConversationMessage(
+                "",
+                "conv-1",
+                ChatMessage.user("hello"),
+                "",
+                true,
+                Instant.now(),
+                Map.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("messageId");
+    }
+}


### PR DESCRIPTION
## Why

Conversation 기반 Chat Platform API 확장을 진행하려면 `studio-platform-ai` 계약 계층에 typed metadata, streaming event, conversation repository port가 먼저 필요하다. 이 PR은 구현체 의존 없이 후속 starter/web 작업이 사용할 provider-neutral 계약만 추가한다.

## What

- `ChatResponseMetadata`, `TokenUsage` typed metadata 계약 추가
- `ChatResponse.typedMetadata()` 추가 및 기존 `metadata()` map 유지
- `ChatPort.stream(ChatRequest)` provider-neutral default fallback 추가
- `ChatStreamEvent`, `ChatStreamEventType` 추가
- `ConversationRepositoryPort` 및 conversation/message/summary 모델 추가
- `studio-platform-ai` README와 계약 테스트 추가

## Related Issues

- Closes #258
- Related #257

## Validation

- Command: `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test`
- Result: SUCCESS
- Command: `git diff --check`
- Result: SUCCESS

## Risk / Rollback

- Risk: `ChatPort.stream()` default fallback은 native streaming이 아니라 `chat()` 결과를 event sequence로 변환한다. 실제 native streaming은 후속 #259에서 adapter가 override해야 한다.
- Rollback: PR revert로 신규 계약을 제거할 수 있다. 기존 `ChatPort.chat()`와 `ChatResponse.metadata()` 계약은 변경하지 않았다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: 계약 단위 테스트와 downstream starter/web 테스트 실행

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
