### PR TITLE
[ai] starter chat metadata streaming 지원

### DIFF
--- a/starter/studio-platform-starter-ai/README.md
+++ b/starter/studio-platform-starter-ai/README.md
@@ -181,6 +181,23 @@ studio:
 `objectType`/`objectId` 메타데이터를 함께 저장하면 AI web starter의 RAG chat API에서 특정 파일이나 객체 범위에 한정해 답변할 수 있다.
 같은 `objectType`/`objectId`를 재색인하면 기존 chunk를 삭제한 뒤 새 chunk를 저장해 stale chunk가 남지 않도록 한다.
 
+### Chat metadata / streaming
+
+`SpringAiChatAdapter`는 기존 metadata key를 유지하면서 `studio-platform-ai`의 typed metadata key도 함께 채운다.
+
+| key | 설명 |
+|---|---|
+| `responseId` | Spring AI response id |
+| `modelName` | Spring AI metadata model name |
+| `finishReason` | generation finish reason |
+| `tokenUsage` | `inputTokens`, `outputTokens`, `totalTokens` |
+| `provider` | provider type (`OPENAI`, `GOOGLE_AI_GEMINI`, `OLLAMA`) |
+| `resolvedModel` | response metadata model, request model, configured model 순서로 해석한 model |
+| `latencyMs` | provider 호출 latency |
+
+`ChatPort.stream(ChatRequest)`는 native Spring AI `ChatModel.stream(Prompt)`를 우선 사용한다. native streaming이 지원되지 않거나 명시적으로 unsupported인 경우 기존 `chat()` 호출 결과를 `delta`, `usage`, `complete` event sequence로 변환하는 fallback을 사용한다.
+HTTP `text/event-stream` endpoint 변환은 `starter-ai-web` 책임이다.
+
 ### RAG 청킹 설정
 
 `starter:studio-platform-starter-chunking`이 classpath에 있으면 `RagPipelineService`는 신규

--- a/starter/studio-platform-starter-ai/README.md
+++ b/starter/studio-platform-starter-ai/README.md
@@ -196,6 +196,8 @@ studio:
 | `latencyMs` | provider 호출 latency |
 
 `ChatPort.stream(ChatRequest)`는 native Spring AI `ChatModel.stream(Prompt)`를 우선 사용한다. native streaming이 지원되지 않거나 명시적으로 unsupported인 경우 기존 `chat()` 호출 결과를 `delta`, `usage`, `complete` event sequence로 변환하는 fallback을 사용한다.
+`usage` / `complete` event의 `tokenUsage`는 provider가 마지막 stream chunk에 제공한 usage metadata를 기준으로 한다.
+`ChatPort.stream(ChatRequest)`는 Java `Stream` 기반 동기 계약이므로 WebFlux/Netty event-loop thread에서 직접 소비하지 말고 web 계층에서 별도 scheduler 또는 blocking boundary를 둔다.
 HTTP `text/event-stream` endpoint 변환은 `starter-ai-web` 책임이다.
 
 ### RAG 청킹 설정

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/adapter/GoogleSpringAiChatAdapter.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/adapter/GoogleSpringAiChatAdapter.java
@@ -12,6 +12,10 @@ public class GoogleSpringAiChatAdapter extends SpringAiChatAdapter {
         super(chatModel);
     }
 
+    public GoogleSpringAiChatAdapter(ChatModel chatModel, String provider, String configuredModel) {
+        super(chatModel, provider, configuredModel);
+    }
+
     @Override
     protected ChatOptions createChatOptions(ChatRequest request) {
         GoogleGenAiChatOptions.Builder builder = GoogleGenAiChatOptions.builder();

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/adapter/SpringAiChatAdapter.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/adapter/SpringAiChatAdapter.java
@@ -88,11 +88,12 @@ public class SpringAiChatAdapter implements ChatPort {
         Prompt prompt = options == null ? new Prompt(messages) : new Prompt(messages, options);
         long startedAt = System.nanoTime();
         try {
+            // ChatPort exposes a synchronous Stream contract; callers must not consume it on an event-loop thread.
             Iterator<org.springframework.ai.chat.model.ChatResponse> source =
                     chatModel.stream(prompt).toIterable().iterator();
             Iterator<ChatStreamEvent> events = new SpringAiStreamIterator(source, request, startedAt);
             return StreamSupport.stream(Spliterators.spliteratorUnknownSize(events, 0), false);
-        } catch (UnsupportedOperationException | IllegalStateException e) {
+        } catch (UnsupportedOperationException e) {
             return ChatPort.super.stream(request);
         }
     }
@@ -128,20 +129,26 @@ public class SpringAiChatAdapter implements ChatPort {
             long latencyMs,
             String requestedModel) {
         Map<String, Object> metadata = new LinkedHashMap<>();
-        metadata.put("responseId", response.getMetadata().getId());
-        metadata.put("modelName", response.getMetadata().getModel());
+        org.springframework.ai.chat.metadata.ChatResponseMetadata responseMetadata = response.getMetadata();
+        if (responseMetadata != null) {
+            metadata.put("responseId", responseMetadata.getId());
+            metadata.put("modelName", responseMetadata.getModel());
+        }
         metadata.put(ChatResponseMetadata.KEY_PROVIDER, provider);
         metadata.put(ChatResponseMetadata.KEY_RESOLVED_MODEL, resolvedModel(response, requestedModel));
         metadata.put(ChatResponseMetadata.KEY_LATENCY_MS, latencyMs);
-        if (response.getMetadata().getUsage() != null) {
-            metadata.put(ChatResponseMetadata.KEY_TOKEN_USAGE, toTokenUsageMap(response.getMetadata().getUsage()));
+        if (responseMetadata != null && responseMetadata.getUsage() != null) {
+            metadata.put(ChatResponseMetadata.KEY_TOKEN_USAGE, toTokenUsageMap(responseMetadata.getUsage()));
         }
-        metadata.put("chatResponseMetadata", response.getMetadata());
+        if (responseMetadata != null) {
+            metadata.put("chatResponseMetadata", responseMetadata);
+        }
         return metadata;
     }
 
     private String resolvedModel(org.springframework.ai.chat.model.ChatResponse response, String requestedModel) {
-        return firstNonBlank(response.getMetadata().getModel(), requestedModel, configuredModel);
+        org.springframework.ai.chat.metadata.ChatResponseMetadata responseMetadata = response.getMetadata();
+        return firstNonBlank(responseMetadata == null ? null : responseMetadata.getModel(), requestedModel, configuredModel);
     }
 
     private Map<String, Integer> toTokenUsageMap(Usage usage) {

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/adapter/SpringAiChatAdapter.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/adapter/SpringAiChatAdapter.java
@@ -1,8 +1,14 @@
 package studio.one.platform.ai.autoconfigure.adapter;
 
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
@@ -17,6 +23,9 @@ import studio.one.platform.ai.core.chat.ChatMessageRole;
 import studio.one.platform.ai.core.chat.ChatPort;
 import studio.one.platform.ai.core.chat.ChatRequest;
 import studio.one.platform.ai.core.chat.ChatResponse;
+import studio.one.platform.ai.core.chat.ChatResponseMetadata;
+import studio.one.platform.ai.core.chat.ChatStreamEvent;
+import studio.one.platform.ai.core.chat.TokenUsage;
 
 /**
  * Spring AI based {@link ChatPort} adapter used for migration spike validation.
@@ -25,8 +34,18 @@ public class SpringAiChatAdapter implements ChatPort {
 
     private final ChatModel chatModel;
 
+    private final String provider;
+
+    private final String configuredModel;
+
     public SpringAiChatAdapter(ChatModel chatModel) {
+        this(chatModel, "", "");
+    }
+
+    public SpringAiChatAdapter(ChatModel chatModel, String provider, String configuredModel) {
         this.chatModel = chatModel;
+        this.provider = normalize(provider);
+        this.configuredModel = normalize(configuredModel);
     }
 
     @Override
@@ -36,8 +55,10 @@ public class SpringAiChatAdapter implements ChatPort {
                 .toList();
 
         org.springframework.ai.chat.prompt.ChatOptions options = createChatOptions(request);
+        long startedAt = System.nanoTime();
         org.springframework.ai.chat.model.ChatResponse response = chatModel.call(
                 options == null ? new Prompt(messages) : new Prompt(messages, options));
+        long latencyMs = elapsedMillis(startedAt);
         if (response == null || response.getResult() == null || response.getResult().getOutput() == null) {
             throw new IllegalStateException("Chat model returned an empty response");
         }
@@ -46,22 +67,34 @@ public class SpringAiChatAdapter implements ChatPort {
             throw new IllegalStateException("Chat model returned an empty response");
         }
 
-        Map<String, Object> metadata = new LinkedHashMap<>();
-        metadata.put("responseId", response.getMetadata().getId());
-        metadata.put("modelName", response.getMetadata().getModel());
+        Map<String, Object> metadata = metadata(response, latencyMs, request.model());
         if (response.getResult().getMetadata() != null && response.getResult().getMetadata().getFinishReason() != null) {
             metadata.put("finishReason", response.getResult().getMetadata().getFinishReason());
         }
-        if (response.getMetadata().getUsage() != null) {
-            metadata.put("tokenUsage", toTokenUsageMap(response.getMetadata().getUsage()));
-        }
-        metadata.put("chatResponseMetadata", response.getMetadata());
         metadata.put("generationMetadata", response.getResult().getMetadata());
 
         return new ChatResponse(
                 List.of(ChatMessage.assistant(assistant.getText())),
-                response.getMetadata().getModel() != null ? response.getMetadata().getModel() : request.model(),
+                resolvedModel(response, request.model()),
                 metadata);
+    }
+
+    @Override
+    public Stream<ChatStreamEvent> stream(ChatRequest request) {
+        List<Message> messages = request.messages().stream()
+                .map(this::toSpringAiMessage)
+                .toList();
+        org.springframework.ai.chat.prompt.ChatOptions options = createChatOptions(request);
+        Prompt prompt = options == null ? new Prompt(messages) : new Prompt(messages, options);
+        long startedAt = System.nanoTime();
+        try {
+            Iterator<org.springframework.ai.chat.model.ChatResponse> source =
+                    chatModel.stream(prompt).toIterable().iterator();
+            Iterator<ChatStreamEvent> events = new SpringAiStreamIterator(source, request, startedAt);
+            return StreamSupport.stream(Spliterators.spliteratorUnknownSize(events, 0), false);
+        } catch (UnsupportedOperationException | IllegalStateException e) {
+            return ChatPort.super.stream(request);
+        }
     }
 
     private Message toSpringAiMessage(ChatMessage message) {
@@ -76,11 +109,135 @@ public class SpringAiChatAdapter implements ChatPort {
         return null;
     }
 
+    private ChatStreamEvent streamEvent(
+            org.springframework.ai.chat.model.ChatResponse response,
+            String requestedModel,
+            long startedAt) {
+        if (response == null || response.getResult() == null || response.getResult().getOutput() == null) {
+            return ChatStreamEvent.delta("", requestedModel, ChatResponseMetadata.empty());
+        }
+        AssistantMessage assistant = response.getResult().getOutput();
+        String text = assistant.getText() == null ? "" : assistant.getText();
+        long latencyMs = elapsedMillis(startedAt);
+        return ChatStreamEvent.delta(text, resolvedModel(response, requestedModel),
+                ChatResponseMetadata.from(metadata(response, latencyMs, requestedModel)));
+    }
+
+    private Map<String, Object> metadata(
+            org.springframework.ai.chat.model.ChatResponse response,
+            long latencyMs,
+            String requestedModel) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("responseId", response.getMetadata().getId());
+        metadata.put("modelName", response.getMetadata().getModel());
+        metadata.put(ChatResponseMetadata.KEY_PROVIDER, provider);
+        metadata.put(ChatResponseMetadata.KEY_RESOLVED_MODEL, resolvedModel(response, requestedModel));
+        metadata.put(ChatResponseMetadata.KEY_LATENCY_MS, latencyMs);
+        if (response.getMetadata().getUsage() != null) {
+            metadata.put(ChatResponseMetadata.KEY_TOKEN_USAGE, toTokenUsageMap(response.getMetadata().getUsage()));
+        }
+        metadata.put("chatResponseMetadata", response.getMetadata());
+        return metadata;
+    }
+
+    private String resolvedModel(org.springframework.ai.chat.model.ChatResponse response, String requestedModel) {
+        return firstNonBlank(response.getMetadata().getModel(), requestedModel, configuredModel);
+    }
+
     private Map<String, Integer> toTokenUsageMap(Usage usage) {
         Map<String, Integer> values = new LinkedHashMap<>();
-        values.put("inputTokens", usage.getPromptTokens());
-        values.put("outputTokens", usage.getCompletionTokens());
-        values.put("totalTokens", usage.getTotalTokens());
+        values.put(TokenUsage.KEY_INPUT_TOKENS, usage.getPromptTokens());
+        values.put(TokenUsage.KEY_OUTPUT_TOKENS, usage.getCompletionTokens());
+        values.put(TokenUsage.KEY_TOTAL_TOKENS, usage.getTotalTokens());
         return values;
+    }
+
+    private long elapsedMillis(long startedAt) {
+        return Math.max(0L, (System.nanoTime() - startedAt) / 1_000_000L);
+    }
+
+    private String firstNonBlank(String... values) {
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return "";
+    }
+
+    private String normalize(String value) {
+        return Objects.toString(value, "").trim();
+    }
+
+    private Stream<ChatStreamEvent> fallbackStream(ChatRequest request) {
+        return ChatPort.super.stream(request);
+    }
+
+    private final class SpringAiStreamIterator implements Iterator<ChatStreamEvent> {
+
+        private final Iterator<org.springframework.ai.chat.model.ChatResponse> source;
+
+        private final ChatRequest request;
+
+        private final long startedAt;
+
+        private Iterator<ChatStreamEvent> fallback;
+
+        private ChatStreamEvent last;
+
+        private boolean sourceExhausted;
+
+        private int terminalIndex;
+
+        private SpringAiStreamIterator(
+                Iterator<org.springframework.ai.chat.model.ChatResponse> source,
+                ChatRequest request,
+                long startedAt) {
+            this.source = source;
+            this.request = request;
+            this.startedAt = startedAt;
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (fallback != null) {
+                return fallback.hasNext();
+            }
+            if (!sourceExhausted && source.hasNext()) {
+                return true;
+            }
+            sourceExhausted = true;
+            if (last == null) {
+                fallback = fallbackStream(request).iterator();
+                return fallback.hasNext();
+            }
+            return terminalIndex < 2;
+        }
+
+        @Override
+        public ChatStreamEvent next() {
+            if (fallback != null) {
+                return fallback.next();
+            }
+            if (!sourceExhausted && source.hasNext()) {
+                last = streamEvent(source.next(), request.model(), startedAt);
+                return last;
+            }
+            sourceExhausted = true;
+            if (last == null) {
+                fallback = fallbackStream(request).iterator();
+                return fallback.next();
+            }
+            if (terminalIndex == 0) {
+                terminalIndex++;
+                return ChatStreamEvent.usage(last.metadata());
+            }
+            if (terminalIndex == 1) {
+                terminalIndex++;
+                String model = last.model().isBlank() ? request.model() : last.model();
+                return ChatStreamEvent.complete(model, last.metadata());
+            }
+            throw new NoSuchElementException();
+        }
     }
 }

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/GoogleGenAiChatPortFactoryConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/GoogleGenAiChatPortFactoryConfiguration.java
@@ -56,7 +56,7 @@ public class GoogleGenAiChatPortFactoryConfiguration {
                             .genAiClient(client)
                             .defaultOptions(defaultOptions)
                             .build();
-            return new GoogleSpringAiChatAdapter(chatModel);
+            return new GoogleSpringAiChatAdapter(chatModel, provider.getType().name(), model);
         }
 
         private static String requireText(String value, String message) {

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/OpenAiPortFactoryConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/OpenAiPortFactoryConfiguration.java
@@ -47,7 +47,7 @@ public class OpenAiPortFactoryConfiguration {
                         "Spring AI ChatModel bean is required for OPENAI provider. " +
                         "Ensure spring-ai-starter-model-openai is on the classpath and spring.ai.openai.api-key is configured.");
             }
-            return new SpringAiChatAdapter(chatModel);
+            return new SpringAiChatAdapter(chatModel, provider.getType().name(), provider.getChat().getModel());
         }
     }
 

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/adapter/SpringAiChatAdapterTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/adapter/SpringAiChatAdapterTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -16,9 +17,13 @@ import org.springframework.ai.chat.metadata.DefaultUsage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
 
+import reactor.core.publisher.Flux;
 import studio.one.platform.ai.core.chat.ChatMessage;
 import studio.one.platform.ai.core.chat.ChatRequest;
+import studio.one.platform.ai.core.chat.ChatStreamEvent;
+import studio.one.platform.ai.core.chat.ChatStreamEventType;
 
 class SpringAiChatAdapterTest {
 
@@ -36,7 +41,7 @@ class SpringAiChatAdapterTest {
                                 .usage(new DefaultUsage(5, 7))
                                 .build()));
 
-        SpringAiChatAdapter adapter = new SpringAiChatAdapter(model);
+        SpringAiChatAdapter adapter = new SpringAiChatAdapter(model, "OPENAI", "configured-model");
 
         studio.one.platform.ai.core.chat.ChatResponse response = adapter.chat(ChatRequest.builder()
                 .messages(List.of(ChatMessage.user("hello")))
@@ -49,10 +54,15 @@ class SpringAiChatAdapterTest {
         assertThat(response.model()).isEqualTo("gpt-4.1-mini");
         assertThat(response.metadata()).containsEntry("responseId", "resp-1");
         assertThat(response.metadata()).containsEntry("modelName", "gpt-4.1-mini");
+        assertThat(response.metadata()).containsEntry(studio.one.platform.ai.core.chat.ChatResponseMetadata.KEY_PROVIDER, "OPENAI");
+        assertThat(response.metadata()).containsEntry(studio.one.platform.ai.core.chat.ChatResponseMetadata.KEY_RESOLVED_MODEL, "gpt-4.1-mini");
+        assertThat(response.metadata()).containsKey(studio.one.platform.ai.core.chat.ChatResponseMetadata.KEY_LATENCY_MS);
         assertThat(response.metadata()).containsEntry("finishReason", "stop");
         assertThat(response.metadata().get("tokenUsage"))
-                .isEqualTo(java.util.Map.of("inputTokens", 5, "outputTokens", 7, "totalTokens", 12));
+                .isEqualTo(Map.of("inputTokens", 5, "outputTokens", 7, "totalTokens", 12));
         assertThat(response.metadata()).containsKeys("chatResponseMetadata", "generationMetadata");
+        assertThat(response.typedMetadata().provider()).isEqualTo("OPENAI");
+        assertThat(response.typedMetadata().resolvedModel()).isEqualTo("gpt-4.1-mini");
     }
 
     @Test
@@ -68,5 +78,85 @@ class SpringAiChatAdapterTest {
                 .build()))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("empty response");
+    }
+
+    @Test
+    void mapsNativeSpringAiStreamIntoChatStreamEvents() {
+        ChatModel model = mock(ChatModel.class);
+        when(model.stream(any(Prompt.class)))
+                .thenReturn(Flux.just(
+                        new ChatResponse(
+                                List.of(new Generation(new AssistantMessage("hel"))),
+                                ChatResponseMetadata.builder()
+                                        .id("stream-1")
+                                        .model("gpt-stream")
+                                        .usage(new DefaultUsage(2, 1))
+                                        .build()),
+                        new ChatResponse(
+                                List.of(new Generation(new AssistantMessage("lo"))),
+                                ChatResponseMetadata.builder()
+                                        .id("stream-1")
+                                        .model("gpt-stream")
+                                        .usage(new DefaultUsage(2, 2))
+                                        .build())));
+        SpringAiChatAdapter adapter = new SpringAiChatAdapter(model, "OPENAI", "configured-model");
+
+        List<ChatStreamEvent> events = adapter.stream(ChatRequest.builder()
+                .messages(List.of(ChatMessage.user("hello")))
+                .model("requested-model")
+                .build()).toList();
+
+        assertThat(events).extracting(ChatStreamEvent::type)
+                .containsExactly(
+                        ChatStreamEventType.DELTA,
+                        ChatStreamEventType.DELTA,
+                        ChatStreamEventType.USAGE,
+                        ChatStreamEventType.COMPLETE);
+        assertThat(events).extracting(ChatStreamEvent::delta)
+                .containsExactly("hel", "lo", "", "");
+        assertThat(events.get(0).metadata().provider()).isEqualTo("OPENAI");
+        assertThat(events.get(3).model()).isEqualTo("gpt-stream");
+    }
+
+    @Test
+    void fallsBackToChatWhenNativeStreamIsUnsupported() {
+        ChatModel model = mock(ChatModel.class);
+        when(model.stream(any(Prompt.class))).thenThrow(new UnsupportedOperationException("no stream"));
+        when(model.call(any(Prompt.class)))
+                .thenReturn(new ChatResponse(
+                        List.of(new Generation(new AssistantMessage("fallback"))),
+                        ChatResponseMetadata.builder()
+                                .model("fallback-model")
+                                .build()));
+        SpringAiChatAdapter adapter = new SpringAiChatAdapter(model, "OPENAI", "configured-model");
+
+        List<ChatStreamEvent> events = adapter.stream(ChatRequest.builder()
+                .messages(List.of(ChatMessage.user("hello")))
+                .build()).toList();
+
+        assertThat(events).extracting(ChatStreamEvent::type)
+                .containsExactly(ChatStreamEventType.DELTA, ChatStreamEventType.USAGE, ChatStreamEventType.COMPLETE);
+        assertThat(events.get(0).delta()).isEqualTo("fallback");
+    }
+
+    @Test
+    void fallsBackToChatWhenNativeStreamIsEmpty() {
+        ChatModel model = mock(ChatModel.class);
+        when(model.stream(any(Prompt.class))).thenReturn(Flux.empty());
+        when(model.call(any(Prompt.class)))
+                .thenReturn(new ChatResponse(
+                        List.of(new Generation(new AssistantMessage("fallback"))),
+                        ChatResponseMetadata.builder()
+                                .model("fallback-model")
+                                .build()));
+        SpringAiChatAdapter adapter = new SpringAiChatAdapter(model, "OPENAI", "configured-model");
+
+        List<ChatStreamEvent> events = adapter.stream(ChatRequest.builder()
+                .messages(List.of(ChatMessage.user("hello")))
+                .build()).toList();
+
+        assertThat(events).extracting(ChatStreamEvent::type)
+                .containsExactly(ChatStreamEventType.DELTA, ChatStreamEventType.USAGE, ChatStreamEventType.COMPLETE);
+        assertThat(events.get(0).delta()).isEqualTo("fallback");
     }
 }

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/adapter/SpringAiChatAdapterTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/adapter/SpringAiChatAdapterTest.java
@@ -81,6 +81,25 @@ class SpringAiChatAdapterTest {
     }
 
     @Test
+    void handlesMissingSpringMetadataAndFallsBackToConfiguredModel() {
+        ChatModel model = mock(ChatModel.class);
+        when(model.call(any(org.springframework.ai.chat.prompt.Prompt.class)))
+                .thenReturn(new ChatResponse(
+                        List.of(new Generation(new AssistantMessage("hello"))),
+                        null));
+        SpringAiChatAdapter adapter = new SpringAiChatAdapter(model, "OPENAI", "configured-model");
+
+        studio.one.platform.ai.core.chat.ChatResponse response = adapter.chat(ChatRequest.builder()
+                .messages(List.of(ChatMessage.user("hello")))
+                .build());
+
+        assertThat(response.model()).isEqualTo("configured-model");
+        assertThat(response.metadata()).doesNotContainKeys("responseId", "modelName", "chatResponseMetadata");
+        assertThat(response.typedMetadata().provider()).isEqualTo("OPENAI");
+        assertThat(response.typedMetadata().resolvedModel()).isEqualTo("configured-model");
+    }
+
+    @Test
     void mapsNativeSpringAiStreamIntoChatStreamEvents() {
         ChatModel model = mock(ChatModel.class);
         when(model.stream(any(Prompt.class)))
@@ -158,5 +177,17 @@ class SpringAiChatAdapterTest {
         assertThat(events).extracting(ChatStreamEvent::type)
                 .containsExactly(ChatStreamEventType.DELTA, ChatStreamEventType.USAGE, ChatStreamEventType.COMPLETE);
         assertThat(events.get(0).delta()).isEqualTo("fallback");
+    }
+
+    @Test
+    void propagatesNativeStreamRuntimeFailures() {
+        ChatModel model = mock(ChatModel.class);
+        when(model.stream(any(Prompt.class))).thenReturn(Flux.error(new IllegalStateException("provider broken")));
+        SpringAiChatAdapter adapter = new SpringAiChatAdapter(model, "OPENAI", "configured-model");
+
+        assertThatThrownBy(() -> adapter.stream(ChatRequest.builder()
+                .messages(List.of(ChatMessage.user("hello")))
+                .build()).toList())
+                .hasMessageContaining("provider broken");
     }
 }


### PR DESCRIPTION
## Why

- starter-ai가 Spring AI 응답 metadata를 provider-neutral typed metadata로 노출해야 한다.
- web 계층의 SSE 구현 전에 starter adapter에서 native stream과 fallback event sequence 기반을 제공해야 한다.

## What

- SpringAiChatAdapter에 provider, resolvedModel, latencyMs 표준 metadata를 추가하고 기존 responseId/modelName/finishReason/tokenUsage key를 유지했다.
- native Spring AI ChatModel.stream(Prompt)를 ChatStreamEvent sequence로 변환하고, unsupported 또는 empty stream은 기존 chat() 기반 fallback으로 변환했다.
- OpenAI/Google provider factory에서 provider type과 configured model을 adapter에 전달하도록 갱신했다.
- starter README에 metadata/streaming 책임 경계와 key contract를 문서화했다.
- adapter 테스트에 metadata, native stream, unsupported fallback, empty fallback 경로를 추가했다.

## Related Issues

- Closes #259

## Validation

- Command: ./gradlew :studio-platform-ai:test :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test && git diff --check
- Result: PASS

## Risk / Rollback

- Risk: native stream 소비 중 provider runtime error가 발생하면 Java Stream 소비 시점에 전파될 수 있다. unsupported/empty stream은 fallback 처리된다.
- Rollback: 이 PR revert 시 기존 chat() 기반 adapter 동작으로 복귀한다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope:
- Main author validation: 관련 core/starter/starter-web test 및 diff whitespace check 수행

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] AI-Assisted value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included