### PR TITLE
[ai] chat web conversation API 확장

### DIFF
--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -64,7 +64,16 @@ studio:
 | 메서드 | 경로 | 설명 | 권한 |
 |---|---|---|---|
 | `POST` | `{basePath}/chat` | 채팅 완성 요청 | `services:ai_chat write` |
+| `POST` | `{basePath}/chat/stream` | SSE 채팅 스트림 | `services:ai_chat write` |
 | `POST` | `{basePath}/chat/rag` | RAG 컨텍스트 주입 후 채팅 | `services:ai_chat write` |
+| `GET` | `{basePath}/chat/conversations` | conversation 목록 조회 | `services:ai_chat read` |
+| `GET` | `{basePath}/chat/conversations/{conversationId}` | conversation 상세 및 메시지 조회 | `services:ai_chat read` |
+| `DELETE` | `{basePath}/chat/conversations/{conversationId}` | conversation 삭제 | `services:ai_chat write` |
+| `POST` | `{basePath}/chat/regenerate` | 마지막 user turn 기준 assistant 응답 재생성 | `services:ai_chat write` |
+| `POST` | `{basePath}/chat/truncate` | 특정 메시지 이후 conversation 절단 | `services:ai_chat write` |
+| `POST` | `{basePath}/chat/fork` | 특정 메시지까지 새 conversation으로 fork | `services:ai_chat write` |
+| `POST` | `{basePath}/chat/compact` | conversation summary 저장 및 compact 상태 표시 | `services:ai_chat write` |
+| `POST` | `{basePath}/chat/cancel` | conversation cancel 상태 표시 | `services:ai_chat write` |
 | `POST` | `{basePath}/query-rewrite` | 검색 쿼리 리라이트 | `services:ai_chat read` |
 | `GET`  | `{basePath}/info/providers` | 프로바이더 및 벡터 스토어 상태 조회 | `services:ai_chat read` 또는 `services:ai_embedding read` |
 | `POST` | `{mgmtBasePath}/embedding` | 텍스트 임베딩 벡터 생성 | `services:ai_embedding write` |
@@ -141,8 +150,66 @@ Content-Type: application/json
 | `studio.ai.endpoints.chat.memory.ttl` | `30m` | 마지막 접근 이후 conversation 보관 시간 |
 
 이 memory는 단일 앱 인스턴스의 in-memory cache다. 애플리케이션 재시작 시 사라지며, 다중 인스턴스 간 공유되지 않는다.
-운영에서 여러 인스턴스 간 대화 memory가 필요하면 `ChatMemoryStore`를 외부 저장소 기반 구현으로 교체한다.
-장기 보관, 감사 로그, conversation 목록 조회, 삭제 API 용도로 사용하지 않는다.
+운영에서 여러 인스턴스 간 대화 memory가 필요하면 `ChatMemoryStore`와 `ConversationRepositoryPort`를 외부 저장소 기반 구현으로 교체한다.
+
+memory가 활성화된 `/chat`, `/chat/rag`, `/chat/stream` 요청은 conversation repository에도 기록된다.
+기본 구현은 단일 인스턴스용 `InMemoryConversationRepository`이며, conversation 목록/상세/삭제/regenerate/fork/truncate/compact/cancel API의 개발 및 smoke 용도다.
+장기 보관, 감사 로그, 다중 인스턴스 공유가 필요하면 운영 저장소 구현을 별도 Bean으로 등록한다.
+
+### Streaming Chat 예시
+
+```http
+POST /api/ai/chat/stream
+Authorization: Bearer <token>
+Content-Type: application/json
+Accept: text/event-stream
+
+{
+  "provider": "openai",
+  "messages": [
+    {"role": "user", "content": "짧게 설명해줘"}
+  ],
+  "memory": {
+    "enabled": true,
+    "conversationId": "chat-123"
+  }
+}
+```
+
+SSE event type은 `delta`, `usage`, `complete`, `error`이다. 각 event data에는 `requestId`가 포함되어 stream lifecycle을 추적할 수 있다.
+Spring MVC의 `StreamingResponseBody`를 사용하므로 WebFlux/Netty event-loop에서 직접 소비하지 않는다.
+
+### Conversation API 예시
+
+```http
+GET /api/ai/chat/conversations?offset=0&limit=20
+Authorization: Bearer <token>
+```
+
+목록 항목에는 `conversationId`, `title`, `summary`, `messageCount`, `lastUpdatedAt`, `status`가 포함된다.
+상세 API는 동일 conversation의 active message 목록을 함께 반환한다.
+
+```http
+POST /api/ai/chat/regenerate
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "conversationId": "chat-123"
+}
+```
+
+`regenerate`는 마지막 user turn까지의 메시지로 provider를 다시 호출하고 마지막 assistant 응답을 대체한다.
+`truncate`, `fork`, `compact`, `cancel`은 다음 공통 request shape를 사용한다.
+
+```json
+{
+  "conversationId": "chat-123",
+  "messageId": "message-id-for-truncate-or-fork",
+  "newConversationId": "chat-copy",
+  "summary": "압축 요약"
+}
+```
 
 ### RAG Chat 예시
 

--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -200,13 +200,21 @@ Content-Type: application/json
 ```
 
 `regenerate`는 마지막 user turn까지의 메시지로 provider를 다시 호출하고 마지막 assistant 응답을 대체한다.
-`truncate`, `fork`, `compact`, `cancel`은 다음 공통 request shape를 사용한다.
+`truncate`와 `fork`는 `messageId`가 필수다.
 
 ```json
 {
   "conversationId": "chat-123",
   "messageId": "message-id-for-truncate-or-fork",
-  "newConversationId": "chat-copy",
+  "newConversationId": "chat-copy"
+}
+```
+
+`compact`는 `summary`가 필수이며, `cancel`은 `conversationId`만 사용한다.
+
+```json
+{
+  "conversationId": "chat-123",
   "summary": "압축 요약"
 }
 ```

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
@@ -13,6 +13,7 @@ import org.springframework.lang.Nullable;
 import studio.one.platform.ai.autoconfigure.config.AiAdapterProperties;
 import studio.one.platform.ai.core.chat.ChatMemoryStore;
 import studio.one.platform.ai.core.chat.ChatPort;
+import studio.one.platform.ai.core.chat.ConversationRepositoryPort;
 import studio.one.platform.ai.core.embedding.EmbeddingPort;
 import studio.one.platform.ai.core.registry.AiProviderRegistry;
 import studio.one.platform.ai.core.vector.VectorStorePort;
@@ -26,6 +27,8 @@ import studio.one.platform.ai.web.controller.QueryRewriteController;
 import studio.one.platform.ai.web.controller.RagController;
 import studio.one.platform.ai.web.controller.RagContextBuilder;
 import studio.one.platform.ai.web.controller.VectorController;
+import studio.one.platform.ai.web.service.ConversationChatService;
+import studio.one.platform.ai.web.service.InMemoryConversationRepository;
 import studio.one.platform.ai.web.service.InMemoryChatMemoryStore;
 import studio.one.platform.constant.PropertyKeys;
 
@@ -48,17 +51,30 @@ public class AiWebAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean(ConversationRepositoryPort.class)
+    ConversationRepositoryPort conversationRepositoryPort() {
+        return new InMemoryConversationRepository();
+    }
+
+    @Bean
+    ConversationChatService conversationChatService(ConversationRepositoryPort repositoryPort) {
+        return new ConversationChatService(repositoryPort);
+    }
+
+    @Bean
     ChatController chatController(
             AiProviderRegistry providerRegistry,
             RagPipelineService ragPipelineService,
             RagContextBuilder ragContextBuilder,
             AiWebRagProperties ragProperties,
             AiWebChatProperties chatProperties,
-            @Nullable ChatMemoryStore chatMemoryStore) {
+            @Nullable ChatMemoryStore chatMemoryStore,
+            ConversationChatService conversationChatService) {
         return new ChatController(providerRegistry, ragPipelineService, ragContextBuilder,
                 ragProperties.getDiagnostics().isAllowClientDebug(),
                 chatMemoryStore,
-                chatProperties.getMemory().isEnabled());
+                chatProperties.getMemory().isEnabled(),
+                conversationChatService);
     }
 
     @Bean

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
@@ -1,5 +1,7 @@
 package studio.one.platform.ai.autoconfigure;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -8,6 +10,7 @@ import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.lang.Nullable;
 
 import studio.one.platform.ai.autoconfigure.config.AiAdapterProperties;
@@ -62,6 +65,12 @@ public class AiWebAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean(ObjectMapper.class)
+    ObjectMapper aiWebObjectMapper() {
+        return Jackson2ObjectMapperBuilder.json().build();
+    }
+
+    @Bean
     ChatController chatController(
             AiProviderRegistry providerRegistry,
             RagPipelineService ragPipelineService,
@@ -69,12 +78,14 @@ public class AiWebAutoConfiguration {
             AiWebRagProperties ragProperties,
             AiWebChatProperties chatProperties,
             @Nullable ChatMemoryStore chatMemoryStore,
-            ConversationChatService conversationChatService) {
+            ConversationChatService conversationChatService,
+            ObjectMapper objectMapper) {
         return new ChatController(providerRegistry, ragPipelineService, ragContextBuilder,
                 ragProperties.getDiagnostics().isAllowClientDebug(),
                 chatMemoryStore,
                 chatProperties.getMemory().isEnabled(),
-                conversationChatService);
+                conversationChatService,
+                objectMapper);
     }
 
     @Bean

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
@@ -41,6 +41,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -75,6 +76,7 @@ import studio.one.platform.ai.web.dto.ChatRequestDto;
 import studio.one.platform.ai.web.dto.ChatResponseDto;
 import studio.one.platform.ai.web.dto.ConversationActionRequestDto;
 import studio.one.platform.ai.web.dto.ConversationDetailDto;
+import studio.one.platform.ai.web.dto.ConversationMessageActionRequestDto;
 import studio.one.platform.ai.web.dto.ConversationSummaryDto;
 import studio.one.platform.ai.web.service.ConversationChatService;
 import studio.one.platform.constant.PropertyKeys;
@@ -101,7 +103,7 @@ public class ChatController {
     private final ChatMemoryStore chatMemoryStore;
     private final boolean chatMemoryEnabled;
     private final ConversationChatService conversationChatService;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper;
 
     public ChatController(AiProviderRegistry providerRegistry, RagPipelineService ragPipelineService) {
         this(providerRegistry, ragPipelineService, RagContextBuilder.defaults());
@@ -141,6 +143,20 @@ public class ChatController {
             ChatMemoryStore chatMemoryStore,
             boolean chatMemoryEnabled,
             ConversationChatService conversationChatService) {
+        this(providerRegistry, ragPipelineService, ragContextBuilder, allowClientDebug,
+                chatMemoryStore, chatMemoryEnabled, conversationChatService,
+                Jackson2ObjectMapperBuilder.json().build());
+    }
+
+    public ChatController(
+            AiProviderRegistry providerRegistry,
+            RagPipelineService ragPipelineService,
+            RagContextBuilder ragContextBuilder,
+            boolean allowClientDebug,
+            ChatMemoryStore chatMemoryStore,
+            boolean chatMemoryEnabled,
+            ConversationChatService conversationChatService,
+            ObjectMapper objectMapper) {
         this.providerRegistry = Objects.requireNonNull(providerRegistry, "providerRegistry");
         this.ragPipelineService = Objects.requireNonNull(ragPipelineService, "ragPipelineService");
         this.ragContextBuilder = Objects.requireNonNull(ragContextBuilder, "ragContextBuilder");
@@ -148,6 +164,7 @@ public class ChatController {
         this.chatMemoryStore = chatMemoryStore;
         this.chatMemoryEnabled = chatMemoryEnabled;
         this.conversationChatService = conversationChatService;
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
     }
 
     /**
@@ -310,8 +327,8 @@ public class ChatController {
             @RequestParam(defaultValue = "0") int offset,
             @RequestParam(defaultValue = "20") int limit,
             Principal principal) {
-        return ResponseEntity.ok(ApiResponse.ok(
-                conversationService().list(conversationService().ownerId(principal), offset, limit)));
+        String ownerId = conversationChatService.ownerId(principal);
+        return ResponseEntity.ok(ApiResponse.ok(conversationChatService.list(ownerId, offset, limit)));
     }
 
     @GetMapping("/conversations/{conversationId}")
@@ -320,7 +337,7 @@ public class ChatController {
             @PathVariable String conversationId,
             Principal principal) {
         return ResponseEntity.ok(ApiResponse.ok(
-                conversationService().detail(conversationService().ownerId(principal), conversationId)));
+                conversationChatService.detail(conversationChatService.ownerId(principal), conversationId)));
     }
 
     @DeleteMapping("/conversations/{conversationId}")
@@ -328,7 +345,7 @@ public class ChatController {
     public ResponseEntity<ApiResponse<Map<String, Object>>> deleteConversation(
             @PathVariable String conversationId,
             Principal principal) {
-        boolean deleted = conversationService().delete(conversationService().ownerId(principal), conversationId);
+        boolean deleted = conversationChatService.delete(conversationChatService.ownerId(principal), conversationId);
         return ResponseEntity.ok(ApiResponse.ok(Map.of("conversationId", conversationId, "deleted", deleted)));
     }
 
@@ -337,15 +354,15 @@ public class ChatController {
     public ResponseEntity<ApiResponse<ChatResponseDto>> regenerate(
             @Valid @RequestBody ConversationActionRequestDto request,
             Principal principal) {
-        String ownerId = conversationService().ownerId(principal);
-        List<ChatMessage> messages = conversationService().messagesForRegenerate(ownerId, request.conversationId()).stream()
+        String ownerId = conversationChatService.ownerId(principal);
+        List<ChatMessage> messages = conversationChatService.messagesForRegenerate(ownerId, request.conversationId()).stream()
                 .map(studio.one.platform.ai.core.chat.ChatConversationMessage::message)
                 .toList();
         ChatRequestDto chat = request.chat();
         String provider = chat == null ? null : chat.provider();
         ChatRequest domainRequest = toDomainChatRequest(chat == null ? minimalChatRequest(messages) : chat, messages);
         ChatResponse response = chatPort(provider).chat(domainRequest);
-        int messageCount = conversationService().replaceLastAssistantResponse(ownerId, request.conversationId(), response);
+        int messageCount = conversationChatService.replaceLastAssistantResponse(ownerId, request.conversationId(), response);
         return ResponseEntity.ok(ApiResponse.ok(toDto(response, null, false,
                 conversationMetadata(request.conversationId(), messageCount))));
     }
@@ -353,10 +370,10 @@ public class ChatController {
     @PostMapping("/truncate")
     @PreAuthorize("@endpointAuthz.can('services:ai_chat','write')")
     public ResponseEntity<ApiResponse<ConversationDetailDto>> truncate(
-            @Valid @RequestBody ConversationActionRequestDto request,
+            @Valid @RequestBody ConversationMessageActionRequestDto request,
             Principal principal) {
-        return ResponseEntity.ok(ApiResponse.ok(conversationService().truncate(
-                conversationService().ownerId(principal),
+        return ResponseEntity.ok(ApiResponse.ok(conversationChatService.truncate(
+                conversationChatService.ownerId(principal),
                 request.conversationId(),
                 request.messageId())));
     }
@@ -364,10 +381,10 @@ public class ChatController {
     @PostMapping("/fork")
     @PreAuthorize("@endpointAuthz.can('services:ai_chat','write')")
     public ResponseEntity<ApiResponse<ConversationDetailDto>> fork(
-            @Valid @RequestBody ConversationActionRequestDto request,
+            @Valid @RequestBody ConversationMessageActionRequestDto request,
             Principal principal) {
-        return ResponseEntity.ok(ApiResponse.ok(conversationService().fork(
-                conversationService().ownerId(principal),
+        return ResponseEntity.ok(ApiResponse.ok(conversationChatService.fork(
+                conversationChatService.ownerId(principal),
                 request.conversationId(),
                 request.messageId(),
                 request.newConversationId())));
@@ -378,8 +395,8 @@ public class ChatController {
     public ResponseEntity<ApiResponse<ConversationDetailDto>> compact(
             @Valid @RequestBody ConversationActionRequestDto request,
             Principal principal) {
-        return ResponseEntity.ok(ApiResponse.ok(conversationService().compact(
-                conversationService().ownerId(principal),
+        return ResponseEntity.ok(ApiResponse.ok(conversationChatService.compact(
+                conversationChatService.ownerId(principal),
                 request.conversationId(),
                 request.summary())));
     }
@@ -389,8 +406,8 @@ public class ChatController {
     public ResponseEntity<ApiResponse<ConversationDetailDto>> cancel(
             @Valid @RequestBody ConversationActionRequestDto request,
             Principal principal) {
-        return ResponseEntity.ok(ApiResponse.ok(conversationService().cancel(
-                conversationService().ownerId(principal),
+        return ResponseEntity.ok(ApiResponse.ok(conversationChatService.cancel(
+                conversationChatService.ownerId(principal),
                 request.conversationId())));
     }
 
@@ -599,14 +616,6 @@ public class ChatController {
                 memory.conversationId(),
                 requestMessages,
                 response);
-    }
-
-    private ConversationChatService conversationService() {
-        if (conversationChatService == null) {
-            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
-                    "Conversation service is not configured");
-        }
-        return conversationChatService;
     }
 
     private void writeStreamEvents(

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
@@ -23,23 +23,36 @@ package studio.one.platform.ai.web.controller;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.security.Principal;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 import jakarta.validation.Valid;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 import studio.one.platform.ai.core.chat.ChatMessage;
 import studio.one.platform.ai.core.chat.ChatMemoryStore;
@@ -47,6 +60,9 @@ import studio.one.platform.ai.core.chat.ChatMessageRole;
 import studio.one.platform.ai.core.chat.ChatPort;
 import studio.one.platform.ai.core.chat.ChatRequest;
 import studio.one.platform.ai.core.chat.ChatResponse;
+import studio.one.platform.ai.core.chat.ChatResponseMetadata;
+import studio.one.platform.ai.core.chat.ChatStreamEvent;
+import studio.one.platform.ai.core.chat.ChatStreamEventType;
 import studio.one.platform.ai.core.registry.AiProviderRegistry;
 import studio.one.platform.ai.core.rag.RagRetrievalDiagnostics;
 import studio.one.platform.ai.core.rag.RagSearchRequest;
@@ -57,6 +73,10 @@ import studio.one.platform.ai.web.dto.ChatMessageDto;
 import studio.one.platform.ai.web.dto.ChatRagRequestDto;
 import studio.one.platform.ai.web.dto.ChatRequestDto;
 import studio.one.platform.ai.web.dto.ChatResponseDto;
+import studio.one.platform.ai.web.dto.ConversationActionRequestDto;
+import studio.one.platform.ai.web.dto.ConversationDetailDto;
+import studio.one.platform.ai.web.dto.ConversationSummaryDto;
+import studio.one.platform.ai.web.service.ConversationChatService;
 import studio.one.platform.constant.PropertyKeys;
 import studio.one.platform.web.dto.ApiResponse;
 
@@ -80,6 +100,8 @@ public class ChatController {
     private final boolean allowClientDebug;
     private final ChatMemoryStore chatMemoryStore;
     private final boolean chatMemoryEnabled;
+    private final ConversationChatService conversationChatService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     public ChatController(AiProviderRegistry providerRegistry, RagPipelineService ragPipelineService) {
         this(providerRegistry, ragPipelineService, RagContextBuilder.defaults());
@@ -107,12 +129,25 @@ public class ChatController {
             boolean allowClientDebug,
             ChatMemoryStore chatMemoryStore,
             boolean chatMemoryEnabled) {
+        this(providerRegistry, ragPipelineService, ragContextBuilder, allowClientDebug,
+                chatMemoryStore, chatMemoryEnabled, null);
+    }
+
+    public ChatController(
+            AiProviderRegistry providerRegistry,
+            RagPipelineService ragPipelineService,
+            RagContextBuilder ragContextBuilder,
+            boolean allowClientDebug,
+            ChatMemoryStore chatMemoryStore,
+            boolean chatMemoryEnabled,
+            ConversationChatService conversationChatService) {
         this.providerRegistry = Objects.requireNonNull(providerRegistry, "providerRegistry");
         this.ragPipelineService = Objects.requireNonNull(ragPipelineService, "ragPipelineService");
         this.ragContextBuilder = Objects.requireNonNull(ragContextBuilder, "ragContextBuilder");
         this.allowClientDebug = allowClientDebug;
         this.chatMemoryStore = chatMemoryStore;
         this.chatMemoryEnabled = chatMemoryEnabled;
+        this.conversationChatService = conversationChatService;
     }
 
     /**
@@ -160,9 +195,34 @@ public class ChatController {
 
     private ResponseEntity<ApiResponse<ChatResponseDto>> chatInternal(ChatRequestDto request, Principal principal) {
         ChatMemoryContext memory = resolveMemory(request, principal);
-        ChatResponse response = chatPort(request.provider()).chat(toDomainChatRequest(request, toDomainMessages(request, memory.history())));
+        List<ChatMessage> domainMessages = toDomainMessages(request, memory.history());
+        ChatResponse response = chatPort(request.provider()).chat(toDomainChatRequest(request, domainMessages));
         int memoryMessageCount = appendMemory(memory, request.messages(), response);
+        appendConversation(principal, memory, request.messages().stream().map(this::toDomainMessage).toList(), response);
         return ResponseEntity.ok(ApiResponse.ok(toDto(response, null, false, memoryMetadata(memory, memoryMessageCount))));
+    }
+
+    @PostMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @PreAuthorize("@endpointAuthz.can('services:ai_chat','write')")
+    public ResponseEntity<StreamingResponseBody> stream(
+            @Valid @RequestBody ChatRequestDto request,
+            Principal principal) {
+        ChatMemoryContext memory = resolveMemory(request, principal);
+        List<ChatMessage> domainMessages = toDomainMessages(request, memory.history());
+        ChatPort port = chatPort(request.provider());
+        ChatRequest domainRequest = toDomainChatRequest(request, domainMessages);
+        String requestId = UUID.randomUUID().toString();
+        StreamingResponseBody body = outputStream -> writeStreamEvents(
+                outputStream,
+                requestId,
+                port,
+                domainRequest,
+                memory,
+                request.messages().stream().map(this::toDomainMessage).toList(),
+                principal);
+        return ResponseEntity.ok()
+                .contentType(MediaType.TEXT_EVENT_STREAM)
+                .body(body);
     }
 
     /**
@@ -236,6 +296,7 @@ public class ChatController {
 
         ChatResponse response = chatPort(chat.provider()).chat(toDomainChatRequest(augmented));
         int memoryMessageCount = appendMemory(memory, chat.messages(), response);
+        appendConversation(principal, memory, chat.messages().stream().map(this::toDomainMessage).toList(), response);
         return ResponseEntity.ok(ApiResponse.ok(toDto(
                 response,
                 diagnostics,
@@ -243,8 +304,111 @@ public class ChatController {
                 memoryMetadata(memory, memoryMessageCount))));
     }
 
+    @GetMapping("/conversations")
+    @PreAuthorize("@endpointAuthz.can('services:ai_chat','read')")
+    public ResponseEntity<ApiResponse<List<ConversationSummaryDto>>> conversations(
+            @RequestParam(defaultValue = "0") int offset,
+            @RequestParam(defaultValue = "20") int limit,
+            Principal principal) {
+        return ResponseEntity.ok(ApiResponse.ok(
+                conversationService().list(conversationService().ownerId(principal), offset, limit)));
+    }
+
+    @GetMapping("/conversations/{conversationId}")
+    @PreAuthorize("@endpointAuthz.can('services:ai_chat','read')")
+    public ResponseEntity<ApiResponse<ConversationDetailDto>> conversation(
+            @PathVariable String conversationId,
+            Principal principal) {
+        return ResponseEntity.ok(ApiResponse.ok(
+                conversationService().detail(conversationService().ownerId(principal), conversationId)));
+    }
+
+    @DeleteMapping("/conversations/{conversationId}")
+    @PreAuthorize("@endpointAuthz.can('services:ai_chat','write')")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> deleteConversation(
+            @PathVariable String conversationId,
+            Principal principal) {
+        boolean deleted = conversationService().delete(conversationService().ownerId(principal), conversationId);
+        return ResponseEntity.ok(ApiResponse.ok(Map.of("conversationId", conversationId, "deleted", deleted)));
+    }
+
+    @PostMapping("/regenerate")
+    @PreAuthorize("@endpointAuthz.can('services:ai_chat','write')")
+    public ResponseEntity<ApiResponse<ChatResponseDto>> regenerate(
+            @Valid @RequestBody ConversationActionRequestDto request,
+            Principal principal) {
+        String ownerId = conversationService().ownerId(principal);
+        List<ChatMessage> messages = conversationService().messagesForRegenerate(ownerId, request.conversationId()).stream()
+                .map(studio.one.platform.ai.core.chat.ChatConversationMessage::message)
+                .toList();
+        ChatRequestDto chat = request.chat();
+        String provider = chat == null ? null : chat.provider();
+        ChatRequest domainRequest = toDomainChatRequest(chat == null ? minimalChatRequest(messages) : chat, messages);
+        ChatResponse response = chatPort(provider).chat(domainRequest);
+        int messageCount = conversationService().replaceLastAssistantResponse(ownerId, request.conversationId(), response);
+        return ResponseEntity.ok(ApiResponse.ok(toDto(response, null, false,
+                conversationMetadata(request.conversationId(), messageCount))));
+    }
+
+    @PostMapping("/truncate")
+    @PreAuthorize("@endpointAuthz.can('services:ai_chat','write')")
+    public ResponseEntity<ApiResponse<ConversationDetailDto>> truncate(
+            @Valid @RequestBody ConversationActionRequestDto request,
+            Principal principal) {
+        return ResponseEntity.ok(ApiResponse.ok(conversationService().truncate(
+                conversationService().ownerId(principal),
+                request.conversationId(),
+                request.messageId())));
+    }
+
+    @PostMapping("/fork")
+    @PreAuthorize("@endpointAuthz.can('services:ai_chat','write')")
+    public ResponseEntity<ApiResponse<ConversationDetailDto>> fork(
+            @Valid @RequestBody ConversationActionRequestDto request,
+            Principal principal) {
+        return ResponseEntity.ok(ApiResponse.ok(conversationService().fork(
+                conversationService().ownerId(principal),
+                request.conversationId(),
+                request.messageId(),
+                request.newConversationId())));
+    }
+
+    @PostMapping("/compact")
+    @PreAuthorize("@endpointAuthz.can('services:ai_chat','write')")
+    public ResponseEntity<ApiResponse<ConversationDetailDto>> compact(
+            @Valid @RequestBody ConversationActionRequestDto request,
+            Principal principal) {
+        return ResponseEntity.ok(ApiResponse.ok(conversationService().compact(
+                conversationService().ownerId(principal),
+                request.conversationId(),
+                request.summary())));
+    }
+
+    @PostMapping("/cancel")
+    @PreAuthorize("@endpointAuthz.can('services:ai_chat','write')")
+    public ResponseEntity<ApiResponse<ConversationDetailDto>> cancel(
+            @Valid @RequestBody ConversationActionRequestDto request,
+            Principal principal) {
+        return ResponseEntity.ok(ApiResponse.ok(conversationService().cancel(
+                conversationService().ownerId(principal),
+                request.conversationId())));
+    }
+
     private ChatRequest toDomainChatRequest(ChatRequestDto request) {
         return toDomainChatRequest(request, toDomainMessages(request));
+    }
+
+    private ChatRequestDto minimalChatRequest(List<ChatMessage> messages) {
+        return new ChatRequestDto(
+                null,
+                null,
+                toDtoMessages(messages),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null);
     }
 
     private ChatRequest toDomainChatRequest(ChatRequestDto request, List<ChatMessage> messages) {
@@ -405,11 +569,94 @@ public class ChatController {
     private Map<String, Object> memoryMetadata(ChatMemoryContext memory, int memoryMessageCount) {
         Map<String, Object> metadata = new HashMap<>();
         metadata.put("memoryEnabled", memory.enabled());
+        metadata.put(ChatResponseMetadata.KEY_MEMORY_USED, memory.enabled());
         if (memory.enabled()) {
             metadata.put("conversationId", memory.conversationId());
+            metadata.put(ChatResponseMetadata.KEY_CONVERSATION_ID, memory.conversationId());
             metadata.put("memoryMessageCount", memoryMessageCount);
         }
         return metadata;
+    }
+
+    private Map<String, Object> conversationMetadata(String conversationId, int messageCount) {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("conversationId", conversationId);
+        metadata.put(ChatResponseMetadata.KEY_CONVERSATION_ID, conversationId);
+        metadata.put("memoryMessageCount", messageCount);
+        return metadata;
+    }
+
+    private void appendConversation(
+            Principal principal,
+            ChatMemoryContext memory,
+            List<ChatMessage> requestMessages,
+            ChatResponse response) {
+        if (!memory.enabled() || conversationChatService == null) {
+            return;
+        }
+        conversationChatService.appendTurn(
+                conversationChatService.ownerId(principal),
+                memory.conversationId(),
+                requestMessages,
+                response);
+    }
+
+    private ConversationChatService conversationService() {
+        if (conversationChatService == null) {
+            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
+                    "Conversation service is not configured");
+        }
+        return conversationChatService;
+    }
+
+    private void writeStreamEvents(
+            OutputStream outputStream,
+            String requestId,
+            ChatPort port,
+            ChatRequest request,
+            ChatMemoryContext memory,
+            List<ChatMessage> requestMessages,
+            Principal principal) throws IOException {
+        StringBuilder assistant = new StringBuilder();
+        ChatStreamEvent last = null;
+        try (java.util.stream.Stream<ChatStreamEvent> events = port.stream(request)) {
+            Iterator<ChatStreamEvent> iterator = events.iterator();
+            while (iterator.hasNext()) {
+                ChatStreamEvent event = iterator.next();
+                last = event;
+                if (event.type() == ChatStreamEventType.DELTA) {
+                    assistant.append(event.delta());
+                }
+                writeSse(outputStream, requestId, event);
+            }
+        } catch (RuntimeException ex) {
+            ChatStreamEvent error = ChatStreamEvent.error(errorMessage(ex), ChatResponseMetadata.empty());
+            writeSse(outputStream, requestId, error);
+            return;
+        }
+        if (memory.enabled() && assistant.length() > 0) {
+            ChatResponse response = new ChatResponse(
+                    List.of(ChatMessage.assistant(assistant.toString())),
+                    last == null ? "" : last.model(),
+                    last == null ? Map.of() : last.metadata().toMap());
+            appendMemory(memory, toDtoMessages(requestMessages), response);
+            appendConversation(principal, memory, requestMessages, response);
+        }
+    }
+
+    private void writeSse(OutputStream outputStream, String requestId, ChatStreamEvent event) throws IOException {
+        Map<String, Object> payload = new HashMap<>(event.toMap());
+        payload.put("requestId", requestId);
+        String serialized = "event: " + event.type().value() + "\n"
+                + "data: " + objectMapper.writeValueAsString(payload) + "\n\n";
+        outputStream.write(serialized.getBytes(StandardCharsets.UTF_8));
+        outputStream.flush();
+    }
+
+    private String errorMessage(RuntimeException ex) {
+        return ex.getMessage() == null || ex.getMessage().isBlank()
+                ? ex.getClass().getSimpleName()
+                : ex.getMessage();
     }
 
     private record ObjectScope(String objectType, String objectId) {

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
@@ -619,11 +619,15 @@ public class ChatController {
             Principal principal) throws IOException {
         StringBuilder assistant = new StringBuilder();
         ChatStreamEvent last = null;
+        boolean streamFailed = false;
         try (java.util.stream.Stream<ChatStreamEvent> events = port.stream(request)) {
             Iterator<ChatStreamEvent> iterator = events.iterator();
             while (iterator.hasNext()) {
                 ChatStreamEvent event = iterator.next();
                 last = event;
+                if (event.type() == ChatStreamEventType.ERROR) {
+                    streamFailed = true;
+                }
                 if (event.type() == ChatStreamEventType.DELTA) {
                     assistant.append(event.delta());
                 }
@@ -634,7 +638,7 @@ public class ChatController {
             writeSse(outputStream, requestId, error);
             return;
         }
-        if (memory.enabled() && assistant.length() > 0) {
+        if (!streamFailed && memory.enabled() && assistant.length() > 0) {
             ChatResponse response = new ChatResponse(
                     List.of(ChatMessage.assistant(assistant.toString())),
                     last == null ? "" : last.model(),

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/ConversationActionRequestDto.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/ConversationActionRequestDto.java
@@ -1,0 +1,14 @@
+package studio.one.platform.ai.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.Valid;
+
+public record ConversationActionRequestDto(
+        @NotBlank(message = "conversationId is required")
+        String conversationId,
+        String messageId,
+        String newConversationId,
+        String summary,
+        @Valid
+        ChatRequestDto chat) {
+}

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/ConversationDetailDto.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/ConversationDetailDto.java
@@ -1,0 +1,19 @@
+package studio.one.platform.ai.web.dto;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public record ConversationDetailDto(
+        String conversationId,
+        String title,
+        String summary,
+        String status,
+        String parentConversationId,
+        String forkedFromMessageId,
+        int messageCount,
+        Instant createdAt,
+        Instant lastUpdatedAt,
+        Map<String, Object> metadata,
+        List<ConversationMessageDto> messages) {
+}

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/ConversationMessageActionRequestDto.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/ConversationMessageActionRequestDto.java
@@ -1,0 +1,11 @@
+package studio.one.platform.ai.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ConversationMessageActionRequestDto(
+        @NotBlank(message = "conversationId is required")
+        String conversationId,
+        @NotBlank(message = "messageId is required")
+        String messageId,
+        String newConversationId) {
+}

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/ConversationMessageDto.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/ConversationMessageDto.java
@@ -1,0 +1,12 @@
+package studio.one.platform.ai.web.dto;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record ConversationMessageDto(
+        String messageId,
+        String role,
+        String content,
+        Instant createdAt,
+        Map<String, Object> metadata) {
+}

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/ConversationSummaryDto.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/ConversationSummaryDto.java
@@ -1,0 +1,12 @@
+package studio.one.platform.ai.web.dto;
+
+import java.time.Instant;
+
+public record ConversationSummaryDto(
+        String conversationId,
+        String title,
+        String summary,
+        int messageCount,
+        Instant lastUpdatedAt,
+        String status) {
+}

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/service/ConversationChatService.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/service/ConversationChatService.java
@@ -27,6 +27,8 @@ public class ConversationChatService {
 
     private static final String OWNER_ANONYMOUS = "anonymous";
 
+    private static final int MESSAGE_PAGE_SIZE = 500;
+
     private final ConversationRepositoryPort repository;
 
     public ConversationChatService(ConversationRepositoryPort repository) {
@@ -59,7 +61,7 @@ public class ConversationChatService {
 
     public ConversationDetailDto detail(String ownerId, String conversationId) {
         ChatConversation conversation = requireConversation(ownerId, conversationId);
-        List<ConversationMessageDto> messages = repository.listMessages(conversation.conversationId(), 0, 500).stream()
+        List<ConversationMessageDto> messages = allMessages(conversation.conversationId()).stream()
                 .map(this::toDto)
                 .toList();
         return new ConversationDetailDto(
@@ -120,12 +122,12 @@ public class ConversationChatService {
                     Instant.now(),
                     Map.of()));
         }
-        return repository.listMessages(conversation.conversationId(), 0, 500).size();
+        return conversation.messageCount() + stored.size();
     }
 
     public List<ChatConversationMessage> messagesForRegenerate(String ownerId, String conversationId) {
         ChatConversation conversation = requireConversation(ownerId, conversationId);
-        List<ChatConversationMessage> messages = repository.listMessages(conversation.conversationId(), 0, 500);
+        List<ChatConversationMessage> messages = allMessages(conversation.conversationId());
         int lastUser = lastMessageIndex(messages, ChatMessageRole.USER);
         if (lastUser < 0) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
@@ -136,7 +138,7 @@ public class ConversationChatService {
 
     public int replaceLastAssistantResponse(String ownerId, String conversationId, ChatResponse response) {
         ChatConversation conversation = requireConversation(ownerId, conversationId);
-        List<ChatConversationMessage> messages = repository.listMessages(conversation.conversationId(), 0, 500);
+        List<ChatConversationMessage> messages = allMessages(conversation.conversationId());
         int assistantAfterLastUser = assistantAfterLastUser(messages);
         ChatConversationMessage replacement = new ChatConversationMessage(
                 UUID.randomUUID().toString(),
@@ -155,10 +157,11 @@ public class ConversationChatService {
                     conversation.conversationId(),
                     messages.get(assistantAfterLastUser).messageId(),
                     replacement);
+            return conversation.messageCount();
         } else {
             repository.saveMessage(replacement);
+            return conversation.messageCount() + 1;
         }
-        return repository.listMessages(conversation.conversationId(), 0, 500).size();
     }
 
     public ConversationDetailDto truncate(String ownerId, String conversationId, String messageId) {
@@ -219,6 +222,22 @@ public class ConversationChatService {
                 message.message().content(),
                 message.createdAt(),
                 message.metadata());
+    }
+
+    private List<ChatConversationMessage> allMessages(String conversationId) {
+        List<ChatConversationMessage> all = new ArrayList<>();
+        int offset = 0;
+        while (true) {
+            List<ChatConversationMessage> page = repository.listMessages(conversationId, offset, MESSAGE_PAGE_SIZE);
+            if (page.isEmpty()) {
+                return List.copyOf(all);
+            }
+            all.addAll(page);
+            if (page.size() < MESSAGE_PAGE_SIZE) {
+                return List.copyOf(all);
+            }
+            offset += page.size();
+        }
     }
 
     private int lastMessageIndex(List<ChatConversationMessage> messages, ChatMessageRole role) {

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/service/ConversationChatService.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/service/ConversationChatService.java
@@ -1,0 +1,282 @@
+package studio.one.platform.ai.web.service;
+
+import java.security.Principal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import studio.one.platform.ai.core.chat.ChatConversation;
+import studio.one.platform.ai.core.chat.ChatConversationMessage;
+import studio.one.platform.ai.core.chat.ChatConversationSummary;
+import studio.one.platform.ai.core.chat.ChatMessage;
+import studio.one.platform.ai.core.chat.ChatMessageRole;
+import studio.one.platform.ai.core.chat.ChatResponse;
+import studio.one.platform.ai.core.chat.ConversationRepositoryPort;
+import studio.one.platform.ai.core.chat.ConversationStatus;
+import studio.one.platform.ai.web.dto.ConversationDetailDto;
+import studio.one.platform.ai.web.dto.ConversationMessageDto;
+import studio.one.platform.ai.web.dto.ConversationSummaryDto;
+
+public class ConversationChatService {
+
+    private static final String OWNER_ANONYMOUS = "anonymous";
+
+    private final ConversationRepositoryPort repository;
+
+    public ConversationChatService(ConversationRepositoryPort repository) {
+        this.repository = repository;
+    }
+
+    public String ownerId(Principal principal) {
+        if (principal == null) {
+            return OWNER_ANONYMOUS;
+        }
+        String name = normalize(principal.getName());
+        if (name == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Principal name is required for conversation APIs");
+        }
+        return "principal:" + name;
+    }
+
+    public List<ConversationSummaryDto> list(String ownerId, int offset, int limit) {
+        return repository.listConversations(ownerId, offset, limit).stream()
+                .map(summary -> new ConversationSummaryDto(
+                        clientConversationId(ownerId, summary.conversationId()),
+                        summary.title(),
+                        summary.summary(),
+                        summary.messageCount(),
+                        summary.lastUpdatedAt(),
+                        summary.status().name().toLowerCase(Locale.ROOT)))
+                .toList();
+    }
+
+    public ConversationDetailDto detail(String ownerId, String conversationId) {
+        ChatConversation conversation = requireConversation(ownerId, conversationId);
+        List<ConversationMessageDto> messages = repository.listMessages(conversation.conversationId(), 0, 500).stream()
+                .map(this::toDto)
+                .toList();
+        return new ConversationDetailDto(
+                clientConversationId(ownerId, conversation.conversationId()),
+                conversation.title(),
+                conversation.summary(),
+                conversation.status().name().toLowerCase(Locale.ROOT),
+                clientConversationId(ownerId, conversation.parentConversationId()),
+                conversation.forkedFromMessageId(),
+                conversation.messageCount(),
+                conversation.createdAt(),
+                conversation.lastUpdatedAt(),
+                conversation.metadata(),
+                messages);
+    }
+
+    public boolean delete(String ownerId, String conversationId) {
+        ChatConversation conversation = requireConversation(ownerId, conversationId);
+        return repository.deleteConversation(conversation.conversationId());
+    }
+
+    public ChatConversation ensureConversation(String ownerId, String conversationId, List<ChatMessage> seedMessages) {
+        String storageId = storageConversationId(ownerId, conversationId);
+        return repository.findConversation(storageId).orElseGet(() -> repository.saveConversation(new ChatConversation(
+                storageId,
+                ownerId,
+                title(seedMessages),
+                summary(seedMessages),
+                ConversationStatus.ACTIVE,
+                "",
+                "",
+                0,
+                Instant.now(),
+                Instant.now(),
+                Map.of())));
+    }
+
+    public int appendTurn(
+            String ownerId,
+            String conversationId,
+            List<ChatMessage> requestMessages,
+            ChatResponse response) {
+        ChatConversation conversation = ensureConversation(ownerId, conversationId, requestMessages);
+        List<ChatMessage> stored = new ArrayList<>();
+        requestMessages.stream()
+                .filter(message -> message.role() != ChatMessageRole.SYSTEM)
+                .forEach(stored::add);
+        response.messages().stream()
+                .filter(message -> message.role() == ChatMessageRole.ASSISTANT)
+                .forEach(stored::add);
+        for (ChatMessage message : stored) {
+            repository.saveMessage(new ChatConversationMessage(
+                    UUID.randomUUID().toString(),
+                    conversation.conversationId(),
+                    message,
+                    "",
+                    true,
+                    Instant.now(),
+                    Map.of()));
+        }
+        return repository.listMessages(conversation.conversationId(), 0, 500).size();
+    }
+
+    public List<ChatConversationMessage> messagesForRegenerate(String ownerId, String conversationId) {
+        ChatConversation conversation = requireConversation(ownerId, conversationId);
+        List<ChatConversationMessage> messages = repository.listMessages(conversation.conversationId(), 0, 500);
+        int lastUser = lastMessageIndex(messages, ChatMessageRole.USER);
+        if (lastUser < 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "No user message available for regenerate");
+        }
+        return messages.subList(0, lastUser + 1);
+    }
+
+    public int replaceLastAssistantResponse(String ownerId, String conversationId, ChatResponse response) {
+        ChatConversation conversation = requireConversation(ownerId, conversationId);
+        List<ChatConversationMessage> messages = repository.listMessages(conversation.conversationId(), 0, 500);
+        int lastAssistant = lastMessageIndex(messages, ChatMessageRole.ASSISTANT);
+        ChatConversationMessage replacement = new ChatConversationMessage(
+                UUID.randomUUID().toString(),
+                conversation.conversationId(),
+                response.messages().stream()
+                        .filter(message -> message.role() == ChatMessageRole.ASSISTANT)
+                        .findFirst()
+                        .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_GATEWAY,
+                                "Provider response does not include assistant message")),
+                "",
+                true,
+                Instant.now(),
+                response.metadata());
+        if (lastAssistant >= 0) {
+            repository.replaceAssistantResponse(
+                    conversation.conversationId(),
+                    messages.get(lastAssistant).messageId(),
+                    replacement);
+        } else {
+            repository.saveMessage(replacement);
+        }
+        return repository.listMessages(conversation.conversationId(), 0, 500).size();
+    }
+
+    public ConversationDetailDto truncate(String ownerId, String conversationId, String messageId) {
+        ChatConversation conversation = requireConversation(ownerId, conversationId);
+        if (!repository.truncateAfter(conversation.conversationId(), requireText(messageId, "messageId"))) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Conversation message not found");
+        }
+        return detail(ownerId, conversationId);
+    }
+
+    public ConversationDetailDto fork(
+            String ownerId,
+            String conversationId,
+            String messageId,
+            String newConversationId) {
+        ChatConversation conversation = requireConversation(ownerId, conversationId);
+        String newId = normalize(newConversationId);
+        if (newId == null) {
+            newId = UUID.randomUUID().toString();
+        }
+        try {
+            repository.fork(conversation.conversationId(), requireText(messageId, "messageId"),
+                    storageConversationId(ownerId, newId));
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+        }
+        return detail(ownerId, newId);
+    }
+
+    public ConversationDetailDto compact(String ownerId, String conversationId, String summary) {
+        ChatConversation conversation = requireConversation(ownerId, conversationId);
+        repository.compact(conversation.conversationId(), requireText(summary, "summary"));
+        return detail(ownerId, conversationId);
+    }
+
+    public ConversationDetailDto cancel(String ownerId, String conversationId) {
+        ChatConversation conversation = requireConversation(ownerId, conversationId);
+        if (!repository.cancel(conversation.conversationId())) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Conversation not found");
+        }
+        return detail(ownerId, conversationId);
+    }
+
+    private ChatConversation requireConversation(String ownerId, String conversationId) {
+        String storageId = storageConversationId(ownerId, requireText(conversationId, "conversationId"));
+        ChatConversation conversation = repository.findConversation(storageId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Conversation not found"));
+        if (!conversation.ownerId().equals(ownerId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Conversation not found");
+        }
+        return conversation;
+    }
+
+    private ConversationMessageDto toDto(ChatConversationMessage message) {
+        return new ConversationMessageDto(
+                message.messageId(),
+                message.message().role().name().toLowerCase(Locale.ROOT),
+                message.message().content(),
+                message.createdAt(),
+                message.metadata());
+    }
+
+    private int lastMessageIndex(List<ChatConversationMessage> messages, ChatMessageRole role) {
+        for (int i = messages.size() - 1; i >= 0; i--) {
+            if (messages.get(i).message().role() == role) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private String title(List<ChatMessage> messages) {
+        return messages.stream()
+                .filter(message -> message.role() == ChatMessageRole.USER)
+                .map(ChatMessage::content)
+                .map(this::normalize)
+                .filter(value -> value != null)
+                .findFirst()
+                .map(value -> value.length() <= 40 ? value : value.substring(0, 40))
+                .orElse("Conversation");
+    }
+
+    private String summary(List<ChatMessage> messages) {
+        return messages.stream()
+                .filter(message -> message.role() == ChatMessageRole.USER)
+                .map(ChatMessage::content)
+                .map(this::normalize)
+                .filter(value -> value != null)
+                .findFirst()
+                .orElse("");
+    }
+
+    private String storageConversationId(String ownerId, String conversationId) {
+        return ownerId + ":" + requireText(conversationId, "conversationId");
+    }
+
+    private String clientConversationId(String ownerId, String storageConversationId) {
+        String normalized = normalize(storageConversationId);
+        if (normalized == null) {
+            return "";
+        }
+        String prefix = ownerId + ":";
+        return normalized.startsWith(prefix) ? normalized.substring(prefix.length()) : normalized;
+    }
+
+    private String requireText(String value, String name) {
+        String normalized = normalize(value);
+        if (normalized == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, name + " is required");
+        }
+        return normalized;
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/service/ConversationChatService.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/service/ConversationChatService.java
@@ -137,7 +137,7 @@ public class ConversationChatService {
     public int replaceLastAssistantResponse(String ownerId, String conversationId, ChatResponse response) {
         ChatConversation conversation = requireConversation(ownerId, conversationId);
         List<ChatConversationMessage> messages = repository.listMessages(conversation.conversationId(), 0, 500);
-        int lastAssistant = lastMessageIndex(messages, ChatMessageRole.ASSISTANT);
+        int assistantAfterLastUser = assistantAfterLastUser(messages);
         ChatConversationMessage replacement = new ChatConversationMessage(
                 UUID.randomUUID().toString(),
                 conversation.conversationId(),
@@ -150,10 +150,10 @@ public class ConversationChatService {
                 true,
                 Instant.now(),
                 response.metadata());
-        if (lastAssistant >= 0) {
+        if (assistantAfterLastUser >= 0) {
             repository.replaceAssistantResponse(
                     conversation.conversationId(),
-                    messages.get(lastAssistant).messageId(),
+                    messages.get(assistantAfterLastUser).messageId(),
                     replacement);
         } else {
             repository.saveMessage(replacement);
@@ -224,6 +224,19 @@ public class ConversationChatService {
     private int lastMessageIndex(List<ChatConversationMessage> messages, ChatMessageRole role) {
         for (int i = messages.size() - 1; i >= 0; i--) {
             if (messages.get(i).message().role() == role) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private int assistantAfterLastUser(List<ChatConversationMessage> messages) {
+        int lastUser = lastMessageIndex(messages, ChatMessageRole.USER);
+        if (lastUser < 0) {
+            return -1;
+        }
+        for (int i = lastUser + 1; i < messages.size(); i++) {
+            if (messages.get(i).message().role() == ChatMessageRole.ASSISTANT) {
                 return i;
             }
         }

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/service/InMemoryConversationRepository.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/service/InMemoryConversationRepository.java
@@ -1,0 +1,236 @@
+package studio.one.platform.ai.web.service;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import studio.one.platform.ai.core.chat.ChatConversation;
+import studio.one.platform.ai.core.chat.ChatConversationMessage;
+import studio.one.platform.ai.core.chat.ChatConversationSummary;
+import studio.one.platform.ai.core.chat.ConversationRepositoryPort;
+import studio.one.platform.ai.core.chat.ConversationStatus;
+
+/**
+ * Single-node in-memory conversation repository for the web starter.
+ */
+public class InMemoryConversationRepository implements ConversationRepositoryPort {
+
+    private final Map<String, ChatConversation> conversations = new LinkedHashMap<>();
+
+    private final Map<String, List<ChatConversationMessage>> messages = new LinkedHashMap<>();
+
+    @Override
+    public synchronized ChatConversation saveConversation(ChatConversation conversation) {
+        conversations.put(conversation.conversationId(), conversation);
+        messages.computeIfAbsent(conversation.conversationId(), ignored -> new ArrayList<>());
+        return conversation;
+    }
+
+    @Override
+    public synchronized Optional<ChatConversation> findConversation(String conversationId) {
+        ChatConversation conversation = conversations.get(conversationId);
+        if (conversation == null || conversation.status() == ConversationStatus.DELETED) {
+            return Optional.empty();
+        }
+        return Optional.of(conversation);
+    }
+
+    @Override
+    public synchronized List<ChatConversationSummary> listConversations(String ownerId, int offset, int limit) {
+        int safeOffset = Math.max(0, offset);
+        int safeLimit = limit <= 0 ? 20 : Math.min(limit, 100);
+        return conversations.values().stream()
+                .filter(conversation -> conversation.status() != ConversationStatus.DELETED)
+                .filter(conversation -> conversation.ownerId().equals(ownerId == null ? "" : ownerId.trim()))
+                .sorted(Comparator.comparing(ChatConversation::lastUpdatedAt).reversed())
+                .skip(safeOffset)
+                .limit(safeLimit)
+                .map(ChatConversationSummary::from)
+                .toList();
+    }
+
+    @Override
+    public synchronized boolean deleteConversation(String conversationId) {
+        ChatConversation existing = conversations.get(conversationId);
+        if (existing == null || existing.status() == ConversationStatus.DELETED) {
+            return false;
+        }
+        conversations.put(conversationId, copy(existing, existing.messageCount(), ConversationStatus.DELETED,
+                existing.summary(), Instant.now()));
+        return true;
+    }
+
+    @Override
+    public synchronized ChatConversationMessage saveMessage(ChatConversationMessage message) {
+        List<ChatConversationMessage> current = messages.computeIfAbsent(message.conversationId(), ignored -> new ArrayList<>());
+        current.add(message);
+        touch(message.conversationId(), null, ConversationStatus.ACTIVE);
+        return message;
+    }
+
+    @Override
+    public synchronized List<ChatConversationMessage> listMessages(String conversationId, int offset, int limit) {
+        int safeOffset = Math.max(0, offset);
+        int safeLimit = limit <= 0 ? 100 : Math.min(limit, 500);
+        return messages.getOrDefault(conversationId, List.of()).stream()
+                .filter(ChatConversationMessage::active)
+                .sorted(Comparator.comparing(ChatConversationMessage::createdAt))
+                .skip(safeOffset)
+                .limit(safeLimit)
+                .toList();
+    }
+
+    @Override
+    public synchronized boolean replaceAssistantResponse(
+            String conversationId,
+            String assistantMessageId,
+            ChatConversationMessage replacement) {
+        List<ChatConversationMessage> current = messages.get(conversationId);
+        if (current == null) {
+            return false;
+        }
+        for (int i = 0; i < current.size(); i++) {
+            ChatConversationMessage existing = current.get(i);
+            if (existing.messageId().equals(assistantMessageId)) {
+                current.set(i, replacement);
+                touch(conversationId, null, ConversationStatus.ACTIVE);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public synchronized boolean truncateAfter(String conversationId, String messageId) {
+        List<ChatConversationMessage> current = messages.get(conversationId);
+        if (current == null) {
+            return false;
+        }
+        int index = -1;
+        for (int i = 0; i < current.size(); i++) {
+            if (current.get(i).messageId().equals(messageId)) {
+                index = i;
+                break;
+            }
+        }
+        if (index < 0) {
+            return false;
+        }
+        current.subList(index + 1, current.size()).clear();
+        touch(conversationId, null, ConversationStatus.ACTIVE);
+        return true;
+    }
+
+    @Override
+    public synchronized ChatConversation fork(String conversationId, String fromMessageId, String newConversationId) {
+        if (conversations.containsKey(newConversationId)) {
+            throw new IllegalArgumentException("Conversation already exists: " + newConversationId);
+        }
+        ChatConversation source = conversations.get(conversationId);
+        if (source == null) {
+            throw new IllegalArgumentException("Conversation not found: " + conversationId);
+        }
+        Instant now = Instant.now();
+        ChatConversation fork = new ChatConversation(
+                newConversationId,
+                source.ownerId(),
+                source.title(),
+                source.summary(),
+                ConversationStatus.ACTIVE,
+                conversationId,
+                fromMessageId,
+                0,
+                now,
+                now,
+                Map.of());
+        conversations.put(newConversationId, fork);
+        List<ChatConversationMessage> copied = new ArrayList<>();
+        boolean found = false;
+        for (ChatConversationMessage message : messages.getOrDefault(conversationId, List.of())) {
+            if (!message.active()) {
+                continue;
+            }
+            copied.add(new ChatConversationMessage(
+                    newConversationId + "-" + message.messageId(),
+                    newConversationId,
+                    message.message(),
+                    message.parentMessageId(),
+                    true,
+                    message.createdAt(),
+                    message.metadata()));
+            if (message.messageId().equals(fromMessageId)) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            conversations.remove(newConversationId);
+            throw new IllegalArgumentException("Conversation message not found: " + fromMessageId);
+        }
+        messages.put(newConversationId, copied);
+        touch(newConversationId, null, ConversationStatus.ACTIVE);
+        return conversations.get(newConversationId);
+    }
+
+    @Override
+    public synchronized ChatConversation compact(String conversationId, String summary) {
+        ChatConversation existing = conversations.get(conversationId);
+        if (existing == null) {
+            throw new IllegalArgumentException("Conversation not found: " + conversationId);
+        }
+        ChatConversation compacted = copy(existing, activeMessageCount(conversationId), ConversationStatus.COMPACTED,
+                summary, Instant.now());
+        conversations.put(conversationId, compacted);
+        return compacted;
+    }
+
+    @Override
+    public synchronized boolean cancel(String conversationId) {
+        ChatConversation existing = conversations.get(conversationId);
+        if (existing == null) {
+            return false;
+        }
+        conversations.put(conversationId, copy(existing, activeMessageCount(conversationId), ConversationStatus.CANCELLED,
+                existing.summary(), Instant.now()));
+        return true;
+    }
+
+    private void touch(String conversationId, String summary, ConversationStatus status) {
+        ChatConversation existing = conversations.get(conversationId);
+        if (existing == null) {
+            return;
+        }
+        conversations.put(conversationId, copy(existing, activeMessageCount(conversationId), status,
+                summary == null ? existing.summary() : summary, Instant.now()));
+    }
+
+    private int activeMessageCount(String conversationId) {
+        return (int) messages.getOrDefault(conversationId, List.of()).stream()
+                .filter(ChatConversationMessage::active)
+                .count();
+    }
+
+    private ChatConversation copy(
+            ChatConversation conversation,
+            int messageCount,
+            ConversationStatus status,
+            String summary,
+            Instant lastUpdatedAt) {
+        return new ChatConversation(
+                conversation.conversationId(),
+                conversation.ownerId(),
+                conversation.title(),
+                summary,
+                status,
+                conversation.parentConversationId(),
+                conversation.forkedFromMessageId(),
+                messageCount,
+                conversation.createdAt(),
+                lastUpdatedAt,
+                conversation.metadata());
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
@@ -277,6 +277,20 @@ class ChatControllerTest {
     }
 
     @Test
+    void streamDoesNotStorePartialAssistantWhenErrorEventOccurs() throws Exception {
+        controller = conversationController();
+        when(defaultChatPort.stream(any(ChatRequest.class))).thenReturn(Stream.of(
+                ChatStreamEvent.delta("partial", "model", ChatResponseMetadata.empty()),
+                ChatStreamEvent.error("provider failed", ChatResponseMetadata.empty())));
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        controller.stream(memoryChat("chat-1", "hello"), null).getBody().writeTo(output);
+
+        assertThat(output.toString(StandardCharsets.UTF_8)).contains("event: error");
+        assertThat(controller.conversations(0, 20, null).getBody().getData()).isEmpty();
+    }
+
+    @Test
     void conversationApisListDetailAndDeleteMemoryConversation() {
         controller = conversationController();
 
@@ -332,6 +346,24 @@ class ChatControllerTest {
         assertThat(detail.messages())
                 .extracting(message -> message.role() + ":" + message.content())
                 .containsExactly("user:hello", "assistant:regenerated");
+    }
+
+    @Test
+    void regenerateAppendsAssistantWhenLastUserHasNoAssistantYet() {
+        controller = conversationController();
+        when(defaultChatPort.chat(any())).thenReturn(response("first"), response("second"), response("regenerated"));
+        controller.chat(memoryChat("chat-1", "hello"));
+        controller.chat(memoryChat("chat-1", "next"));
+        ConversationDetailDto before = controller.conversation("chat-1", null).getBody().getData();
+        String secondUserId = before.messages().get(2).messageId();
+
+        controller.truncate(new ConversationActionRequestDto("chat-1", secondUserId, null, null, null), null);
+        controller.regenerate(new ConversationActionRequestDto("chat-1", null, null, null, null), null);
+
+        ConversationDetailDto detail = controller.conversation("chat-1", null).getBody().getData();
+        assertThat(detail.messages())
+                .extracting(message -> message.role() + ":" + message.content())
+                .containsExactly("user:hello", "assistant:first", "user:next", "assistant:regenerated");
     }
 
     @Test

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
@@ -11,6 +11,9 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,6 +29,8 @@ import studio.one.platform.ai.core.chat.ChatMemoryStore;
 import studio.one.platform.ai.core.chat.ChatPort;
 import studio.one.platform.ai.core.chat.ChatRequest;
 import studio.one.platform.ai.core.chat.ChatResponse;
+import studio.one.platform.ai.core.chat.ChatResponseMetadata;
+import studio.one.platform.ai.core.chat.ChatStreamEvent;
 import studio.one.platform.ai.core.registry.AiProviderRegistry;
 import studio.one.platform.ai.core.rag.RagRetrievalDiagnostics;
 import studio.one.platform.ai.core.rag.RagSearchRequest;
@@ -36,7 +41,12 @@ import studio.one.platform.ai.web.dto.ChatMessageDto;
 import studio.one.platform.ai.web.dto.ChatRagRequestDto;
 import studio.one.platform.ai.web.dto.ChatRequestDto;
 import studio.one.platform.ai.web.dto.ChatResponseDto;
+import studio.one.platform.ai.web.dto.ConversationActionRequestDto;
+import studio.one.platform.ai.web.dto.ConversationDetailDto;
+import studio.one.platform.ai.web.dto.ConversationSummaryDto;
+import studio.one.platform.ai.web.service.ConversationChatService;
 import studio.one.platform.ai.web.service.InMemoryChatMemoryStore;
+import studio.one.platform.ai.web.service.InMemoryConversationRepository;
 import studio.one.platform.web.dto.ApiResponse;
 
 class ChatControllerTest {
@@ -233,8 +243,126 @@ class ChatControllerTest {
                 .containsExactly("USER:hello", "ASSISTANT:default", "USER:next");
         assertThat(response.metadata())
                 .containsEntry("memoryEnabled", true)
+                .containsEntry("memoryUsed", true)
                 .containsEntry("conversationId", "chat-1")
                 .containsEntry("memoryMessageCount", 4);
+    }
+
+    @Test
+    void streamWritesSseEventsWithRequestId() throws Exception {
+        when(defaultChatPort.stream(any(ChatRequest.class))).thenReturn(Stream.of(
+                ChatStreamEvent.delta("hel", "model", ChatResponseMetadata.empty()),
+                ChatStreamEvent.delta("lo", "model", ChatResponseMetadata.empty()),
+                ChatStreamEvent.usage(ChatResponseMetadata.empty()),
+                ChatStreamEvent.complete("model", ChatResponseMetadata.empty())));
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        controller.stream(new ChatRequestDto(
+                null,
+                null,
+                List.of(new ChatMessageDto("user", "hello")),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null), null).getBody().writeTo(output);
+
+        String body = output.toString(StandardCharsets.UTF_8);
+        assertThat(body)
+                .contains("event: delta")
+                .contains("event: usage")
+                .contains("event: complete")
+                .contains("\"requestId\"");
+    }
+
+    @Test
+    void conversationApisListDetailAndDeleteMemoryConversation() {
+        controller = conversationController();
+
+        controller.chat(memoryChat("chat-1", "hello"));
+
+        List<ConversationSummaryDto> conversations = controller.conversations(0, 20, null)
+                .getBody()
+                .getData();
+        assertThat(conversations).hasSize(1);
+        assertThat(conversations.get(0).conversationId()).isEqualTo("chat-1");
+        assertThat(conversations.get(0).messageCount()).isEqualTo(2);
+
+        ConversationDetailDto detail = controller.conversation("chat-1", null).getBody().getData();
+        assertThat(detail.messages())
+                .extracting(message -> message.role() + ":" + message.content())
+                .containsExactly("user:hello", "assistant:default");
+
+        assertThat(controller.deleteConversation("chat-1", null).getBody().getData())
+                .containsEntry("deleted", true);
+        assertThat(controller.conversations(0, 20, null).getBody().getData()).isEmpty();
+    }
+
+    @Test
+    void conversationApisKeepPrincipalScopesSeparate() {
+        controller = conversationController();
+
+        controller.chat(memoryChat("chat-1", "hello from user a"), () -> "user-a");
+        controller.chat(memoryChat("chat-1", "hello from user b"), () -> "user-b");
+
+        ConversationDetailDto userA = controller.conversation("chat-1", () -> "user-a").getBody().getData();
+        ConversationDetailDto userB = controller.conversation("chat-1", () -> "user-b").getBody().getData();
+
+        assertThat(userA.messages())
+                .extracting(message -> message.role() + ":" + message.content())
+                .containsExactly("user:hello from user a", "assistant:default");
+        assertThat(userB.messages())
+                .extracting(message -> message.role() + ":" + message.content())
+                .containsExactly("user:hello from user b", "assistant:default");
+    }
+
+    @Test
+    void regenerateReplacesLastAssistantResponse() {
+        controller = conversationController();
+        when(defaultChatPort.chat(any())).thenReturn(response("first"), response("regenerated"));
+
+        controller.chat(memoryChat("chat-1", "hello"));
+        ChatResponseDto regenerated = controller.regenerate(
+                new ConversationActionRequestDto("chat-1", null, null, null, null),
+                null).getBody().getData();
+
+        assertThat(regenerated.messages().get(0).content()).isEqualTo("regenerated");
+        ConversationDetailDto detail = controller.conversation("chat-1", null).getBody().getData();
+        assertThat(detail.messages())
+                .extracting(message -> message.role() + ":" + message.content())
+                .containsExactly("user:hello", "assistant:regenerated");
+    }
+
+    @Test
+    void truncateForkCompactAndCancelConversation() {
+        controller = conversationController();
+        controller.chat(memoryChat("chat-1", "hello"));
+        controller.chat(memoryChat("chat-1", "next"));
+        ConversationDetailDto detail = controller.conversation("chat-1", null).getBody().getData();
+        String firstMessageId = detail.messages().get(0).messageId();
+
+        ConversationDetailDto forked = controller.fork(
+                new ConversationActionRequestDto("chat-1", firstMessageId, "chat-copy", null, null),
+                null).getBody().getData();
+        assertThat(forked.conversationId()).isEqualTo("chat-copy");
+        assertThat(forked.messages()).hasSize(1);
+
+        ConversationDetailDto truncated = controller.truncate(
+                new ConversationActionRequestDto("chat-1", firstMessageId, null, null, null),
+                null).getBody().getData();
+        assertThat(truncated.messages()).hasSize(1);
+
+        ConversationDetailDto compacted = controller.compact(
+                new ConversationActionRequestDto("chat-1", null, null, "short summary", null),
+                null).getBody().getData();
+        assertThat(compacted.status()).isEqualTo("compacted");
+        assertThat(compacted.summary()).isEqualTo("short summary");
+
+        ConversationDetailDto cancelled = controller.cancel(
+                new ConversationActionRequestDto("chat-1", null, null, null, null),
+                null).getBody().getData();
+        assertThat(cancelled.status()).isEqualTo("cancelled");
     }
 
     @Test
@@ -630,6 +758,11 @@ class ChatControllerTest {
     private ChatController memoryController() {
         return new ChatController(providerRegistry, ragPipelineService, RagContextBuilder.defaults(), false,
                 memoryStore(), true);
+    }
+
+    private ChatController conversationController() {
+        return new ChatController(providerRegistry, ragPipelineService, RagContextBuilder.defaults(), false,
+                memoryStore(), true, new ConversationChatService(new InMemoryConversationRepository()));
     }
 
     private ChatMemoryStore memoryStore() {

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
@@ -43,6 +43,7 @@ import studio.one.platform.ai.web.dto.ChatRequestDto;
 import studio.one.platform.ai.web.dto.ChatResponseDto;
 import studio.one.platform.ai.web.dto.ConversationActionRequestDto;
 import studio.one.platform.ai.web.dto.ConversationDetailDto;
+import studio.one.platform.ai.web.dto.ConversationMessageActionRequestDto;
 import studio.one.platform.ai.web.dto.ConversationSummaryDto;
 import studio.one.platform.ai.web.service.ConversationChatService;
 import studio.one.platform.ai.web.service.InMemoryChatMemoryStore;
@@ -291,6 +292,29 @@ class ChatControllerTest {
     }
 
     @Test
+    void streamFlushesErrorEventWhenIteratorFails() throws Exception {
+        when(defaultChatPort.stream(any(ChatRequest.class))).thenReturn(Stream.generate(() -> {
+            throw new IllegalStateException("provider failed");
+        }));
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        controller.stream(new ChatRequestDto(
+                null,
+                null,
+                List.of(new ChatMessageDto("user", "hello")),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null), null).getBody().writeTo(output);
+
+        assertThat(output.toString(StandardCharsets.UTF_8))
+                .contains("event: error")
+                .contains("provider failed");
+    }
+
+    @Test
     void conversationApisListDetailAndDeleteMemoryConversation() {
         controller = conversationController();
 
@@ -332,6 +356,18 @@ class ChatControllerTest {
     }
 
     @Test
+    void conversationDetailCanReadBeyondSingleRepositoryPage() {
+        controller = conversationController();
+
+        for (int i = 0; i < 251; i++) {
+            controller.chat(memoryChat("chat-1", "hello " + i));
+        }
+
+        ConversationDetailDto detail = controller.conversation("chat-1", null).getBody().getData();
+        assertThat(detail.messages()).hasSize(502);
+    }
+
+    @Test
     void regenerateReplacesLastAssistantResponse() {
         controller = conversationController();
         when(defaultChatPort.chat(any())).thenReturn(response("first"), response("regenerated"));
@@ -357,7 +393,7 @@ class ChatControllerTest {
         ConversationDetailDto before = controller.conversation("chat-1", null).getBody().getData();
         String secondUserId = before.messages().get(2).messageId();
 
-        controller.truncate(new ConversationActionRequestDto("chat-1", secondUserId, null, null, null), null);
+        controller.truncate(new ConversationMessageActionRequestDto("chat-1", secondUserId, null), null);
         controller.regenerate(new ConversationActionRequestDto("chat-1", null, null, null, null), null);
 
         ConversationDetailDto detail = controller.conversation("chat-1", null).getBody().getData();
@@ -375,13 +411,13 @@ class ChatControllerTest {
         String firstMessageId = detail.messages().get(0).messageId();
 
         ConversationDetailDto forked = controller.fork(
-                new ConversationActionRequestDto("chat-1", firstMessageId, "chat-copy", null, null),
+                new ConversationMessageActionRequestDto("chat-1", firstMessageId, "chat-copy"),
                 null).getBody().getData();
         assertThat(forked.conversationId()).isEqualTo("chat-copy");
         assertThat(forked.messages()).hasSize(1);
 
         ConversationDetailDto truncated = controller.truncate(
-                new ConversationActionRequestDto("chat-1", firstMessageId, null, null, null),
+                new ConversationMessageActionRequestDto("chat-1", firstMessageId, null),
                 null).getBody().getData();
         assertThat(truncated.messages()).hasSize(1);
 


### PR DESCRIPTION
## Why

- starter-ai-web의 기존 단발성 chat API를 Conversation 기반 API로 확장해야 한다.
- #258 계약 계층과 #259 starter metadata/streaming 기반 위에 web endpoint, SSE, regenerate/fork/truncate/compact/cancel 최소 구현이 필요하다.

## What

- 기존 `/api/ai/chat` 응답 shape를 유지하면서 memory metadata에 `memoryUsed` / `conversationId` 표준 key를 추가했다.
- `/api/ai/chat/stream` SSE endpoint를 추가하고 `delta`, `usage`, `complete`, `error` event와 `requestId`를 출력한다.
- memory enabled `/chat`, `/chat/rag`, `/chat/stream` 요청을 conversation repository에도 기록한다.
- `GET/DELETE /api/ai/chat/conversations*`, `POST /regenerate`, `POST /truncate`, `POST /fork`, `POST /compact`, `POST /cancel` endpoint를 추가했다.
- `ConversationRepositoryPort`의 기본 web 구현인 `InMemoryConversationRepository`와 orchestration service를 추가했다.
- README와 controller 테스트를 갱신했다.

## Related Issues

- Closes #260

## Validation

- Command: `./gradlew :starter:studio-platform-starter-ai-web:test --tests studio.one.platform.ai.web.controller.ChatControllerTest`
- Result: PASS
- Command: `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test && git diff --check`
- Result: PASS

## Risk / Rollback

- Risk: 기본 conversation repository는 단일 인스턴스 in-memory 구현이므로 운영 장기 보관/다중 인스턴스 공유에는 외부 구현 Bean이 필요하다.
- Rollback: 이 PR revert 시 기존 `/api/ai/chat` 및 `/api/ai/chat/rag` 중심 동작으로 복귀한다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope:
- Main author validation: controller test, 관련 starter/core test, README endpoint contract 확인

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] AI-Assisted value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
