### PR TITLE
[ai] chat platform 테스트 README 정리

### DIFF
--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -205,13 +205,13 @@ Spring MVC의 `StreamingResponseBody`를 사용하므로 WebFlux/Netty event-loo
 
 ```text
 event: delta
-data: {"type":"delta","requestId":"...","delta":"짧게","model":"gpt-4o-mini","metadata":{"provider":"OPENAI","resolvedModel":"gpt-4o-mini"}}
+data: {"type":"delta","requestId":"req-abc123","delta":"짧게","model":"gpt-4o-mini","metadata":{"provider":"OPENAI","resolvedModel":"gpt-4o-mini"}}
 
 event: usage
-data: {"type":"usage","requestId":"...","metadata":{"tokenUsage":{"inputTokens":10,"outputTokens":5,"totalTokens":15},"latencyMs":120}}
+data: {"type":"usage","requestId":"req-abc123","metadata":{"tokenUsage":{"inputTokens":10,"outputTokens":5,"totalTokens":15},"latencyMs":120}}
 
 event: complete
-data: {"type":"complete","requestId":"...","model":"gpt-4o-mini","metadata":{"provider":"OPENAI","resolvedModel":"gpt-4o-mini"}}
+data: {"type":"complete","requestId":"req-abc123","model":"gpt-4o-mini","metadata":{"provider":"OPENAI","resolvedModel":"gpt-4o-mini"}}
 ```
 
 ### Conversation API 예시

--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -149,12 +149,36 @@ Content-Type: application/json
 | `studio.ai.endpoints.chat.memory.max-conversations` | `1000` | 인스턴스 메모리에 보관할 최대 conversation 수 |
 | `studio.ai.endpoints.chat.memory.ttl` | `30m` | 마지막 접근 이후 conversation 보관 시간 |
 
+응답 metadata는 기존 map 구조를 유지하면서 provider/model/latency/memory 정보를 추가한다.
+
+```json
+{
+  "messages": [
+    {"role": "assistant", "content": "안녕하세요"}
+  ],
+  "model": "gpt-4o-mini",
+  "metadata": {
+    "provider": "OPENAI",
+    "resolvedModel": "gpt-4o-mini",
+    "latencyMs": 120,
+    "memoryUsed": true,
+    "conversationId": "chat-123",
+    "tokenUsage": {
+      "inputTokens": 10,
+      "outputTokens": 5,
+      "totalTokens": 15
+    }
+  }
+}
+```
+
 이 memory는 단일 앱 인스턴스의 in-memory cache다. 애플리케이션 재시작 시 사라지며, 다중 인스턴스 간 공유되지 않는다.
 운영에서 여러 인스턴스 간 대화 memory가 필요하면 `ChatMemoryStore`와 `ConversationRepositoryPort`를 외부 저장소 기반 구현으로 교체한다.
 
 memory가 활성화된 `/chat`, `/chat/rag`, `/chat/stream` 요청은 conversation repository에도 기록된다.
 기본 구현은 단일 인스턴스용 `InMemoryConversationRepository`이며, conversation 목록/상세/삭제/regenerate/fork/truncate/compact/cancel API의 개발 및 smoke 용도다.
 장기 보관, 감사 로그, 다중 인스턴스 공유가 필요하면 운영 저장소 구현을 별도 Bean으로 등록한다.
+기존 `/chat` 응답 shape는 유지되며, conversation 관련 필드는 metadata에 additive하게 추가된다.
 
 ### Streaming Chat 예시
 
@@ -178,6 +202,17 @@ Accept: text/event-stream
 
 SSE event type은 `delta`, `usage`, `complete`, `error`이다. 각 event data에는 `requestId`가 포함되어 stream lifecycle을 추적할 수 있다.
 Spring MVC의 `StreamingResponseBody`를 사용하므로 WebFlux/Netty event-loop에서 직접 소비하지 않는다.
+
+```text
+event: delta
+data: {"type":"delta","requestId":"...","delta":"짧게","model":"gpt-4o-mini","metadata":{"provider":"OPENAI","resolvedModel":"gpt-4o-mini"}}
+
+event: usage
+data: {"type":"usage","requestId":"...","metadata":{"tokenUsage":{"inputTokens":10,"outputTokens":5,"totalTokens":15},"latencyMs":120}}
+
+event: complete
+data: {"type":"complete","requestId":"...","model":"gpt-4o-mini","metadata":{"provider":"OPENAI","resolvedModel":"gpt-4o-mini"}}
+```
 
 ### Conversation API 예시
 

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
@@ -17,6 +17,7 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -87,6 +88,10 @@ class OpenAiProviderAutoConfigurationTest {
             assertThat(context).hasSingleBean(ConversationChatService.class);
             assertThat(context).hasSingleBean(ObjectMapper.class);
             assertThat(context).doesNotHaveBean(ChatMemoryStore.class);
+
+            ChatController controller = context.getBean(ChatController.class);
+            ObjectMapper objectMapper = context.getBean(ObjectMapper.class);
+            assertThat(ReflectionTestUtils.getField(controller, "objectMapper")).isSameAs(objectMapper);
 
             AiProviderRegistry registry = context.getBean(AiProviderRegistry.class);
             assertThat(registry.defaultProvider()).isEqualTo("openai");

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
@@ -18,10 +18,13 @@ import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAut
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.http.ResponseEntity;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import studio.one.platform.ai.autoconfigure.AiWebAutoConfiguration;
 import studio.one.platform.ai.autoconfigure.AiSecretPresenceGuard;
 import studio.one.platform.ai.core.chat.ChatMemoryStore;
 import studio.one.platform.ai.core.chat.ChatPort;
+import studio.one.platform.ai.core.chat.ConversationRepositoryPort;
 import studio.one.platform.ai.core.embedding.EmbeddingPort;
 import studio.one.platform.ai.core.registry.AiProviderRegistry;
 import studio.one.platform.ai.service.prompt.PromptRenderer;
@@ -37,6 +40,7 @@ import studio.one.platform.ai.web.dto.ChatRequestDto;
 import studio.one.platform.ai.web.dto.ChatResponseDto;
 import studio.one.platform.ai.web.dto.EmbeddingRequestDto;
 import studio.one.platform.ai.web.dto.EmbeddingResponseDto;
+import studio.one.platform.ai.web.service.ConversationChatService;
 import studio.one.platform.service.I18n;
 import studio.one.platform.web.dto.ApiResponse;
 
@@ -79,6 +83,9 @@ class OpenAiProviderAutoConfigurationTest {
             assertThat(context).hasSingleBean(ChatController.class);
             assertThat(context).hasSingleBean(EmbeddingController.class);
             assertThat(context).hasSingleBean(AiInfoController.class);
+            assertThat(context).hasSingleBean(ConversationRepositoryPort.class);
+            assertThat(context).hasSingleBean(ConversationChatService.class);
+            assertThat(context).hasSingleBean(ObjectMapper.class);
             assertThat(context).doesNotHaveBean(ChatMemoryStore.class);
 
             AiProviderRegistry registry = context.getBean(AiProviderRegistry.class);

--- a/starter/studio-platform-starter-ai/README.md
+++ b/starter/studio-platform-starter-ai/README.md
@@ -200,6 +200,13 @@ studio:
 `ChatPort.stream(ChatRequest)`는 Java `Stream` 기반 동기 계약이므로 WebFlux/Netty event-loop thread에서 직접 소비하지 말고 web 계층에서 별도 scheduler 또는 blocking boundary를 둔다.
 HTTP `text/event-stream` endpoint 변환은 `starter-ai-web` 책임이다.
 
+호환성 기준:
+
+- 기존 `ChatResponse.metadata()` map은 유지되며 신규 key는 additive하게 추가된다.
+- `resolvedModel`은 response metadata model, request model, configured model 순서로 결정된다.
+- native stream이 빈 stream을 반환하거나 unsupported를 명시하면 fallback stream으로 대체된다.
+- stream 도중 provider 오류가 발생하면 오류를 숨기지 않고 소비 시점에 전파한다. HTTP error event 변환은 web starter가 담당한다.
+
 ### RAG 청킹 설정
 
 `starter:studio-platform-starter-chunking`이 classpath에 있으면 `RagPipelineService`는 신규

--- a/studio-platform-ai/README.md
+++ b/studio-platform-ai/README.md
@@ -86,6 +86,15 @@ stream event type:
 - `complete`: stream 완료
 - `error`: provider 호출 실패
 
+event payload는 `ChatStreamEvent.toMap()` 기준으로 비어 있지 않은 필드만 포함한다.
+예를 들어 기본 fallback stream은 아래 순서를 보장한다.
+
+```json
+{"type":"delta","delta":"답변 조각","model":"gpt-4o-mini","metadata":{"provider":"OPENAI","resolvedModel":"gpt-4o-mini"}}
+{"type":"usage","metadata":{"tokenUsage":{"inputTokens":10,"outputTokens":5,"totalTokens":15},"latencyMs":120}}
+{"type":"complete","model":"gpt-4o-mini","metadata":{"provider":"OPENAI","resolvedModel":"gpt-4o-mini"}}
+```
+
 이 계약은 Reactor, Spring Web, SSE 구현체에 의존하지 않는다. HTTP `text/event-stream` 변환은 web starter 책임이다.
 
 ## Conversation contracts

--- a/studio-platform-ai/README.md
+++ b/studio-platform-ai/README.md
@@ -89,7 +89,7 @@ stream event type:
 event payload는 `ChatStreamEvent.toMap()` 기준으로 비어 있지 않은 필드만 포함한다.
 예를 들어 기본 fallback stream은 아래 순서를 보장한다.
 
-```json
+```jsonl
 {"type":"delta","delta":"답변 조각","model":"gpt-4o-mini","metadata":{"provider":"OPENAI","resolvedModel":"gpt-4o-mini"}}
 {"type":"usage","metadata":{"tokenUsage":{"inputTokens":10,"outputTokens":5,"totalTokens":15},"latencyMs":120}}
 {"type":"complete","model":"gpt-4o-mini","metadata":{"provider":"OPENAI","resolvedModel":"gpt-4o-mini"}}

--- a/studio-platform-ai/README.md
+++ b/studio-platform-ai/README.md
@@ -87,7 +87,7 @@ stream event type:
 - `error`: provider 호출 실패
 
 event payload는 `ChatStreamEvent.toMap()` 기준으로 비어 있지 않은 필드만 포함한다.
-예를 들어 기본 fallback stream은 아래 순서를 보장한다.
+예를 들어 기본 fallback stream은 아래 순서를 보장한다. `requestId`는 HTTP SSE adapter가 추가하는 web 전용 필드이므로 core event에는 포함되지 않는다.
 
 ```jsonl
 {"type":"delta","delta":"답변 조각","model":"gpt-4o-mini","metadata":{"provider":"OPENAI","resolvedModel":"gpt-4o-mini"}}


### PR DESCRIPTION
## Why

- AI Chat Platform 확장(#258~#260)으로 metadata, streaming, conversation API 계약이 추가되었고 README와 테스트 설명을 최신 상태로 맞출 필요가 있다.
- web auto-configuration에서 conversation repository/service와 ObjectMapper가 함께 등록되는지 회귀 검증이 필요하다.

## What

- `studio-platform-ai` README에 `ChatStreamEvent.toMap()` 기반 stream payload 예시를 추가했다.
- `starter-ai` README에 native streaming/fallback 및 metadata additive 호환성 기준을 보강했다.
- `starter-ai-web` README에 chat response metadata 예시, SSE event payload 예시, conversation metadata 호환성 설명을 추가했다.
- OpenAI web auto-configuration 테스트에 `ConversationRepositoryPort`, `ConversationChatService`, `ObjectMapper` 등록 검증을 추가했다.

## Related Issues

- Closes #261

## Validation

- Command: `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test`
- Result: PASS
- Command: `git diff --check`
- Result: PASS

## Risk / Rollback

- Risk: 문서 예시와 실제 DTO/event shape가 어긋나면 소비자가 혼동할 수 있다. 테스트로 auto-configuration bean 등록 회귀를 보강했고, 예시는 현재 public API 필드 기준으로 작성했다.
- Rollback: 이 PR 커밋을 revert하면 README/test 보강만 제거되며 런타임 동작에는 영향이 없다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope:
- Main author validation: 대상 3개 모듈 테스트와 `git diff --check`를 실행했다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included
