### PR TITLE
[ai-assisted] feat(chunking): parent-child chunking 기반 도입

### DIFF
--- a/starter/studio-platform-starter-chunking/README.md
+++ b/starter/studio-platform-starter-chunking/README.md
@@ -85,6 +85,9 @@ It also creates deterministic parent section ids and links each child chunk thro
 - `blockIds`
 - `confidence`
 
+Neighbor links do not cross parent section boundaries. If a document starts without a heading, the first parent context
+uses an empty `section` value and body-only `parentChunkContent`.
+
 The strategy does not parse files, run OCR, call embedding APIs, call LLMs, or write vector stores.
 
 When `studio-platform-textract` is available, `TextractNormalizedDocumentAdapter` can convert `ParsedFile` into `NormalizedDocument`:

--- a/starter/studio-platform-starter-chunking/README.md
+++ b/starter/studio-platform-starter-chunking/README.md
@@ -4,7 +4,7 @@
 
 ## Responsibility
 
-- Provides Phase 1 text-only chunking implementations.
+- Provides pure chunking implementations for text and normalized structured documents.
 - Registers chunking beans with `@ConditionalOnMissingBean` so applications can override them.
 - Keeps Spring AI, embedding, vector storage, and web endpoint concerns out of this starter.
 - Leaves `starter:studio-platform-starter-ai-web` as an HTTP adapter only.
@@ -74,7 +74,16 @@ Chunk ids are deterministic:
 ## Structure-Based Strategy
 
 `StructureBasedChunker` consumes `NormalizedDocument` and preserves parser provenance in `ChunkMetadata`.
-It keeps heading boundaries as `section` / `headingPath`, packs paragraph-like blocks by configured size, and emits table, OCR text, and image-caption blocks as standalone chunks.
+It keeps heading boundaries as `section` / `headingPath`, packs paragraph-like blocks by configured size, and emits table, OCR text, and image-caption blocks as standalone child chunks.
+It also creates deterministic parent section ids and links each child chunk through additive metadata:
+
+- `chunkType`
+- `parentChunkId`
+- `parentChunkContent`
+- `previousChunkId`
+- `nextChunkId`
+- `blockIds`
+- `confidence`
 
 The strategy does not parse files, run OCR, call embedding APIs, call LLMs, or write vector stores.
 
@@ -92,11 +101,50 @@ The adapter maps:
 - `ParsedBlock` to normalized heading, paragraph, list, footnote, OCR, and other logical blocks.
 - `ExtractedTable.vectorText()` to table chunks.
 - `ExtractedImage.caption()`, `altText()`, or `ocrText()` to image-caption/OCR chunks.
+- `ParsedBlock.confidence()` and table/image source references into normalized provenance fields.
 
 When a parsed table block and an `ExtractedTable` share the same `sourceRef`, the adapter keeps one table block based on
 `ExtractedTable.vectorText()` and carries over the parsed table block order/provenance. `ExtractedImage` does not currently
 carry an independent order value, so image-caption/OCR chunks are sorted after ordered parsed blocks unless the source
 metadata provides a future ordering field.
+
+### Parent-Child Example
+
+```java
+NormalizedDocument document = NormalizedDocument.builder("doc-1")
+        .sourceFormat("PDF")
+        .blocks(List.of(
+                NormalizedBlock.builder(NormalizedBlockType.HEADING, "Install")
+                        .id("page[1]/h[0]")
+                        .order(0)
+                        .headingPath("Install")
+                        .blockIds(List.of("page[1]/h[0]"))
+                        .build(),
+                NormalizedBlock.builder(NormalizedBlockType.PARAGRAPH, "Install the engine.")
+                        .id("page[1]/p[1]")
+                        .order(1)
+                        .blockIds(List.of("page[1]/p[1]"))
+                        .build(),
+                NormalizedBlock.builder(NormalizedBlockType.PARAGRAPH, "Configure tessdata.")
+                        .id("page[1]/p[2]")
+                        .order(2)
+                        .blockIds(List.of("page[1]/p[2]"))
+                        .build()))
+        .build();
+
+List<Chunk> chunks = chunkingOrchestrator.chunk(document);
+Chunk chunk = chunks.get(0);
+
+chunk.metadata().chunkType();      // CHILD
+chunk.metadata().parentChunkId();  // doc-1-parent-0
+chunk.metadata().toMap().get("parentChunkContent"); // Install\n\nInstall the engine.\n\nConfigure tessdata.
+chunk.metadata().previousChunkId();// null
+chunk.metadata().nextChunkId();    // null for a single child
+chunk.metadata().blockIds();       // [page[1]/p[1], page[1]/p[2]]
+```
+
+The default return value remains the child chunk list for compatibility. Parent content is persisted additively in child
+metadata so later context-expansion strategies can recover section context without changing the indexing contract.
 
 ## Size Policy
 

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/FixedSizeChunker.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/FixedSizeChunker.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import studio.one.platform.chunking.core.Chunk;
 import studio.one.platform.chunking.core.ChunkMetadata;
+import studio.one.platform.chunking.core.ChunkType;
 import studio.one.platform.chunking.core.Chunker;
 import studio.one.platform.chunking.core.ChunkingContext;
 import studio.one.platform.chunking.core.ChunkingStrategyType;
@@ -48,7 +49,10 @@ public class FixedSizeChunker implements Chunker {
             int end = Math.min(start + maxSize, text.length());
             String content = text.substring(start, end).trim();
             if (!content.isBlank()) {
-                chunks.add(chunk(context, content, order++, start, end));
+                int currentOrder = order++;
+                chunks.add(chunk(context, content, currentOrder, start, end,
+                        currentOrder == 0 ? null : chunkId(context.sourceDocumentId(), currentOrder - 1),
+                        end == text.length() ? null : chunkId(context.sourceDocumentId(), currentOrder + 1)));
             }
             if (end == text.length()) {
                 break;
@@ -59,10 +63,20 @@ public class FixedSizeChunker implements Chunker {
         return chunks;
     }
 
-    private Chunk chunk(ChunkingContext context, String content, int order, int startOffset, int endOffset) {
+    private Chunk chunk(
+            ChunkingContext context,
+            String content,
+            int order,
+            int startOffset,
+            int endOffset,
+            String previousChunkId,
+            String nextChunkId) {
         String id = chunkId(context.sourceDocumentId(), order);
         ChunkMetadata metadata = ChunkMetadata.builder(strategy(), order)
                 .sourceDocumentId(context.sourceDocumentId())
+                .chunkType(ChunkType.CHILD)
+                .previousChunkId(previousChunkId)
+                .nextChunkId(nextChunkId)
                 .objectType(context.objectType())
                 .objectId(context.objectId())
                 .startOffset(startOffset)

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/RecursiveChunker.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/RecursiveChunker.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 
 import studio.one.platform.chunking.core.Chunk;
 import studio.one.platform.chunking.core.ChunkMetadata;
+import studio.one.platform.chunking.core.ChunkType;
 import studio.one.platform.chunking.core.Chunker;
 import studio.one.platform.chunking.core.ChunkingContext;
 import studio.one.platform.chunking.core.ChunkingStrategyType;
@@ -81,6 +82,7 @@ public class RecursiveChunker implements Chunker {
             String content = current.toString().trim();
             chunks.add(chunk(context, content, order, cursor, cursor + content.length()));
         }
+        linkNeighbors(context, chunks);
         return chunks;
     }
 
@@ -88,6 +90,7 @@ public class RecursiveChunker implements Chunker {
         String id = chunkId(context.sourceDocumentId(), order);
         ChunkMetadata metadata = ChunkMetadata.builder(strategy(), order)
                 .sourceDocumentId(context.sourceDocumentId())
+                .chunkType(ChunkType.CHILD)
                 .objectType(context.objectType())
                 .objectId(context.objectId())
                 .startOffset(startOffset)
@@ -95,6 +98,33 @@ public class RecursiveChunker implements Chunker {
                 .charCount(content.length())
                 .build();
         return Chunk.of(id, content, metadata);
+    }
+
+    private void linkNeighbors(ChunkingContext context, List<Chunk> chunks) {
+        for (int i = 0; i < chunks.size(); i++) {
+            Chunk chunk = chunks.get(i);
+            String previousChunkId = i == 0 ? null : chunkId(context.sourceDocumentId(), i - 1);
+            String nextChunkId = i == chunks.size() - 1 ? null : chunkId(context.sourceDocumentId(), i + 1);
+            ChunkMetadata metadata = ChunkMetadata.builder(chunk.metadata().strategy(), chunk.metadata().order())
+                    .sourceDocumentId(chunk.metadata().sourceDocumentId())
+                    .parentId(chunk.metadata().parentId())
+                    .chunkType(chunk.metadata().chunkType())
+                    .parentChunkId(chunk.metadata().parentChunkId())
+                    .previousChunkId(previousChunkId)
+                    .nextChunkId(nextChunkId)
+                    .section(chunk.metadata().section())
+                    .objectType(chunk.metadata().objectType())
+                    .objectId(chunk.metadata().objectId())
+                    .startOffset(chunk.metadata().startOffset())
+                    .endOffset(chunk.metadata().endOffset())
+                    .tokenCount(chunk.metadata().tokenCount())
+                    .charCount(chunk.metadata().charCount())
+                    .blockIds(chunk.metadata().blockIds())
+                    .confidence(chunk.metadata().confidence())
+                    .attributes(chunk.metadata().attributes())
+                    .build();
+            chunks.set(i, Chunk.of(chunk.id(), chunk.content(), metadata));
+        }
     }
 
     private List<String> splitRecursively(String text, int maxSize) {

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/RecursiveChunker.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/RecursiveChunker.java
@@ -103,8 +103,8 @@ public class RecursiveChunker implements Chunker {
     private void linkNeighbors(ChunkingContext context, List<Chunk> chunks) {
         for (int i = 0; i < chunks.size(); i++) {
             Chunk chunk = chunks.get(i);
-            String previousChunkId = i == 0 ? null : chunkId(context.sourceDocumentId(), i - 1);
-            String nextChunkId = i == chunks.size() - 1 ? null : chunkId(context.sourceDocumentId(), i + 1);
+            String previousChunkId = i == 0 ? null : chunks.get(i - 1).id();
+            String nextChunkId = i == chunks.size() - 1 ? null : chunks.get(i + 1).id();
             ChunkMetadata metadata = ChunkMetadata.builder(chunk.metadata().strategy(), chunk.metadata().order())
                     .sourceDocumentId(chunk.metadata().sourceDocumentId())
                     .parentId(chunk.metadata().parentId())

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/StructureBasedChunker.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/StructureBasedChunker.java
@@ -4,9 +4,11 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import studio.one.platform.chunking.core.Chunk;
 import studio.one.platform.chunking.core.ChunkMetadata;
+import studio.one.platform.chunking.core.ChunkType;
 import studio.one.platform.chunking.core.ChunkUnit;
 import studio.one.platform.chunking.core.Chunker;
 import studio.one.platform.chunking.core.ChunkingContext;
@@ -58,70 +60,110 @@ public class StructureBasedChunker implements NormalizedDocumentChunker {
         int maxSize = ChunkSizing.effectiveMaxSize(context.maxSize(), defaultMaxSize);
         int overlap = ChunkSizing.effectiveOverlap(context.overlap(), defaultOverlap, maxSize);
         ChunkUnit unit = context.unit();
+        List<Section> sections = splitSections(document.blocks());
         List<Chunk> chunks = new ArrayList<>();
+        int childOrder = 0;
+
+        for (Section section : sections) {
+            ParentChunk parentChunk = createParentChunk(document, context, section, maxSize, overlap, unit);
+            childOrder = appendChildChunks(document, context, section, parentChunk, maxSize, overlap, unit, chunks, childOrder);
+        }
+        return linkNeighbors(chunks);
+    }
+
+    private ParentChunk createParentChunk(
+            NormalizedDocument document,
+            ChunkingContext context,
+            Section section,
+            int maxSize,
+            int overlap,
+            ChunkUnit unit) {
+        String content = content(section.parentBlocks());
+        Map<String, Object> attributes = attributes(document, section.parentBlocks(), section.headingPath(),
+                maxSize, overlap, unit, ChunkType.PARENT, null);
+        ChunkMetadata metadata = ChunkMetadata.builder(strategy(), section.startOrder())
+                .sourceDocumentId(effectiveSourceDocumentId(document, context))
+                .chunkType(resolveParentChunkType(section))
+                .section(section.headingPath())
+                .objectType(context.objectType())
+                .objectId(context.objectId())
+                .charCount(content.length())
+                .tokenCount(ChunkSizing.estimateTokens(content))
+                .blockIds(collectBlockIds(section.parentBlocks()))
+                .confidence(aggregateConfidence(section.parentBlocks()))
+                .attributes(attributes)
+                .build();
+        return new ParentChunk(parentChunkId(effectiveSourceDocumentId(document, context), section.startOrder()),
+                content, metadata, section);
+    }
+
+    private int appendChildChunks(
+            NormalizedDocument document,
+            ChunkingContext context,
+            Section section,
+            ParentChunk parentChunk,
+            int maxSize,
+            int overlap,
+            ChunkUnit unit,
+            List<Chunk> chunks,
+            int initialOrder) {
         List<NormalizedBlock> current = new ArrayList<>();
-        String headingPath = "";
+        int order = initialOrder;
 
-        for (NormalizedBlock block : document.blocks()) {
-            if (isHeading(block)) {
-                flush(document, context, chunks, current, headingPath, maxSize, overlap, unit);
-                headingPath = block.text();
-                current.clear();
-                current.add(block);
-                continue;
-            }
-
+        for (NormalizedBlock block : section.blocks()) {
             if (isStandalone(block)) {
-                flush(document, context, chunks, current, headingPath, maxSize, overlap, unit);
-                current.clear();
-                chunks.add(toChunk(document, context, List.of(block), chunks.size(), headingPath, maxSize, overlap, unit));
+                if (!current.isEmpty()) {
+                    chunks.add(toChildChunk(document, context, current, order++, section.headingPath(),
+                            parentChunk, maxSize, overlap, unit));
+                    current = new ArrayList<>();
+                }
+                chunks.add(toChildChunk(document, context, List.of(block), order++, section.headingPath(),
+                        parentChunk, maxSize, overlap, unit));
                 continue;
             }
 
             if (!current.isEmpty() && sizeOf(current, block, unit) > maxSize) {
-                flush(document, context, chunks, current, headingPath, maxSize, overlap, unit);
+                chunks.add(toChildChunk(document, context, current, order++, section.headingPath(),
+                        parentChunk, maxSize, overlap, unit));
                 current = overlapTail(current, overlap, unit);
+            }
+            if (current.isEmpty()) {
+                current = new ArrayList<>();
             }
             current.add(block);
         }
 
-        flush(document, context, chunks, current, headingPath, maxSize, overlap, unit);
-        return chunks;
-    }
-
-    private void flush(
-            NormalizedDocument document,
-            ChunkingContext context,
-            List<Chunk> chunks,
-            List<NormalizedBlock> current,
-            String headingPath,
-            int maxSize,
-            int overlap,
-            ChunkUnit unit) {
-        if (current.isEmpty()) {
-            return;
+        if (!current.isEmpty()) {
+            chunks.add(toChildChunk(document, context, current, order++, section.headingPath(),
+                    parentChunk, maxSize, overlap, unit));
         }
-        chunks.add(toChunk(document, context, current, chunks.size(), headingPath, maxSize, overlap, unit));
+        return order;
     }
 
-    private Chunk toChunk(
+    private Chunk toChildChunk(
             NormalizedDocument document,
             ChunkingContext context,
             List<NormalizedBlock> blocks,
             int order,
             String headingPath,
+            ParentChunk parentChunk,
             int maxSize,
             int overlap,
             ChunkUnit unit) {
         String content = content(blocks);
-        Map<String, Object> attributes = attributes(document, blocks, headingPath, maxSize, overlap, unit);
+        Map<String, Object> attributes = attributes(document, blocks, headingPath, maxSize, overlap, unit,
+                resolveChunkType(blocks), parentChunk);
         ChunkMetadata metadata = ChunkMetadata.builder(strategy(), order)
                 .sourceDocumentId(effectiveSourceDocumentId(document, context))
+                .chunkType(resolveChunkType(blocks))
+                .parentChunkId(parentChunk.id())
                 .section(headingPath)
                 .objectType(context.objectType())
                 .objectId(context.objectId())
                 .charCount(content.length())
                 .tokenCount(ChunkSizing.estimateTokens(content))
+                .blockIds(collectBlockIds(blocks))
+                .confidence(aggregateConfidence(blocks))
                 .attributes(attributes)
                 .build();
         return Chunk.of(chunkId(effectiveSourceDocumentId(document, context), order), content, metadata);
@@ -133,7 +175,9 @@ public class StructureBasedChunker implements NormalizedDocumentChunker {
             String headingPath,
             int maxSize,
             int overlap,
-            ChunkUnit unit) {
+            ChunkUnit unit,
+            ChunkType chunkType,
+            ParentChunk parentChunk) {
         Map<String, Object> attributes = new LinkedHashMap<>(document.metadata());
         NormalizedBlock first = blocks.get(0);
         putIfPresent(attributes, ChunkMetadata.KEY_SOURCE_FORMAT, document.sourceFormat());
@@ -145,13 +189,22 @@ public class StructureBasedChunker implements NormalizedDocumentChunker {
         putIfPresent(attributes, ChunkMetadata.KEY_HEADING_PATH, headingPath);
         putIfPresent(attributes, ChunkMetadata.KEY_TOKEN_ESTIMATE, ChunkSizing.estimateTokens(content(blocks)));
         putIfPresent(attributes, ChunkMetadata.KEY_CHUNK_UNIT, unit.value());
+        putIfPresent(attributes, ChunkMetadata.KEY_CHUNK_TYPE, chunkType.value());
         putIfPresent(attributes, ChunkMetadata.KEY_MAX_SIZE, maxSize);
         putIfPresent(attributes, ChunkMetadata.KEY_OVERLAP, overlap);
+        putIfPresent(attributes, ChunkMetadata.KEY_BLOCK_IDS, collectBlockIds(blocks));
+        putIfPresent(attributes, ChunkMetadata.KEY_CONFIDENCE, aggregateConfidence(blocks));
         putIfPresent(attributes, ChunkMetadata.KEY_SOURCE_REFS, blocks.stream()
                 .map(NormalizedBlock::effectiveSourceRef)
                 .filter(ref -> ref != null && !ref.isBlank())
                 .distinct()
                 .toList());
+        if (parentChunk != null) {
+            putIfPresent(attributes, ChunkMetadata.KEY_PARENT_CHUNK_CONTENT, parentChunk.content());
+            putIfPresent(attributes, ChunkMetadata.KEY_PARENT_CHUNK_BLOCK_IDS, parentChunk.metadata().blockIds());
+            putIfPresent(attributes, ChunkMetadata.KEY_PARENT_CHUNK_SOURCE_REFS,
+                    parentChunk.metadata().toMap().get(ChunkMetadata.KEY_SOURCE_REFS));
+        }
         return attributes;
     }
 
@@ -199,6 +252,38 @@ public class StructureBasedChunker implements NormalizedDocumentChunker {
         return tail;
     }
 
+    private List<Section> splitSections(List<NormalizedBlock> blocks) {
+        List<Section> sections = new ArrayList<>();
+        List<NormalizedBlock> current = new ArrayList<>();
+        List<NormalizedBlock> currentParentBlocks = new ArrayList<>();
+        String headingPath = "";
+        int startOrder = 0;
+
+        for (NormalizedBlock block : blocks) {
+            if (isHeading(block)) {
+                if (!current.isEmpty()) {
+                    sections.add(new Section(headingPath, startOrder, List.copyOf(current), List.copyOf(currentParentBlocks)));
+                }
+                current = new ArrayList<>();
+                currentParentBlocks = new ArrayList<>();
+                headingPath = resolveHeadingPath(block);
+                startOrder = block.order() == null ? sections.size() : block.order();
+                currentParentBlocks.add(block);
+                continue;
+            }
+            if (current.isEmpty() && currentParentBlocks.isEmpty()) {
+                startOrder = block.order() == null ? sections.size() : block.order();
+            }
+            current.add(block);
+            currentParentBlocks.add(block);
+        }
+
+        if (!current.isEmpty() || !currentParentBlocks.isEmpty()) {
+            sections.add(new Section(headingPath, startOrder, List.copyOf(current), List.copyOf(currentParentBlocks)));
+        }
+        return sections;
+    }
+
     private boolean isHeading(NormalizedBlock block) {
         return block.type() == NormalizedBlockType.TITLE || block.type() == NormalizedBlockType.HEADING;
     }
@@ -214,6 +299,13 @@ public class StructureBasedChunker implements NormalizedDocumentChunker {
         return isHeading(block) || isStandalone(block);
     }
 
+    private String resolveHeadingPath(NormalizedBlock block) {
+        if (block.headingPath() != null && !block.headingPath().isBlank()) {
+            return block.headingPath();
+        }
+        return block.text();
+    }
+
     private String effectiveSourceDocumentId(NormalizedDocument document, ChunkingContext context) {
         if (!document.sourceDocumentId().isBlank()) {
             return document.sourceDocumentId();
@@ -224,5 +316,96 @@ public class StructureBasedChunker implements NormalizedDocumentChunker {
     private String chunkId(String sourceDocumentId, int order) {
         String prefix = sourceDocumentId == null || sourceDocumentId.isBlank() ? "document" : sourceDocumentId;
         return prefix + "-" + order;
+    }
+
+    private String parentChunkId(String sourceDocumentId, int order) {
+        String prefix = sourceDocumentId == null || sourceDocumentId.isBlank() ? "document" : sourceDocumentId;
+        return prefix + "-parent-" + order;
+    }
+
+    private ChunkType resolveChunkType(List<NormalizedBlock> blocks) {
+        if (blocks.size() == 1) {
+            NormalizedBlockType type = blocks.get(0).type();
+            if (type == NormalizedBlockType.TABLE) {
+                return ChunkType.TABLE;
+            }
+            if (type == NormalizedBlockType.OCR_TEXT) {
+                return ChunkType.OCR;
+            }
+            if (type == NormalizedBlockType.IMAGE || type == NormalizedBlockType.IMAGE_CAPTION) {
+                return ChunkType.IMAGE_CAPTION;
+            }
+            if (type == NormalizedBlockType.PAGE) {
+                return ChunkType.SLIDE;
+            }
+        }
+        return ChunkType.CHILD;
+    }
+
+    private ChunkType resolveParentChunkType(Section section) {
+        if (section.parentBlocks().stream().anyMatch(block -> block.slide() != null)) {
+            return ChunkType.SLIDE;
+        }
+        return ChunkType.PARENT;
+    }
+
+    private List<String> collectBlockIds(List<NormalizedBlock> blocks) {
+        return blocks.stream()
+                .map(NormalizedBlock::blockIds)
+                .filter(Objects::nonNull)
+                .flatMap(List::stream)
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(id -> !id.isBlank())
+                .distinct()
+                .toList();
+    }
+
+    private Double aggregateConfidence(List<NormalizedBlock> blocks) {
+        List<Double> values = blocks.stream()
+                .map(NormalizedBlock::confidence)
+                .filter(Objects::nonNull)
+                .toList();
+        if (values.isEmpty()) {
+            return null;
+        }
+        return values.stream().mapToDouble(Double::doubleValue).average().orElse(0.0d);
+    }
+
+    private List<Chunk> linkNeighbors(List<Chunk> chunks) {
+        if (chunks.isEmpty()) {
+            return chunks;
+        }
+        List<Chunk> linked = new ArrayList<>(chunks.size());
+        for (int i = 0; i < chunks.size(); i++) {
+            Chunk chunk = chunks.get(i);
+            ChunkMetadata metadata = ChunkMetadata.builder(chunk.metadata().strategy(), chunk.metadata().order())
+                    .sourceDocumentId(chunk.metadata().sourceDocumentId())
+                    .parentId(chunk.metadata().parentId())
+                    .chunkType(chunk.metadata().chunkType())
+                    .parentChunkId(chunk.metadata().parentChunkId())
+                    .previousChunkId(i == 0 ? null : chunks.get(i - 1).id())
+                    .nextChunkId(i == chunks.size() - 1 ? null : chunks.get(i + 1).id())
+                    .section(chunk.metadata().section())
+                    .objectType(chunk.metadata().objectType())
+                    .objectId(chunk.metadata().objectId())
+                    .startOffset(chunk.metadata().startOffset())
+                    .endOffset(chunk.metadata().endOffset())
+                    .tokenCount(chunk.metadata().tokenCount())
+                    .charCount(chunk.metadata().charCount())
+                    .blockIds(chunk.metadata().blockIds())
+                    .confidence(chunk.metadata().confidence())
+                    .attributes(chunk.metadata().attributes())
+                    .build();
+            linked.add(Chunk.of(chunk.id(), chunk.content(), metadata));
+        }
+        return linked;
+    }
+
+    private record Section(String headingPath, int startOrder, List<NormalizedBlock> blocks,
+                           List<NormalizedBlock> parentBlocks) {
+    }
+
+    private record ParentChunk(String id, String content, ChunkMetadata metadata, Section section) {
     }
 }

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/StructureBasedChunker.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/StructureBasedChunker.java
@@ -68,7 +68,7 @@ public class StructureBasedChunker implements NormalizedDocumentChunker {
             ParentChunk parentChunk = createParentChunk(document, context, section, maxSize, overlap, unit);
             childOrder = appendChildChunks(document, context, section, parentChunk, maxSize, overlap, unit, chunks, childOrder);
         }
-        return linkNeighbors(chunks);
+        return linkNeighborsWithinParent(chunks);
     }
 
     private ParentChunk createParentChunk(
@@ -192,8 +192,6 @@ public class StructureBasedChunker implements NormalizedDocumentChunker {
         putIfPresent(attributes, ChunkMetadata.KEY_CHUNK_TYPE, chunkType.value());
         putIfPresent(attributes, ChunkMetadata.KEY_MAX_SIZE, maxSize);
         putIfPresent(attributes, ChunkMetadata.KEY_OVERLAP, overlap);
-        putIfPresent(attributes, ChunkMetadata.KEY_BLOCK_IDS, collectBlockIds(blocks));
-        putIfPresent(attributes, ChunkMetadata.KEY_CONFIDENCE, aggregateConfidence(blocks));
         putIfPresent(attributes, ChunkMetadata.KEY_SOURCE_REFS, blocks.stream()
                 .map(NormalizedBlock::effectiveSourceRef)
                 .filter(ref -> ref != null && !ref.isBlank())
@@ -343,7 +341,7 @@ public class StructureBasedChunker implements NormalizedDocumentChunker {
     }
 
     private ChunkType resolveParentChunkType(Section section) {
-        if (section.parentBlocks().stream().anyMatch(block -> block.slide() != null)) {
+        if (section.parentBlocks().stream().anyMatch(block -> block.slide() != null && block.page() == null)) {
             return ChunkType.SLIDE;
         }
         return ChunkType.PARENT;
@@ -372,20 +370,22 @@ public class StructureBasedChunker implements NormalizedDocumentChunker {
         return values.stream().mapToDouble(Double::doubleValue).average().orElse(0.0d);
     }
 
-    private List<Chunk> linkNeighbors(List<Chunk> chunks) {
+    private List<Chunk> linkNeighborsWithinParent(List<Chunk> chunks) {
         if (chunks.isEmpty()) {
             return chunks;
         }
         List<Chunk> linked = new ArrayList<>(chunks.size());
         for (int i = 0; i < chunks.size(); i++) {
             Chunk chunk = chunks.get(i);
+            Chunk previous = i == 0 ? null : chunks.get(i - 1);
+            Chunk next = i == chunks.size() - 1 ? null : chunks.get(i + 1);
             ChunkMetadata metadata = ChunkMetadata.builder(chunk.metadata().strategy(), chunk.metadata().order())
                     .sourceDocumentId(chunk.metadata().sourceDocumentId())
                     .parentId(chunk.metadata().parentId())
                     .chunkType(chunk.metadata().chunkType())
                     .parentChunkId(chunk.metadata().parentChunkId())
-                    .previousChunkId(i == 0 ? null : chunks.get(i - 1).id())
-                    .nextChunkId(i == chunks.size() - 1 ? null : chunks.get(i + 1).id())
+                    .previousChunkId(sameParent(chunk, previous) ? previous.id() : null)
+                    .nextChunkId(sameParent(chunk, next) ? next.id() : null)
                     .section(chunk.metadata().section())
                     .objectType(chunk.metadata().objectType())
                     .objectId(chunk.metadata().objectId())
@@ -400,6 +400,10 @@ public class StructureBasedChunker implements NormalizedDocumentChunker {
             linked.add(Chunk.of(chunk.id(), chunk.content(), metadata));
         }
         return linked;
+    }
+
+    private boolean sameParent(Chunk current, Chunk other) {
+        return other != null && Objects.equals(current.metadata().parentChunkId(), other.metadata().parentChunkId());
     }
 
     private record Section(String headingPath, int startOrder, List<NormalizedBlock> blocks,

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/TextractNormalizedDocumentAdapter.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/TextractNormalizedDocumentAdapter.java
@@ -14,6 +14,7 @@ import studio.one.platform.chunking.core.NormalizedDocument;
 import studio.one.platform.textract.model.BlockType;
 import studio.one.platform.textract.model.ExtractedImage;
 import studio.one.platform.textract.model.ExtractedTable;
+import studio.one.platform.textract.model.ExtractedTableCell;
 import studio.one.platform.textract.model.ParsedBlock;
 import studio.one.platform.textract.model.ParsedFile;
 
@@ -81,6 +82,8 @@ public class TextractNormalizedDocumentAdapter {
                 .slide(block.slide())
                 .order(block.order())
                 .parentBlockId(block.parentBlockId())
+                .blockIds(List.of(block.id()))
+                .confidence(block.confidence())
                 .metadata(block.metadata())
                 .build();
     }
@@ -97,6 +100,8 @@ public class TextractNormalizedDocumentAdapter {
                 .slide(tableBlock == null ? null : tableBlock.slide())
                 .order(tableBlock == null ? null : tableBlock.order())
                 .parentBlockId(tableBlock == null ? null : tableBlock.parentBlockId())
+                .blockIds(tableCellRefs(table, tableBlock))
+                .confidence(tableBlock == null ? null : tableBlock.confidence())
                 .metadata(metadata)
                 .build();
     }
@@ -111,8 +116,24 @@ public class TextractNormalizedDocumentAdapter {
         return NormalizedBlock.builder(image.ocrApplied() ? NormalizedBlockType.OCR_TEXT : NormalizedBlockType.IMAGE_CAPTION, text)
                 .id(image.path())
                 .sourceRef(image.sourceRef())
+                .blockIds(image.sourceRefs().isEmpty() ? List.of(image.path()) : image.sourceRefs())
                 .metadata(metadata)
                 .build();
+    }
+
+    private List<String> tableCellRefs(ExtractedTable table, ParsedBlock tableBlock) {
+        List<String> refs = table.cells().stream()
+                .map(ExtractedTableCell::sourceRef)
+                .filter(ref -> ref != null && !ref.isBlank())
+                .distinct()
+                .toList();
+        if (!refs.isEmpty()) {
+            return refs;
+        }
+        if (tableBlock != null && tableBlock.id() != null && !tableBlock.id().isBlank()) {
+            return List.of(tableBlock.id());
+        }
+        return table.path() == null || table.path().isBlank() ? List.of() : List.of(table.path());
     }
 
     private String filename(Map<String, Object> metadata) {

--- a/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/StructureBasedChunkerTest.java
+++ b/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/StructureBasedChunkerTest.java
@@ -83,6 +83,62 @@ class StructureBasedChunkerTest {
     }
 
     @Test
+    void doesNotLinkChildChunksAcrossSectionParents() {
+        StructureBasedChunker chunker = new StructureBasedChunker(120, 0, new RecursiveChunker(120, 0));
+        NormalizedDocument document = NormalizedDocument.builder("doc")
+                .blocks(List.of(
+                        block(NormalizedBlockType.HEADING, "First", "h1", 0, 0.99d),
+                        block(NormalizedBlockType.PARAGRAPH, "First body", "p1", 1, 0.90d),
+                        block(NormalizedBlockType.HEADING, "Second", "h2", 2, 0.99d),
+                        block(NormalizedBlockType.PARAGRAPH, "Second body", "p2", 3, 0.90d)))
+                .build();
+
+        List<Chunk> chunks = chunker.chunk(document, context(document, 120, 0));
+
+        assertThat(chunks).hasSize(2);
+        assertThat(chunks.get(0).metadata().parentChunkId()).isEqualTo("doc-parent-0");
+        assertThat(chunks.get(0).metadata().previousChunkId()).isNull();
+        assertThat(chunks.get(0).metadata().nextChunkId()).isNull();
+        assertThat(chunks.get(1).metadata().parentChunkId()).isEqualTo("doc-parent-2");
+        assertThat(chunks.get(1).metadata().previousChunkId()).isNull();
+        assertThat(chunks.get(1).metadata().nextChunkId()).isNull();
+    }
+
+    @Test
+    void createsParentContextForDocumentsWithoutHeading() {
+        StructureBasedChunker chunker = new StructureBasedChunker(120, 0, new RecursiveChunker(120, 0));
+        NormalizedDocument document = NormalizedDocument.builder("doc")
+                .blocks(List.of(
+                        block(NormalizedBlockType.PARAGRAPH, "Intro body", "p1", 0, 0.90d),
+                        block(NormalizedBlockType.PARAGRAPH, "More body", "p2", 1, 0.80d)))
+                .build();
+
+        List<Chunk> chunks = chunker.chunk(document, context(document, 120, 0));
+
+        assertThat(chunks).hasSize(1);
+        assertThat(chunks.get(0).metadata().section()).isEmpty();
+        assertThat(chunks.get(0).metadata().parentChunkId()).isEqualTo("doc-parent-0");
+        assertThat(chunks.get(0).metadata().toMap())
+                .containsEntry(ChunkMetadata.KEY_PARENT_CHUNK_CONTENT, "Intro body\n\nMore body");
+    }
+
+    @Test
+    void standardBlockIdsAndConfidenceAreStoredOnlyAsMetadataFields() {
+        StructureBasedChunker chunker = new StructureBasedChunker(120, 0, new RecursiveChunker(120, 0));
+        NormalizedDocument document = NormalizedDocument.builder("doc")
+                .blocks(List.of(block(NormalizedBlockType.PARAGRAPH, "Body", "p1", 0, 0.90d)))
+                .build();
+
+        Chunk chunk = chunker.chunk(document, context(document, 120, 0)).get(0);
+
+        assertThat(chunk.metadata().attributes())
+                .doesNotContainKeys(ChunkMetadata.KEY_BLOCK_IDS, ChunkMetadata.KEY_CONFIDENCE);
+        assertThat(chunk.metadata().toMap())
+                .containsEntry(ChunkMetadata.KEY_BLOCK_IDS, List.of("p1"))
+                .containsEntry(ChunkMetadata.KEY_CONFIDENCE, 0.90d);
+    }
+
+    @Test
     void tokenUnitUsesDeterministicEstimateWithoutTokenizer() {
         StructureBasedChunker chunker = new StructureBasedChunker(8, 0, new RecursiveChunker(8, 0));
         NormalizedDocument document = NormalizedDocument.builder("doc")

--- a/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/StructureBasedChunkerTest.java
+++ b/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/StructureBasedChunkerTest.java
@@ -24,23 +24,31 @@ class StructureBasedChunkerTest {
         NormalizedDocument document = NormalizedDocument.builder("doc")
                 .sourceFormat("PDF")
                 .blocks(List.of(
-                        block(NormalizedBlockType.HEADING, "Install", "page[1]/h[0]", 0),
-                        block(NormalizedBlockType.PARAGRAPH, "Install the engine.", "page[1]/p[1]", 1),
-                        block(NormalizedBlockType.PARAGRAPH, "Configure tessdata.", "page[1]/p[2]", 2)))
+                        block(NormalizedBlockType.HEADING, "Install", "page[1]/h[0]", 0, 0.99d),
+                        block(NormalizedBlockType.PARAGRAPH, "Install the engine.", "page[1]/p[1]", 1, 0.90d),
+                        block(NormalizedBlockType.PARAGRAPH, "Configure tessdata.", "page[1]/p[2]", 2, 0.80d)))
                 .build();
 
         List<Chunk> chunks = chunker.chunk(document, context(document, 120, 0));
 
         assertThat(chunks).hasSize(1);
-        assertThat(chunks.get(0).content()).contains("Install", "Install the engine.", "Configure tessdata.");
+        assertThat(chunks.get(0).content()).isEqualTo("Install the engine.\n\nConfigure tessdata.");
         assertThat(chunks.get(0).metadata().section()).isEqualTo("Install");
+        assertThat(chunks.get(0).metadata().chunkType()).isEqualTo(studio.one.platform.chunking.core.ChunkType.CHILD);
+        assertThat(chunks.get(0).metadata().parentChunkId()).isEqualTo("doc-parent-0");
+        assertThat(chunks.get(0).metadata().blockIds()).containsExactly("page[1]/p[1]", "page[1]/p[2]");
+        assertThat(chunks.get(0).metadata().confidence()).isCloseTo((0.90d + 0.80d) / 2, org.assertj.core.data.Offset.offset(0.0001d));
         assertThat(chunks.get(0).metadata().toMap())
-                .containsEntry(ChunkMetadata.KEY_BLOCK_TYPE, "HEADING")
+                .containsEntry(ChunkMetadata.KEY_BLOCK_TYPE, "PARAGRAPH")
                 .containsEntry(ChunkMetadata.KEY_SOURCE_FORMAT, "PDF")
+                .containsEntry(ChunkMetadata.KEY_CHUNK_TYPE, "child")
                 .containsEntry(ChunkMetadata.KEY_HEADING_PATH, "Install")
+                .containsEntry(ChunkMetadata.KEY_PARENT_CHUNK_CONTENT, "Install\n\nInstall the engine.\n\nConfigure tessdata.")
+                .containsEntry(ChunkMetadata.KEY_PARENT_CHUNK_BLOCK_IDS, List.of("page[1]/h[0]", "page[1]/p[1]", "page[1]/p[2]"))
                 .containsEntry(ChunkMetadata.KEY_CHUNK_UNIT, "character")
                 .containsEntry(ChunkMetadata.KEY_MAX_SIZE, 120)
                 .containsEntry(ChunkMetadata.KEY_OVERLAP, 0)
+                .containsEntry(ChunkMetadata.KEY_BLOCK_IDS, List.of("page[1]/p[1]", "page[1]/p[2]"))
                 .containsKey(ChunkMetadata.KEY_SOURCE_REFS);
     }
 
@@ -50,19 +58,26 @@ class StructureBasedChunkerTest {
         NormalizedDocument document = NormalizedDocument.builder("doc")
                 .sourceFormat("HTML")
                 .blocks(List.of(
-                        block(NormalizedBlockType.HEADING, "Metrics", "h1", 0),
-                        block(NormalizedBlockType.TABLE, "Name: Alice\nScore: 90", "table[0]", 1),
-                        block(NormalizedBlockType.OCR_TEXT, "scanned caption", "image[0]/ocr", 2)))
+                        block(NormalizedBlockType.HEADING, "Metrics", "h1", 0, 0.99d),
+                        block(NormalizedBlockType.TABLE, "Name: Alice\nScore: 90", "table[0]", 1, 0.88d),
+                        block(NormalizedBlockType.OCR_TEXT, "scanned caption", "image[0]/ocr", 2, 0.77d)))
                 .build();
 
         List<Chunk> chunks = chunker.chunk(document, context(document, 120, 10));
 
         assertThat(chunks).extracting(Chunk::content)
-                .containsExactly("Metrics", "Name: Alice\nScore: 90", "scanned caption");
-        assertThat(chunks.get(1).metadata().toMap())
+                .containsExactly("Name: Alice\nScore: 90", "scanned caption");
+        assertThat(chunks.get(0).metadata().previousChunkId()).isNull();
+        assertThat(chunks.get(0).metadata().nextChunkId()).isEqualTo("doc-1");
+        assertThat(chunks.get(1).metadata().previousChunkId()).isEqualTo("doc-0");
+        assertThat(chunks.get(1).metadata().nextChunkId()).isNull();
+        assertThat(chunks.get(0).metadata().toMap())
+                .containsEntry(ChunkMetadata.KEY_CHUNK_TYPE, "table")
                 .containsEntry(ChunkMetadata.KEY_BLOCK_TYPE, "TABLE")
-                .containsEntry(ChunkMetadata.KEY_SOURCE_REF, "table[0]");
-        assertThat(chunks.get(2).metadata().toMap())
+                .containsEntry(ChunkMetadata.KEY_SOURCE_REF, "table[0]")
+                .containsEntry(ChunkMetadata.KEY_PARENT_CHUNK_CONTENT, "Metrics\n\nName: Alice\nScore: 90\n\nscanned caption");
+        assertThat(chunks.get(1).metadata().toMap())
+                .containsEntry(ChunkMetadata.KEY_CHUNK_TYPE, "ocr")
                 .containsEntry(ChunkMetadata.KEY_BLOCK_TYPE, "OCR_TEXT")
                 .containsEntry(ChunkMetadata.KEY_SOURCE_REF, "image[0]/ocr");
     }
@@ -72,8 +87,8 @@ class StructureBasedChunkerTest {
         StructureBasedChunker chunker = new StructureBasedChunker(8, 0, new RecursiveChunker(8, 0));
         NormalizedDocument document = NormalizedDocument.builder("doc")
                 .blocks(List.of(
-                        block(NormalizedBlockType.PARAGRAPH, "alpha beta gamma delta", "p1", 0),
-                        block(NormalizedBlockType.PARAGRAPH, "epsilon zeta eta theta", "p2", 1)))
+                        block(NormalizedBlockType.PARAGRAPH, "alpha beta gamma delta", "p1", 0, 0.95d),
+                        block(NormalizedBlockType.PARAGRAPH, "epsilon zeta eta theta", "p2", 1, 0.85d)))
                 .build();
 
         List<Chunk> chunks = chunker.chunk(document, document.toContextBuilder()
@@ -104,11 +119,13 @@ class StructureBasedChunkerTest {
                 .isEqualTo(ChunkingStrategyType.RECURSIVE);
     }
 
-    private NormalizedBlock block(NormalizedBlockType type, String text, String sourceRef, int order) {
+    private NormalizedBlock block(NormalizedBlockType type, String text, String sourceRef, int order, double confidence) {
         return NormalizedBlock.builder(type, text)
                 .id(sourceRef)
                 .sourceRef(sourceRef)
                 .order(order)
+                .blockIds(List.of(sourceRef))
+                .confidence(confidence)
                 .metadata(Map.of("format", "test"))
                 .build();
     }

--- a/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/TextractNormalizedDocumentAdapterTest.java
+++ b/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/TextractNormalizedDocumentAdapterTest.java
@@ -25,8 +25,10 @@ class TextractNormalizedDocumentAdapterTest {
                 DocumentFormat.HTML,
                 "plain",
                 List.of(
-                        ParsedBlock.text("body/h1", BlockType.HEADING, "Title", 1, 0, Map.of()),
-                        ParsedBlock.text("body/table[0]", BlockType.TABLE, "| A |\n| --- |\n| 1 |", 1, 1, Map.of()),
+                        ParsedBlock.text("body/h1", BlockType.HEADING, "Title", 1, 0,
+                                Map.of(ParsedBlock.KEY_CONFIDENCE, 0.98d)),
+                        ParsedBlock.text("body/table[0]", BlockType.TABLE, "| A |\n| --- |\n| 1 |", 1, 1,
+                                Map.of(ParsedBlock.KEY_CONFIDENCE, 0.87d)),
                         ParsedBlock.text("body/p[1]", BlockType.PARAGRAPH, "After table", 1, 2, Map.of())),
                 Map.of("filename", "sample.html"),
                 List.of(),
@@ -34,7 +36,8 @@ class TextractNormalizedDocumentAdapterTest {
                 List.of(new ExtractedTable(
                         "body/table[0]",
                         "| A |\n| --- |\n| 1 |",
-                        List.of(new ExtractedTableCell(0, 0, 1, 1, "A", Map.of())),
+                        List.of(new ExtractedTableCell(0, 0, 1, 1, "A",
+                                Map.of(ExtractedTableCell.KEY_SOURCE_REF, "body/table[0]/cell[0,0]"))),
                         Map.of(ExtractedTable.KEY_VECTOR_TEXT, "A: 1", ExtractedTable.KEY_SOURCE_REF, "body/table[0]"))),
                 List.of(new ExtractedImage(
                         "body/img[0]",
@@ -60,5 +63,9 @@ class TextractNormalizedDocumentAdapterTest {
                 .contains("Title", "A: 1", "After table", "architecture diagram")
                 .doesNotContain("| A |\n| --- |\n| 1 |");
         assertThat(document.blocks().get(1).order()).isEqualTo(1);
+        assertThat(document.blocks().get(0).confidence()).isEqualTo(0.98d);
+        assertThat(document.blocks().get(1).blockIds()).containsExactly("body/table[0]/cell[0,0]");
+        assertThat(document.blocks().get(1).confidence()).isEqualTo(0.87d);
+        assertThat(document.blocks().get(3).blockIds()).containsExactly("body/img[0]");
     }
 }

--- a/studio-platform-chunking/README.md
+++ b/studio-platform-chunking/README.md
@@ -79,7 +79,9 @@ without schema breaks.
 - Child chunks are the default retrieval unit.
 - Parent chunks are modeled by deterministic `parentChunkId` values.
 - Parent chunk content can be persisted additively as `parentChunkContent` when a strategy needs parent context recovery.
-- `previousChunkId` and `nextChunkId` link adjacent child chunks.
+- `previousChunkId` and `nextChunkId` link adjacent child chunks within the same parent section only.
+- Documents that start without a heading still receive a parent context with an empty `section` value and body-only
+  `parentChunkContent`.
 - `blockIds`, `headingPath`, `page`, `slide`, `sourceRef`, and `confidence` preserve provenance needed for later
   context expansion.
 

--- a/studio-platform-chunking/README.md
+++ b/studio-platform-chunking/README.md
@@ -6,6 +6,7 @@
 
 - Define immutable chunking request/result models.
 - Define strategy-neutral chunking extension points.
+- Model search-oriented child chunks and expansion-oriented parent relationships.
 - Keep chunking contracts independent from Spring, Spring AI, JDBC, and vector-store implementations.
 
 ## Core Types
@@ -15,6 +16,7 @@
 - `ChunkingContext`: immutable input context for chunk generation.
 - `Chunk`: immutable chunk content with metadata.
 - `ChunkMetadata`: standard metadata for vector indexing.
+- `ChunkType`: logical chunk role such as `child`, `parent`, `table`, `ocr`.
 - `ChunkingStrategyType`: supported strategy identifiers.
 - `ChunkUnit`: size unit for character-based or token-based chunking.
 - `NormalizedDocument`: parser-neutral structured input for structure-aware chunking.
@@ -29,8 +31,11 @@
 - `ChunkMetadata.order` is intended to map to the same value as `chunkOrder` when persisted by downstream modules.
 - Structured provenance keys are standardized for downstream consumers:
   - `sourceRef`, `sourceRefs`, `blockType`, `page`, `slide`
-  - `parentBlockId`, `headingPath`, `sourceFormat`
+  - `parentBlockId`, `headingPath`, `sourceFormat`, `blockIds`, `confidence`
   - `tokenEstimate`, `chunkUnit`, `maxSize`, `overlap`
+- Parent-child relationship keys are additive and do not replace legacy keys:
+  - `chunkType`, `parentChunkId`, `parentChunkContent`, `previousChunkId`, `nextChunkId`
+- `parentId` remains for legacy compatibility and is not redefined as `parentChunkId`.
 
 ## Structured Input
 
@@ -49,10 +54,34 @@ Structured chunking should use normalized blocks:
 NormalizedDocument document = NormalizedDocument.builder("doc-1")
         .sourceFormat("PDF")
         .blocks(List.of(
-                NormalizedBlock.builder(NormalizedBlockType.HEADING, "Install").order(0).build(),
-                NormalizedBlock.builder(NormalizedBlockType.PARAGRAPH, "Install the engine.").order(1).build()))
+                NormalizedBlock.builder(NormalizedBlockType.HEADING, "Install")
+                        .id("page[1]/h[0]")
+                        .order(0)
+                        .headingPath("Install")
+                        .blockIds(List.of("page[1]/h[0]"))
+                        .confidence(0.98d)
+                        .build(),
+                NormalizedBlock.builder(NormalizedBlockType.PARAGRAPH, "Install the engine.")
+                        .id("page[1]/p[1]")
+                        .order(1)
+                        .blockIds(List.of("page[1]/p[1]"))
+                        .confidence(0.92d)
+                        .build()))
         .build();
 ```
+
+## Parent-Child Model
+
+The compatibility return type remains `List<Chunk>`, and the default output remains search-oriented child chunks.
+Parent section chunks are modeled through additive metadata links so downstream indexing can keep indexing child chunks
+without schema breaks.
+
+- Child chunks are the default retrieval unit.
+- Parent chunks are modeled by deterministic `parentChunkId` values.
+- Parent chunk content can be persisted additively as `parentChunkContent` when a strategy needs parent context recovery.
+- `previousChunkId` and `nextChunkId` link adjacent child chunks.
+- `blockIds`, `headingPath`, `page`, `slide`, `sourceRef`, and `confidence` preserve provenance needed for later
+  context expansion.
 
 ## Dependency Boundary
 

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkMetadata.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkMetadata.java
@@ -10,6 +10,10 @@ import java.util.Objects;
 public record ChunkMetadata(
         String sourceDocumentId,
         String parentId,
+        ChunkType chunkType,
+        String parentChunkId,
+        String previousChunkId,
+        String nextChunkId,
         String section,
         int order,
         ChunkingStrategyType strategy,
@@ -19,10 +23,19 @@ public record ChunkMetadata(
         Integer endOffset,
         Integer tokenCount,
         Integer charCount,
+        java.util.List<String> blockIds,
+        Double confidence,
         Map<String, Object> attributes) {
 
     public static final String KEY_SOURCE_DOCUMENT_ID = "sourceDocumentId";
     public static final String KEY_PARENT_ID = "parentId";
+    public static final String KEY_CHUNK_TYPE = "chunkType";
+    public static final String KEY_PARENT_CHUNK_ID = "parentChunkId";
+    public static final String KEY_PARENT_CHUNK_CONTENT = "parentChunkContent";
+    public static final String KEY_PARENT_CHUNK_BLOCK_IDS = "parentChunkBlockIds";
+    public static final String KEY_PARENT_CHUNK_SOURCE_REFS = "parentChunkSourceRefs";
+    public static final String KEY_PREVIOUS_CHUNK_ID = "previousChunkId";
+    public static final String KEY_NEXT_CHUNK_ID = "nextChunkId";
     public static final String KEY_SECTION = "section";
     public static final String KEY_CHUNK_ORDER = "chunkOrder";
     public static final String KEY_STRATEGY = "strategy";
@@ -38,6 +51,8 @@ public record ChunkMetadata(
     public static final String KEY_PAGE = "page";
     public static final String KEY_SLIDE = "slide";
     public static final String KEY_PARENT_BLOCK_ID = "parentBlockId";
+    public static final String KEY_BLOCK_IDS = "blockIds";
+    public static final String KEY_CONFIDENCE = "confidence";
     public static final String KEY_HEADING_PATH = "headingPath";
     public static final String KEY_SOURCE_FORMAT = "sourceFormat";
     public static final String KEY_TOKEN_ESTIMATE = "tokenEstimate";
@@ -49,7 +64,9 @@ public record ChunkMetadata(
         if (order < 0) {
             throw new IllegalArgumentException("order must not be negative");
         }
+        chunkType = chunkType == null ? ChunkType.CHILD : chunkType;
         strategy = Objects.requireNonNull(strategy, "strategy must not be null");
+        blockIds = sanitizeList(blockIds);
         attributes = sanitize(attributes);
     }
 
@@ -66,6 +83,10 @@ public record ChunkMetadata(
         Map<String, Object> metadata = new LinkedHashMap<>(attributes);
         putIfPresent(metadata, KEY_SOURCE_DOCUMENT_ID, sourceDocumentId);
         putIfPresent(metadata, KEY_PARENT_ID, parentId);
+        putIfPresent(metadata, KEY_CHUNK_TYPE, chunkType == null ? null : chunkType.value());
+        putIfPresent(metadata, KEY_PARENT_CHUNK_ID, parentChunkId);
+        putIfPresent(metadata, KEY_PREVIOUS_CHUNK_ID, previousChunkId);
+        putIfPresent(metadata, KEY_NEXT_CHUNK_ID, nextChunkId);
         putIfPresent(metadata, KEY_SECTION, section);
         metadata.putIfAbsent(KEY_CHUNK_ORDER, order);
         metadata.putIfAbsent(KEY_STRATEGY, strategy.value());
@@ -75,6 +96,8 @@ public record ChunkMetadata(
         putIfPresent(metadata, KEY_END_OFFSET, endOffset);
         putIfPresent(metadata, KEY_TOKEN_COUNT, tokenCount);
         putIfPresent(metadata, KEY_CHAR_COUNT, charCount);
+        putIfPresent(metadata, KEY_BLOCK_IDS, blockIds);
+        putIfPresent(metadata, KEY_CONFIDENCE, confidence);
         return Map.copyOf(metadata);
     }
 
@@ -105,11 +128,27 @@ public record ChunkMetadata(
         return Map.copyOf(sanitized);
     }
 
+    private static java.util.List<String> sanitizeList(java.util.List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return java.util.List.of();
+        }
+        return values.stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(value -> !value.isBlank())
+                .distinct()
+                .toList();
+    }
+
     public static final class Builder {
         private final ChunkingStrategyType strategy;
         private final int order;
         private String sourceDocumentId;
         private String parentId;
+        private ChunkType chunkType = ChunkType.CHILD;
+        private String parentChunkId;
+        private String previousChunkId;
+        private String nextChunkId;
         private String section;
         private String objectType;
         private String objectId;
@@ -117,6 +156,8 @@ public record ChunkMetadata(
         private Integer endOffset;
         private Integer tokenCount;
         private Integer charCount;
+        private java.util.List<String> blockIds = java.util.List.of();
+        private Double confidence;
         private Map<String, Object> attributes = Map.of();
 
         private Builder(ChunkingStrategyType strategy, int order) {
@@ -131,6 +172,26 @@ public record ChunkMetadata(
 
         public Builder parentId(String parentId) {
             this.parentId = parentId;
+            return this;
+        }
+
+        public Builder chunkType(ChunkType chunkType) {
+            this.chunkType = chunkType;
+            return this;
+        }
+
+        public Builder parentChunkId(String parentChunkId) {
+            this.parentChunkId = parentChunkId;
+            return this;
+        }
+
+        public Builder previousChunkId(String previousChunkId) {
+            this.previousChunkId = previousChunkId;
+            return this;
+        }
+
+        public Builder nextChunkId(String nextChunkId) {
+            this.nextChunkId = nextChunkId;
             return this;
         }
 
@@ -169,6 +230,16 @@ public record ChunkMetadata(
             return this;
         }
 
+        public Builder blockIds(java.util.List<String> blockIds) {
+            this.blockIds = blockIds;
+            return this;
+        }
+
+        public Builder confidence(Double confidence) {
+            this.confidence = confidence;
+            return this;
+        }
+
         public Builder attributes(Map<String, Object> attributes) {
             this.attributes = attributes;
             return this;
@@ -185,6 +256,10 @@ public record ChunkMetadata(
             return new ChunkMetadata(
                     sourceDocumentId,
                     parentId,
+                    chunkType,
+                    parentChunkId,
+                    previousChunkId,
+                    nextChunkId,
                     section,
                     order,
                     strategy,
@@ -194,6 +269,8 @@ public record ChunkMetadata(
                     endOffset,
                     tokenCount,
                     charCount,
+                    blockIds,
+                    confidence,
                     attributes);
         }
     }

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkMetadata.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkMetadata.java
@@ -1,6 +1,7 @@
 package studio.one.platform.chunking.core;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -23,7 +24,7 @@ public record ChunkMetadata(
         Integer endOffset,
         Integer tokenCount,
         Integer charCount,
-        java.util.List<String> blockIds,
+        List<String> blockIds,
         Double confidence,
         Map<String, Object> attributes) {
 
@@ -84,7 +85,7 @@ public record ChunkMetadata(
             Integer charCount,
             Map<String, Object> attributes) {
         this(sourceDocumentId, parentId, ChunkType.CHILD, null, null, null, section, order, strategy,
-                objectType, objectId, startOffset, endOffset, tokenCount, charCount, java.util.List.of(), null,
+                objectType, objectId, startOffset, endOffset, tokenCount, charCount, List.of(), null,
                 attributes);
     }
 
@@ -146,9 +147,9 @@ public record ChunkMetadata(
         return Map.copyOf(sanitized);
     }
 
-    private static java.util.List<String> sanitizeList(java.util.List<String> values) {
+    private static List<String> sanitizeList(List<String> values) {
         if (values == null || values.isEmpty()) {
-            return java.util.List.of();
+            return List.of();
         }
         return values.stream()
                 .filter(Objects::nonNull)
@@ -174,7 +175,7 @@ public record ChunkMetadata(
         private Integer endOffset;
         private Integer tokenCount;
         private Integer charCount;
-        private java.util.List<String> blockIds = java.util.List.of();
+        private List<String> blockIds = List.of();
         private Double confidence;
         private Map<String, Object> attributes = Map.of();
 
@@ -248,7 +249,7 @@ public record ChunkMetadata(
             return this;
         }
 
-        public Builder blockIds(java.util.List<String> blockIds) {
+        public Builder blockIds(List<String> blockIds) {
             this.blockIds = blockIds;
             return this;
         }

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkMetadata.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkMetadata.java
@@ -70,6 +70,24 @@ public record ChunkMetadata(
         attributes = sanitize(attributes);
     }
 
+    public ChunkMetadata(
+            String sourceDocumentId,
+            String parentId,
+            String section,
+            int order,
+            ChunkingStrategyType strategy,
+            String objectType,
+            String objectId,
+            Integer startOffset,
+            Integer endOffset,
+            Integer tokenCount,
+            Integer charCount,
+            Map<String, Object> attributes) {
+        this(sourceDocumentId, parentId, ChunkType.CHILD, null, null, null, section, order, strategy,
+                objectType, objectId, startOffset, endOffset, tokenCount, charCount, java.util.List.of(), null,
+                attributes);
+    }
+
     public static Builder builder(ChunkingStrategyType strategy, int order) {
         return new Builder(strategy, order);
     }

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkType.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkType.java
@@ -9,7 +9,8 @@ public enum ChunkType {
     TABLE("table"),
     OCR("ocr"),
     IMAGE_CAPTION("image-caption"),
-    SLIDE("slide");
+    SLIDE("slide"),
+    UNKNOWN("unknown");
 
     private final String value;
 
@@ -31,6 +32,6 @@ public enum ChunkType {
                 return type;
             }
         }
-        throw new IllegalArgumentException("Unsupported chunk type: " + value);
+        return UNKNOWN;
     }
 }

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkType.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkType.java
@@ -1,0 +1,36 @@
+package studio.one.platform.chunking.core;
+
+/**
+ * Logical chunk role used by RAG-oriented chunking.
+ */
+public enum ChunkType {
+    PARENT("parent"),
+    CHILD("child"),
+    TABLE("table"),
+    OCR("ocr"),
+    IMAGE_CAPTION("image-caption"),
+    SLIDE("slide");
+
+    private final String value;
+
+    ChunkType(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static ChunkType from(String value) {
+        if (value == null || value.isBlank()) {
+            return CHILD;
+        }
+        String normalized = value.trim().replace('-', '_').toUpperCase();
+        for (ChunkType type : values()) {
+            if (type.name().equals(normalized) || type.value.equalsIgnoreCase(value.trim())) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Unsupported chunk type: " + value);
+    }
+}

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/NormalizedBlock.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/NormalizedBlock.java
@@ -15,10 +15,16 @@ public record NormalizedBlock(
         Integer slide,
         Integer order,
         String parentBlockId,
+        String headingPath,
+        java.util.List<String> blockIds,
+        Double confidence,
         Map<String, Object> metadata) {
 
     public static final String KEY_ROW_COUNT = "rowCount";
     public static final String KEY_CELL_COUNT = "cellCount";
+    public static final String KEY_HEADING_PATH = "headingPath";
+    public static final String KEY_BLOCK_IDS = "blockIds";
+    public static final String KEY_CONFIDENCE = "confidence";
 
     public NormalizedBlock {
         id = normalize(id);
@@ -26,6 +32,8 @@ public record NormalizedBlock(
         text = text == null ? "" : text.trim();
         sourceRef = normalize(sourceRef);
         parentBlockId = normalize(parentBlockId);
+        headingPath = normalize(headingPath);
+        blockIds = sanitizeList(blockIds, id, sourceRef);
         metadata = sanitize(metadata);
     }
 
@@ -61,6 +69,22 @@ public record NormalizedBlock(
         return Map.copyOf(sanitized);
     }
 
+    private static java.util.List<String> sanitizeList(java.util.List<String> values, String fallbackId, String fallbackSourceRef) {
+        java.util.List<String> sanitized = values == null ? java.util.List.of() : values.stream()
+                .filter(java.util.Objects::nonNull)
+                .map(String::trim)
+                .filter(value -> !value.isBlank())
+                .distinct()
+                .toList();
+        if (!sanitized.isEmpty()) {
+            return sanitized;
+        }
+        if (fallbackSourceRef != null && !fallbackSourceRef.isBlank()) {
+            return java.util.List.of(fallbackSourceRef);
+        }
+        return fallbackId == null || fallbackId.isBlank() ? java.util.List.of() : java.util.List.of(fallbackId);
+    }
+
     private static String normalize(String value) {
         return value == null ? "" : value.trim();
     }
@@ -74,6 +98,9 @@ public record NormalizedBlock(
         private Integer slide;
         private Integer order;
         private String parentBlockId;
+        private String headingPath;
+        private java.util.List<String> blockIds = java.util.List.of();
+        private Double confidence;
         private Map<String, Object> metadata = Map.of();
 
         private Builder(NormalizedBlockType type, String text) {
@@ -111,13 +138,29 @@ public record NormalizedBlock(
             return this;
         }
 
+        public Builder headingPath(String headingPath) {
+            this.headingPath = headingPath;
+            return this;
+        }
+
+        public Builder blockIds(java.util.List<String> blockIds) {
+            this.blockIds = blockIds;
+            return this;
+        }
+
+        public Builder confidence(Double confidence) {
+            this.confidence = confidence;
+            return this;
+        }
+
         public Builder metadata(Map<String, Object> metadata) {
             this.metadata = metadata;
             return this;
         }
 
         public NormalizedBlock build() {
-            return new NormalizedBlock(id, type, text, sourceRef, page, slide, order, parentBlockId, metadata);
+            return new NormalizedBlock(id, type, text, sourceRef, page, slide, order, parentBlockId,
+                    headingPath, blockIds, confidence, metadata);
         }
     }
 }

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/NormalizedBlock.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/NormalizedBlock.java
@@ -37,6 +37,19 @@ public record NormalizedBlock(
         metadata = sanitize(metadata);
     }
 
+    public NormalizedBlock(
+            String id,
+            NormalizedBlockType type,
+            String text,
+            String sourceRef,
+            Integer page,
+            Integer slide,
+            Integer order,
+            String parentBlockId,
+            Map<String, Object> metadata) {
+        this(id, type, text, sourceRef, page, slide, order, parentBlockId, "", java.util.List.of(), null, metadata);
+    }
+
     public boolean hasText() {
         return !text.isBlank();
     }

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/NormalizedBlock.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/NormalizedBlock.java
@@ -1,7 +1,9 @@
 package studio.one.platform.chunking.core;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Parser-neutral logical block prepared for chunking.
@@ -16,7 +18,7 @@ public record NormalizedBlock(
         Integer order,
         String parentBlockId,
         String headingPath,
-        java.util.List<String> blockIds,
+        List<String> blockIds,
         Double confidence,
         Map<String, Object> metadata) {
 
@@ -47,7 +49,7 @@ public record NormalizedBlock(
             Integer order,
             String parentBlockId,
             Map<String, Object> metadata) {
-        this(id, type, text, sourceRef, page, slide, order, parentBlockId, "", java.util.List.of(), null, metadata);
+        this(id, type, text, sourceRef, page, slide, order, parentBlockId, "", List.of(), null, metadata);
     }
 
     public boolean hasText() {
@@ -82,9 +84,9 @@ public record NormalizedBlock(
         return Map.copyOf(sanitized);
     }
 
-    private static java.util.List<String> sanitizeList(java.util.List<String> values, String fallbackId, String fallbackSourceRef) {
-        java.util.List<String> sanitized = values == null ? java.util.List.of() : values.stream()
-                .filter(java.util.Objects::nonNull)
+    private static List<String> sanitizeList(List<String> values, String fallbackId, String fallbackSourceRef) {
+        List<String> sanitized = values == null ? List.of() : values.stream()
+                .filter(Objects::nonNull)
                 .map(String::trim)
                 .filter(value -> !value.isBlank())
                 .distinct()
@@ -93,9 +95,9 @@ public record NormalizedBlock(
             return sanitized;
         }
         if (fallbackSourceRef != null && !fallbackSourceRef.isBlank()) {
-            return java.util.List.of(fallbackSourceRef);
+            return List.of(fallbackSourceRef);
         }
-        return fallbackId == null || fallbackId.isBlank() ? java.util.List.of() : java.util.List.of(fallbackId);
+        return fallbackId == null || fallbackId.isBlank() ? List.of() : List.of(fallbackId);
     }
 
     private static String normalize(String value) {
@@ -112,7 +114,7 @@ public record NormalizedBlock(
         private Integer order;
         private String parentBlockId;
         private String headingPath;
-        private java.util.List<String> blockIds = java.util.List.of();
+        private List<String> blockIds = List.of();
         private Double confidence;
         private Map<String, Object> metadata = Map.of();
 
@@ -156,7 +158,7 @@ public record NormalizedBlock(
             return this;
         }
 
-        public Builder blockIds(java.util.List<String> blockIds) {
+        public Builder blockIds(List<String> blockIds) {
             this.blockIds = blockIds;
             return this;
         }

--- a/studio-platform-chunking/src/test/java/studio/one/platform/chunking/core/ChunkMetadataTest.java
+++ b/studio-platform-chunking/src/test/java/studio/one/platform/chunking/core/ChunkMetadataTest.java
@@ -73,4 +73,28 @@ class ChunkMetadataTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("order");
     }
+
+    @Test
+    void legacyConstructorDefaultsNewParentChildFields() {
+        ChunkMetadata metadata = new ChunkMetadata(
+                "doc-1",
+                "parent-1",
+                "section",
+                1,
+                ChunkingStrategyType.RECURSIVE,
+                "attachment",
+                "123",
+                0,
+                10,
+                null,
+                10,
+                Map.of());
+
+        assertThat(metadata.chunkType()).isEqualTo(ChunkType.CHILD);
+        assertThat(metadata.parentChunkId()).isNull();
+        assertThat(metadata.previousChunkId()).isNull();
+        assertThat(metadata.nextChunkId()).isNull();
+        assertThat(metadata.blockIds()).isEmpty();
+        assertThat(metadata.confidence()).isNull();
+    }
 }

--- a/studio-platform-chunking/src/test/java/studio/one/platform/chunking/core/ChunkMetadataTest.java
+++ b/studio-platform-chunking/src/test/java/studio/one/platform/chunking/core/ChunkMetadataTest.java
@@ -21,9 +21,15 @@ class ChunkMetadataTest {
         ChunkMetadata metadata = ChunkMetadata.builder(ChunkingStrategyType.RECURSIVE, 2)
                 .sourceDocumentId("doc-1")
                 .parentId(" ")
+                .chunkType(ChunkType.CHILD)
+                .parentChunkId("parent-1")
+                .previousChunkId("doc-1-1")
+                .nextChunkId("doc-1-3")
                 .section(null)
                 .objectType("attachment")
                 .objectId("123")
+                .blockIds(java.util.List.of("block-1", " ", "block-2"))
+                .confidence(0.92d)
                 .attributes(attributes)
                 .build();
 
@@ -32,10 +38,16 @@ class ChunkMetadataTest {
         assertThat(metadata.toMap())
                 .containsEntry("existing", "value")
                 .containsEntry("sourceDocumentId", "doc-1")
+                .containsEntry("chunkType", "child")
+                .containsEntry("parentChunkId", "parent-1")
+                .containsEntry("previousChunkId", "doc-1-1")
+                .containsEntry("nextChunkId", "doc-1-3")
                 .containsEntry("chunkOrder", 2)
                 .containsEntry("strategy", "recursive")
                 .containsEntry("objectType", "attachment")
                 .containsEntry("objectId", "123")
+                .containsEntry("blockIds", java.util.List.of("block-1", "block-2"))
+                .containsEntry("confidence", 0.92d)
                 .doesNotContainKeys("parentId", "section");
     }
 

--- a/studio-platform-chunking/src/test/java/studio/one/platform/chunking/core/ChunkMetadataTest.java
+++ b/studio-platform-chunking/src/test/java/studio/one/platform/chunking/core/ChunkMetadataTest.java
@@ -97,4 +97,10 @@ class ChunkMetadataTest {
         assertThat(metadata.blockIds()).isEmpty();
         assertThat(metadata.confidence()).isNull();
     }
+
+    @Test
+    void chunkTypeFallsBackSafelyForUnknownPersistedValues() {
+        assertThat(ChunkType.from("unexpected-value")).isEqualTo(ChunkType.UNKNOWN);
+        assertThat(ChunkType.from(null)).isEqualTo(ChunkType.CHILD);
+    }
 }

--- a/studio-platform-chunking/src/test/java/studio/one/platform/chunking/core/NormalizedDocumentTest.java
+++ b/studio-platform-chunking/src/test/java/studio/one/platform/chunking/core/NormalizedDocumentTest.java
@@ -30,6 +30,7 @@ class NormalizedDocumentTest {
         assertThat(document.blocks()).extracting(NormalizedBlock::text).containsExactly("first", "second");
         assertThat(document.chunkableText()).isEqualTo("first\n\nsecond");
         assertThat(document.blocks().get(0).effectiveSourceRef()).isEqualTo("page[1]/h[0]");
+        assertThat(document.blocks().get(0).blockIds()).containsExactly("page[1]/h[0]");
     }
 
     @Test

--- a/studio-platform-chunking/src/test/java/studio/one/platform/chunking/core/NormalizedDocumentTest.java
+++ b/studio-platform-chunking/src/test/java/studio/one/platform/chunking/core/NormalizedDocumentTest.java
@@ -49,4 +49,22 @@ class NormalizedDocumentTest {
                 .containsEntry(ChunkMetadata.KEY_BLOCK_TYPE, "TABLE")
                 .containsEntry(ChunkMetadata.KEY_TOKEN_ESTIMATE, 12);
     }
+
+    @Test
+    void legacyBlockConstructorDefaultsNewStructuredFields() {
+        NormalizedBlock block = new NormalizedBlock(
+                "block-1",
+                NormalizedBlockType.PARAGRAPH,
+                "content",
+                "page[1]/p[0]",
+                1,
+                null,
+                0,
+                "",
+                Map.of());
+
+        assertThat(block.headingPath()).isEmpty();
+        assertThat(block.blockIds()).containsExactly("page[1]/p[0]");
+        assertThat(block.confidence()).isNull();
+    }
 }


### PR DESCRIPTION
## Why

- `studio-platform-chunking`을 parent-child chunking 기반으로 확장해 child 검색 단위와 parent context 복구 기반을 마련해야 했습니다.
- 구조화 chunking에서 `parentChunkId`만 있고 실제 parent context를 복구할 수 없던 문제와 heading이 여전히 child 검색 단위에 포함되던 문제를 함께 정리해야 했습니다.
- 기존 텍스트 기반 API와 `chunkOrder`/chunk id 규칙은 유지하면서 provenance metadata를 강화할 필요가 있었습니다.

## What

- `ChunkType`, 관계 metadata, provenance 필드를 `studio-platform-chunking` 계약에 추가했습니다.
- `StructureBasedChunker`가 heading을 parent 구조로만 유지하고 child chunk는 paragraph/table/OCR 중심으로 생성하도록 수정했습니다.
- child metadata에 `parentChunkContent`와 parent provenance를 기록해 downstream이 parent context를 복구할 수 있게 했습니다.
- `TextractNormalizedDocumentAdapter`와 관련 테스트/README를 갱신했습니다.
- 리뷰 반영 후 `ChunkMetadata`, `NormalizedBlock`의 하위 호환 생성자도 복원했습니다.

## Related Issues

- #277
- #278
- #279
- #280
- #281

## Validation

- `./gradlew :studio-platform-chunking:test :starter:studio-platform-starter-chunking:test` → passed

## Risk / Rollback

- 주요 리스크는 구조화 chunking 결과 metadata shape가 달라지면서 downstream 검색/색인 해석에 영향이 갈 수 있다는 점입니다.
- rollback은 이 PR revert로 가능하며, 기존 `StructureBasedChunker` 동작과 contract field 세트로 되돌릴 수 있습니다.

## AI / Subagent Usage

- AI 사용: 요구사항 분석, 구현, 리뷰 반영, 테스트 정리, PR 초안 작성
- Subagent used: No

## Checklist

- [x] commit message follows policy
- [x] issue template was used or exception was recorded
- [x] AI-Assisted value is correct
- [x] validation is recorded
- [x] subagent usage is recorded when used
- [x] CI or repository verification passed locally
- [x] human review is required before merge
- [x] unrelated changes are excluded
