### PR TITLE
[chunking] context expansion 계약 추가

### DIFF
--- a/studio-platform-chunking/README.md
+++ b/studio-platform-chunking/README.md
@@ -22,6 +22,8 @@
 - `NormalizedDocument`: parser-neutral structured input for structure-aware chunking.
 - `NormalizedBlock`: parser-neutral logical block with source provenance.
 - `NormalizedDocumentChunker`: chunker extension for normalized documents.
+- `ChunkContextExpander`: contract for expanding a retrieved child chunk into answer context.
+- `ChunkContextExpansionRequest` / `ChunkContextExpansion`: request/result models for context expansion.
 
 ## Metadata Rules
 
@@ -84,6 +86,26 @@ without schema breaks.
   `parentChunkContent`.
 - `blockIds`, `headingPath`, `page`, `slide`, `sourceRef`, and `confidence` preserve provenance needed for later
   context expansion.
+
+## Context Expansion Contract
+
+`ChunkContextExpander` defines how a retrieved child chunk can be expanded into a larger answer context. The contract is
+implementation-neutral and does not perform retrieval, embedding, vector store access, LLM calls, or parser work.
+
+```java
+ChunkContextExpansionRequest request = ChunkContextExpansionRequest.builder(retrievedChunk)
+        .availableChunks(candidateChunks)
+        .previousWindow(1)
+        .nextWindow(1)
+        .includeParentContent(true)
+        .build();
+
+ChunkContextExpansion expansion = expander.expand(request);
+String answerContext = expansion.content();
+```
+
+Built-in strategy identifiers are `parent-child`, `window`, `heading`, `table`, `custom`, and `unknown`.
+Concrete expansion implementations live in starter modules.
 
 ## Dependency Boundary
 

--- a/studio-platform-chunking/README.md
+++ b/studio-platform-chunking/README.md
@@ -91,6 +91,8 @@ without schema breaks.
 
 `ChunkContextExpander` defines how a retrieved child chunk can be expanded into a larger answer context. The contract is
 implementation-neutral and does not perform retrieval, embedding, vector store access, LLM calls, or parser work.
+`Chunk` itself rejects blank content, so expansion content is also non-blank. `availableChunks` should be a small,
+pre-filtered candidate set around the seed chunk, not an entire corpus or unbounded retrieval result.
 
 ```java
 ChunkContextExpansionRequest request = ChunkContextExpansionRequest.builder(retrievedChunk)

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkContextExpander.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkContextExpander.java
@@ -1,0 +1,12 @@
+package studio.one.platform.chunking.core;
+
+/**
+ * Expands a retrieved chunk into a larger answer context without calling
+ * embedding APIs, vector stores, LLMs, or parsers.
+ */
+public interface ChunkContextExpander {
+
+    ChunkContextExpansionStrategy strategy();
+
+    ChunkContextExpansion expand(ChunkContextExpansionRequest request);
+}

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkContextExpansion.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkContextExpansion.java
@@ -38,6 +38,7 @@ public record ChunkContextExpansion(
             List<Chunk> contextChunks,
             ChunkContextExpansionStrategy strategy,
             Map<String, Object> metadata) {
+        Objects.requireNonNull(seedChunk, "seedChunk must not be null");
         return new ChunkContextExpansion(seedChunk, contextChunks, joinedContent(contextChunks, seedChunk), strategy,
                 metadata);
     }

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkContextExpansion.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkContextExpansion.java
@@ -1,0 +1,82 @@
+package studio.one.platform.chunking.core;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Expanded context returned by a {@link ChunkContextExpander}.
+ */
+public record ChunkContextExpansion(
+        Chunk seedChunk,
+        List<Chunk> contextChunks,
+        String content,
+        ChunkContextExpansionStrategy strategy,
+        Map<String, Object> metadata) {
+
+    public ChunkContextExpansion {
+        seedChunk = Objects.requireNonNull(seedChunk, "seedChunk must not be null");
+        contextChunks = sanitizeChunks(contextChunks);
+        content = content == null ? "" : content.trim();
+        if (content.isBlank()) {
+            throw new IllegalArgumentException("content must not be blank");
+        }
+        strategy = strategy == null ? ChunkContextExpansionStrategy.UNKNOWN : strategy;
+        metadata = sanitize(metadata);
+    }
+
+    public static ChunkContextExpansion of(
+            Chunk seedChunk,
+            List<Chunk> contextChunks,
+            ChunkContextExpansionStrategy strategy) {
+        return of(seedChunk, contextChunks, strategy, Map.of());
+    }
+
+    public static ChunkContextExpansion of(
+            Chunk seedChunk,
+            List<Chunk> contextChunks,
+            ChunkContextExpansionStrategy strategy,
+            Map<String, Object> metadata) {
+        return new ChunkContextExpansion(seedChunk, contextChunks, joinedContent(contextChunks, seedChunk), strategy,
+                metadata);
+    }
+
+    private static String joinedContent(List<Chunk> contextChunks, Chunk fallback) {
+        List<Chunk> chunks = sanitizeChunks(contextChunks);
+        if (chunks.isEmpty()) {
+            return fallback.content();
+        }
+        return chunks.stream()
+                .map(Chunk::content)
+                .filter(text -> text != null && !text.isBlank())
+                .reduce((left, right) -> left + "\n\n" + right)
+                .orElse(fallback.content());
+    }
+
+    private static List<Chunk> sanitizeChunks(List<Chunk> chunks) {
+        if (chunks == null || chunks.isEmpty()) {
+            return List.of();
+        }
+        return chunks.stream()
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    private static Map<String, Object> sanitize(Map<String, Object> values) {
+        if (values == null || values.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, Object> sanitized = new LinkedHashMap<>();
+        values.forEach((key, value) -> {
+            if (key == null || key.isBlank() || value == null) {
+                return;
+            }
+            if (value instanceof String stringValue && stringValue.isBlank()) {
+                return;
+            }
+            sanitized.put(key, value);
+        });
+        return Map.copyOf(sanitized);
+    }
+}

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkContextExpansion.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkContextExpansion.java
@@ -1,12 +1,12 @@
 package studio.one.platform.chunking.core;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 /**
  * Expanded context returned by a {@link ChunkContextExpander}.
+ * The content is non-blank because {@link Chunk} also rejects blank content.
  */
 public record ChunkContextExpansion(
         Chunk seedChunk,
@@ -23,7 +23,7 @@ public record ChunkContextExpansion(
             throw new IllegalArgumentException("content must not be blank");
         }
         strategy = strategy == null ? ChunkContextExpansionStrategy.UNKNOWN : strategy;
-        metadata = sanitize(metadata);
+        metadata = ChunkMetadataMaps.sanitize(metadata);
     }
 
     public static ChunkContextExpansion of(
@@ -64,20 +64,4 @@ public record ChunkContextExpansion(
                 .toList();
     }
 
-    private static Map<String, Object> sanitize(Map<String, Object> values) {
-        if (values == null || values.isEmpty()) {
-            return Map.of();
-        }
-        Map<String, Object> sanitized = new LinkedHashMap<>();
-        values.forEach((key, value) -> {
-            if (key == null || key.isBlank() || value == null) {
-                return;
-            }
-            if (value instanceof String stringValue && stringValue.isBlank()) {
-                return;
-            }
-            sanitized.put(key, value);
-        });
-        return Map.copyOf(sanitized);
-    }
 }

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkContextExpansionRequest.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkContextExpansionRequest.java
@@ -1,6 +1,5 @@
 package studio.one.platform.chunking.core;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -8,6 +7,8 @@ import java.util.Optional;
 
 /**
  * Input for expanding a retrieval child chunk into a larger answer context.
+ * {@code availableChunks} is expected to be a small, pre-filtered candidate set
+ * around the seed chunk, not an entire corpus or unbounded retrieval result.
  */
 public record ChunkContextExpansionRequest(
         Chunk seedChunk,
@@ -26,7 +27,7 @@ public record ChunkContextExpansionRequest(
         if (nextWindow < 0) {
             throw new IllegalArgumentException("nextWindow must not be negative");
         }
-        options = sanitize(options);
+        options = ChunkMetadataMaps.sanitize(options);
     }
 
     public static Builder builder(Chunk seedChunk) {
@@ -57,23 +58,6 @@ public record ChunkContextExpansionRequest(
         return chunks.stream()
                 .filter(Objects::nonNull)
                 .toList();
-    }
-
-    private static Map<String, Object> sanitize(Map<String, Object> values) {
-        if (values == null || values.isEmpty()) {
-            return Map.of();
-        }
-        Map<String, Object> sanitized = new LinkedHashMap<>();
-        values.forEach((key, value) -> {
-            if (key == null || key.isBlank() || value == null) {
-                return;
-            }
-            if (value instanceof String stringValue && stringValue.isBlank()) {
-                return;
-            }
-            sanitized.put(key, value);
-        });
-        return Map.copyOf(sanitized);
     }
 
     public static final class Builder {

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkContextExpansionRequest.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkContextExpansionRequest.java
@@ -1,0 +1,121 @@
+package studio.one.platform.chunking.core;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Input for expanding a retrieval child chunk into a larger answer context.
+ */
+public record ChunkContextExpansionRequest(
+        Chunk seedChunk,
+        List<Chunk> availableChunks,
+        int previousWindow,
+        int nextWindow,
+        boolean includeParentContent,
+        Map<String, Object> options) {
+
+    public ChunkContextExpansionRequest {
+        seedChunk = Objects.requireNonNull(seedChunk, "seedChunk must not be null");
+        availableChunks = sanitizeChunks(availableChunks);
+        if (previousWindow < 0) {
+            throw new IllegalArgumentException("previousWindow must not be negative");
+        }
+        if (nextWindow < 0) {
+            throw new IllegalArgumentException("nextWindow must not be negative");
+        }
+        options = sanitize(options);
+    }
+
+    public static Builder builder(Chunk seedChunk) {
+        return new Builder(seedChunk);
+    }
+
+    public Optional<Chunk> chunkById(String chunkId) {
+        if (chunkId == null || chunkId.isBlank()) {
+            return Optional.empty();
+        }
+        String normalized = chunkId.trim();
+        return availableChunks.stream()
+                .filter(chunk -> chunk.id().equals(normalized))
+                .findFirst();
+    }
+
+    public Optional<Object> option(String key) {
+        if (key == null || key.isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(options.get(key));
+    }
+
+    private static List<Chunk> sanitizeChunks(List<Chunk> chunks) {
+        if (chunks == null || chunks.isEmpty()) {
+            return List.of();
+        }
+        return chunks.stream()
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    private static Map<String, Object> sanitize(Map<String, Object> values) {
+        if (values == null || values.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, Object> sanitized = new LinkedHashMap<>();
+        values.forEach((key, value) -> {
+            if (key == null || key.isBlank() || value == null) {
+                return;
+            }
+            if (value instanceof String stringValue && stringValue.isBlank()) {
+                return;
+            }
+            sanitized.put(key, value);
+        });
+        return Map.copyOf(sanitized);
+    }
+
+    public static final class Builder {
+        private final Chunk seedChunk;
+        private List<Chunk> availableChunks = List.of();
+        private int previousWindow;
+        private int nextWindow;
+        private boolean includeParentContent = true;
+        private Map<String, Object> options = Map.of();
+
+        private Builder(Chunk seedChunk) {
+            this.seedChunk = seedChunk;
+        }
+
+        public Builder availableChunks(List<Chunk> availableChunks) {
+            this.availableChunks = availableChunks;
+            return this;
+        }
+
+        public Builder previousWindow(int previousWindow) {
+            this.previousWindow = previousWindow;
+            return this;
+        }
+
+        public Builder nextWindow(int nextWindow) {
+            this.nextWindow = nextWindow;
+            return this;
+        }
+
+        public Builder includeParentContent(boolean includeParentContent) {
+            this.includeParentContent = includeParentContent;
+            return this;
+        }
+
+        public Builder options(Map<String, Object> options) {
+            this.options = options;
+            return this;
+        }
+
+        public ChunkContextExpansionRequest build() {
+            return new ChunkContextExpansionRequest(seedChunk, availableChunks, previousWindow, nextWindow,
+                    includeParentContent, options);
+        }
+    }
+}

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkContextExpansionStrategy.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkContextExpansionStrategy.java
@@ -1,0 +1,36 @@
+package studio.one.platform.chunking.core;
+
+/**
+ * Provider-neutral context expansion strategy identifier.
+ */
+public enum ChunkContextExpansionStrategy {
+    PARENT_CHILD("parent-child"),
+    WINDOW("window"),
+    HEADING("heading"),
+    TABLE("table"),
+    CUSTOM("custom"),
+    UNKNOWN("unknown");
+
+    private final String value;
+
+    ChunkContextExpansionStrategy(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static ChunkContextExpansionStrategy from(String value) {
+        if (value == null || value.isBlank()) {
+            return UNKNOWN;
+        }
+        String normalized = value.trim().replace('-', '_').toUpperCase();
+        for (ChunkContextExpansionStrategy strategy : values()) {
+            if (strategy.name().equals(normalized) || strategy.value.equalsIgnoreCase(value.trim())) {
+                return strategy;
+            }
+        }
+        return UNKNOWN;
+    }
+}

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkMetadataMaps.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkMetadataMaps.java
@@ -1,0 +1,27 @@
+package studio.one.platform.chunking.core;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+final class ChunkMetadataMaps {
+
+    private ChunkMetadataMaps() {
+    }
+
+    static Map<String, Object> sanitize(Map<String, Object> values) {
+        if (values == null || values.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, Object> sanitized = new LinkedHashMap<>();
+        values.forEach((key, value) -> {
+            if (key == null || key.isBlank() || value == null) {
+                return;
+            }
+            if (value instanceof String stringValue && stringValue.isBlank()) {
+                return;
+            }
+            sanitized.put(key, value);
+        });
+        return Map.copyOf(sanitized);
+    }
+}

--- a/studio-platform-chunking/src/test/java/studio/one/platform/chunking/core/ChunkContextExpansionContractTest.java
+++ b/studio-platform-chunking/src/test/java/studio/one/platform/chunking/core/ChunkContextExpansionContractTest.java
@@ -58,7 +58,7 @@ class ChunkContextExpansionContractTest {
     }
 
     @Test
-    void expansionFactoryRejectsNullSeedWithStableMessage() {
+    void expansionFactoryRejectsNullSeed() {
         assertThatThrownBy(() -> ChunkContextExpansion.of(null, List.of(), ChunkContextExpansionStrategy.WINDOW))
                 .isInstanceOf(NullPointerException.class)
                 .hasMessageContaining("seedChunk");

--- a/studio-platform-chunking/src/test/java/studio/one/platform/chunking/core/ChunkContextExpansionContractTest.java
+++ b/studio-platform-chunking/src/test/java/studio/one/platform/chunking/core/ChunkContextExpansionContractTest.java
@@ -1,0 +1,71 @@
+package studio.one.platform.chunking.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class ChunkContextExpansionContractTest {
+
+    @Test
+    void requestSanitizesChunksAndOptions() {
+        Chunk seed = chunk("doc-1", "seed", 0);
+        Chunk sibling = chunk("doc-2", "sibling", 1);
+
+        ChunkContextExpansionRequest request = ChunkContextExpansionRequest.builder(seed)
+                .availableChunks(Arrays.asList(seed, null, sibling))
+                .previousWindow(1)
+                .nextWindow(2)
+                .options(Map.of("mode", "parent", "blank", " "))
+                .build();
+
+        assertThat(request.availableChunks()).containsExactly(seed, sibling);
+        assertThat(request.option("mode")).contains("parent");
+        assertThat(request.option("blank")).isEmpty();
+        assertThat(request.chunkById("doc-2")).contains(sibling);
+        assertThat(request.includeParentContent()).isTrue();
+    }
+
+    @Test
+    void requestRejectsNegativeWindow() {
+        Chunk seed = chunk("doc-1", "seed", 0);
+
+        assertThatThrownBy(() -> ChunkContextExpansionRequest.builder(seed).previousWindow(-1).build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("previousWindow");
+    }
+
+    @Test
+    void expansionJoinsContextChunksAndKeepsSeed() {
+        Chunk seed = chunk("doc-1", "seed", 0);
+        Chunk next = chunk("doc-2", "next", 1);
+
+        ChunkContextExpansion expansion = ChunkContextExpansion.of(
+                seed,
+                List.of(seed, next),
+                ChunkContextExpansionStrategy.WINDOW,
+                Map.of("source", "test"));
+
+        assertThat(expansion.seedChunk()).isSameAs(seed);
+        assertThat(expansion.contextChunks()).containsExactly(seed, next);
+        assertThat(expansion.content()).isEqualTo("seed\n\nnext");
+        assertThat(expansion.strategy()).isEqualTo(ChunkContextExpansionStrategy.WINDOW);
+        assertThat(expansion.metadata()).containsEntry("source", "test");
+    }
+
+    @Test
+    void strategyFromFallsBackToUnknownForPersistenceSafety() {
+        assertThat(ChunkContextExpansionStrategy.from("parent-child"))
+                .isEqualTo(ChunkContextExpansionStrategy.PARENT_CHILD);
+        assertThat(ChunkContextExpansionStrategy.from("unexpected"))
+                .isEqualTo(ChunkContextExpansionStrategy.UNKNOWN);
+    }
+
+    private Chunk chunk(String id, String content, int order) {
+        return Chunk.of(id, content, ChunkMetadata.builder(ChunkingStrategyType.RECURSIVE, order).build());
+    }
+}

--- a/studio-platform-chunking/src/test/java/studio/one/platform/chunking/core/ChunkContextExpansionContractTest.java
+++ b/studio-platform-chunking/src/test/java/studio/one/platform/chunking/core/ChunkContextExpansionContractTest.java
@@ -58,6 +58,13 @@ class ChunkContextExpansionContractTest {
     }
 
     @Test
+    void expansionFactoryRejectsNullSeedWithStableMessage() {
+        assertThatThrownBy(() -> ChunkContextExpansion.of(null, List.of(), ChunkContextExpansionStrategy.WINDOW))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("seedChunk");
+    }
+
+    @Test
     void strategyFromFallsBackToUnknownForPersistenceSafety() {
         assertThat(ChunkContextExpansionStrategy.from("parent-child"))
                 .isEqualTo(ChunkContextExpansionStrategy.PARENT_CHILD);


### PR DESCRIPTION
## Why

- #277 parent-child chunking 계획에서 downstream이 검색된 child chunk를 parent/window/heading/table context로 확장할 수 있는 core 계약이 필요하다.
- 구현체는 starter 범위에 두되, `studio-platform-chunking` core는 Spring/AI/vector/parser 의존 없이 request/result/interface 모델만 제공해야 한다.

## What

- `ChunkContextExpander` interface를 추가했다.
- `ChunkContextExpansionRequest`, `ChunkContextExpansion`, `ChunkContextExpansionStrategy` 계약 모델을 추가했다.
- request/result 모델의 null/blank sanitizing, chunk lookup, joined content factory를 테스트로 고정했다.
- `studio-platform-chunking/README.md`에 context expansion 계약과 책임 경계를 문서화했다.

## Related Issues

- Closes #278

## Validation

- Command: `./gradlew :studio-platform-chunking:test`
- Result: PASS
- Command: `git diff --check`
- Result: PASS

## Risk / Rollback

- Risk: 신규 public API 추가이므로 downstream이 조기 사용하면 후속 구현체 설계와 맞춰야 한다. 기존 API 변경이나 런타임 동작 변경은 없다.
- Rollback: 이 PR을 revert하면 context expansion 계약 추가만 제거된다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope:
- Main author validation: core 테스트와 diff check를 실행했다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
