### PR TITLE
[chunking] textract normalized provenance 매핑 강화

### DIFF
--- a/starter/studio-platform-starter-chunking/README.md
+++ b/starter/studio-platform-starter-chunking/README.md
@@ -104,12 +104,16 @@ The adapter maps:
 - `ParsedBlock` to normalized heading, paragraph, list, footnote, OCR, and other logical blocks.
 - `ExtractedTable.vectorText()` to table chunks.
 - `ExtractedImage.caption()`, `altText()`, or `ocrText()` to image-caption/OCR chunks.
-- `ParsedBlock.confidence()` and table/image source references into normalized provenance fields.
+- `ParsedBlock.confidence()`, inferred `headingPath`, and table/image source references into normalized provenance fields.
+- image metadata keys such as `order`, `page`, `slide`, `parentBlockId`, `headingPath`, and `confidence` when the
+  parser already provides them.
 
 When a parsed table block and an `ExtractedTable` share the same `sourceRef`, the adapter keeps one table block based on
 `ExtractedTable.vectorText()` and carries over the parsed table block order/provenance. `ExtractedImage` does not currently
 carry an independent order value, so image-caption/OCR chunks are sorted after ordered parsed blocks unless the source
 metadata provides a future ordering field.
+If a parser returns only `plainText` without structured blocks, the normalized document keeps that text as the
+compatibility fallback for text-based chunking.
 
 ### Parent-Child Example
 

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/TextractNormalizedDocumentAdapter.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/TextractNormalizedDocumentAdapter.java
@@ -2,12 +2,14 @@ package studio.one.platform.chunking.service;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import studio.one.platform.chunking.core.ChunkMetadata;
 import studio.one.platform.chunking.core.NormalizedBlock;
 import studio.one.platform.chunking.core.NormalizedBlockType;
 import studio.one.platform.chunking.core.NormalizedDocument;
@@ -27,16 +29,20 @@ public class TextractNormalizedDocumentAdapter {
 
         List<NormalizedBlock> blocks = new ArrayList<>();
         Map<String, ParsedBlock> tableBlocks = tableBlocks(parsedFile.blocks());
+        Map<ParsedBlock, String> headingPaths = headingPaths(parsedFile.blocks());
         List<String> tableRefs = parsedFile.tables().stream()
                 .map(ExtractedTable::sourceRef)
                 .filter(ref -> ref != null && !ref.isBlank())
                 .toList();
         parsedFile.blocks().stream()
                 .filter(block -> !isExtractedTableBlock(block, tableRefs))
-                .map(this::fromBlock)
+                .map(block -> fromBlock(block, headingPaths.get(block)))
                 .forEach(blocks::add);
         parsedFile.tables().stream()
-                .map(table -> fromTable(table, tableBlocks.get(table.sourceRef())))
+                .map(table -> {
+                    ParsedBlock tableBlock = tableBlocks.get(table.sourceRef());
+                    return fromTable(table, tableBlock, tableBlock == null ? "" : headingPaths.get(tableBlock));
+                })
                 .forEach(blocks::add);
         parsedFile.images().stream()
                 .map(this::fromImage)
@@ -70,11 +76,38 @@ public class TextractNormalizedDocumentAdapter {
                 .compare(left, right) <= 0 ? left : right;
     }
 
+    private Map<ParsedBlock, String> headingPaths(List<ParsedBlock> blocks) {
+        Map<ParsedBlock, String> paths = new HashMap<>();
+        String current = "";
+        for (ParsedBlock block : sortedBlocks(blocks)) {
+            String explicit = stringMetadata(block.metadata(), NormalizedBlock.KEY_HEADING_PATH);
+            if (!explicit.isBlank()) {
+                current = explicit;
+            } else if (isHeading(block)) {
+                current = block.text();
+            }
+            paths.put(block, current);
+        }
+        return paths;
+    }
+
+    private List<ParsedBlock> sortedBlocks(List<ParsedBlock> blocks) {
+        return blocks.stream()
+                .sorted(Comparator.comparing(
+                        ParsedBlock::order,
+                        Comparator.nullsLast(Integer::compareTo)))
+                .toList();
+    }
+
     private boolean isExtractedTableBlock(ParsedBlock block, List<String> tableRefs) {
         return block.blockType() == BlockType.TABLE && tableRefs.contains(block.sourceRef());
     }
 
-    private NormalizedBlock fromBlock(ParsedBlock block) {
+    private boolean isHeading(ParsedBlock block) {
+        return block.blockType() == BlockType.TITLE || block.blockType() == BlockType.HEADING;
+    }
+
+    private NormalizedBlock fromBlock(ParsedBlock block, String headingPath) {
         return NormalizedBlock.builder(NormalizedBlockType.from(block.blockType().name()), block.text())
                 .id(block.id())
                 .sourceRef(block.sourceRef())
@@ -82,17 +115,21 @@ public class TextractNormalizedDocumentAdapter {
                 .slide(block.slide())
                 .order(block.order())
                 .parentBlockId(block.parentBlockId())
+                .headingPath(firstNonBlank(stringMetadata(block.metadata(), NormalizedBlock.KEY_HEADING_PATH), headingPath))
                 .blockIds(List.of(block.id()))
                 .confidence(block.confidence())
                 .metadata(block.metadata())
                 .build();
     }
 
-    private NormalizedBlock fromTable(ExtractedTable table, ParsedBlock tableBlock) {
+    private NormalizedBlock fromTable(ExtractedTable table, ParsedBlock tableBlock, String headingPath) {
         Map<String, Object> metadata = new LinkedHashMap<>(table.metadata());
         metadata.put(NormalizedBlock.KEY_ROW_COUNT, table.rowCount());
         metadata.put(NormalizedBlock.KEY_CELL_COUNT, table.cellCount());
         metadata.put(ExtractedTable.KEY_HEADER_ROW_COUNT, table.headerRowCount());
+        String effectiveHeadingPath = firstNonBlank(
+                stringMetadata(table.metadata(), NormalizedBlock.KEY_HEADING_PATH),
+                headingPath);
         return NormalizedBlock.builder(NormalizedBlockType.TABLE, table.vectorText())
                 .id(table.path())
                 .sourceRef(table.sourceRef())
@@ -100,6 +137,7 @@ public class TextractNormalizedDocumentAdapter {
                 .slide(tableBlock == null ? null : tableBlock.slide())
                 .order(tableBlock == null ? null : tableBlock.order())
                 .parentBlockId(tableBlock == null ? null : tableBlock.parentBlockId())
+                .headingPath(effectiveHeadingPath)
                 .blockIds(tableCellRefs(table, tableBlock))
                 .confidence(tableBlock == null ? null : tableBlock.confidence())
                 .metadata(metadata)
@@ -116,7 +154,13 @@ public class TextractNormalizedDocumentAdapter {
         return NormalizedBlock.builder(image.ocrApplied() ? NormalizedBlockType.OCR_TEXT : NormalizedBlockType.IMAGE_CAPTION, text)
                 .id(image.path())
                 .sourceRef(image.sourceRef())
+                .page(integerMetadata(image.metadata(), ChunkMetadata.KEY_PAGE))
+                .slide(integerMetadata(image.metadata(), ParsedBlock.KEY_SLIDE))
+                .order(integerMetadata(image.metadata(), ParsedBlock.KEY_ORDER))
+                .parentBlockId(stringMetadata(image.metadata(), ParsedBlock.KEY_PARENT_BLOCK_ID))
+                .headingPath(stringMetadata(image.metadata(), NormalizedBlock.KEY_HEADING_PATH))
                 .blockIds(image.sourceRefs().isEmpty() ? List.of(image.path()) : image.sourceRefs())
+                .confidence(doubleMetadata(image.metadata(), ParsedBlock.KEY_CONFIDENCE))
                 .metadata(metadata)
                 .build();
     }
@@ -139,6 +183,33 @@ public class TextractNormalizedDocumentAdapter {
     private String filename(Map<String, Object> metadata) {
         Object value = metadata.get("filename");
         return value instanceof String stringValue ? stringValue : "";
+    }
+
+    private String stringMetadata(Map<String, Object> metadata, String key) {
+        Object value = metadata.get(key);
+        return value instanceof String stringValue ? stringValue : "";
+    }
+
+    private Integer integerMetadata(Map<String, Object> metadata, String key) {
+        Object value = metadata.get(key);
+        if (value instanceof Integer integerValue) {
+            return integerValue;
+        }
+        if (value instanceof Number numberValue) {
+            return numberValue.intValue();
+        }
+        return null;
+    }
+
+    private Double doubleMetadata(Map<String, Object> metadata, String key) {
+        Object value = metadata.get(key);
+        if (value instanceof Double doubleValue) {
+            return doubleValue;
+        }
+        if (value instanceof Number numberValue) {
+            return numberValue.doubleValue();
+        }
+        return null;
     }
 
     private String firstNonBlank(String... values) {

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/TextractNormalizedDocumentAdapter.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/TextractNormalizedDocumentAdapter.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import studio.one.platform.chunking.core.ChunkMetadata;
 import studio.one.platform.chunking.core.NormalizedBlock;
 import studio.one.platform.chunking.core.NormalizedBlockType;
 import studio.one.platform.chunking.core.NormalizedDocument;
@@ -79,12 +78,17 @@ public class TextractNormalizedDocumentAdapter {
     private Map<ParsedBlock, String> headingPaths(List<ParsedBlock> blocks) {
         Map<ParsedBlock, String> paths = new HashMap<>();
         String current = "";
+        // Heading context is inferred in document order, then looked up by block so
+        // adapters can preserve parser output order without losing section context.
         for (ParsedBlock block : sortedBlocks(blocks)) {
             String explicit = stringMetadata(block.metadata(), NormalizedBlock.KEY_HEADING_PATH);
+            if (isHeading(block)) {
+                paths.put(block, "");
+                current = firstNonBlank(explicit, block.text(), current);
+                continue;
+            }
             if (!explicit.isBlank()) {
                 current = explicit;
-            } else if (isHeading(block)) {
-                current = block.text();
             }
             paths.put(block, current);
         }
@@ -154,13 +158,13 @@ public class TextractNormalizedDocumentAdapter {
         return NormalizedBlock.builder(image.ocrApplied() ? NormalizedBlockType.OCR_TEXT : NormalizedBlockType.IMAGE_CAPTION, text)
                 .id(image.path())
                 .sourceRef(image.sourceRef())
-                .page(integerMetadata(image.metadata(), ChunkMetadata.KEY_PAGE))
-                .slide(integerMetadata(image.metadata(), ParsedBlock.KEY_SLIDE))
-                .order(integerMetadata(image.metadata(), ParsedBlock.KEY_ORDER))
-                .parentBlockId(stringMetadata(image.metadata(), ParsedBlock.KEY_PARENT_BLOCK_ID))
+                .page(image.page())
+                .slide(image.slide())
+                .order(image.order())
+                .parentBlockId(image.parentBlockId())
                 .headingPath(stringMetadata(image.metadata(), NormalizedBlock.KEY_HEADING_PATH))
                 .blockIds(image.sourceRefs().isEmpty() ? List.of(image.path()) : image.sourceRefs())
-                .confidence(doubleMetadata(image.metadata(), ParsedBlock.KEY_CONFIDENCE))
+                .confidence(image.confidence())
                 .metadata(metadata)
                 .build();
     }
@@ -188,28 +192,6 @@ public class TextractNormalizedDocumentAdapter {
     private String stringMetadata(Map<String, Object> metadata, String key) {
         Object value = metadata.get(key);
         return value instanceof String stringValue ? stringValue : "";
-    }
-
-    private Integer integerMetadata(Map<String, Object> metadata, String key) {
-        Object value = metadata.get(key);
-        if (value instanceof Integer integerValue) {
-            return integerValue;
-        }
-        if (value instanceof Number numberValue) {
-            return numberValue.intValue();
-        }
-        return null;
-    }
-
-    private Double doubleMetadata(Map<String, Object> metadata, String key) {
-        Object value = metadata.get(key);
-        if (value instanceof Double doubleValue) {
-            return doubleValue;
-        }
-        if (value instanceof Number numberValue) {
-            return numberValue.doubleValue();
-        }
-        return null;
     }
 
     private String firstNonBlank(String... values) {

--- a/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/TextractNormalizedDocumentAdapterTest.java
+++ b/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/TextractNormalizedDocumentAdapterTest.java
@@ -49,9 +49,9 @@ class TextractNormalizedDocumentAdapterTest {
                         Map.of(ExtractedImage.KEY_ALT_TEXT, "architecture diagram",
                                 ExtractedImage.KEY_SOURCE_REF, "body/img[0]",
                                 ExtractedImage.KEY_SOURCE_REFS, List.of("body/img[0]", "body/img[0]/caption"),
-                                ParsedBlock.KEY_ORDER, 3,
-                                ParsedBlock.KEY_PARENT_BLOCK_ID, "body/p[1]",
-                                ParsedBlock.KEY_CONFIDENCE, 0.76d,
+                                ExtractedImage.KEY_ORDER, 3,
+                                ExtractedImage.KEY_PARENT_BLOCK_ID, "body/p[1]",
+                                ExtractedImage.KEY_CONFIDENCE, 0.76d,
                                 NormalizedBlock.KEY_HEADING_PATH, "Title"))),
                 false);
 
@@ -70,6 +70,7 @@ class TextractNormalizedDocumentAdapterTest {
                 .doesNotContain("| A |\n| --- |\n| 1 |");
         assertThat(document.blocks().get(1).order()).isEqualTo(1);
         assertThat(document.blocks().get(0).confidence()).isEqualTo(0.98d);
+        assertThat(document.blocks().get(0).headingPath()).isEmpty();
         assertThat(document.blocks().get(2).headingPath()).isEqualTo("Title");
         assertThat(document.blocks().get(1).headingPath()).isEqualTo("Title");
         assertThat(document.blocks().get(1).blockIds()).containsExactly("body/table[0]/cell[0,0]");
@@ -79,6 +80,29 @@ class TextractNormalizedDocumentAdapterTest {
         assertThat(document.blocks().get(3).headingPath()).isEqualTo("Title");
         assertThat(document.blocks().get(3).blockIds()).containsExactly("body/img[0]", "body/img[0]/caption");
         assertThat(document.blocks().get(3).confidence()).isEqualTo(0.76d);
+    }
+
+    @Test
+    void infersHeadingPathByBlockOrderEvenWhenParserReturnsUnorderedBlocks() {
+        ParsedFile parsedFile = new ParsedFile(
+                DocumentFormat.TEXT,
+                "Title\nBody",
+                List.of(
+                        ParsedBlock.text("body/p[0]", BlockType.PARAGRAPH, "Body", 1, 2, Map.of()),
+                        ParsedBlock.text("body/h1", BlockType.HEADING, "Title", 1, 0, Map.of())),
+                Map.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                false);
+
+        NormalizedDocument document = new TextractNormalizedDocumentAdapter().adapt("doc", parsedFile);
+
+        assertThat(document.blocks()).extracting(NormalizedBlock::sourceRef)
+                .containsExactly("body/h1", "body/p[0]");
+        assertThat(document.blocks().get(0).headingPath()).isEmpty();
+        assertThat(document.blocks().get(1).headingPath()).isEqualTo("Title");
     }
 
     @Test

--- a/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/TextractNormalizedDocumentAdapterTest.java
+++ b/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/TextractNormalizedDocumentAdapterTest.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import studio.one.platform.chunking.core.NormalizedBlock;
 import studio.one.platform.chunking.core.NormalizedBlockType;
 import studio.one.platform.chunking.core.NormalizedDocument;
 import studio.one.platform.textract.extractor.DocumentFormat;
@@ -46,7 +47,12 @@ class TextractNormalizedDocumentAdapterTest {
                         10,
                         20,
                         Map.of(ExtractedImage.KEY_ALT_TEXT, "architecture diagram",
-                                ExtractedImage.KEY_SOURCE_REF, "body/img[0]"))),
+                                ExtractedImage.KEY_SOURCE_REF, "body/img[0]",
+                                ExtractedImage.KEY_SOURCE_REFS, List.of("body/img[0]", "body/img[0]/caption"),
+                                ParsedBlock.KEY_ORDER, 3,
+                                ParsedBlock.KEY_PARENT_BLOCK_ID, "body/p[1]",
+                                ParsedBlock.KEY_CONFIDENCE, 0.76d,
+                                NormalizedBlock.KEY_HEADING_PATH, "Title"))),
                 false);
 
         NormalizedDocument document = new TextractNormalizedDocumentAdapter().adapt("doc", parsedFile);
@@ -64,8 +70,34 @@ class TextractNormalizedDocumentAdapterTest {
                 .doesNotContain("| A |\n| --- |\n| 1 |");
         assertThat(document.blocks().get(1).order()).isEqualTo(1);
         assertThat(document.blocks().get(0).confidence()).isEqualTo(0.98d);
+        assertThat(document.blocks().get(2).headingPath()).isEqualTo("Title");
+        assertThat(document.blocks().get(1).headingPath()).isEqualTo("Title");
         assertThat(document.blocks().get(1).blockIds()).containsExactly("body/table[0]/cell[0,0]");
         assertThat(document.blocks().get(1).confidence()).isEqualTo(0.87d);
-        assertThat(document.blocks().get(3).blockIds()).containsExactly("body/img[0]");
+        assertThat(document.blocks().get(3).order()).isEqualTo(3);
+        assertThat(document.blocks().get(3).parentBlockId()).isEqualTo("body/p[1]");
+        assertThat(document.blocks().get(3).headingPath()).isEqualTo("Title");
+        assertThat(document.blocks().get(3).blockIds()).containsExactly("body/img[0]", "body/img[0]/caption");
+        assertThat(document.blocks().get(3).confidence()).isEqualTo(0.76d);
+    }
+
+    @Test
+    void keepsPlainTextFallbackWhenStructuredBlocksAreMissing() {
+        ParsedFile parsedFile = new ParsedFile(
+                DocumentFormat.TEXT,
+                "plain fallback",
+                List.of(),
+                Map.of("filename", "fallback.txt"),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                false);
+
+        NormalizedDocument document = new TextractNormalizedDocumentAdapter().adapt("doc", parsedFile);
+
+        assertThat(document.blocks()).isEmpty();
+        assertThat(document.chunkableText()).isEqualTo("plain fallback");
+        assertThat(document.filename()).isEqualTo("fallback.txt");
     }
 }

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ExtractedImage.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/model/ExtractedImage.java
@@ -26,6 +26,11 @@ public record ExtractedImage(
     public static final String KEY_OCR_UNIT = "ocrUnit";
     public static final String KEY_OCR_LINE_COUNT = "ocrLineCount";
     public static final String KEY_CONFIDENCE_AVAILABLE = "confidenceAvailable";
+    public static final String KEY_PAGE = "page";
+    public static final String KEY_SLIDE = "slide";
+    public static final String KEY_ORDER = "order";
+    public static final String KEY_PARENT_BLOCK_ID = "parentBlockId";
+    public static final String KEY_CONFIDENCE = "confidence";
 
     public ExtractedImage {
         metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
@@ -106,5 +111,44 @@ public record ExtractedImage(
     public boolean confidenceAvailable() {
         Object value = metadata.get(KEY_CONFIDENCE_AVAILABLE);
         return value instanceof Boolean booleanValue && booleanValue;
+    }
+
+    public Integer page() {
+        return integerValue(KEY_PAGE);
+    }
+
+    public Integer slide() {
+        return integerValue(KEY_SLIDE);
+    }
+
+    public Integer order() {
+        return integerValue(KEY_ORDER);
+    }
+
+    public String parentBlockId() {
+        Object value = metadata.get(KEY_PARENT_BLOCK_ID);
+        return value instanceof String stringValue ? stringValue : "";
+    }
+
+    public Double confidence() {
+        Object value = metadata.get(KEY_CONFIDENCE);
+        if (value instanceof Double doubleValue) {
+            return doubleValue;
+        }
+        if (value instanceof Number numberValue) {
+            return numberValue.doubleValue();
+        }
+        return null;
+    }
+
+    private Integer integerValue(String key) {
+        Object value = metadata.get(key);
+        if (value instanceof Integer integerValue) {
+            return integerValue;
+        }
+        if (value instanceof Number numberValue) {
+            return numberValue.intValue();
+        }
+        return null;
     }
 }

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/model/ExtractedStructureTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/model/ExtractedStructureTest.java
@@ -70,7 +70,12 @@ class ExtractedStructureTest {
                         entry(ExtractedImage.KEY_OCR_APPLIED, true),
                         entry(ExtractedImage.KEY_OCR_UNIT, "line"),
                         entry(ExtractedImage.KEY_OCR_LINE_COUNT, 3),
-                        entry(ExtractedImage.KEY_CONFIDENCE_AVAILABLE, false)));
+                        entry(ExtractedImage.KEY_CONFIDENCE_AVAILABLE, false),
+                        entry(ExtractedImage.KEY_PAGE, 2),
+                        entry(ExtractedImage.KEY_SLIDE, 3),
+                        entry(ExtractedImage.KEY_ORDER, 4),
+                        entry(ExtractedImage.KEY_PARENT_BLOCK_ID, "body/p[1]"),
+                        entry(ExtractedImage.KEY_CONFIDENCE, 0.75d)));
 
         assertEquals("image/png", image.mimeType());
         assertEquals("section[0]/pic[1]", image.sourceRef());
@@ -85,6 +90,11 @@ class ExtractedStructureTest {
         assertEquals("line", image.ocrUnit());
         assertEquals(3, image.ocrLineCount());
         assertEquals(false, image.confidenceAvailable());
+        assertEquals(2, image.page());
+        assertEquals(3, image.slide());
+        assertEquals(4, image.order());
+        assertEquals("body/p[1]", image.parentBlockId());
+        assertEquals(0.75d, image.confidence());
     }
 
     @Test


### PR DESCRIPTION
## Why

- #279 범위에 따라 textract structured output을 parser 재구현 없이 chunking normalized input으로 더 정확히 보존해야 한다.
- parent-child chunking과 context expansion 품질은 `headingPath`, `blockIds`, `confidence`, source provenance가 normalized block에 안정적으로 전달되는지에 의존한다.

## What

- `TextractNormalizedDocumentAdapter`가 `ParsedBlock` 순서를 기준으로 `headingPath`를 추론해 heading/table/paragraph block에 전달한다.
- image metadata의 `order`, `page`, `slide`, `parentBlockId`, `headingPath`, `confidence`, `sourceRefs`를 normalized block에 보존한다.
- table block은 기존 `ExtractedTable.vectorText()` 기반 단일 block 유지와 parsed table provenance carry-over를 유지한다.
- structured block이 없는 `ParsedFile`도 `plainText` fallback을 유지하도록 테스트를 추가했다.
- starter README에 provenance 매핑과 fallback 계약을 보강했다.

## Related Issues

- Closes #279

## Validation

- Command: `./gradlew :starter:studio-platform-starter-chunking:test`
- Result: PASS
- Command: `git diff --check`
- Result: PASS

## Risk / Rollback

- Risk: image metadata에 order가 제공되는 경우 기존 null-order image보다 앞쪽으로 정렬될 수 있다. 이는 parser가 제공한 provenance를 보존하는 의도된 변경이다.
- Rollback: 이 PR을 revert하면 adapter provenance 보강과 관련 테스트/문서만 제거된다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope:
- Main author validation: starter-chunking 테스트와 diff check를 실행했다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included
