### PR TITLE
feat(chunking): context expansion 구현체 추가

### DIFF
--- a/starter/studio-platform-starter-chunking/README.md
+++ b/starter/studio-platform-starter-chunking/README.md
@@ -153,6 +153,32 @@ chunk.metadata().blockIds();       // [page[1]/p[1], page[1]/p[2]]
 The default return value remains the child chunk list for compatibility. Parent content is persisted additively in child
 metadata so later context-expansion strategies can recover section context without changing the indexing contract.
 
+## Context Expansion
+
+The starter provides pure in-memory `ChunkContextExpander` implementations for expanding a retrieved child chunk after
+vector search. They consume only the supplied `seedChunk` and a small pre-filtered `availableChunks` list; they do not
+call embedding APIs, vector stores, LLMs, parsers, or OCR engines.
+
+- `WindowChunkContextExpander`: follows `previousChunkId` / `nextChunkId` links up to the requested window.
+- `ParentChildChunkContextExpander`: restores `parentChunkContent` when present, otherwise joins siblings with the same
+  `parentChunkId`.
+- `HeadingChunkContextExpander`: joins chunks with the same `section` / heading context.
+- `TableChunkContextExpander`: keeps table chunks as a single retrieval unit and can restore stored parent context.
+
+```java
+ChunkContextExpansionRequest request = ChunkContextExpansionRequest.builder(retrievedChunk)
+        .availableChunks(candidateChunks)
+        .previousWindow(1)
+        .nextWindow(1)
+        .includeParentContent(true)
+        .build();
+
+ChunkContextExpansion expansion = windowChunkContextExpander.expand(request);
+```
+
+`availableChunks` should already be scoped by the caller, for example to neighbor chunks from the same document or the
+top retrieval candidates for the same parent. Passing an entire corpus defeats the contract and can increase memory use.
+
 ## Size Policy
 
 Character size remains the default policy. `ChunkUnit.TOKEN` uses a deterministic estimate based on compacted character length and does not call an external tokenizer.

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/autoconfigure/ChunkingAutoConfiguration.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/autoconfigure/ChunkingAutoConfiguration.java
@@ -12,8 +12,12 @@ import studio.one.platform.chunking.core.Chunker;
 import studio.one.platform.chunking.core.ChunkingOrchestrator;
 import studio.one.platform.chunking.service.DefaultChunkingOrchestrator;
 import studio.one.platform.chunking.service.FixedSizeChunker;
+import studio.one.platform.chunking.service.HeadingChunkContextExpander;
+import studio.one.platform.chunking.service.ParentChildChunkContextExpander;
 import studio.one.platform.chunking.service.RecursiveChunker;
 import studio.one.platform.chunking.service.StructureBasedChunker;
+import studio.one.platform.chunking.service.TableChunkContextExpander;
+import studio.one.platform.chunking.service.WindowChunkContextExpander;
 
 @AutoConfiguration
 @EnableConfigurationProperties(ChunkingProperties.class)
@@ -38,6 +42,30 @@ public class ChunkingAutoConfiguration {
             ChunkingProperties properties,
             RecursiveChunker recursiveChunker) {
         return new StructureBasedChunker(properties.getMaxSize(), properties.getOverlap(), recursiveChunker);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public WindowChunkContextExpander windowChunkContextExpander() {
+        return new WindowChunkContextExpander();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ParentChildChunkContextExpander parentChildChunkContextExpander() {
+        return new ParentChildChunkContextExpander();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public HeadingChunkContextExpander headingChunkContextExpander() {
+        return new HeadingChunkContextExpander();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public TableChunkContextExpander tableChunkContextExpander() {
+        return new TableChunkContextExpander();
     }
 
     @Bean

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/ChunkContextExpansionSupport.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/ChunkContextExpansionSupport.java
@@ -15,11 +15,25 @@ final class ChunkContextExpansionSupport {
     }
 
     static List<Chunk> order(List<Chunk> chunks) {
-        return chunks.stream()
-                .filter(chunk -> chunk != null && chunk.content() != null && !chunk.content().isBlank())
-                .distinct()
+        Map<String, Chunk> unique = new LinkedHashMap<>();
+        chunks.stream()
+                .filter(ChunkContextExpansionSupport::hasContent)
+                .forEach(chunk -> unique.putIfAbsent(chunk.id(), chunk));
+        return unique.values().stream()
                 .sorted(Comparator.comparingInt(chunk -> chunk.metadata().order()))
                 .toList();
+    }
+
+    static List<Chunk> withSeed(Chunk seed, List<Chunk> chunks) {
+        Map<String, Chunk> unique = new LinkedHashMap<>();
+        if (chunks != null) {
+            chunks.stream()
+                    .filter(ChunkContextExpansionSupport::hasContent)
+                    .filter(chunk -> !chunk.id().equals(seed.id()))
+                    .forEach(chunk -> unique.putIfAbsent(chunk.id(), chunk));
+        }
+        unique.put(seed.id(), seed);
+        return List.copyOf(unique.values());
     }
 
     static List<Chunk> sameParent(String parentChunkId, List<Chunk> chunks) {
@@ -62,5 +76,9 @@ final class ChunkContextExpansionSupport {
             }
         }
         return metadata;
+    }
+
+    private static boolean hasContent(Chunk chunk) {
+        return chunk != null && chunk.content() != null && !chunk.content().isBlank();
     }
 }

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/ChunkContextExpansionSupport.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/ChunkContextExpansionSupport.java
@@ -1,0 +1,66 @@
+package studio.one.platform.chunking.service;
+
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import studio.one.platform.chunking.core.Chunk;
+import studio.one.platform.chunking.core.ChunkMetadata;
+import studio.one.platform.chunking.core.ChunkType;
+
+final class ChunkContextExpansionSupport {
+
+    private ChunkContextExpansionSupport() {
+    }
+
+    static List<Chunk> order(List<Chunk> chunks) {
+        return chunks.stream()
+                .filter(chunk -> chunk != null && chunk.content() != null && !chunk.content().isBlank())
+                .distinct()
+                .sorted(Comparator.comparingInt(chunk -> chunk.metadata().order()))
+                .toList();
+    }
+
+    static List<Chunk> sameParent(String parentChunkId, List<Chunk> chunks) {
+        if (parentChunkId == null || parentChunkId.isBlank()) {
+            return List.of();
+        }
+        return order(chunks.stream()
+                .filter(chunk -> parentChunkId.equals(chunk.metadata().parentChunkId()))
+                .toList());
+    }
+
+    static List<Chunk> sameSection(String section, List<Chunk> chunks) {
+        if (section == null || section.isBlank()) {
+            return List.of();
+        }
+        return order(chunks.stream()
+                .filter(chunk -> section.equals(chunk.metadata().section()))
+                .toList());
+    }
+
+    static ChunkType chunkType(Chunk chunk) {
+        ChunkType type = chunk.metadata().chunkType();
+        if (type != null) {
+            return type;
+        }
+        Object value = chunk.metadata().toMap().get(ChunkMetadata.KEY_CHUNK_TYPE);
+        return value instanceof String stringValue ? ChunkType.from(stringValue) : ChunkType.CHILD;
+    }
+
+    static String parentContent(Chunk chunk) {
+        Object value = chunk.metadata().toMap().get(ChunkMetadata.KEY_PARENT_CHUNK_CONTENT);
+        return value instanceof String stringValue ? stringValue.trim() : "";
+    }
+
+    static Map<String, Object> metadata(String key, Object value) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        if (key != null && !key.isBlank() && value != null) {
+            if (!(value instanceof String stringValue) || !stringValue.isBlank()) {
+                metadata.put(key, value);
+            }
+        }
+        return metadata;
+    }
+}

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/ChunkContextExpansionSupport.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/ChunkContextExpansionSupport.java
@@ -55,12 +55,7 @@ final class ChunkContextExpansionSupport {
     }
 
     static ChunkType chunkType(Chunk chunk) {
-        ChunkType type = chunk.metadata().chunkType();
-        if (type != null) {
-            return type;
-        }
-        Object value = chunk.metadata().toMap().get(ChunkMetadata.KEY_CHUNK_TYPE);
-        return value instanceof String stringValue ? ChunkType.from(stringValue) : ChunkType.CHILD;
+        return chunk.metadata().chunkType();
     }
 
     static String parentContent(Chunk chunk) {

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/HeadingChunkContextExpander.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/HeadingChunkContextExpander.java
@@ -2,7 +2,6 @@ package studio.one.platform.chunking.service;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 import studio.one.platform.chunking.core.Chunk;
 import studio.one.platform.chunking.core.ChunkContextExpander;
@@ -22,7 +21,8 @@ public class HeadingChunkContextExpander implements ChunkContextExpander {
     public ChunkContextExpansion expand(ChunkContextExpansionRequest request) {
         Chunk seed = request.seedChunk();
         String section = seed.metadata().section();
-        List<Chunk> contextChunks = ChunkContextExpansionSupport.sameSection(section, candidates(request));
+        List<Chunk> contextChunks = ChunkContextExpansionSupport.sameSection(section,
+                ChunkContextExpansionSupport.withSeed(seed, request.availableChunks()));
         if (contextChunks.isEmpty()) {
             contextChunks = List.of(seed);
         }
@@ -33,11 +33,4 @@ public class HeadingChunkContextExpander implements ChunkContextExpander {
                 ChunkContextExpansionSupport.metadata(ChunkMetadata.KEY_SECTION, section));
     }
 
-    private List<Chunk> candidates(ChunkContextExpansionRequest request) {
-        if (request.availableChunks().contains(request.seedChunk())) {
-            return request.availableChunks();
-        }
-        return Stream.concat(request.availableChunks().stream(), Stream.of(request.seedChunk()))
-                .toList();
-    }
 }

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/HeadingChunkContextExpander.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/HeadingChunkContextExpander.java
@@ -1,0 +1,43 @@
+package studio.one.platform.chunking.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import studio.one.platform.chunking.core.Chunk;
+import studio.one.platform.chunking.core.ChunkContextExpander;
+import studio.one.platform.chunking.core.ChunkContextExpansion;
+import studio.one.platform.chunking.core.ChunkContextExpansionRequest;
+import studio.one.platform.chunking.core.ChunkContextExpansionStrategy;
+import studio.one.platform.chunking.core.ChunkMetadata;
+
+public class HeadingChunkContextExpander implements ChunkContextExpander {
+
+    @Override
+    public ChunkContextExpansionStrategy strategy() {
+        return ChunkContextExpansionStrategy.HEADING;
+    }
+
+    @Override
+    public ChunkContextExpansion expand(ChunkContextExpansionRequest request) {
+        Chunk seed = request.seedChunk();
+        String section = seed.metadata().section();
+        List<Chunk> contextChunks = ChunkContextExpansionSupport.sameSection(section, candidates(request));
+        if (contextChunks.isEmpty()) {
+            contextChunks = List.of(seed);
+        }
+        return ChunkContextExpansion.of(
+                seed,
+                contextChunks,
+                strategy(),
+                ChunkContextExpansionSupport.metadata(ChunkMetadata.KEY_SECTION, section));
+    }
+
+    private List<Chunk> candidates(ChunkContextExpansionRequest request) {
+        if (request.availableChunks().contains(request.seedChunk())) {
+            return request.availableChunks();
+        }
+        return Stream.concat(request.availableChunks().stream(), Stream.of(request.seedChunk()))
+                .toList();
+    }
+}

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/ParentChildChunkContextExpander.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/ParentChildChunkContextExpander.java
@@ -1,0 +1,48 @@
+package studio.one.platform.chunking.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import studio.one.platform.chunking.core.Chunk;
+import studio.one.platform.chunking.core.ChunkContextExpander;
+import studio.one.platform.chunking.core.ChunkContextExpansion;
+import studio.one.platform.chunking.core.ChunkContextExpansionRequest;
+import studio.one.platform.chunking.core.ChunkContextExpansionStrategy;
+import studio.one.platform.chunking.core.ChunkMetadata;
+
+public class ParentChildChunkContextExpander implements ChunkContextExpander {
+
+    @Override
+    public ChunkContextExpansionStrategy strategy() {
+        return ChunkContextExpansionStrategy.PARENT_CHILD;
+    }
+
+    @Override
+    public ChunkContextExpansion expand(ChunkContextExpansionRequest request) {
+        Chunk seed = request.seedChunk();
+        String parentChunkId = seed.metadata().parentChunkId();
+        List<Chunk> contextChunks = ChunkContextExpansionSupport.sameParent(parentChunkId, candidates(request));
+        if (contextChunks.isEmpty()) {
+            contextChunks = List.of(seed);
+        }
+        Map<String, Object> metadata = ChunkContextExpansionSupport.metadata(
+                ChunkMetadata.KEY_PARENT_CHUNK_ID,
+                parentChunkId);
+        String parentContent = request.includeParentContent()
+                ? ChunkContextExpansionSupport.parentContent(seed)
+                : "";
+        if (!parentContent.isBlank()) {
+            return new ChunkContextExpansion(seed, contextChunks, parentContent, strategy(), metadata);
+        }
+        return ChunkContextExpansion.of(seed, contextChunks, strategy(), metadata);
+    }
+
+    private List<Chunk> candidates(ChunkContextExpansionRequest request) {
+        if (request.availableChunks().contains(request.seedChunk())) {
+            return request.availableChunks();
+        }
+        return Stream.concat(request.availableChunks().stream(), Stream.of(request.seedChunk()))
+                .toList();
+    }
+}

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/ParentChildChunkContextExpander.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/ParentChildChunkContextExpander.java
@@ -2,7 +2,6 @@ package studio.one.platform.chunking.service;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 import studio.one.platform.chunking.core.Chunk;
 import studio.one.platform.chunking.core.ChunkContextExpander;
@@ -22,7 +21,8 @@ public class ParentChildChunkContextExpander implements ChunkContextExpander {
     public ChunkContextExpansion expand(ChunkContextExpansionRequest request) {
         Chunk seed = request.seedChunk();
         String parentChunkId = seed.metadata().parentChunkId();
-        List<Chunk> contextChunks = ChunkContextExpansionSupport.sameParent(parentChunkId, candidates(request));
+        List<Chunk> contextChunks = ChunkContextExpansionSupport.sameParent(parentChunkId,
+                ChunkContextExpansionSupport.withSeed(seed, request.availableChunks()));
         if (contextChunks.isEmpty()) {
             contextChunks = List.of(seed);
         }
@@ -38,11 +38,4 @@ public class ParentChildChunkContextExpander implements ChunkContextExpander {
         return ChunkContextExpansion.of(seed, contextChunks, strategy(), metadata);
     }
 
-    private List<Chunk> candidates(ChunkContextExpansionRequest request) {
-        if (request.availableChunks().contains(request.seedChunk())) {
-            return request.availableChunks();
-        }
-        return Stream.concat(request.availableChunks().stream(), Stream.of(request.seedChunk()))
-                .toList();
-    }
 }

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/TableChunkContextExpander.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/TableChunkContextExpander.java
@@ -21,10 +21,11 @@ public class TableChunkContextExpander implements ChunkContextExpander {
     @Override
     public ChunkContextExpansion expand(ChunkContextExpansionRequest request) {
         Chunk seed = request.seedChunk();
+        ChunkType chunkType = ChunkContextExpansionSupport.chunkType(seed);
         Map<String, Object> metadata = ChunkContextExpansionSupport.metadata(
                 ChunkMetadata.KEY_CHUNK_TYPE,
-                ChunkContextExpansionSupport.chunkType(seed).value());
-        if (ChunkContextExpansionSupport.chunkType(seed) != ChunkType.TABLE) {
+                chunkType.value());
+        if (chunkType != ChunkType.TABLE) {
             return ChunkContextExpansion.of(seed, List.of(seed), strategy(), metadata);
         }
         String parentContent = request.includeParentContent()

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/TableChunkContextExpander.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/TableChunkContextExpander.java
@@ -1,0 +1,38 @@
+package studio.one.platform.chunking.service;
+
+import java.util.List;
+import java.util.Map;
+
+import studio.one.platform.chunking.core.Chunk;
+import studio.one.platform.chunking.core.ChunkContextExpander;
+import studio.one.platform.chunking.core.ChunkContextExpansion;
+import studio.one.platform.chunking.core.ChunkContextExpansionRequest;
+import studio.one.platform.chunking.core.ChunkContextExpansionStrategy;
+import studio.one.platform.chunking.core.ChunkMetadata;
+import studio.one.platform.chunking.core.ChunkType;
+
+public class TableChunkContextExpander implements ChunkContextExpander {
+
+    @Override
+    public ChunkContextExpansionStrategy strategy() {
+        return ChunkContextExpansionStrategy.TABLE;
+    }
+
+    @Override
+    public ChunkContextExpansion expand(ChunkContextExpansionRequest request) {
+        Chunk seed = request.seedChunk();
+        Map<String, Object> metadata = ChunkContextExpansionSupport.metadata(
+                ChunkMetadata.KEY_CHUNK_TYPE,
+                ChunkContextExpansionSupport.chunkType(seed).value());
+        if (ChunkContextExpansionSupport.chunkType(seed) != ChunkType.TABLE) {
+            return ChunkContextExpansion.of(seed, List.of(seed), strategy(), metadata);
+        }
+        String parentContent = request.includeParentContent()
+                ? ChunkContextExpansionSupport.parentContent(seed)
+                : "";
+        if (!parentContent.isBlank()) {
+            return new ChunkContextExpansion(seed, List.of(seed), parentContent, strategy(), metadata);
+        }
+        return ChunkContextExpansion.of(seed, List.of(seed), strategy(), metadata);
+    }
+}

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/TableChunkContextExpander.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/TableChunkContextExpander.java
@@ -11,6 +11,11 @@ import studio.one.platform.chunking.core.ChunkContextExpansionStrategy;
 import studio.one.platform.chunking.core.ChunkMetadata;
 import studio.one.platform.chunking.core.ChunkType;
 
+/**
+ * Expands table chunks as atomic retrieval units.
+ * Non-table seed chunks are returned unchanged so callers can safely route
+ * through this expander without pre-validating the chunk type.
+ */
 public class TableChunkContextExpander implements ChunkContextExpander {
 
     @Override

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/WindowChunkContextExpander.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/WindowChunkContextExpander.java
@@ -2,8 +2,11 @@ package studio.one.platform.chunking.service;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import studio.one.platform.chunking.core.Chunk;
 import studio.one.platform.chunking.core.ChunkContextExpander;
@@ -30,19 +33,21 @@ public class WindowChunkContextExpander implements ChunkContextExpander {
                 request.seedChunk(),
                 context,
                 strategy(),
-                Map.of("previousCount", previous.size(), "nextCount", next.size()));
+                metadata(previous.size(), next.size()));
     }
 
     private List<Chunk> collectPrevious(ChunkContextExpansionRequest request) {
         List<Chunk> chunks = new ArrayList<>();
         Chunk current = request.seedChunk();
+        Set<String> visited = new HashSet<>();
+        visited.add(request.seedChunk().id());
         for (int i = 0; i < request.previousWindow(); i++) {
             String previousChunkId = current.metadata().previousChunkId();
             if (previousChunkId == null || previousChunkId.isBlank()) {
                 break;
             }
             Chunk previous = request.chunkById(previousChunkId).orElse(null);
-            if (previous == null || request.seedChunk().id().equals(previous.id()) || chunks.contains(previous)) {
+            if (previous == null || !visited.add(previous.id())) {
                 break;
             }
             chunks.add(previous);
@@ -55,18 +60,27 @@ public class WindowChunkContextExpander implements ChunkContextExpander {
     private List<Chunk> collectNext(ChunkContextExpansionRequest request) {
         List<Chunk> chunks = new ArrayList<>();
         Chunk current = request.seedChunk();
+        Set<String> visited = new HashSet<>();
+        visited.add(request.seedChunk().id());
         for (int i = 0; i < request.nextWindow(); i++) {
             String nextChunkId = current.metadata().nextChunkId();
             if (nextChunkId == null || nextChunkId.isBlank()) {
                 break;
             }
             Chunk next = request.chunkById(nextChunkId).orElse(null);
-            if (next == null || request.seedChunk().id().equals(next.id()) || chunks.contains(next)) {
+            if (next == null || !visited.add(next.id())) {
                 break;
             }
             chunks.add(next);
             current = next;
         }
         return chunks;
+    }
+
+    private Map<String, Object> metadata(int previousCount, int nextCount) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.putAll(ChunkContextExpansionSupport.metadata("previousCount", previousCount));
+        metadata.putAll(ChunkContextExpansionSupport.metadata("nextCount", nextCount));
+        return metadata;
     }
 }

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/WindowChunkContextExpander.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/WindowChunkContextExpander.java
@@ -1,0 +1,72 @@
+package studio.one.platform.chunking.service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import studio.one.platform.chunking.core.Chunk;
+import studio.one.platform.chunking.core.ChunkContextExpander;
+import studio.one.platform.chunking.core.ChunkContextExpansion;
+import studio.one.platform.chunking.core.ChunkContextExpansionRequest;
+import studio.one.platform.chunking.core.ChunkContextExpansionStrategy;
+
+public class WindowChunkContextExpander implements ChunkContextExpander {
+
+    @Override
+    public ChunkContextExpansionStrategy strategy() {
+        return ChunkContextExpansionStrategy.WINDOW;
+    }
+
+    @Override
+    public ChunkContextExpansion expand(ChunkContextExpansionRequest request) {
+        List<Chunk> previous = collectPrevious(request);
+        List<Chunk> next = collectNext(request);
+        List<Chunk> context = new ArrayList<>(previous.size() + next.size() + 1);
+        context.addAll(previous);
+        context.add(request.seedChunk());
+        context.addAll(next);
+        return ChunkContextExpansion.of(
+                request.seedChunk(),
+                context,
+                strategy(),
+                Map.of("previousCount", previous.size(), "nextCount", next.size()));
+    }
+
+    private List<Chunk> collectPrevious(ChunkContextExpansionRequest request) {
+        List<Chunk> chunks = new ArrayList<>();
+        Chunk current = request.seedChunk();
+        for (int i = 0; i < request.previousWindow(); i++) {
+            String previousChunkId = current.metadata().previousChunkId();
+            if (previousChunkId == null || previousChunkId.isBlank()) {
+                break;
+            }
+            Chunk previous = request.chunkById(previousChunkId).orElse(null);
+            if (previous == null || chunks.contains(previous)) {
+                break;
+            }
+            chunks.add(previous);
+            current = previous;
+        }
+        Collections.reverse(chunks);
+        return chunks;
+    }
+
+    private List<Chunk> collectNext(ChunkContextExpansionRequest request) {
+        List<Chunk> chunks = new ArrayList<>();
+        Chunk current = request.seedChunk();
+        for (int i = 0; i < request.nextWindow(); i++) {
+            String nextChunkId = current.metadata().nextChunkId();
+            if (nextChunkId == null || nextChunkId.isBlank()) {
+                break;
+            }
+            Chunk next = request.chunkById(nextChunkId).orElse(null);
+            if (next == null || chunks.contains(next)) {
+                break;
+            }
+            chunks.add(next);
+            current = next;
+        }
+        return chunks;
+    }
+}

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/WindowChunkContextExpander.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/WindowChunkContextExpander.java
@@ -42,7 +42,7 @@ public class WindowChunkContextExpander implements ChunkContextExpander {
                 break;
             }
             Chunk previous = request.chunkById(previousChunkId).orElse(null);
-            if (previous == null || chunks.contains(previous)) {
+            if (previous == null || request.seedChunk().id().equals(previous.id()) || chunks.contains(previous)) {
                 break;
             }
             chunks.add(previous);
@@ -61,7 +61,7 @@ public class WindowChunkContextExpander implements ChunkContextExpander {
                 break;
             }
             Chunk next = request.chunkById(nextChunkId).orElse(null);
-            if (next == null || chunks.contains(next)) {
+            if (next == null || request.seedChunk().id().equals(next.id()) || chunks.contains(next)) {
                 break;
             }
             chunks.add(next);

--- a/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/autoconfigure/ChunkingAutoConfigurationTest.java
+++ b/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/autoconfigure/ChunkingAutoConfigurationTest.java
@@ -6,11 +6,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
-import studio.one.platform.chunking.core.ChunkingOrchestrator;
-import studio.one.platform.chunking.service.StructureBasedChunker;
-import studio.one.platform.chunking.service.FixedSizeChunker;
-import studio.one.platform.chunking.service.RecursiveChunker;
 import studio.one.platform.chunking.core.ChunkingContext;
+import studio.one.platform.chunking.core.ChunkingOrchestrator;
+import studio.one.platform.chunking.service.FixedSizeChunker;
+import studio.one.platform.chunking.service.HeadingChunkContextExpander;
+import studio.one.platform.chunking.service.ParentChildChunkContextExpander;
+import studio.one.platform.chunking.service.RecursiveChunker;
+import studio.one.platform.chunking.service.StructureBasedChunker;
+import studio.one.platform.chunking.service.TableChunkContextExpander;
+import studio.one.platform.chunking.service.WindowChunkContextExpander;
 
 class ChunkingAutoConfigurationTest {
 
@@ -24,6 +28,10 @@ class ChunkingAutoConfigurationTest {
                 .hasSingleBean(FixedSizeChunker.class)
                 .hasSingleBean(RecursiveChunker.class)
                 .hasSingleBean(StructureBasedChunker.class)
+                .hasSingleBean(WindowChunkContextExpander.class)
+                .hasSingleBean(ParentChildChunkContextExpander.class)
+                .hasSingleBean(HeadingChunkContextExpander.class)
+                .hasSingleBean(TableChunkContextExpander.class)
                 .hasSingleBean(ChunkingOrchestrator.class));
     }
 
@@ -34,6 +42,10 @@ class ChunkingAutoConfigurationTest {
                         .doesNotHaveBean(FixedSizeChunker.class)
                         .doesNotHaveBean(RecursiveChunker.class)
                         .doesNotHaveBean(StructureBasedChunker.class)
+                        .doesNotHaveBean(WindowChunkContextExpander.class)
+                        .doesNotHaveBean(ParentChildChunkContextExpander.class)
+                        .doesNotHaveBean(HeadingChunkContextExpander.class)
+                        .doesNotHaveBean(TableChunkContextExpander.class)
                         .doesNotHaveBean(ChunkingOrchestrator.class));
     }
 

--- a/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/ChunkContextExpanderTest.java
+++ b/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/ChunkContextExpanderTest.java
@@ -75,6 +75,25 @@ class ChunkContextExpanderTest {
     }
 
     @Test
+    void parentChildExpansionDeduplicatesAvailableChunkWithSameSeedId() {
+        Chunk staleSeed = chunk("doc-1", "stale", 1, "parent", null, null, "Install", ChunkType.CHILD,
+                Map.of());
+        Chunk seed = chunk("doc-1", "fresh", 1, "parent", null, null, "Install", ChunkType.CHILD,
+                Map.of());
+        Chunk next = chunk("doc-2", "next", 2, "parent", null, null, "Install", ChunkType.CHILD,
+                Map.of());
+
+        ChunkContextExpansion expansion = new ParentChildChunkContextExpander().expand(
+                ChunkContextExpansionRequest.builder(seed)
+                        .availableChunks(List.of(staleSeed, next))
+                        .includeParentContent(false)
+                        .build());
+
+        assertThat(expansion.contextChunks()).containsExactly(seed, next);
+        assertThat(expansion.content()).isEqualTo("fresh\n\nnext");
+    }
+
+    @Test
     void headingExpansionUsesSameSectionCandidates() {
         Chunk seed = chunk("doc-1", "seed", 1, "parent-a", null, null, "Install", ChunkType.CHILD, Map.of());
         Chunk sameHeading = chunk("doc-2", "same", 2, "parent-a", null, null, "Install", ChunkType.CHILD, Map.of());

--- a/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/ChunkContextExpanderTest.java
+++ b/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/ChunkContextExpanderTest.java
@@ -40,6 +40,23 @@ class ChunkContextExpanderTest {
     }
 
     @Test
+    void windowExpansionStopsWhenLinksCycleBackToSeed() {
+        Chunk seed = chunk("doc-1", "seed", 1, "parent", "doc-0", null, "Install", ChunkType.CHILD,
+                Map.of());
+        Chunk previous = chunk("doc-0", "previous", 0, "parent", "doc-1", null, "Install", ChunkType.CHILD,
+                Map.of());
+
+        ChunkContextExpansion expansion = new WindowChunkContextExpander().expand(
+                ChunkContextExpansionRequest.builder(seed)
+                        .availableChunks(List.of(previous, seed))
+                        .previousWindow(3)
+                        .build());
+
+        assertThat(expansion.contextChunks()).containsExactly(previous, seed);
+        assertThat(expansion.content()).isEqualTo("previous\n\nseed");
+    }
+
+    @Test
     void parentChildExpansionPrefersStoredParentContentAndKeepsSiblingOrder() {
         Chunk seed = chunk("doc-1", "child", 1, "parent", null, null, "Install", ChunkType.CHILD,
                 Map.of(ChunkMetadata.KEY_PARENT_CHUNK_CONTENT, "Install\n\nchild\n\nnext"));

--- a/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/ChunkContextExpanderTest.java
+++ b/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/ChunkContextExpanderTest.java
@@ -1,0 +1,112 @@
+package studio.one.platform.chunking.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.chunking.core.Chunk;
+import studio.one.platform.chunking.core.ChunkContextExpansion;
+import studio.one.platform.chunking.core.ChunkContextExpansionRequest;
+import studio.one.platform.chunking.core.ChunkContextExpansionStrategy;
+import studio.one.platform.chunking.core.ChunkMetadata;
+import studio.one.platform.chunking.core.ChunkType;
+import studio.one.platform.chunking.core.ChunkingStrategyType;
+
+class ChunkContextExpanderTest {
+
+    @Test
+    void windowExpansionFollowsPreviousAndNextLinksWithinAvailableChunks() {
+        Chunk first = chunk("doc-0", "first", 0, "parent", null, "doc-1", "Install", ChunkType.CHILD,
+                Map.of());
+        Chunk seed = chunk("doc-1", "seed", 1, "parent", "doc-0", "doc-2", "Install", ChunkType.CHILD,
+                Map.of());
+        Chunk last = chunk("doc-2", "last", 2, "parent", "doc-1", null, "Install", ChunkType.CHILD,
+                Map.of());
+
+        ChunkContextExpansion expansion = new WindowChunkContextExpander().expand(
+                ChunkContextExpansionRequest.builder(seed)
+                        .availableChunks(List.of(last, seed, first))
+                        .previousWindow(1)
+                        .nextWindow(1)
+                        .build());
+
+        assertThat(expansion.strategy()).isEqualTo(ChunkContextExpansionStrategy.WINDOW);
+        assertThat(expansion.contextChunks()).containsExactly(first, seed, last);
+        assertThat(expansion.content()).isEqualTo("first\n\nseed\n\nlast");
+        assertThat(expansion.metadata()).containsEntry("previousCount", 1).containsEntry("nextCount", 1);
+    }
+
+    @Test
+    void parentChildExpansionPrefersStoredParentContentAndKeepsSiblingOrder() {
+        Chunk seed = chunk("doc-1", "child", 1, "parent", null, null, "Install", ChunkType.CHILD,
+                Map.of(ChunkMetadata.KEY_PARENT_CHUNK_CONTENT, "Install\n\nchild\n\nnext"));
+        Chunk next = chunk("doc-2", "next", 2, "parent", null, null, "Install", ChunkType.CHILD,
+                Map.of(ChunkMetadata.KEY_PARENT_CHUNK_CONTENT, "Install\n\nchild\n\nnext"));
+
+        ChunkContextExpansion expansion = new ParentChildChunkContextExpander().expand(
+                ChunkContextExpansionRequest.builder(seed)
+                        .availableChunks(List.of(next, seed))
+                        .build());
+
+        assertThat(expansion.strategy()).isEqualTo(ChunkContextExpansionStrategy.PARENT_CHILD);
+        assertThat(expansion.contextChunks()).containsExactly(seed, next);
+        assertThat(expansion.content()).isEqualTo("Install\n\nchild\n\nnext");
+        assertThat(expansion.metadata()).containsEntry(ChunkMetadata.KEY_PARENT_CHUNK_ID, "parent");
+    }
+
+    @Test
+    void headingExpansionUsesSameSectionCandidates() {
+        Chunk seed = chunk("doc-1", "seed", 1, "parent-a", null, null, "Install", ChunkType.CHILD, Map.of());
+        Chunk sameHeading = chunk("doc-2", "same", 2, "parent-a", null, null, "Install", ChunkType.CHILD, Map.of());
+        Chunk otherHeading = chunk("doc-3", "other", 3, "parent-b", null, null, "Operate", ChunkType.CHILD, Map.of());
+
+        ChunkContextExpansion expansion = new HeadingChunkContextExpander().expand(
+                ChunkContextExpansionRequest.builder(seed)
+                        .availableChunks(List.of(otherHeading, sameHeading, seed))
+                        .build());
+
+        assertThat(expansion.strategy()).isEqualTo(ChunkContextExpansionStrategy.HEADING);
+        assertThat(expansion.contextChunks()).containsExactly(seed, sameHeading);
+        assertThat(expansion.content()).isEqualTo("seed\n\nsame");
+        assertThat(expansion.metadata()).containsEntry(ChunkMetadata.KEY_SECTION, "Install");
+    }
+
+    @Test
+    void tableExpansionKeepsTableAsSeedAndCanUseParentContent() {
+        Chunk table = chunk("doc-table", "Name: Alice", 0, "parent", null, null, "Metrics", ChunkType.TABLE,
+                Map.of(ChunkMetadata.KEY_PARENT_CHUNK_CONTENT, "Metrics\n\nName: Alice"));
+
+        ChunkContextExpansion expansion = new TableChunkContextExpander().expand(
+                ChunkContextExpansionRequest.builder(table).build());
+
+        assertThat(expansion.strategy()).isEqualTo(ChunkContextExpansionStrategy.TABLE);
+        assertThat(expansion.contextChunks()).containsExactly(table);
+        assertThat(expansion.content()).isEqualTo("Metrics\n\nName: Alice");
+        assertThat(expansion.metadata()).containsEntry(ChunkMetadata.KEY_CHUNK_TYPE, "table");
+    }
+
+    private Chunk chunk(
+            String id,
+            String content,
+            int order,
+            String parentChunkId,
+            String previousChunkId,
+            String nextChunkId,
+            String section,
+            ChunkType chunkType,
+            Map<String, Object> attributes) {
+        ChunkMetadata metadata = ChunkMetadata.builder(ChunkingStrategyType.STRUCTURE_BASED, order)
+                .sourceDocumentId("doc")
+                .chunkType(chunkType)
+                .parentChunkId(parentChunkId)
+                .previousChunkId(previousChunkId)
+                .nextChunkId(nextChunkId)
+                .section(section)
+                .attributes(attributes)
+                .build();
+        return Chunk.of(id, content, metadata);
+    }
+}

--- a/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/ChunkContextExpanderTest.java
+++ b/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/ChunkContextExpanderTest.java
@@ -57,6 +57,25 @@ class ChunkContextExpanderTest {
     }
 
     @Test
+    void windowExpansionStopsWhenLinksCycleOutsideSeed() {
+        Chunk seed = chunk("doc-1", "seed", 1, "parent", null, "doc-2", "Install", ChunkType.CHILD,
+                Map.of());
+        Chunk next = chunk("doc-2", "next", 2, "parent", null, "doc-3", "Install", ChunkType.CHILD,
+                Map.of());
+        Chunk cycle = chunk("doc-3", "cycle", 3, "parent", null, "doc-2", "Install", ChunkType.CHILD,
+                Map.of());
+
+        ChunkContextExpansion expansion = new WindowChunkContextExpander().expand(
+                ChunkContextExpansionRequest.builder(seed)
+                        .availableChunks(List.of(seed, next, cycle))
+                        .nextWindow(5)
+                        .build());
+
+        assertThat(expansion.contextChunks()).containsExactly(seed, next, cycle);
+        assertThat(expansion.content()).isEqualTo("seed\n\nnext\n\ncycle");
+    }
+
+    @Test
     void parentChildExpansionPrefersStoredParentContentAndKeepsSiblingOrder() {
         Chunk seed = chunk("doc-1", "child", 1, "parent", null, null, "Install", ChunkType.CHILD,
                 Map.of(ChunkMetadata.KEY_PARENT_CHUNK_CONTENT, "Install\n\nchild\n\nnext"));
@@ -122,6 +141,18 @@ class ChunkContextExpanderTest {
         assertThat(expansion.contextChunks()).containsExactly(table);
         assertThat(expansion.content()).isEqualTo("Metrics\n\nName: Alice");
         assertThat(expansion.metadata()).containsEntry(ChunkMetadata.KEY_CHUNK_TYPE, "table");
+    }
+
+    @Test
+    void tableExpansionReturnsNonTableSeedUnchanged() {
+        Chunk paragraph = chunk("doc-1", "Body", 0, "parent", null, null, "Install", ChunkType.CHILD, Map.of());
+
+        ChunkContextExpansion expansion = new TableChunkContextExpander().expand(
+                ChunkContextExpansionRequest.builder(paragraph).build());
+
+        assertThat(expansion.contextChunks()).containsExactly(paragraph);
+        assertThat(expansion.content()).isEqualTo("Body");
+        assertThat(expansion.metadata()).containsEntry(ChunkMetadata.KEY_CHUNK_TYPE, "child");
     }
 
     private Chunk chunk(


### PR DESCRIPTION
# PR

## Type

- [x] Feature
- [ ] Bug
- [ ] Refactor
- [ ] Docs
- [ ] Chore

## Size

- [ ] Small (1): 단순 수정 / 단일 파일
- [x] Medium (2): 기능 단위 변경 / 다중 파일
- [ ] Large (3): 구조 변경 / 복수 모듈

## Summary

`starter-chunking`에 structure-aware context expansion 구현체를 추가합니다.

## Related Issue

Closes #280
Parent: #277

## Changes

- `WindowChunkContextExpander` 추가: `previousChunkId` / `nextChunkId` 기반 window 확장
- `ParentChildChunkContextExpander` 추가: `parentChunkContent` 또는 동일 `parentChunkId` sibling 기반 parent-child 확장
- `HeadingChunkContextExpander` 추가: 동일 `section` / heading context 확장
- `TableChunkContextExpander` 추가: table chunk 단위 유지 및 parent context 복구
- context expander 기본 bean auto-configuration 등록
- expander 단위 테스트 및 auto-configuration 테스트 보강
- README에 context expansion 책임 경계와 사용 예시 추가

## Responsibility Boundary

- embedding API 호출 없음
- vector store 저장 없음
- LLM 호출 없음
- textract parser 로직 중복 없음
- 입력으로 전달된 `seedChunk`와 pre-filtered `availableChunks`만 사용

## Validation

- [x] `./gradlew :studio-platform-chunking:test :starter:studio-platform-starter-chunking:test`
- [x] `git diff --check`

## AI-Assisted

- [x] Yes

## AI Usage

- Issue #280 범위에 맞춰 구현, 테스트, 문서, validation 준비에 AI를 사용했습니다.
