### PR TITLE
docs(chunking): 문서와 시나리오 테스트 보강

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-04-25
+
+### 변경됨
+- 이슈 #281 대응으로 `studio-platform-chunking`과 `starter:studio-platform-starter-chunking` README를 한국어 기준으로 현행화했다.
+- chunk metadata key reference, parent-child 모델, context expansion 계약, textract 연계, 하위 호환성 기준을 문서화했다.
+- README 예시와 실제 public API가 어긋나지 않도록 parent-child chunking, context expansion, text fallback 문서 시나리오 테스트를 추가했다.
+
+### 검증
+- `./gradlew :studio-platform-chunking:test :starter:studio-platform-starter-chunking:test`
+- `git diff --check`
+
 ## 2026-04-24
 
 ### 변경됨

--- a/starter/studio-platform-starter-chunking/README.md
+++ b/starter/studio-platform-starter-chunking/README.md
@@ -1,28 +1,28 @@
 # Studio Platform Starter Chunking
 
-`studio-platform-starter-chunking` provides auto-configured chunking strategies for Studio RAG indexing.
+`studio-platform-starter-chunking`은 Studio RAG indexing에 사용할 chunking 전략 구현체와 Spring Boot auto-configuration을 제공합니다.
 
-## Responsibility
+## 책임 범위
 
-- Provides pure chunking implementations for text and normalized structured documents.
-- Registers chunking beans with `@ConditionalOnMissingBean` so applications can override them.
-- Keeps Spring AI, embedding, vector storage, and web endpoint concerns out of this starter.
-- Leaves `starter:studio-platform-starter-ai-web` as an HTTP adapter only.
+- 텍스트와 normalized structured document를 위한 순수 chunking 구현체를 제공합니다.
+- 애플리케이션이 bean을 교체할 수 있도록 `@ConditionalOnMissingBean` 기반으로 등록합니다.
+- Spring AI, embedding, vector storage, web endpoint 책임을 포함하지 않습니다.
+- `starter:studio-platform-starter-ai-web`은 HTTP adapter, AI starter는 embedding/vector/RAG 소비자 역할로 남깁니다.
 
-## Supported Strategies
+## 지원 전략
 
-Phase 1 supports:
+Phase 1 지원 전략:
 
 - `recursive` (default)
 - `fixed-size`
 - `structure-based`
 
-Planned Phase 2 strategies:
+Phase 2 후보이며 이 starter에는 포함하지 않는 전략:
 
-- `semantic` (AI-linked, not in this pure starter)
-- `llm-based` (AI-linked, not in this pure starter)
+- `semantic` (AI-linked)
+- `llm-based` (AI-linked)
 
-## Configuration
+## 설정
 
 ```yaml
 studio:
@@ -33,29 +33,33 @@ studio:
     overlap: 100
 ```
 
-| Property | Default | Description |
+| Property | Default | 설명 |
 | --- | --- | --- |
-| `studio.chunking.enabled` | `true` | Registers default chunking beans when enabled. |
-| `studio.chunking.strategy` | `recursive` | Pure chunking strategy. Supported values: `recursive`, `fixed-size`, `structure-based`. |
-| `studio.chunking.max-size` | `800` | Maximum chunk size in characters. |
-| `studio.chunking.overlap` | `100` | Character overlap carried from the previous chunk. |
+| `studio.chunking.enabled` | `true` | 기본 chunking bean 등록 여부입니다. |
+| `studio.chunking.strategy` | `recursive` | 기본 순수 chunking 전략입니다. 지원값: `recursive`, `fixed-size`, `structure-based`. |
+| `studio.chunking.max-size` | `800` | character 기준 최대 chunk size입니다. |
+| `studio.chunking.overlap` | `100` | 이전 chunk에서 이어받는 character overlap입니다. |
 
-Invalid `max-size <= 0`, `overlap < 0`, or `overlap >= max-size` settings fail fast during auto-configuration.
+`max-size <= 0`, `overlap < 0`, `overlap >= max-size` 설정은 auto-configuration 단계에서 fail-fast 됩니다.
 
 ## Override
 
-Applications can override the default behavior by registering custom beans:
+애플리케이션은 다음 bean을 직접 등록해 기본 동작을 교체할 수 있습니다.
 
 - `ChunkingOrchestrator`
 - `FixedSizeChunker`
 - `RecursiveChunker`
 - `StructureBasedChunker`
+- `WindowChunkContextExpander`
+- `ParentChildChunkContextExpander`
+- `HeadingChunkContextExpander`
+- `TableChunkContextExpander`
 
-`DefaultChunkingOrchestrator` receives all `Chunker` beans and executes `FIXED_SIZE`, `RECURSIVE`, and `STRUCTURE_BASED`.
+`DefaultChunkingOrchestrator`는 모든 `Chunker` bean을 받아 `FIXED_SIZE`, `RECURSIVE`, `STRUCTURE_BASED`를 실행합니다.
 
 ## Recursive Strategy
 
-`RecursiveChunker` splits in this order:
+`RecursiveChunker`는 다음 순서로 분할합니다.
 
 1. blank paragraph
 2. newline
@@ -63,19 +67,21 @@ Applications can override the default behavior by registering custom beans:
 4. whitespace
 5. fixed-size fallback
 
-Chunk ids are deterministic:
+chunk id는 deterministic합니다.
 
 ```text
 {sourceDocumentId}-{chunkOrder}
 ```
 
-`chunkOrder` starts at `0`.
+`chunkOrder`는 `0`부터 시작합니다.
 
 ## Structure-Based Strategy
 
-`StructureBasedChunker` consumes `NormalizedDocument` and preserves parser provenance in `ChunkMetadata`.
-It keeps heading boundaries as `section` / `headingPath`, packs paragraph-like blocks by configured size, and emits table, OCR text, and image-caption blocks as standalone child chunks.
-It also creates deterministic parent section ids and links each child chunk through additive metadata:
+`StructureBasedChunker`는 `NormalizedDocument`를 입력으로 받아 parser provenance를 `ChunkMetadata`에 보존합니다.
+heading boundary는 `section` / `headingPath`로 유지하고, paragraph-like block은 size 정책에 따라 pack합니다.
+table, OCR text, image-caption block은 standalone child chunk로 생성합니다.
+
+각 child chunk는 additive metadata로 parent/neighbor/provenance 정보를 보존합니다.
 
 - `chunkType`
 - `parentChunkId`
@@ -85,12 +91,12 @@ It also creates deterministic parent section ids and links each child chunk thro
 - `blockIds`
 - `confidence`
 
-Neighbor links do not cross parent section boundaries. If a document starts without a heading, the first parent context
-uses an empty `section` value and body-only `parentChunkContent`.
+neighbor link는 parent section boundary를 넘지 않습니다.
+heading 없이 시작하는 문서는 빈 `section` 값과 body-only `parentChunkContent`를 사용합니다.
 
-The strategy does not parse files, run OCR, call embedding APIs, call LLMs, or write vector stores.
+이 전략은 파일 parsing, OCR 실행, embedding API 호출, LLM 호출, vector store 저장을 하지 않습니다.
 
-When `studio-platform-textract` is available, `TextractNormalizedDocumentAdapter` can convert `ParsedFile` into `NormalizedDocument`:
+`studio-platform-textract`가 classpath에 있으면 `TextractNormalizedDocumentAdapter`로 `ParsedFile`을 `NormalizedDocument`로 변환할 수 있습니다.
 
 ```java
 ParsedFile parsedFile = fileContentExtractionService.parseStructured(...);
@@ -99,23 +105,19 @@ NormalizedDocument document = new TextractNormalizedDocumentAdapter()
 List<Chunk> chunks = chunkingOrchestrator.chunk(document);
 ```
 
-The adapter maps:
+adapter mapping:
 
-- `ParsedBlock` to normalized heading, paragraph, list, footnote, OCR, and other logical blocks.
-- `ExtractedTable.vectorText()` to table chunks.
-- `ExtractedImage.caption()`, `altText()`, or `ocrText()` to image-caption/OCR chunks.
-- `ParsedBlock.confidence()`, inferred `headingPath`, and table/image source references into normalized provenance fields.
-- image metadata keys such as `order`, `page`, `slide`, `parentBlockId`, `headingPath`, and `confidence` when the
-  parser already provides them.
+- `ParsedBlock`은 heading, paragraph, list, footnote, OCR 등 normalized block으로 매핑합니다.
+- `ExtractedTable.vectorText()`는 table chunk text로 사용합니다.
+- `ExtractedImage.caption()`, `altText()`, `ocrText()`는 image-caption/OCR chunk text 후보로 사용합니다.
+- `ParsedBlock.confidence()`, inferred `headingPath`, table/image source reference를 normalized provenance field로 전달합니다.
+- image metadata의 `order`, `page`, `slide`, `parentBlockId`, `headingPath`, `confidence`는 parser가 제공한 경우 보존합니다.
 
-When a parsed table block and an `ExtractedTable` share the same `sourceRef`, the adapter keeps one table block based on
-`ExtractedTable.vectorText()` and carries over the parsed table block order/provenance. `ExtractedImage` does not currently
-carry an independent order value, so image-caption/OCR chunks are sorted after ordered parsed blocks unless the source
-metadata provides a future ordering field.
-If a parser returns only `plainText` without structured blocks, the normalized document keeps that text as the
-compatibility fallback for text-based chunking.
+parsed table block과 `ExtractedTable`이 같은 `sourceRef`를 공유하면 중복 table block을 만들지 않고,
+`ExtractedTable.vectorText()` 기반 table block 하나만 유지합니다. 이때 parsed table block의 order/provenance를 넘겨받습니다.
+parser가 structured block 없이 `plainText`만 반환하면 normalized document는 해당 text를 text chunking fallback으로 유지합니다.
 
-### Parent-Child Example
+### Parent-Child 예시
 
 ```java
 NormalizedDocument document = NormalizedDocument.builder("doc-1")
@@ -150,20 +152,27 @@ chunk.metadata().nextChunkId();    // null for a single child
 chunk.metadata().blockIds();       // [page[1]/p[1], page[1]/p[2]]
 ```
 
-The default return value remains the child chunk list for compatibility. Parent content is persisted additively in child
-metadata so later context-expansion strategies can recover section context without changing the indexing contract.
+기본 반환값은 호환성을 위해 child chunk list입니다.
+parent content는 child metadata에 additive로 저장되므로 indexing contract를 바꾸지 않고도 이후 context expansion에서 section context를 복구할 수 있습니다.
+
+### 하위 호환성
+
+- text-only 호출은 계속 `ChunkingContext`와 configured text strategy를 사용합니다.
+- `StructureBasedChunker.chunk(ChunkingContext)`는 fallback text chunker로 위임하므로 oversized plain text도 기존 recursive/fixed-size 방식으로 분할됩니다.
+- `DefaultChunkingOrchestrator.chunk(NormalizedDocument)`는 opt-in이며 `STRUCTURE_BASED`만 사용합니다.
+- parent chunk는 기본적으로 별도 indexing record로 반환되지 않습니다. parent context는 child metadata에 저장됩니다.
+- context expander는 chunk retrieval을 직접 수행하지 않습니다. caller가 storage/retrieval layer에서 작은 `availableChunks` 후보 목록을 전달해야 합니다.
 
 ## Context Expansion
 
-The starter provides pure in-memory `ChunkContextExpander` implementations for expanding a retrieved child chunk after
-vector search. They consume only the supplied `seedChunk` and a small pre-filtered `availableChunks` list; they do not
-call embedding APIs, vector stores, LLMs, parsers, or OCR engines.
+starter는 vector search 이후 검색된 child chunk를 답변 context로 확장하기 위한 순수 in-memory `ChunkContextExpander` 구현체를 제공합니다.
+이 구현체들은 전달받은 `seedChunk`와 작은 pre-filtered `availableChunks` 목록만 소비합니다.
+embedding API, vector store, LLM, parser, OCR engine을 호출하지 않습니다.
 
-- `WindowChunkContextExpander`: follows `previousChunkId` / `nextChunkId` links up to the requested window.
-- `ParentChildChunkContextExpander`: restores `parentChunkContent` when present, otherwise joins siblings with the same
-  `parentChunkId`.
-- `HeadingChunkContextExpander`: joins chunks with the same `section` / heading context.
-- `TableChunkContextExpander`: keeps table chunks as a single retrieval unit and can restore stored parent context.
+- `WindowChunkContextExpander`: `previousChunkId` / `nextChunkId` link를 요청된 window만큼 따라갑니다.
+- `ParentChildChunkContextExpander`: `parentChunkContent`가 있으면 우선 사용하고, 없으면 같은 `parentChunkId` sibling을 join합니다.
+- `HeadingChunkContextExpander`: 같은 `section` / heading context의 chunk를 join합니다.
+- `TableChunkContextExpander`: table chunk를 atomic retrieval unit으로 유지하고 저장된 parent context를 복구할 수 있습니다.
 
 ```java
 ChunkContextExpansionRequest request = ChunkContextExpansionRequest.builder(retrievedChunk)
@@ -176,10 +185,21 @@ ChunkContextExpansionRequest request = ChunkContextExpansionRequest.builder(retr
 ChunkContextExpansion expansion = windowChunkContextExpander.expand(request);
 ```
 
-`availableChunks` should already be scoped by the caller, for example to neighbor chunks from the same document or the
-top retrieval candidates for the same parent. Passing an entire corpus defeats the contract and can increase memory use.
+`availableChunks`는 caller가 이미 범위를 좁힌 후보여야 합니다.
+예를 들어 같은 문서의 neighbor chunk, 같은 parent의 sibling chunk, 또는 같은 heading section에서 검색된 상위 후보만 전달합니다.
+전체 corpus를 전달하면 계약 의도에 맞지 않고 메모리 사용량이 증가할 수 있습니다.
+
+권장 routing:
+
+| Retrieved chunk | Recommended expander |
+| --- | --- |
+| neighbor link가 있는 paragraph/list child | `WindowChunkContextExpander` |
+| `parentChunkContent`가 있는 child | `ParentChildChunkContextExpander` |
+| 같은 heading section의 복수 hit | `HeadingChunkContextExpander` |
+| table chunk | `TableChunkContextExpander` |
 
 ## Size Policy
 
-Character size remains the default policy. `ChunkUnit.TOKEN` uses a deterministic estimate based on compacted character length and does not call an external tokenizer.
-Structure-based overlap is conservative: heading, table, OCR, and image-caption boundaries are not carried as overlap tails.
+기본 size 정책은 character 기준입니다.
+`ChunkUnit.TOKEN`은 외부 tokenizer를 호출하지 않고 compacted character length 기반 deterministic estimate를 사용합니다.
+structure-based overlap은 보수적으로 동작하며 heading, table, OCR, image-caption boundary는 overlap tail로 넘기지 않습니다.

--- a/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/ChunkingDocumentationScenarioTest.java
+++ b/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/ChunkingDocumentationScenarioTest.java
@@ -63,6 +63,7 @@ class ChunkingDocumentationScenarioTest {
 
     @Test
     void contextExpansionReadmeScenarioRestoresAnswerContextWithoutRetrievalSideEffects() {
+        // This mirrors the README happy path. Cycle hardening is covered by ChunkContextExpanderTest.
         Chunk seed = chunk("doc-1-0", "Install the engine.", 0, "doc-1-parent-0", null, "doc-1-1",
                 "Install\n\nInstall the engine.\n\nConfigure tessdata.");
         Chunk next = chunk("doc-1-1", "Configure tessdata.", 1, "doc-1-parent-0", "doc-1-0", null,
@@ -84,7 +85,7 @@ class ChunkingDocumentationScenarioTest {
     }
 
     @Test
-    void textCompatibilityPathStillUsesConfiguredTextStrategy() {
+    void textCompatibilityPathStillSplitsOversizedPlainText() {
         StructureBasedChunker chunker = new StructureBasedChunker(10, 0, new RecursiveChunker(10, 0));
 
         List<Chunk> chunks = chunker.chunk(ChunkingContext.builder("alpha beta gamma")
@@ -95,8 +96,6 @@ class ChunkingDocumentationScenarioTest {
                 .build());
 
         assertThat(chunks).extracting(Chunk::content).containsExactly("alpha beta", "gamma");
-        assertThat(chunks).extracting(chunk -> chunk.metadata().strategy())
-                .containsOnly(ChunkingStrategyType.RECURSIVE);
     }
 
     private DefaultChunkingOrchestrator orchestrator() {
@@ -107,8 +106,7 @@ class ChunkingDocumentationScenarioTest {
         RecursiveChunker recursiveChunker = new RecursiveChunker(120, 0);
         return new DefaultChunkingOrchestrator(
                 properties,
-                List.of(new FixedSizeChunker(120, 0), recursiveChunker,
-                        new StructureBasedChunker(120, 0, recursiveChunker)));
+                List.of(recursiveChunker, new StructureBasedChunker(120, 0, recursiveChunker)));
     }
 
     private Chunk chunk(

--- a/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/ChunkingDocumentationScenarioTest.java
+++ b/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/ChunkingDocumentationScenarioTest.java
@@ -1,0 +1,133 @@
+package studio.one.platform.chunking.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.chunking.autoconfigure.ChunkingProperties;
+import studio.one.platform.chunking.core.Chunk;
+import studio.one.platform.chunking.core.ChunkContextExpansion;
+import studio.one.platform.chunking.core.ChunkContextExpansionRequest;
+import studio.one.platform.chunking.core.ChunkMetadata;
+import studio.one.platform.chunking.core.ChunkType;
+import studio.one.platform.chunking.core.ChunkingContext;
+import studio.one.platform.chunking.core.ChunkingStrategyType;
+import studio.one.platform.chunking.core.NormalizedBlock;
+import studio.one.platform.chunking.core.NormalizedBlockType;
+import studio.one.platform.chunking.core.NormalizedDocument;
+
+class ChunkingDocumentationScenarioTest {
+
+    @Test
+    void parentChildReadmeScenarioProducesChildChunkWithRecoverableParentContext() {
+        DefaultChunkingOrchestrator orchestrator = orchestrator();
+        NormalizedDocument document = NormalizedDocument.builder("doc-1")
+                .sourceFormat("PDF")
+                .blocks(List.of(
+                        NormalizedBlock.builder(NormalizedBlockType.HEADING, "Install")
+                                .id("page[1]/h[0]")
+                                .order(0)
+                                .headingPath("Install")
+                                .blockIds(List.of("page[1]/h[0]"))
+                                .build(),
+                        NormalizedBlock.builder(NormalizedBlockType.PARAGRAPH, "Install the engine.")
+                                .id("page[1]/p[1]")
+                                .order(1)
+                                .blockIds(List.of("page[1]/p[1]"))
+                                .build(),
+                        NormalizedBlock.builder(NormalizedBlockType.PARAGRAPH, "Configure tessdata.")
+                                .id("page[1]/p[2]")
+                                .order(2)
+                                .blockIds(List.of("page[1]/p[2]"))
+                                .build()))
+                .build();
+
+        List<Chunk> chunks = orchestrator.chunk(document);
+
+        assertThat(chunks).hasSize(1);
+        Chunk chunk = chunks.get(0);
+        assertThat(chunk.content()).isEqualTo("Install the engine.\n\nConfigure tessdata.");
+        assertThat(chunk.metadata().chunkType()).isEqualTo(ChunkType.CHILD);
+        assertThat(chunk.metadata().parentChunkId()).isEqualTo("doc-1-parent-0");
+        assertThat(chunk.metadata().previousChunkId()).isNull();
+        assertThat(chunk.metadata().nextChunkId()).isNull();
+        assertThat(chunk.metadata().blockIds()).containsExactly("page[1]/p[1]", "page[1]/p[2]");
+        assertThat(chunk.metadata().toMap())
+                .containsEntry(ChunkMetadata.KEY_PARENT_CHUNK_CONTENT,
+                        "Install\n\nInstall the engine.\n\nConfigure tessdata.")
+                .containsEntry(ChunkMetadata.KEY_HEADING_PATH, "Install")
+                .containsEntry(ChunkMetadata.KEY_SOURCE_FORMAT, "PDF");
+    }
+
+    @Test
+    void contextExpansionReadmeScenarioRestoresAnswerContextWithoutRetrievalSideEffects() {
+        Chunk seed = chunk("doc-1-0", "Install the engine.", 0, "doc-1-parent-0", null, "doc-1-1",
+                "Install\n\nInstall the engine.\n\nConfigure tessdata.");
+        Chunk next = chunk("doc-1-1", "Configure tessdata.", 1, "doc-1-parent-0", "doc-1-0", null,
+                "Install\n\nInstall the engine.\n\nConfigure tessdata.");
+
+        ChunkContextExpansionRequest request = ChunkContextExpansionRequest.builder(seed)
+                .availableChunks(List.of(seed, next))
+                .previousWindow(1)
+                .nextWindow(1)
+                .includeParentContent(true)
+                .build();
+
+        ChunkContextExpansion window = new WindowChunkContextExpander().expand(request);
+        ChunkContextExpansion parent = new ParentChildChunkContextExpander().expand(request);
+
+        assertThat(window.content()).isEqualTo("Install the engine.\n\nConfigure tessdata.");
+        assertThat(parent.content()).isEqualTo("Install\n\nInstall the engine.\n\nConfigure tessdata.");
+        assertThat(parent.metadata()).containsEntry(ChunkMetadata.KEY_PARENT_CHUNK_ID, "doc-1-parent-0");
+    }
+
+    @Test
+    void textCompatibilityPathStillUsesConfiguredTextStrategy() {
+        StructureBasedChunker chunker = new StructureBasedChunker(10, 0, new RecursiveChunker(10, 0));
+
+        List<Chunk> chunks = chunker.chunk(ChunkingContext.builder("alpha beta gamma")
+                .sourceDocumentId("doc")
+                .strategy(ChunkingStrategyType.STRUCTURE_BASED)
+                .maxSize(10)
+                .overlap(0)
+                .build());
+
+        assertThat(chunks).extracting(Chunk::content).containsExactly("alpha beta", "gamma");
+        assertThat(chunks).extracting(chunk -> chunk.metadata().strategy())
+                .containsOnly(ChunkingStrategyType.RECURSIVE);
+    }
+
+    private DefaultChunkingOrchestrator orchestrator() {
+        ChunkingProperties properties = new ChunkingProperties();
+        properties.setStrategy("structure-based");
+        properties.setMaxSize(120);
+        properties.setOverlap(0);
+        RecursiveChunker recursiveChunker = new RecursiveChunker(120, 0);
+        return new DefaultChunkingOrchestrator(
+                properties,
+                List.of(new FixedSizeChunker(120, 0), recursiveChunker,
+                        new StructureBasedChunker(120, 0, recursiveChunker)));
+    }
+
+    private Chunk chunk(
+            String id,
+            String content,
+            int order,
+            String parentChunkId,
+            String previousChunkId,
+            String nextChunkId,
+            String parentContent) {
+        ChunkMetadata metadata = ChunkMetadata.builder(ChunkingStrategyType.STRUCTURE_BASED, order)
+                .sourceDocumentId("doc-1")
+                .chunkType(ChunkType.CHILD)
+                .parentChunkId(parentChunkId)
+                .previousChunkId(previousChunkId)
+                .nextChunkId(nextChunkId)
+                .section("Install")
+                .attribute(ChunkMetadata.KEY_PARENT_CHUNK_CONTENT, parentContent)
+                .build();
+        return Chunk.of(id, content, metadata);
+    }
+}

--- a/studio-platform-chunking/README.md
+++ b/studio-platform-chunking/README.md
@@ -1,48 +1,62 @@
 # Studio Platform Chunking
 
-`studio-platform-chunking` provides provider-neutral chunking contracts for AI/RAG indexing.
+`studio-platform-chunking`은 AI/RAG 색인을 위한 provider-neutral chunking 계약 모듈입니다.
 
-## Responsibilities
+## 책임 범위
 
-- Define immutable chunking request/result models.
-- Define strategy-neutral chunking extension points.
-- Model search-oriented child chunks and expansion-oriented parent relationships.
-- Keep chunking contracts independent from Spring, Spring AI, JDBC, and vector-store implementations.
+- 불변 chunking 요청/결과 모델을 정의합니다.
+- 전략 중립적인 chunking 확장 지점을 정의합니다.
+- 검색용 child chunk와 context 복구용 parent 관계를 모델링합니다.
+- Spring, Spring AI, JDBC, vector store 구현에 의존하지 않습니다.
+- embedding API 호출, vector DB 저장, LLM 호출, OCR 실행, 파일 parser 실행을 하지 않습니다.
 
-## Core Types
+## 핵심 타입
 
-- `Chunker`: strategy implementation contract.
-- `ChunkingOrchestrator`: strategy selection and composition contract.
-- `ChunkingContext`: immutable input context for chunk generation.
-- `Chunk`: immutable chunk content with metadata.
-- `ChunkMetadata`: standard metadata for vector indexing.
-- `ChunkType`: logical chunk role such as `child`, `parent`, `table`, `ocr`.
-- `ChunkingStrategyType`: supported strategy identifiers.
-- `ChunkUnit`: size unit for character-based or token-based chunking.
-- `NormalizedDocument`: parser-neutral structured input for structure-aware chunking.
-- `NormalizedBlock`: parser-neutral logical block with source provenance.
-- `NormalizedDocumentChunker`: chunker extension for normalized documents.
-- `ChunkContextExpander`: contract for expanding a retrieved child chunk into answer context.
-- `ChunkContextExpansionRequest` / `ChunkContextExpansion`: request/result models for context expansion.
+- `Chunker`: chunking 전략 구현 계약입니다.
+- `ChunkingOrchestrator`: 전략 선택과 조합 계약입니다.
+- `ChunkingContext`: 텍스트 chunking 입력 컨텍스트입니다.
+- `Chunk`: chunk content와 metadata를 담는 불변 결과입니다.
+- `ChunkMetadata`: vector indexing 전에 보존할 표준 metadata입니다.
+- `ChunkType`: `child`, `parent`, `table`, `ocr` 등 chunk 역할입니다.
+- `ChunkingStrategyType`: 지원 전략 식별자입니다.
+- `ChunkUnit`: character/token 기준 size 단위입니다.
+- `NormalizedDocument`: parser에 독립적인 구조화 문서 입력입니다.
+- `NormalizedBlock`: parser에 독립적인 논리 block과 provenance입니다.
+- `NormalizedDocumentChunker`: normalized document chunking 확장 계약입니다.
+- `ChunkContextExpander`: 검색된 child chunk를 답변 context로 확장하는 계약입니다.
+- `ChunkContextExpansionRequest` / `ChunkContextExpansion`: context expansion 요청/결과 모델입니다.
 
-## Metadata Rules
+## Metadata 규칙
 
-- Metadata maps are defensively copied.
-- Null keys, blank keys, null values, and blank string values are omitted.
-- `chunkOrder` remains the canonical persisted order key for Phase 1 compatibility.
-- `ChunkMetadata.order` is intended to map to the same value as `chunkOrder` when persisted by downstream modules.
-- Structured provenance keys are standardized for downstream consumers:
-  - `sourceRef`, `sourceRefs`, `blockType`, `page`, `slide`
-  - `parentBlockId`, `headingPath`, `sourceFormat`, `blockIds`, `confidence`
-  - `tokenEstimate`, `chunkUnit`, `maxSize`, `overlap`
-- Parent-child relationship keys are additive and do not replace legacy keys:
-  - `chunkType`, `parentChunkId`, `parentChunkContent`, `previousChunkId`, `nextChunkId`
-- `parentId` remains for legacy compatibility and is not redefined as `parentChunkId`.
+- metadata map은 defensive copy 됩니다.
+- null key, blank key, null value, blank string value는 제거됩니다.
+- `chunkOrder`는 Phase 1 호환성을 위한 canonical persisted order key로 유지됩니다.
+- `ChunkMetadata.order`는 downstream 저장 시 `chunkOrder`와 같은 값으로 매핑되는 것을 전제로 합니다.
+- 구조화 provenance key는 downstream 소비자를 위해 표준화합니다.
+- parent-child 관계 key는 additive metadata이며 기존 key를 대체하지 않습니다.
+- `parentId`는 legacy compatibility 용도로 유지하며 `parentChunkId`와 다른 의미입니다.
 
-## Structured Input
+### Metadata Key Reference
 
-`NormalizedDocument` and `NormalizedBlock` allow chunking to consume structured extraction results without depending on a parser implementation.
-The text-based API remains the compatibility baseline:
+| Key | 목적 | 호환성 |
+| --- | --- | --- |
+| `sourceDocumentId` | 생성된 chunk를 원본 문서 단위로 묶는 식별자입니다. | 기존 key |
+| `chunkOrder` | 저장/정렬용 chunk 순서입니다. | 기존 key, order 기준 유지 |
+| `strategy` | `recursive`, `structure-based` 등 chunking 전략입니다. | 기존 key |
+| `chunkType` | `child`, `parent`, `table`, `ocr`, `image-caption` 등 검색 역할입니다. | 추가 key |
+| `parentChunkId` | child chunk가 속한 deterministic parent section id입니다. | 추가 key, `parentId`와 별도 |
+| `parentChunkContent` | 답변 시 parent context 복구에 사용할 저장된 section content입니다. | 추가 key |
+| `previousChunkId` / `nextChunkId` | 같은 parent section 안의 인접 child chunk 링크입니다. | 추가 key |
+| `sourceRef` / `sourceRefs` | parser/source provenance 참조입니다. | 추가 key |
+| `blockType`, `blockIds`, `parentBlockId` | 구조화 추출 block identity와 hierarchy입니다. | 추가 key |
+| `page`, `slide`, `headingPath`, `sourceFormat` | 위치와 section context입니다. | 추가 key |
+| `confidence` | parser/OCR confidence가 있는 경우 보존합니다. | 추가 key |
+| `tokenEstimate`, `chunkUnit`, `maxSize`, `overlap` | size 정책과 검증 evidence입니다. | 추가 key |
+
+## 구조화 입력
+
+`NormalizedDocument`와 `NormalizedBlock`은 chunking이 parser 구현에 직접 의존하지 않고 구조화 추출 결과를 소비하기 위한 입력 모델입니다.
+기존 텍스트 기반 API는 호환성 기준으로 유지됩니다.
 
 ```java
 ChunkingContext context = ChunkingContext.builder("plain text")
@@ -50,7 +64,7 @@ ChunkingContext context = ChunkingContext.builder("plain text")
         .build();
 ```
 
-Structured chunking should use normalized blocks:
+구조 기반 chunking은 normalized block을 사용합니다.
 
 ```java
 NormalizedDocument document = NormalizedDocument.builder("doc-1")
@@ -72,27 +86,25 @@ NormalizedDocument document = NormalizedDocument.builder("doc-1")
         .build();
 ```
 
-## Parent-Child Model
+## Parent-Child 모델
 
-The compatibility return type remains `List<Chunk>`, and the default output remains search-oriented child chunks.
-Parent section chunks are modeled through additive metadata links so downstream indexing can keep indexing child chunks
-without schema breaks.
+호환성을 위해 반환 타입은 계속 `List<Chunk>`이며, 기본 출력은 검색용 child chunk입니다.
+parent section chunk는 별도 indexing record로 반환하지 않고 additive metadata link로 표현합니다.
 
-- Child chunks are the default retrieval unit.
-- Parent chunks are modeled by deterministic `parentChunkId` values.
-- Parent chunk content can be persisted additively as `parentChunkContent` when a strategy needs parent context recovery.
-- `previousChunkId` and `nextChunkId` link adjacent child chunks within the same parent section only.
-- Documents that start without a heading still receive a parent context with an empty `section` value and body-only
-  `parentChunkContent`.
-- `blockIds`, `headingPath`, `page`, `slide`, `sourceRef`, and `confidence` preserve provenance needed for later
-  context expansion.
+- child chunk는 기본 retrieval 단위입니다.
+- parent context는 deterministic `parentChunkId`로 식별합니다.
+- `parentChunkContent`는 parent context 복구가 필요한 전략에서 additive metadata로 보존할 수 있습니다.
+- `previousChunkId`와 `nextChunkId`는 같은 parent section 안에서만 연결됩니다.
+- heading 없이 시작하는 문서도 빈 `section` 값과 body-only `parentChunkContent`로 parent context를 가질 수 있습니다.
+- `blockIds`, `headingPath`, `page`, `slide`, `sourceRef`, `confidence`는 context expansion에 필요한 provenance입니다.
 
-## Context Expansion Contract
+## Context Expansion 계약
 
-`ChunkContextExpander` defines how a retrieved child chunk can be expanded into a larger answer context. The contract is
-implementation-neutral and does not perform retrieval, embedding, vector store access, LLM calls, or parser work.
-`Chunk` itself rejects blank content, so expansion content is also non-blank. `availableChunks` should be a small,
-pre-filtered candidate set around the seed chunk, not an entire corpus or unbounded retrieval result.
+`ChunkContextExpander`는 검색된 child chunk를 더 큰 답변 context로 확장하는 방법을 정의합니다.
+이 계약은 retrieval, embedding, vector store 접근, LLM 호출, parser 실행을 수행하지 않습니다.
+
+`Chunk`는 blank content를 허용하지 않으므로 expansion content도 non-blank입니다.
+`availableChunks`는 seed chunk 주변의 작은 pre-filtered 후보 목록이어야 하며, 전체 corpus나 unbounded retrieval 결과를 전달하면 안 됩니다.
 
 ```java
 ChunkContextExpansionRequest request = ChunkContextExpansionRequest.builder(retrievedChunk)
@@ -106,10 +118,19 @@ ChunkContextExpansion expansion = expander.expand(request);
 String answerContext = expansion.content();
 ```
 
-Built-in strategy identifiers are `parent-child`, `window`, `heading`, `table`, `custom`, and `unknown`.
-Concrete expansion implementations live in starter modules.
+내장 strategy identifier는 `parent-child`, `window`, `heading`, `table`, `custom`, `unknown`입니다.
+구체 구현체는 starter 모듈에 둡니다.
 
-## Dependency Boundary
+## 하위 호환성
 
-This module must not depend on Spring, Spring AI, JDBC, pgvector, or web modules. Strategy implementations and auto-configuration belong in a starter module.
-This module also does not call embedding APIs, vector stores, LLMs, OCR engines, or file parsers.
+- `ChunkingContext.builder(String text)`는 텍스트 API 기준으로 유지됩니다.
+- `Chunker.chunk(ChunkingContext)`는 변경 없이 `List<Chunk>`를 반환합니다.
+- 기존 text strategy는 normalized document와 context expansion 계약을 몰라도 됩니다.
+- 새 metadata field는 additive입니다. `content`, `chunkOrder`, `strategy`, 기존 custom attribute만 읽는 소비자는 변경이 필요 없습니다.
+- `NormalizedDocument`, `NormalizedBlock`, `ChunkContextExpander`는 structure-aware indexing과 answer-time context recovery를 위한 opt-in 계약입니다.
+
+## 의존성 경계
+
+이 모듈은 Spring, Spring AI, JDBC, pgvector, web module에 의존하지 않습니다.
+전략 구현체와 auto-configuration은 starter module 책임입니다.
+이 모듈은 embedding API, vector store, LLM, OCR engine, file parser를 호출하지 않습니다.

--- a/studio-platform-chunking/README.md
+++ b/studio-platform-chunking/README.md
@@ -41,6 +41,7 @@
 | Key | 목적 | 호환성 |
 | --- | --- | --- |
 | `sourceDocumentId` | 생성된 chunk를 원본 문서 단위로 묶는 식별자입니다. | 기존 key |
+| `parentId` | legacy parent 식별자입니다. `parentChunkId`와 의미가 다릅니다. | 기존 key |
 | `chunkOrder` | 저장/정렬용 chunk 순서입니다. | 기존 key, order 기준 유지 |
 | `strategy` | `recursive`, `structure-based` 등 chunking 전략입니다. | 기존 key |
 | `chunkType` | `child`, `parent`, `table`, `ocr`, `image-caption` 등 검색 역할입니다. | 추가 key |


### PR DESCRIPTION
# PR

## Type

- [ ] Feature
- [ ] Bug
- [ ] Refactor
- [x] Docs
- [ ] Chore

## Size

- [ ] Small (1): 단순 수정 / 단일 파일
- [x] Medium (2): 기능 단위 변경 / 다중 파일
- [ ] Large (3): 구조 변경 / 복수 모듈

## Summary

chunking 계약/전략 개선에 맞춰 README와 테스트를 보강합니다.

## Related Issue

Closes #281
Parent: #277

## Changes

- `studio-platform-chunking/README.md`를 한국어 기준으로 현행화
- `starter/studio-platform-starter-chunking/README.md`를 한국어 기준으로 현행화
- metadata key reference, parent-child 모델, context expansion 계약, textract 연계, 하위 호환성 기준 문서화
- README 예시와 public API 정합성을 검증하는 문서 시나리오 테스트 추가
- `CHANGELOG.md` 기록 추가

## Responsibility Boundary

- embedding API 호출 없음
- vector store 저장 없음
- LLM 호출 없음
- textract parser 로직 중복 없음
- 런타임 구현 변경 없이 문서와 테스트 정합성 보강

## Validation

- [x] `./gradlew :studio-platform-chunking:test :starter:studio-platform-starter-chunking:test`
- [x] `git diff --check`

## AI-Assisted

- [x] Yes

## AI Usage

- README 정리, 시나리오 테스트 작성, validation 준비에 AI를 사용했습니다.
