### PR TITLE
[user] PostgreSQL group member summary 검색 최적화

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,16 @@
 ## 2026-04-25
 
 ### 변경됨
+- 이슈 #188 대응으로 PostgreSQL 그룹 멤버 summary 검색에 `pg_trgm` 기반 `lower(username|name|email)` GIN trigram index migration을 추가했다.
+- MySQL/MariaDB에는 PostgreSQL 전용 검색 최적화와 schema version 이력을 맞추기 위한 V301 schema-neutral migration을 추가했다.
+- 그룹 멤버 summary 검색에서 blank keyword를 null keyword와 동일하게 전체 조회로 처리하도록 service/JPA repository 경로를 정리했다.
+- 그룹 멤버 summary repository 검색 테스트에 null, blank, username/name/email 매칭 케이스를 추가했다.
 - 이슈 #281 대응으로 `studio-platform-chunking`과 `starter:studio-platform-starter-chunking` README를 한국어 기준으로 현행화했다.
 - chunk metadata key reference, parent-child 모델, context expansion 계약, textract 연계, 하위 호환성 기준을 문서화했다.
 - README 예시와 실제 public API가 어긋나지 않도록 parent-child chunking, context expansion, text fallback 문서 시나리오 테스트를 추가했다.
 
 ### 검증
+- `./gradlew :studio-platform-user:test --tests 'studio.one.base.user.persistence.jpa.ApplicationGroupMembershipJpaRepositorySearchTest' --tests 'studio.one.base.user.persistence.jdbc.ApplicationGroupMembershipJdbcRepositoryTest'`
 - `./gradlew :studio-platform-chunking:test :starter:studio-platform-starter-chunking:test`
 - `git diff --check`
 

--- a/starter/studio-platform-starter-user/README.md
+++ b/starter/studio-platform-starter-user/README.md
@@ -150,3 +150,10 @@ studio:
 - 사용자 스키마는 `studio-platform-user-default`에 포함된다:
   `studio-platform-user-default/src/main/resources/schema/user/{db}/V300__create_user_tables.sql`
   (`docs/flyway-versioning.md`의 user 범위 V300-V399 참고)
+- PostgreSQL에서는 그룹 멤버 summary 검색의 `username`/`name`/`email` 부분 검색을 위해
+  `schema/user/postgres/V301__optimize_group_member_summary_search.sql`가 `pg_trgm` 확장과
+  `lower(...)` GIN trigram index를 추가한다. 운영 DB의 Flyway 계정은 `CREATE EXTENSION IF NOT EXISTS pg_trgm`
+  실행 권한을 가져야 한다.
+- MySQL/MariaDB의 V301 migration은 PostgreSQL 전용 최적화와 버전 이력을 맞추기 위한 schema-neutral migration이다.
+  선행 wildcard 검색(`LIKE '%keyword%'`)은 일반 B-tree index로 안정적으로 최적화되지 않으므로 별도 full-text/search 정책이 필요하면
+  후속 DB별 설계로 분리한다.

--- a/studio-platform-user-default/src/main/resources/schema/user/mariadb/V301__optimize_group_member_summary_search.sql
+++ b/studio-platform-user-default/src/main/resources/schema/user/mariadb/V301__optimize_group_member_summary_search.sql
@@ -1,0 +1,8 @@
+-- MariaDB group member summary search migration marker.
+--
+-- The optimized infix search path is PostgreSQL-specific and is implemented with
+-- pg_trgm in schema/user/postgres/V301__optimize_group_member_summary_search.sql.
+-- MariaDB keeps the existing USERNAME and EMAIL unique indexes from V300. A normal
+-- B-tree index does not optimize LIKE '%keyword%' reliably, so this migration is
+-- intentionally schema-neutral to keep the user schema history explicit.
+

--- a/studio-platform-user-default/src/main/resources/schema/user/mysql/V301__optimize_group_member_summary_search.sql
+++ b/studio-platform-user-default/src/main/resources/schema/user/mysql/V301__optimize_group_member_summary_search.sql
@@ -1,0 +1,8 @@
+-- MySQL group member summary search migration marker.
+--
+-- The optimized infix search path is PostgreSQL-specific and is implemented with
+-- pg_trgm in schema/user/postgres/V301__optimize_group_member_summary_search.sql.
+-- MySQL keeps the existing USERNAME and EMAIL unique indexes from V300. A normal
+-- B-tree index does not optimize LIKE '%keyword%' reliably, so this migration is
+-- intentionally schema-neutral to keep the user schema history explicit.
+

--- a/studio-platform-user-default/src/main/resources/schema/user/postgres/V301__optimize_group_member_summary_search.sql
+++ b/studio-platform-user-default/src/main/resources/schema/user/postgres/V301__optimize_group_member_summary_search.sql
@@ -1,0 +1,13 @@
+-- PostgreSQL group member summary search optimization.
+-- Supports lower(username|name|email) LIKE '%keyword%' through trigram expression indexes.
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS IDX_APP_USER_USERNAME_TRGM
+    ON TB_APPLICATION_USER USING GIN (lower(USERNAME) gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS IDX_APP_USER_NAME_TRGM
+    ON TB_APPLICATION_USER USING GIN (lower(NAME) gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS IDX_APP_USER_EMAIL_TRGM
+    ON TB_APPLICATION_USER USING GIN (lower(EMAIL) gin_trgm_ops);

--- a/studio-platform-user/src/main/java/studio/one/base/user/persistence/jpa/ApplicationGroupMembershipJpaRepository.java
+++ b/studio-platform-user/src/main/java/studio/one/base/user/persistence/jpa/ApplicationGroupMembershipJpaRepository.java
@@ -51,10 +51,10 @@ public interface ApplicationGroupMembershipJpaRepository
             join ApplicationUser u on u.userId = gm.id.userId
            where gm.id.groupId = :groupId
              and (
-                   :keyword is null
-                or lower(u.username) like lower(concat('%', CAST(:keyword AS String), '%'))
-                or lower(u.name) like lower(concat('%', CAST(:keyword AS String), '%'))
-                or lower(u.email) like lower(concat('%', CAST(:keyword AS String), '%'))
+                   :#{#keyword == null || #keyword.trim().isEmpty()} = true
+                or lower(u.username) like lower(concat('%', CAST(:#{#keyword == null ? '' : #keyword.trim()} AS String), '%'))
+                or lower(u.name) like lower(concat('%', CAST(:#{#keyword == null ? '' : #keyword.trim()} AS String), '%'))
+                or lower(u.email) like lower(concat('%', CAST(:#{#keyword == null ? '' : #keyword.trim()} AS String), '%'))
              )
           """,
       countQuery = """
@@ -63,10 +63,10 @@ public interface ApplicationGroupMembershipJpaRepository
             join ApplicationUser u on u.userId = gm.id.userId
            where gm.id.groupId = :groupId
              and (
-                   :keyword is null
-                or lower(u.username) like lower(concat('%', CAST(:keyword AS String), '%'))
-                or lower(u.name) like lower(concat('%', CAST(:keyword AS String), '%'))
-                or lower(u.email) like lower(concat('%', CAST(:keyword AS String), '%'))
+                   :#{#keyword == null || #keyword.trim().isEmpty()} = true
+                or lower(u.username) like lower(concat('%', CAST(:#{#keyword == null ? '' : #keyword.trim()} AS String), '%'))
+                or lower(u.name) like lower(concat('%', CAST(:#{#keyword == null ? '' : #keyword.trim()} AS String), '%'))
+                or lower(u.email) like lower(concat('%', CAST(:#{#keyword == null ? '' : #keyword.trim()} AS String), '%'))
              )
           """)
   Page<ApplicationGroupMemberSummary> findMemberSummariesByGroupId(

--- a/studio-platform-user/src/main/java/studio/one/base/user/service/impl/ApplicationGroupServiceImpl.java
+++ b/studio-platform-user/src/main/java/studio/one/base/user/service/impl/ApplicationGroupServiceImpl.java
@@ -347,7 +347,15 @@ public class ApplicationGroupServiceImpl
     @Override
     @Transactional(readOnly = true)
     public Page<ApplicationGroupMemberSummary> getMemberSummaries(Long groupId, @Nullable String q, Pageable pageable) {
-        return membershipRepo.findMemberSummariesByGroupId(groupId, q, pageable);
+        return membershipRepo.findMemberSummariesByGroupId(groupId, normalizeSearchKeyword(q), pageable);
+    }
+
+    @Nullable
+    private static String normalizeSearchKeyword(@Nullable String q) {
+        if (q == null || q.isBlank()) {
+            return null;
+        }
+        return q.trim();
     }
 
     @Override

--- a/studio-platform-user/src/test/java/studio/one/base/user/persistence/jpa/ApplicationGroupMembershipJpaRepositorySearchTest.java
+++ b/studio-platform-user/src/test/java/studio/one/base/user/persistence/jpa/ApplicationGroupMembershipJpaRepositorySearchTest.java
@@ -1,0 +1,141 @@
+package studio.one.base.user.persistence.jpa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import studio.one.base.user.domain.entity.ApplicationGroup;
+import studio.one.base.user.domain.entity.ApplicationGroupMemberSummary;
+import studio.one.base.user.domain.entity.ApplicationGroupMembership;
+import studio.one.base.user.domain.entity.ApplicationUser;
+
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+class ApplicationGroupMembershipJpaRepositorySearchTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @Autowired
+    TestEntityManager em;
+
+    @Autowired
+    ApplicationGroupMembershipJpaRepository repo;
+
+    @Test
+    void findMemberSummariesByGroupIdWithNullKeywordReturnsAllMembers() {
+        ApplicationGroup group = group("summary-null");
+        ApplicationUser alice = user("alice-null", "Alice Kim", "alice.null@example.com");
+        ApplicationUser bob = user("bob-null", "Bob Lee", "bob.null@example.com");
+        member(group, alice);
+        member(group, bob);
+
+        Page<ApplicationGroupMemberSummary> result = repo.findMemberSummariesByGroupId(
+                group.getGroupId(), null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).extracting(ApplicationGroupMemberSummary::getUsername)
+                .containsExactlyInAnyOrder("alice-null", "bob-null");
+    }
+
+    @Test
+    void findMemberSummariesByGroupIdWithBlankKeywordReturnsAllMembers() {
+        ApplicationGroup group = group("summary-blank");
+        ApplicationUser alice = user("alice-blank", "Alice Blank", "alice.blank@example.com");
+        ApplicationUser bob = user("bob-blank", "Bob Blank", "bob.blank@example.com");
+        member(group, alice);
+        member(group, bob);
+
+        Page<ApplicationGroupMemberSummary> result = repo.findMemberSummariesByGroupId(
+                group.getGroupId(), "   ", PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).extracting(ApplicationGroupMemberSummary::getUsername)
+                .containsExactlyInAnyOrder("alice-blank", "bob-blank");
+    }
+
+    @Test
+    void findMemberSummariesByGroupIdMatchesUsernameNameAndEmail() {
+        ApplicationGroup group = group("summary-match");
+        ApplicationUser usernameMatch = user("engineer-kim", "No Match", "username@example.com");
+        ApplicationUser nameMatch = user("name-user", "Platform Owner", "name@example.com");
+        ApplicationUser emailMatch = user("email-user", "Email User", "owner@example.com");
+        ApplicationUser other = user("other-user", "Other User", "other@example.com");
+        member(group, usernameMatch);
+        member(group, nameMatch);
+        member(group, emailMatch);
+        member(group, other);
+
+        List<String> usernameResults = usernames(
+                repo.findMemberSummariesByGroupId(group.getGroupId(), "ENGINEER", PageRequest.of(0, 10)));
+        List<String> nameResults = usernames(
+                repo.findMemberSummariesByGroupId(group.getGroupId(), "platform", PageRequest.of(0, 10)));
+        List<String> emailResults = usernames(
+                repo.findMemberSummariesByGroupId(group.getGroupId(), "OWNER@", PageRequest.of(0, 10)));
+
+        assertThat(usernameResults)
+                .containsExactly("engineer-kim");
+        assertThat(nameResults)
+                .containsExactly("name-user");
+        assertThat(emailResults)
+                .containsExactly("email-user");
+    }
+
+    private java.util.List<String> usernames(Page<ApplicationGroupMemberSummary> page) {
+        return page.getContent().stream()
+                .map(ApplicationGroupMemberSummary::getUsername)
+                .toList();
+    }
+
+    private ApplicationGroup group(String name) {
+        return em.persistAndFlush(ApplicationGroup.builder()
+                .name(name)
+                .description(name)
+                .build());
+    }
+
+    private ApplicationUser user(String username, String name, String email) {
+        ApplicationUser user = new ApplicationUser();
+        user.setUsername(username);
+        user.setName(name);
+        user.setEmail(email);
+        user.setPassword("{noop}password");
+        user.setNameVisible(true);
+        user.setEmailVisible(true);
+        user.setEnabled(true);
+        user.setExternal(false);
+        user.setFailedAttempts(0);
+        return em.persistAndFlush(user);
+    }
+
+    private void member(ApplicationGroup group, ApplicationUser user) {
+        em.persistAndFlush(ApplicationGroupMembership.of(group, user.getUserId(), "test"));
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    @EntityScan(basePackageClasses = {
+            ApplicationGroup.class,
+            ApplicationGroupMembership.class,
+            ApplicationUser.class
+    })
+    @EnableJpaRepositories(basePackageClasses = ApplicationGroupMembershipJpaRepository.class)
+    static class TestBootConfig {
+    }
+}


### PR DESCRIPTION
## Why

그룹 멤버 summary 검색은 `username`, `name`, `email`에 대한 부분 검색을 제공하지만 PostgreSQL에서 `lower(...) LIKE '%keyword%'` 패턴이 커질수록 full scan으로 이어질 수 있다.

이 변경은 기존 검색 계약을 유지하면서 PostgreSQL 운영 환경에서 검색 성능을 개선하고, blank keyword 처리 계약을 null keyword와 동일하게 정리하기 위한 것이다.

## What

- PostgreSQL user schema V301 migration에 `pg_trgm` 확장과 `lower(username|name|email)` GIN trigram index를 추가했다.
- MySQL/MariaDB에는 동일 V301 버전의 schema-neutral migration을 추가해 PostgreSQL 전용 최적화임을 명시했다.
- `ApplicationGroupServiceImpl`에서 blank 검색어를 null로 정규화한다.
- JPA repository 직접 호출 경로도 null/blank keyword를 전체 조회로 처리하도록 유지했다.
- Testcontainers 기반 PostgreSQL JPA repository 테스트에 null, blank, username/name/email match 케이스를 추가했다.
- `starter:studio-platform-starter-user` README와 `CHANGELOG.md`에 PostgreSQL `pg_trgm` 운영 요구사항과 DB별 migration 의도를 기록했다.

## Related Issues

- Closes #188

## Validation

- Command: `./gradlew :studio-platform-user:test --tests 'studio.one.base.user.persistence.jpa.ApplicationGroupMembershipJpaRepositorySearchTest' --tests 'studio.one.base.user.persistence.jdbc.ApplicationGroupMembershipJdbcRepositoryTest'`
- Result: Passed
- Command: `git diff --check`
- Result: Passed

## Risk / Rollback

- Risk: PostgreSQL Flyway 실행 계정에 `CREATE EXTENSION IF NOT EXISTS pg_trgm` 권한이 없으면 V301 migration 적용이 실패할 수 있다.
- Risk: `pg_trgm` GIN index 생성 시 기존 사용자 데이터 규모에 따라 migration 시간이 증가할 수 있다.
- Rollback: PR revert 후 PostgreSQL에 생성된 `IDX_APP_USER_USERNAME_TRGM`, `IDX_APP_USER_NAME_TRGM`, `IDX_APP_USER_EMAIL_TRGM` index를 제거한다. 이미 적용된 Flyway 이력은 운영 DB 정책에 따라 보정 migration으로 처리한다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: `./gradlew :studio-platform-user:test --tests 'studio.one.base.user.persistence.jpa.ApplicationGroupMembershipJpaRepositorySearchTest' --tests 'studio.one.base.user.persistence.jdbc.ApplicationGroupMembershipJdbcRepositoryTest'`, `git diff --check`

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
