### PR TITLE
[codex] RAG retrieval filter 계약 보강

### DIFF
--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -281,6 +281,8 @@ Content-Type: application/json
 
 RAG context는 이슈 #202부터 설정된 chunk 수와 문자 수를 넘지 않도록 제한된다.
 문자 수 한도는 context header를 포함해 계산하며, 한도를 초과하는 chunk는 문장 중간에서 자르지 않고 통째로 제외한다.
+현재 context assembly 구현은 web starter 내부의 `RagContextBuilder`가 담당한다.
+별도 core `ContextAssembler` 계약은 만들지 않고, chunk 주변 문맥 확장은 `studio-platform-chunking`의 `ChunkContextExpander`를 우선 사용한다.
 
 ```yaml
 studio:
@@ -334,6 +336,24 @@ Content-Type: application/json
   "useLlmKeywordExtraction": true
 }
 ```
+
+### RAG 검색 예시
+
+```http
+POST /api/mgmt/ai/rag/search
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "query": "검색어",
+  "topK": 5,
+  "objectType": "attachment",
+  "objectId": "123"
+}
+```
+
+`objectType`/`objectId`는 core `MetadataFilter.objectScope(...)`로 변환되어 RAG pipeline에 전달된다.
+둘 다 생략하면 전체 RAG 인덱스 검색을 수행한다.
 
 ### 파일 기반 RAG 흐름
 

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
@@ -64,6 +64,7 @@ import studio.one.platform.ai.core.chat.ChatResponse;
 import studio.one.platform.ai.core.chat.ChatResponseMetadata;
 import studio.one.platform.ai.core.chat.ChatStreamEvent;
 import studio.one.platform.ai.core.chat.ChatStreamEventType;
+import studio.one.platform.ai.core.MetadataFilter;
 import studio.one.platform.ai.core.registry.AiProviderRegistry;
 import studio.one.platform.ai.core.rag.RagRetrievalDiagnostics;
 import studio.one.platform.ai.core.rag.RagSearchRequest;
@@ -280,8 +281,10 @@ public class ChatController {
         } else {
             String resolvedQuery = resolveRagQuery(request);
             if (hasFilter) {
-                ragResults = ragPipelineService.searchByObject(
-                        new RagSearchRequest(resolvedQuery, ragTopK), objectType, objectId);
+                ragResults = ragPipelineService.search(new RagSearchRequest(
+                        resolvedQuery,
+                        ragTopK,
+                        MetadataFilter.objectScope(objectType, objectId)));
             } else {
                 ragResults = ragPipelineService.search(new RagSearchRequest(resolvedQuery, ragTopK));
             }

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import studio.one.platform.ai.core.MetadataFilter;
 import studio.one.platform.ai.core.rag.RagIndexRequest;
 import studio.one.platform.ai.core.rag.RagSearchRequest;
 import studio.one.platform.ai.core.rag.RagSearchResult;
@@ -96,7 +97,10 @@ public class RagController {
     @PostMapping("/search")
     @PreAuthorize("@endpointAuthz.can('services:ai_rag','read')")
     public ResponseEntity<SearchResponse> search(@Valid @RequestBody SearchRequest request) {
-        List<RagSearchResult> results = ragPipelineService.search(new RagSearchRequest(request.query(), request.topK()));
+        List<RagSearchResult> results = ragPipelineService.search(new RagSearchRequest(
+                request.query(),
+                request.topK(),
+                MetadataFilter.objectScope(request.objectType(), request.objectId())));
         List<SearchResult> payload = results.stream()
                 .map(result -> new SearchResult(
                         result.documentId(),

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/VectorController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/VectorController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
 import lombok.extern.slf4j.Slf4j;
+import studio.one.platform.ai.core.MetadataFilter;
 import studio.one.platform.ai.core.embedding.EmbeddingPort;
 import studio.one.platform.ai.core.embedding.EmbeddingRequest;
 import studio.one.platform.ai.core.embedding.EmbeddingResponse;
@@ -130,7 +131,11 @@ public class VectorController {
 
         VectorStorePort store = requireVectorStore();
         List<Double> queryEmbedding = resolveEmbedding(request);
-        VectorSearchRequest searchRequest = new VectorSearchRequest(queryEmbedding, request.topK());
+        VectorSearchRequest searchRequest = new VectorSearchRequest(
+                queryEmbedding,
+                request.topK(),
+                MetadataFilter.objectScope(request.objectType(), request.objectId()),
+                request.minScore());
         List<VectorSearchResult> results = executeSearch(store, request, searchRequest);
         List<VectorSearchResultDto> payload = results.stream()
                 .map(this::toVectorSearchResultDto)
@@ -164,13 +169,14 @@ public class VectorController {
     private List<VectorSearchResult> executeSearch(VectorStorePort store, VectorSearchRequestDto request,
             VectorSearchRequest searchRequest) {
         boolean useHybrid = Boolean.TRUE.equals(request.hybrid());
-        boolean hasObjectFilter = hasText(request.objectType()) || hasText(request.objectId());
+        MetadataFilter filter = searchRequest.metadataFilter();
+        boolean hasObjectFilter = filter.hasObjectScope();
         List<VectorSearchResult> results;
         if (!useHybrid) {
             results = hasObjectFilter
-                    ? store.searchByObject(request.objectType(), request.objectId(), searchRequest)
+                    ? store.searchByObject(filter.objectType(), filter.objectId(), searchRequest)
                     : store.search(searchRequest);
-            return applyMinScore(results, request.minScore());
+            return applyMinScore(results, searchRequest.minScore());
         }
         if (request.query() == null || request.query().isBlank()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "hybrid search requires a query string");
@@ -178,13 +184,13 @@ public class VectorController {
         results = hasObjectFilter
                 ? store.hybridSearchByObject(
                         request.query(),
-                        request.objectType(),
-                        request.objectId(),
+                        filter.objectType(),
+                        filter.objectId(),
                         searchRequest,
                         HYBRID_VECTOR_WEIGHT,
                         HYBRID_LEXICAL_WEIGHT)
                 : store.hybridSearch(request.query(), searchRequest, HYBRID_VECTOR_WEIGHT, HYBRID_LEXICAL_WEIGHT);
-        return applyMinScore(results, request.minScore());
+        return applyMinScore(results, searchRequest.minScore());
     }
 
     private List<Double> normalizeEmbedding(List<Double> embedding, int expectedDim) {

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/SearchRequest.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/SearchRequest.java
@@ -5,5 +5,11 @@ import jakarta.validation.constraints.NotBlank;
 
 public record SearchRequest(
                 @NotBlank String query,
-                @Min(1) int topK) {
+                @Min(1) int topK,
+                String objectType,
+                String objectId) {
+
+    public SearchRequest(String query, int topK) {
+        this(query, topK, null, null);
+    }
 }

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
@@ -476,7 +476,7 @@ class ChatControllerTest {
     void ragChatStoresOnlyConversationMessagesWhenMemoryIsEnabled() {
         controller = memoryController();
         ArgumentCaptor<ChatRequest> captor = ArgumentCaptor.forClass(ChatRequest.class);
-        when(ragPipelineService.searchByObject(any(RagSearchRequest.class), any(), any()))
+        when(ragPipelineService.search(any(RagSearchRequest.class)))
                 .thenReturn(List.of(new RagSearchResult("doc-1", "file text", Map.of(), 0.9d)));
 
         controller.chatWithRag(new ChatRagRequestDto(
@@ -511,7 +511,8 @@ class ChatControllerTest {
     @Test
     void ragChatAddsContextAndClientSystemPromptAndSearchesByObject() {
         ArgumentCaptor<ChatRequest> chatCaptor = ArgumentCaptor.forClass(ChatRequest.class);
-        when(ragPipelineService.searchByObject(any(RagSearchRequest.class), any(), any()))
+        ArgumentCaptor<RagSearchRequest> ragCaptor = ArgumentCaptor.forClass(RagSearchRequest.class);
+        when(ragPipelineService.search(any(RagSearchRequest.class)))
                 .thenReturn(List.of(new RagSearchResult("doc-1", "file text", Map.of(), 0.9d)));
 
         controller.chatWithRag(new ChatRagRequestDto(
@@ -530,8 +531,9 @@ class ChatControllerTest {
                 "attachment",
                 "123"));
 
-        verify(ragPipelineService).searchByObject(any(RagSearchRequest.class), org.mockito.Mockito.eq("attachment"),
-                org.mockito.Mockito.eq("123"));
+        verify(ragPipelineService).search(ragCaptor.capture());
+        assertThat(ragCaptor.getValue().metadataFilter().objectType()).isEqualTo("attachment");
+        assertThat(ragCaptor.getValue().metadataFilter().objectId()).isEqualTo("123");
         verify(googleChatPort).chat(chatCaptor.capture());
         assertThat(chatCaptor.getValue().messages()).hasSize(3);
         assertThat(chatCaptor.getValue().messages().get(0).role().name()).isEqualTo("SYSTEM");

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagControllerTest.java
@@ -1,0 +1,38 @@
+package studio.one.platform.ai.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import studio.one.platform.ai.core.rag.RagSearchRequest;
+import studio.one.platform.ai.core.rag.RagSearchResult;
+import studio.one.platform.ai.service.pipeline.RagPipelineService;
+import studio.one.platform.ai.web.dto.SearchRequest;
+
+class RagControllerTest {
+
+    @Test
+    void searchMapsObjectFilterToCoreRequest() {
+        RagPipelineService ragPipelineService = mock(RagPipelineService.class);
+        RagController controller = new RagController(ragPipelineService);
+        ArgumentCaptor<RagSearchRequest> captor = ArgumentCaptor.forClass(RagSearchRequest.class);
+        when(ragPipelineService.search(any(RagSearchRequest.class)))
+                .thenReturn(List.of(new RagSearchResult("doc-1", "chunk", Map.of(), 0.9d)));
+
+        controller.search(new SearchRequest("hello", 3, "attachment", "42"));
+
+        verify(ragPipelineService).search(captor.capture());
+        assertThat(captor.getValue().query()).isEqualTo("hello");
+        assertThat(captor.getValue().topK()).isEqualTo(3);
+        assertThat(captor.getValue().metadataFilter().objectType()).isEqualTo("attachment");
+        assertThat(captor.getValue().metadataFilter().objectId()).isEqualTo("42");
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/VectorControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/VectorControllerTest.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -56,6 +57,24 @@ class VectorControllerTest {
         assertThat(response.getBody().getData().get(0).id()).isEqualTo("doc-1");
         assertThat(response.getBody().getData().get(0).documentId()).isEqualTo("doc-1");
         verify(vectorStorePort).searchByObject(eq("attachment"), eq("42"), any(VectorSearchRequest.class));
+    }
+
+    @Test
+    void passesObjectFilterAndMinScoreThroughCoreSearchRequest() {
+        ArgumentCaptor<VectorSearchRequest> captor = ArgumentCaptor.forClass(VectorSearchRequest.class);
+        when(embeddingPort.embed(any()))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("query", List.of(1.0, 0.0)))));
+        when(vectorStorePort.searchByObject(eq("attachment"), eq("42"), any(VectorSearchRequest.class)))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-1", "chunk", Map.of(), List.of()),
+                        0.8d)));
+
+        controller.search(new VectorSearchRequestDto("hello", null, 3, false, "attachment", "42", 0.4d));
+
+        verify(vectorStorePort).searchByObject(eq("attachment"), eq("42"), captor.capture());
+        assertThat(captor.getValue().metadataFilter().objectType()).isEqualTo("attachment");
+        assertThat(captor.getValue().metadataFilter().objectId()).isEqualTo("42");
+        assertThat(captor.getValue().minScore()).isEqualTo(0.4d);
     }
 
     @Test

--- a/starter/studio-platform-starter-ai/README.md
+++ b/starter/studio-platform-starter-ai/README.md
@@ -180,6 +180,8 @@ studio:
 `RagPipelineService`는 문서/파일/도메인 객체별 텍스트를 chunk로 나누고, 임베딩과 메타데이터를 벡터 스토어에 저장한다.
 `objectType`/`objectId` 메타데이터를 함께 저장하면 AI web starter의 RAG chat API에서 특정 파일이나 객체 범위에 한정해 답변할 수 있다.
 같은 `objectType`/`objectId`를 재색인하면 기존 chunk를 삭제한 뒤 새 chunk를 저장해 stale chunk가 남지 않도록 한다.
+검색 요청은 기존 `searchByObject(...)`와 함께 `RagSearchRequest`의 `MetadataFilter.objectScope(...)` 경로도 지원한다.
+두 경로는 같은 객체 범위 retrieval 동작을 사용한다.
 
 ### Chat metadata / streaming
 
@@ -323,6 +325,12 @@ studio:
 - `studio-platform-starter-ai-web` — AI HTTP 엔드포인트를 노출하는 짝 스타터 (이 스타터와 함께 사용)
 - `studio-application-modules/content-embedding-pipeline` — 이 스타터의 `EmbeddingPort`/`VectorStorePort`를 소비하는 임베딩 파이프라인 모듈
 - `docs/dev/spring-ai-openai.md` — OpenAI provider의 Spring AI 전환 방향과 롤백 참고 문서
+
+## Adapter 분리 원칙
+
+이 스타터는 현재 Spring AI provider adapter와 pgvector `VectorStorePort` adapter를 함께 자동 구성한다.
+첫 호환 범위에서는 기존 자동 구성을 유지하지만, 새 provider-specific 구현이나 새 vector DB 구현은 `studio-platform-ai` core에 넣지 않는다.
+반복 사용이 확인된 provider/vector DB 구현은 별도 adapter 또는 starter 모듈로 분리하는 방향을 우선한다.
 
 ## 5) 참고 사항
 

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagPipelineService.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagPipelineService.java
@@ -13,6 +13,7 @@ import com.github.benmanes.caffeine.cache.Cache;
 
 import io.github.resilience4j.retry.Retry;
 import lombok.extern.slf4j.Slf4j;
+import studio.one.platform.ai.core.MetadataFilter;
 import studio.one.platform.ai.core.chunk.TextChunk;
 import studio.one.platform.ai.core.chunk.TextChunker;
 import studio.one.platform.ai.core.embedding.EmbeddingPort;
@@ -265,9 +266,16 @@ public class DefaultRagPipelineService implements RagPipelineService {
 
     @Override
     public List<RagSearchResult> search(RagSearchRequest request) {
+        MetadataFilter filter = request.metadataFilter();
+        if (filter.hasObjectScope()) {
+            return searchByObject(
+                    new RagSearchRequest(request.query(), request.topK()),
+                    filter.objectType(),
+                    filter.objectId());
+        }
         clearDiagnostics();
         List<Double> queryEmbedding = embedWithCache(request.query());
-        VectorSearchRequest searchRequest = new VectorSearchRequest(queryEmbedding, request.topK());
+        VectorSearchRequest searchRequest = new VectorSearchRequest(queryEmbedding, request.topK(), filter);
         List<VectorSearchResult> results = searchWithFallback(
                 request.query(),
                 searchRequest,
@@ -282,7 +290,10 @@ public class DefaultRagPipelineService implements RagPipelineService {
     public List<RagSearchResult> searchByObject(RagSearchRequest request, String objectType, String objectId) {
         clearDiagnostics();
         List<Double> queryEmbedding = embedWithCache(request.query());
-        VectorSearchRequest searchRequest = new VectorSearchRequest(queryEmbedding, request.topK());
+        VectorSearchRequest searchRequest = new VectorSearchRequest(
+                queryEmbedding,
+                request.topK(),
+                MetadataFilter.objectScope(objectType, objectId));
         List<VectorSearchResult> results = searchWithFallback(
                 request.query(),
                 searchRequest,

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagPipelineService.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagPipelineService.java
@@ -266,14 +266,11 @@ public class DefaultRagPipelineService implements RagPipelineService {
 
     @Override
     public List<RagSearchResult> search(RagSearchRequest request) {
+        clearDiagnostics();
         MetadataFilter filter = request.metadataFilter();
         if (filter.hasObjectScope()) {
-            return searchByObject(
-                    new RagSearchRequest(request.query(), request.topK()),
-                    filter.objectType(),
-                    filter.objectId());
+            return searchObjectScope(request.query(), request.topK(), filter);
         }
-        clearDiagnostics();
         List<Double> queryEmbedding = embedWithCache(request.query());
         VectorSearchRequest searchRequest = new VectorSearchRequest(queryEmbedding, request.topK(), filter);
         List<VectorSearchResult> results = searchWithFallback(
@@ -289,24 +286,32 @@ public class DefaultRagPipelineService implements RagPipelineService {
     @Override
     public List<RagSearchResult> searchByObject(RagSearchRequest request, String objectType, String objectId) {
         clearDiagnostics();
-        List<Double> queryEmbedding = embedWithCache(request.query());
+        MetadataFilter filter = MetadataFilter.objectScope(objectType, objectId);
+        if (filter.isEmpty()) {
+            filter = request.metadataFilter();
+        }
+        return searchObjectScope(request.query(), request.topK(), filter);
+    }
+
+    private List<RagSearchResult> searchObjectScope(String queryText, int topK, MetadataFilter filter) {
+        List<Double> queryEmbedding = embedWithCache(queryText);
         VectorSearchRequest searchRequest = new VectorSearchRequest(
                 queryEmbedding,
-                request.topK(),
-                MetadataFilter.objectScope(objectType, objectId));
+                topK,
+                filter);
         List<VectorSearchResult> results = searchWithFallback(
-                request.query(),
+                queryText,
                 searchRequest,
                 query -> vectorStorePort.hybridSearchByObject(
                         query,
-                        objectType,
-                        objectId,
+                        filter.objectType(),
+                        filter.objectId(),
                         searchRequest,
                         options.vectorWeight(),
                         options.lexicalWeight()),
-                () -> vectorStorePort.searchByObject(objectType, objectId, searchRequest),
-                objectType,
-                objectId);
+                () -> vectorStorePort.searchByObject(filter.objectType(), filter.objectId(), searchRequest),
+                filter.objectType(),
+                filter.objectId());
         return toRagSearchResults(results);
     }
 

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
@@ -11,6 +11,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import studio.one.platform.ai.core.MetadataFilter;
 import studio.one.platform.ai.core.chunk.TextChunk;
 import studio.one.platform.ai.core.chunk.TextChunker;
 import studio.one.platform.ai.core.embedding.EmbeddingPort;
@@ -374,6 +375,42 @@ class RagPipelineServiceTest {
         assertThat(result.documentId()).isEqualTo("doc-1");
         assertThat(result.metadata()).containsEntry("author", "test");
         assertThat(result.score()).isEqualTo(0.9);
+    }
+
+    @Test
+    void shouldSearchWithMetadataFilterUsingObjectScopedRetrievalPath() {
+        RagSearchRequest request = new RagSearchRequest(
+                "hello",
+                2,
+                MetadataFilter.objectScope("attachment", "42"));
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("hello", List.of(0.5, 0.6)))));
+        when(vectorStorePort.hybridSearchByObject(
+                eq("hello"),
+                eq("attachment"),
+                eq("42"),
+                any(VectorSearchRequest.class),
+                anyDouble(),
+                anyDouble()))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-filtered", "chunk", Map.of("objectType", "attachment", "objectId", "42"), List.of()),
+                        0.9)));
+
+        List<RagSearchResult> results = ragPipelineService.search(request);
+
+        assertThat(results)
+                .extracting(RagSearchResult::documentId)
+                .containsExactly("doc-filtered");
+        verify(vectorStorePort).hybridSearchByObject(
+                eq("hello"),
+                eq("attachment"),
+                eq("42"),
+                org.mockito.ArgumentMatchers.argThat(searchRequest ->
+                        searchRequest.metadataFilter().hasObjectScope()
+                                && "attachment".equals(searchRequest.metadataFilter().objectType())
+                                && "42".equals(searchRequest.metadataFilter().objectId())),
+                anyDouble(),
+                anyDouble());
     }
 
     @Test

--- a/starter/studio-platform-starter-chunking/README.md
+++ b/starter/studio-platform-starter-chunking/README.md
@@ -97,6 +97,7 @@ heading 없이 시작하는 문서는 빈 `section` 값과 body-only `parentChun
 이 전략은 파일 parsing, OCR 실행, embedding API 호출, LLM 호출, vector store 저장을 하지 않습니다.
 
 `studio-platform-textract`가 classpath에 있으면 `TextractNormalizedDocumentAdapter`로 `ParsedFile`을 `NormalizedDocument`로 변환할 수 있습니다.
+실제 파일 읽기, embedding 생성, vector upsert는 이 starter의 책임이 아니며, `content-embedding-pipeline` 같은 조립 모듈에서 실행합니다.
 
 ```java
 ParsedFile parsedFile = fileContentExtractionService.parseStructured(...);

--- a/studio-platform-ai/README.md
+++ b/studio-platform-ai/README.md
@@ -18,11 +18,13 @@ RAG indexing용 chunking 계약과 구현은 `studio-platform-chunking`과 `stud
 - `RagPipelineService`: 인덱싱(`index`)과 검색(`search`, `searchByObject`, `listByObject`)을 정의하는 RAG facade 계약
 - `TextCleaner` / `KeywordExtractor` / `PromptRenderer`: RAG 전처리와 프롬프트 확장점 계약
 - `RagPipelineOptions` 계열: 기본 RAG 구현을 대체하거나 테스트할 때 사용할 설정 계약
+- `MetadataFilter`: retrieval 요청에서 `objectType`/`objectId` metadata convention을 표현하는 최소 필터 계약
 
 ## 주요 타입
 
 | 타입 | 패키지 | 설명 |
 |---|---|---|
+| `MetadataFilter` | `core` | RAG/vector retrieval 요청의 object scope metadata filter |
 | `ChatPort` | `core.chat` | 챗 완성 요청/응답 계약 |
 | `ChatResponseMetadata` | `core.chat` | token usage, latency, provider, resolved model, memory, conversation metadata typed view |
 | `ChatStreamEvent` | `core.chat` | streaming chat event 계약 |
@@ -61,6 +63,18 @@ Keyword metadata는 trim, blank 제거, case-insensitive 중복 제거를 거친
 기본 `scope=document`는 기존 동작과 동일하게 문서 단위 keyword만 기록한다.
 `scope=chunk` 또는 `both`는 chunk별 keyword를 추가해 긴 파일에서 chunk 의미가 희석되는 문제를 줄이는 기반을 제공한다.
 현재 PostgreSQL hybrid SQL ranking은 기존 `simple` text search config 동작을 유지한다.
+
+## RAG retrieval filters
+
+`MetadataFilter`는 RAG와 vector 검색 요청에서 객체 범위 metadata convention을 표준화한다.
+현재 표준 필드는 `objectType`과 `objectId`이며, 기존 `searchByObject(...)` API는 하위 호환을 위해 유지한다.
+신규 호출자는 `RagSearchRequest` 또는 `VectorSearchRequest`에 `MetadataFilter.objectScope(...)`를 담아 같은 객체 범위 검색을 요청할 수 있다.
+
+중복 계약은 만들지 않는다.
+
+- 새 `EmbeddingPort` 또는 `VectorStorePort` 대신 기존 포트를 확장한다.
+- 새 `VectorRecord` 대신 `VectorDocument`를 사용한다.
+- 새 context assembly 계약은 아직 만들지 않는다. web context 조립은 `starter-ai-web`의 `RagContextBuilder`, chunk 주변 문맥 확장은 `studio-platform-chunking`의 `ChunkContextExpander`를 우선 사용한다.
 
 ## Chat metadata
 `ChatResponse.metadata()` map은 기존 호환성을 위해 유지한다. 신규 코드는 `ChatResponse.typedMetadata()`로 표준 metadata를 타입 안전하게 읽을 수 있다.
@@ -151,6 +165,10 @@ ragPipelineService.index(RagIndexRequest.builder()
 // RAG 검색
 List<RagSearchResult> results = ragPipelineService.searchByObject(
     new RagSearchRequest("검색어", 5), "article", "42");
+
+// filter 기반 RAG 검색
+List<RagSearchResult> filtered = ragPipelineService.search(
+    new RagSearchRequest("검색어", 5, MetadataFilter.objectScope("article", "42")));
 ```
 
 ## 관련 모듈

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/MetadataFilter.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/MetadataFilter.java
@@ -1,0 +1,71 @@
+package studio.one.platform.ai.core;
+
+import java.util.Map;
+
+/**
+ * Provider-neutral metadata filter for retrieval requests.
+ * <p>
+ * The first supported convention is object scope filtering through
+ * {@code objectType}/{@code objectId}. Additional metadata predicates can be
+ * added later without replacing existing request contracts.
+ */
+public final class MetadataFilter {
+
+    private static final MetadataFilter EMPTY = new MetadataFilter(null, null);
+
+    private final String objectType;
+    private final String objectId;
+
+    public MetadataFilter(String objectType, String objectId) {
+        this.objectType = normalize(objectType);
+        this.objectId = normalize(objectId);
+    }
+
+    public static MetadataFilter empty() {
+        return EMPTY;
+    }
+
+    public static MetadataFilter objectScope(String objectType, String objectId) {
+        MetadataFilter filter = new MetadataFilter(objectType, objectId);
+        return filter.hasObjectScope() ? filter : EMPTY;
+    }
+
+    public String objectType() {
+        return objectType;
+    }
+
+    public String objectId() {
+        return objectId;
+    }
+
+    public boolean hasObjectScope() {
+        return objectType != null || objectId != null;
+    }
+
+    public boolean isEmpty() {
+        return !hasObjectScope();
+    }
+
+    public boolean matchesObjectScope(Map<String, Object> metadata) {
+        if (!hasObjectScope()) {
+            return true;
+        }
+        if (metadata == null || metadata.isEmpty()) {
+            return false;
+        }
+        boolean typeOk = objectType == null || objectType.equalsIgnoreCase(stringValue(metadata.get("objectType")));
+        boolean idOk = objectId == null || objectId.equals(stringValue(metadata.get("objectId")));
+        return typeOk && idOk;
+    }
+
+    private static String normalize(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.trim();
+    }
+
+    private static String stringValue(Object value) {
+        return value == null ? "" : value.toString();
+    }
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/MetadataFilter.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/MetadataFilter.java
@@ -1,13 +1,16 @@
 package studio.one.platform.ai.core;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Provider-neutral metadata filter for retrieval requests.
  * <p>
  * The first supported convention is object scope filtering through
- * {@code objectType}/{@code objectId}. Additional metadata predicates can be
- * added later without replacing existing request contracts.
+ * {@code objectType}/{@code objectId}. Supplying only one of the two fields is
+ * intentional and means "filter by this single metadata key". Additional
+ * metadata predicates can be added later without replacing existing request
+ * contracts.
  */
 public final class MetadataFilter {
 
@@ -56,6 +59,31 @@ public final class MetadataFilter {
         boolean typeOk = objectType == null || objectType.equalsIgnoreCase(stringValue(metadata.get("objectType")));
         boolean idOk = objectId == null || objectId.equals(stringValue(metadata.get("objectId")));
         return typeOk && idOk;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof MetadataFilter that)) {
+            return false;
+        }
+        return Objects.equals(objectType, that.objectType)
+                && Objects.equals(objectId, that.objectId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(objectType, objectId);
+    }
+
+    @Override
+    public String toString() {
+        return "MetadataFilter{"
+                + "objectType='" + objectType + '\''
+                + ", objectId='" + objectId + '\''
+                + '}';
     }
 
     private static String normalize(String value) {

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/rag/RagSearchRequest.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/rag/RagSearchRequest.java
@@ -2,6 +2,8 @@ package studio.one.platform.ai.core.rag;
 
 import java.util.Objects;
 
+import studio.one.platform.ai.core.MetadataFilter;
+
 /**
  * Request to query the RAG pipeline.
  */
@@ -9,13 +11,19 @@ public final class RagSearchRequest {
 
     private final String query;
     private final int topK;
+    private final MetadataFilter metadataFilter;
 
     public RagSearchRequest(String query, int topK) {
+        this(query, topK, MetadataFilter.empty());
+    }
+
+    public RagSearchRequest(String query, int topK, MetadataFilter metadataFilter) {
         this.query = Objects.requireNonNull(query, "query");
         if (topK <= 0) {
             throw new IllegalArgumentException("topK must be greater than zero");
         }
         this.topK = topK;
+        this.metadataFilter = metadataFilter == null ? MetadataFilter.empty() : metadataFilter;
     }
 
     public String query() {
@@ -24,5 +32,9 @@ public final class RagSearchRequest {
 
     public int topK() {
         return topK;
+    }
+
+    public MetadataFilter metadataFilter() {
+        return metadataFilter;
     }
 }

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorSearchRequest.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorSearchRequest.java
@@ -3,6 +3,8 @@ package studio.one.platform.ai.core.vector;
 import java.util.List;
 import java.util.Objects;
 
+import studio.one.platform.ai.core.MetadataFilter;
+
 /**
  * Encapsulates a similarity search query for a vector store.
  */
@@ -10,8 +12,18 @@ public final class VectorSearchRequest {
 
     private final List<Double> embedding;
     private final int topK;
+    private final MetadataFilter metadataFilter;
+    private final Double minScore;
 
     public VectorSearchRequest(List<Double> embedding, int topK) {
+        this(embedding, topK, MetadataFilter.empty(), null);
+    }
+
+    public VectorSearchRequest(List<Double> embedding, int topK, MetadataFilter metadataFilter) {
+        this(embedding, topK, metadataFilter, null);
+    }
+
+    public VectorSearchRequest(List<Double> embedding, int topK, MetadataFilter metadataFilter, Double minScore) {
         this.embedding = List.copyOf(Objects.requireNonNull(embedding, "embedding"));
         if (embedding.isEmpty()) {
             throw new IllegalArgumentException("Search embedding must not be empty");
@@ -19,7 +31,12 @@ public final class VectorSearchRequest {
         if (topK <= 0) {
             throw new IllegalArgumentException("topK must be greater than zero");
         }
+        if (minScore != null && minScore < 0.0d) {
+            throw new IllegalArgumentException("minScore must be greater than or equal to zero");
+        }
         this.topK = topK;
+        this.metadataFilter = metadataFilter == null ? MetadataFilter.empty() : metadataFilter;
+        this.minScore = minScore;
     }
 
     public List<Double> embedding() {
@@ -28,5 +45,17 @@ public final class VectorSearchRequest {
 
     public int topK() {
         return topK;
+    }
+
+    public MetadataFilter metadataFilter() {
+        return metadataFilter;
+    }
+
+    public Double minScore() {
+        return minScore;
+    }
+
+    public boolean hasMinScore() {
+        return minScore != null;
     }
 }

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/core/rag/RagRetrievalRequestContractTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/core/rag/RagRetrievalRequestContractTest.java
@@ -32,6 +32,18 @@ class RagRetrievalRequestContractTest {
     }
 
     @Test
+    void metadataFilterUsesValueSemanticsAndAllowsPartialObjectScope() {
+        MetadataFilter left = new MetadataFilter(" attachment ", null);
+        MetadataFilter right = MetadataFilter.objectScope("attachment", null);
+
+        assertThat(left).isEqualTo(right);
+        assertThat(left.hashCode()).isEqualTo(right.hashCode());
+        assertThat(left.hasObjectScope()).isTrue();
+        assertThat(left.matchesObjectScope(java.util.Map.of("objectType", "ATTACHMENT"))).isTrue();
+        assertThat(left.toString()).contains("attachment");
+    }
+
+    @Test
     void legacyVectorSearchRequestConstructorKeepsEmptyFilterAndMinScore() {
         VectorSearchRequest request = new VectorSearchRequest(List.of(0.1d, 0.2d), 5);
 

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/core/rag/RagRetrievalRequestContractTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/core/rag/RagRetrievalRequestContractTest.java
@@ -1,0 +1,58 @@
+package studio.one.platform.ai.core.rag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.ai.core.MetadataFilter;
+import studio.one.platform.ai.core.vector.VectorSearchRequest;
+
+class RagRetrievalRequestContractTest {
+
+    @Test
+    void legacyRagSearchRequestConstructorKeepsEmptyFilter() {
+        RagSearchRequest request = new RagSearchRequest("hello", 3);
+
+        assertThat(request.query()).isEqualTo("hello");
+        assertThat(request.topK()).isEqualTo(3);
+        assertThat(request.metadataFilter().isEmpty()).isTrue();
+    }
+
+    @Test
+    void ragSearchRequestCanCarryObjectScopeFilter() {
+        RagSearchRequest request = new RagSearchRequest(
+                "hello",
+                3,
+                MetadataFilter.objectScope(" attachment ", " 42 "));
+
+        assertThat(request.metadataFilter().objectType()).isEqualTo("attachment");
+        assertThat(request.metadataFilter().objectId()).isEqualTo("42");
+    }
+
+    @Test
+    void legacyVectorSearchRequestConstructorKeepsEmptyFilterAndMinScore() {
+        VectorSearchRequest request = new VectorSearchRequest(List.of(0.1d, 0.2d), 5);
+
+        assertThat(request.embedding()).containsExactly(0.1d, 0.2d);
+        assertThat(request.topK()).isEqualTo(5);
+        assertThat(request.metadataFilter().isEmpty()).isTrue();
+        assertThat(request.minScore()).isNull();
+    }
+
+    @Test
+    void vectorSearchRequestCanCarryFilterAndMinScore() {
+        VectorSearchRequest request = new VectorSearchRequest(
+                List.of(0.1d, 0.2d),
+                5,
+                MetadataFilter.objectScope("attachment", "42"),
+                0.4d);
+
+        assertThat(request.metadataFilter().hasObjectScope()).isTrue();
+        assertThat(request.metadataFilter().objectType()).isEqualTo("attachment");
+        assertThat(request.metadataFilter().objectId()).isEqualTo("42");
+        assertThat(request.minScore()).isEqualTo(0.4d);
+        assertThat(request.hasMinScore()).isTrue();
+    }
+}

--- a/studio-platform-textract/README.md
+++ b/studio-platform-textract/README.md
@@ -34,6 +34,10 @@ String plainText = parsed.plainText();
 List<ParsedBlock> blocks = parsed.blocks();
 ```
 
+구조화 RAG 색인은 `parseStructured(...)` 결과를 조립 모듈에서 `TextractNormalizedDocumentAdapter`로
+`NormalizedDocument`로 변환한 뒤 `ChunkingOrchestrator`에 전달하는 흐름을 권장한다.
+이 모듈은 chunking, embedding, vector indexing을 직접 수행하지 않는다.
+
 `FileParser.parse(byte[], String, String)`은 하위 호환을 위해 계속 `String`을 반환한다.
 새 parser는 `StructuredFileParser.parseStructured(...)`를 구현하고, `parse(...)`는 `ParsedFile.plainText()`를 반환하도록 구성한다.
 


### PR DESCRIPTION
## Why
RAG/vector 검색의 `objectType`/`objectId` 범위 조건이 web DTO와 서비스 구현에 흩어져 있어 core 계약으로 표현할 필요가 있습니다.

## What
- `MetadataFilter`를 추가하고 `RagSearchRequest`, `VectorSearchRequest`에 하위 호환 확장을 적용했습니다.
- `starter-ai`와 `starter-ai-web`이 filter 기반 요청을 기존 object scoped retrieval 경로로 전달하도록 정리했습니다.
- 중복 계약 금지, `RagContextBuilder`/`ChunkContextExpander` 경계, 구조화 textract-to-chunking 흐름, adapter 분리 원칙을 README에 기록했습니다.

## Validation
- `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test --tests 'studio.one.platform.ai.core.rag.RagRetrievalRequestContractTest' --tests 'studio.one.platform.ai.service.pipeline.RagPipelineServiceTest' --tests 'studio.one.platform.ai.web.controller.ChatControllerTest' --tests 'studio.one.platform.ai.web.controller.VectorControllerTest' --tests 'studio.one.platform.ai.web.controller.RagControllerTest'` 성공\n- `./gradlew :studio-platform-chunking:test :starter:studio-platform-starter-chunking:test :studio-platform-textract:test :starter:studio-platform-textract-starter:test` 성공\n- `./gradlew :starter:studio-platform-starter-ai-web:test` 성공\n- `git diff --check` 성공\n\n## Issue\n별도 Issue가 제공되지 않아 사용자 직접 요청에 따른 예외로 기록합니다.\n\n## AI-Assisted\nYes