### PR TITLE
[ai-assisted] feat(ai): RAG vector store core 계약 보강

### DIFF
--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
@@ -251,7 +251,7 @@ class RagPipelineServiceTest {
         ragPipelineService.index(request);
 
         verify(vectorStorePort).deleteByObject("attachment", "42");
-        verify(vectorStorePort, never()).upsert(any());
+        verify(vectorStorePort, never()).upsert(org.mockito.ArgumentMatchers.<List<VectorDocument>>any());
         verify(vectorStorePort, never()).replaceByObject(anyString(), anyString(), any());
     }
 

--- a/studio-platform-ai/README.md
+++ b/studio-platform-ai/README.md
@@ -71,11 +71,17 @@ Keyword metadata는 trim, blank 제거, case-insensitive 중복 제거를 거친
 `MetadataFilter`는 RAG와 vector 검색 요청에서 객체 범위 metadata convention을 표준화한다.
 현재 표준 필드는 `objectType`과 `objectId`이며, 기존 `searchByObject(...)` API는 하위 호환을 위해 유지한다.
 신규 호출자는 `RagSearchRequest` 또는 `VectorSearchRequest`에 `MetadataFilter.objectScope(...)`를 담아 같은 객체 범위 검색을 요청할 수 있다.
+`MetadataFilter.of(...)`의 `equalsCriteria`에 `objectType` 또는 `objectId` key가 있으면 동일한 object scope convention으로 해석되어 `hasObjectScope()`가 `true`를 반환한다.
 
 중복 계약은 만들지 않는다.
 
 - 새 `EmbeddingPort` 또는 `VectorStorePort` 대신 기존 포트를 확장한다.
-- `VectorRecord`는 RAG chunk 저장을 표현하는 core vector storage 모델이다.
+- `VectorRecord`는 RAG chunk 저장을 표현하는 core vector storage 모델이다. 신규 호출자는 긴 생성자 대신 `VectorRecord.builder()`를 우선 사용한다.
+- `chunkIndex`, `previousChunkId`, `nextChunkId`, `tenantId`, `createdAt`, `indexedAt`은 표준 metadata key로만 정의한다. first-class field가 아니므로 `metadata` map을 통해 전달한다.
+- `embeddingDimension`은 `Number` metadata로 소비해야 한다. 현재 `VectorRecord.toMetadata()`는 Java `Integer` 값을 저장하지만 adapter는 DB/driver별 숫자 타입 차이를 고려해 `Number`로 읽어야 한다.
+- `VectorSearchRequest.includeText=false`이면 `VectorSearchHit.text()`는 `null`일 수 있고, `includeMetadata=false`이면 `metadata()`는 empty map일 수 있다.
+- `VectorStorePort.searchWithFilter(...)`는 filtered-search override를 위한 확장점이며 기본 구현은 `searchRecords(...)`에 위임한다.
+- `VectorStorePort.existsByContentHash(...)`의 기본 `false`는 미구현 fallback이다. content hash deduplication이 필요한 adapter는 반드시 override해야 한다.
 - 기존 `VectorDocument`와 `VectorSearchResult`는 기존 호출자 호환성을 위해 유지한다.
 - 새 context assembly 계약은 아직 만들지 않는다. web context 조립은 `starter-ai-web`의 `RagContextBuilder`, chunk 주변 문맥 확장은 `studio-platform-chunking`의 `ChunkContextExpander`를 우선 사용한다.
 

--- a/studio-platform-ai/README.md
+++ b/studio-platform-ai/README.md
@@ -32,6 +32,8 @@ RAG indexing용 chunking 계약과 구현은 `studio-platform-chunking`과 `stud
 | `ChatConversation` / `ChatConversationMessage` / `ChatConversationSummary` | `core.chat` | conversation API 구현을 위한 provider-neutral 모델 |
 | `EmbeddingPort` | `core.embedding` | 텍스트 임베딩 벡터 생성 계약 |
 | `VectorStorePort` | `core.vector` | 벡터 저장/검색/하이브리드 검색 계약 |
+| `VectorRecord` | `core.vector` | RAG chunk 저장을 표현하는 core vector storage 모델 |
+| `VectorDocument` / `VectorSearchResult` | `core.vector` | 기존 vector 저장/검색 호출자 호환성을 위해 유지하는 모델 |
 | `AiProviderRegistry` | `core.registry` | 공급자별 ChatPort/EmbeddingPort 룩업 |
 | `TextChunker` | `core.chunk` | 문서를 TextChunk 리스트로 분할 |
 | `RagPipelineService` | `service.pipeline` | 인덱싱/검색 RAG facade 계약 |
@@ -73,7 +75,8 @@ Keyword metadata는 trim, blank 제거, case-insensitive 중복 제거를 거친
 중복 계약은 만들지 않는다.
 
 - 새 `EmbeddingPort` 또는 `VectorStorePort` 대신 기존 포트를 확장한다.
-- 새 `VectorRecord` 대신 `VectorDocument`를 사용한다.
+- `VectorRecord`는 RAG chunk 저장을 표현하는 core vector storage 모델이다.
+- 기존 `VectorDocument`와 `VectorSearchResult`는 기존 호출자 호환성을 위해 유지한다.
 - 새 context assembly 계약은 아직 만들지 않는다. web context 조립은 `starter-ai-web`의 `RagContextBuilder`, chunk 주변 문맥 확장은 `studio-platform-chunking`의 `ChunkContextExpander`를 우선 사용한다.
 
 ## Chat metadata
@@ -130,7 +133,9 @@ result count, score threshold, hybrid weight, object scope, topK를 `RagRetrieva
 Web API에서 client debug 노출 여부는 `studio-platform-starter-ai-web` 설정이 결정한다.
 
 ## 구현 분리 원칙
-이 모듈은 구현체를 포함하지 않는다. 의존성 역전 원칙에 따라 애플리케이션은 `ChatPort` 등 포트만 참조하며, 공급자별 어댑터는 스타터 모듈이 조건부로 등록한다. 공급자를 교체하거나 추가할 때 이 모듈을 수정할 필요가 없다.
+이 모듈은 구현체를 포함하지 않는다. `ai.core`는 provider 구현과 DB 구현에 의존하지 않는 계약 계층으로 유지한다.
+의존성 역전 원칙에 따라 애플리케이션은 `ChatPort` 등 포트만 참조하며, 공급자별 어댑터는 스타터 모듈이 조건부로 등록한다.
+공급자를 교체하거나 추가할 때 이 모듈을 수정할 필요가 없다. Adapter 구현과 RAG pipeline 구현 변경은 이 core 계약 문서의 범위 밖이다.
 
 ## 사용법
 - `studio-platform-starter-ai` 의존성 추가 (런타임 구현 포함)

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/MetadataFilter.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/MetadataFilter.java
@@ -1,5 +1,7 @@
 package studio.one.platform.ai.core;
 
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -14,14 +16,29 @@ import java.util.Objects;
  */
 public final class MetadataFilter {
 
-    private static final MetadataFilter EMPTY = new MetadataFilter(null, null);
+    private static final String KEY_OBJECT_TYPE = "objectType";
+    private static final String KEY_OBJECT_ID = "objectId";
+    private static final MetadataFilter EMPTY = new MetadataFilter(Map.of(), Map.of(), Map.of());
 
     private final String objectType;
     private final String objectId;
+    private final Map<String, Object> equalsCriteria;
+    private final Map<String, List<Object>> inCriteria;
+    private final Map<String, MetadataRange<?>> rangeCriteria;
 
     public MetadataFilter(String objectType, String objectId) {
-        this.objectType = normalize(objectType);
-        this.objectId = normalize(objectId);
+        this(objectScopeEquals(objectType, objectId), Map.of(), Map.of());
+    }
+
+    public MetadataFilter(
+            Map<String, Object> equalsCriteria,
+            Map<String, List<Object>> inCriteria,
+            Map<String, MetadataRange<?>> rangeCriteria) {
+        this.equalsCriteria = sanitizeEquals(equalsCriteria);
+        this.inCriteria = sanitizeIn(inCriteria);
+        this.rangeCriteria = sanitizeRanges(rangeCriteria);
+        this.objectType = normalize(stringValue(this.equalsCriteria.get(KEY_OBJECT_TYPE)));
+        this.objectId = normalize(stringValue(this.equalsCriteria.get(KEY_OBJECT_ID)));
     }
 
     public static MetadataFilter empty() {
@@ -31,6 +48,14 @@ public final class MetadataFilter {
     public static MetadataFilter objectScope(String objectType, String objectId) {
         MetadataFilter filter = new MetadataFilter(objectType, objectId);
         return filter.hasObjectScope() ? filter : EMPTY;
+    }
+
+    public static MetadataFilter of(
+            Map<String, Object> equalsCriteria,
+            Map<String, List<Object>> inCriteria,
+            Map<String, MetadataRange<?>> rangeCriteria) {
+        MetadataFilter filter = new MetadataFilter(equalsCriteria, inCriteria, rangeCriteria);
+        return filter.isEmpty() ? EMPTY : filter;
     }
 
     public String objectType() {
@@ -46,7 +71,19 @@ public final class MetadataFilter {
     }
 
     public boolean isEmpty() {
-        return !hasObjectScope();
+        return equalsCriteria.isEmpty() && inCriteria.isEmpty() && rangeCriteria.isEmpty();
+    }
+
+    public Map<String, Object> equalsCriteria() {
+        return equalsCriteria;
+    }
+
+    public Map<String, List<Object>> inCriteria() {
+        return inCriteria;
+    }
+
+    public Map<String, MetadataRange<?>> rangeCriteria() {
+        return rangeCriteria;
     }
 
     public boolean matchesObjectScope(Map<String, Object> metadata) {
@@ -70,12 +107,15 @@ public final class MetadataFilter {
             return false;
         }
         return Objects.equals(objectType, that.objectType)
-                && Objects.equals(objectId, that.objectId);
+                && Objects.equals(objectId, that.objectId)
+                && Objects.equals(equalsCriteria, that.equalsCriteria)
+                && Objects.equals(inCriteria, that.inCriteria)
+                && Objects.equals(rangeCriteria, that.rangeCriteria);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(objectType, objectId);
+        return Objects.hash(objectType, objectId, equalsCriteria, inCriteria, rangeCriteria);
     }
 
     @Override
@@ -83,7 +123,75 @@ public final class MetadataFilter {
         return "MetadataFilter{"
                 + "objectType='" + objectType + '\''
                 + ", objectId='" + objectId + '\''
+                + ", equalsCriteria=" + equalsCriteria
+                + ", inCriteria=" + inCriteria
+                + ", rangeCriteria=" + rangeCriteria
                 + '}';
+    }
+
+    private static Map<String, Object> objectScopeEquals(String objectType, String objectId) {
+        Map<String, Object> values = new LinkedHashMap<>();
+        String normalizedObjectType = normalize(objectType);
+        String normalizedObjectId = normalize(objectId);
+        if (normalizedObjectType != null) {
+            values.put(KEY_OBJECT_TYPE, normalizedObjectType);
+        }
+        if (normalizedObjectId != null) {
+            values.put(KEY_OBJECT_ID, normalizedObjectId);
+        }
+        return values;
+    }
+
+    private static Map<String, Object> sanitizeEquals(Map<String, Object> values) {
+        if (values == null || values.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, Object> sanitized = new LinkedHashMap<>();
+        values.forEach((key, value) -> {
+            String normalizedKey = normalize(key);
+            if (normalizedKey != null && value != null
+                    && (!(value instanceof String text) || !text.isBlank())) {
+                sanitized.put(normalizedKey, value instanceof String text ? text.trim() : value);
+            }
+        });
+        return Map.copyOf(sanitized);
+    }
+
+    private static Map<String, List<Object>> sanitizeIn(Map<String, List<Object>> values) {
+        if (values == null || values.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, List<Object>> sanitized = new LinkedHashMap<>();
+        values.forEach((key, candidates) -> {
+            String normalizedKey = normalize(key);
+            if (normalizedKey == null || candidates == null || candidates.isEmpty()) {
+                return;
+            }
+            List<Object> sanitizedCandidates = candidates.stream()
+                    .filter(Objects::nonNull)
+                    .filter(value -> !(value instanceof String text) || !text.isBlank())
+                    .map(value -> value instanceof String text ? text.trim() : value)
+                    .distinct()
+                    .toList();
+            if (!sanitizedCandidates.isEmpty()) {
+                sanitized.put(normalizedKey, sanitizedCandidates);
+            }
+        });
+        return Map.copyOf(sanitized);
+    }
+
+    private static Map<String, MetadataRange<?>> sanitizeRanges(Map<String, MetadataRange<?>> values) {
+        if (values == null || values.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, MetadataRange<?>> sanitized = new LinkedHashMap<>();
+        values.forEach((key, value) -> {
+            String normalizedKey = normalize(key);
+            if (normalizedKey != null && value != null) {
+                sanitized.put(normalizedKey, value);
+            }
+        });
+        return Map.copyOf(sanitized);
     }
 
     private static String normalize(String value) {

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/MetadataFilter.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/MetadataFilter.java
@@ -13,6 +13,11 @@ import java.util.Objects;
  * intentional and means "filter by this single metadata key". Additional
  * metadata predicates can be added later without replacing existing request
  * contracts.
+ * <p>
+ * {@link #objectScope(String, String)} and {@link #of(Map, Map, Map)} use the
+ * same convention: when {@code equalsCriteria} contains {@code objectType} or
+ * {@code objectId}, {@link #hasObjectScope()} returns {@code true} and
+ * {@link #objectType()}/{@link #objectId()} expose those normalized values.
  */
 public final class MetadataFilter {
 
@@ -50,6 +55,12 @@ public final class MetadataFilter {
         return filter.hasObjectScope() ? filter : EMPTY;
     }
 
+    /**
+     * Creates a general metadata filter.
+     * <p>
+     * {@code equalsCriteria} keys named {@code objectType} and {@code objectId}
+     * are also treated as the legacy object scope convention.
+     */
     public static MetadataFilter of(
             Map<String, Object> equalsCriteria,
             Map<String, List<Object>> inCriteria,

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/MetadataRange.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/MetadataRange.java
@@ -1,0 +1,92 @@
+package studio.one.platform.ai.core;
+
+import java.util.Objects;
+
+/**
+ * Provider-neutral range predicate for metadata filtering.
+ */
+public final class MetadataRange<T extends Comparable<T>> {
+
+    private final T from;
+    private final T to;
+    private final boolean includeFrom;
+    private final boolean includeTo;
+
+    public MetadataRange(T from, T to) {
+        this(from, to, true, true);
+    }
+
+    public MetadataRange(T from, T to, boolean includeFrom, boolean includeTo) {
+        if (from == null && to == null) {
+            throw new IllegalArgumentException("from or to must be provided");
+        }
+        if (from != null && to != null && from.compareTo(to) > 0) {
+            throw new IllegalArgumentException("from must be less than or equal to to");
+        }
+        this.from = from;
+        this.to = to;
+        this.includeFrom = includeFrom;
+        this.includeTo = includeTo;
+    }
+
+    public static <T extends Comparable<T>> MetadataRange<T> closed(T from, T to) {
+        return new MetadataRange<>(from, to, true, true);
+    }
+
+    public static <T extends Comparable<T>> MetadataRange<T> open(T from, T to) {
+        return new MetadataRange<>(from, to, false, false);
+    }
+
+    public static <T extends Comparable<T>> MetadataRange<T> atLeast(T from) {
+        return new MetadataRange<>(from, null, true, true);
+    }
+
+    public static <T extends Comparable<T>> MetadataRange<T> atMost(T to) {
+        return new MetadataRange<>(null, to, true, true);
+    }
+
+    public T from() {
+        return from;
+    }
+
+    public T to() {
+        return to;
+    }
+
+    public boolean includeFrom() {
+        return includeFrom;
+    }
+
+    public boolean includeTo() {
+        return includeTo;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof MetadataRange<?> that)) {
+            return false;
+        }
+        return includeFrom == that.includeFrom
+                && includeTo == that.includeTo
+                && Objects.equals(from, that.from)
+                && Objects.equals(to, that.to);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(from, to, includeFrom, includeTo);
+    }
+
+    @Override
+    public String toString() {
+        return "MetadataRange{"
+                + "from=" + from
+                + ", to=" + to
+                + ", includeFrom=" + includeFrom
+                + ", includeTo=" + includeTo
+                + '}';
+    }
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorRecord.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorRecord.java
@@ -1,0 +1,206 @@
+package studio.one.platform.ai.core.vector;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * RAG chunk record persisted by a vector store.
+ */
+public final class VectorRecord {
+
+    public static final String KEY_TENANT_ID = "tenantId";
+    public static final String KEY_OBJECT_TYPE = "objectType";
+    public static final String KEY_OBJECT_ID = "objectId";
+    public static final String KEY_DOCUMENT_ID = "documentId";
+    public static final String KEY_CHUNK_ID = "chunkId";
+    public static final String KEY_PARENT_CHUNK_ID = "parentChunkId";
+    public static final String KEY_CHUNK_INDEX = "chunkIndex";
+    public static final String KEY_PREVIOUS_CHUNK_ID = "previousChunkId";
+    public static final String KEY_NEXT_CHUNK_ID = "nextChunkId";
+    public static final String KEY_CHUNK_TYPE = "chunkType";
+    public static final String KEY_HEADING_PATH = "headingPath";
+    public static final String KEY_SOURCE_REF = "sourceRef";
+    public static final String KEY_PAGE = "page";
+    public static final String KEY_SLIDE = "slide";
+    public static final String KEY_CONTENT_HASH = "contentHash";
+    public static final String KEY_EMBEDDING_MODEL = "embeddingModel";
+    public static final String KEY_EMBEDDING_DIMENSION = "embeddingDimension";
+    public static final String KEY_CREATED_AT = "createdAt";
+    public static final String KEY_INDEXED_AT = "indexedAt";
+
+    private final String id;
+    private final String documentId;
+    private final String chunkId;
+    private final String parentChunkId;
+    private final String contentHash;
+    private final String text;
+    private final List<Double> embedding;
+    private final String embeddingModel;
+    private final int embeddingDimension;
+    private final String chunkType;
+    private final String headingPath;
+    private final String sourceRef;
+    private final Integer page;
+    private final Integer slide;
+    private final Map<String, Object> metadata;
+
+    public VectorRecord(
+            String id,
+            String documentId,
+            String chunkId,
+            String parentChunkId,
+            String contentHash,
+            String text,
+            List<Double> embedding,
+            String embeddingModel,
+            int embeddingDimension,
+            String chunkType,
+            String headingPath,
+            String sourceRef,
+            Integer page,
+            Integer slide,
+            Map<String, Object> metadata) {
+        this.id = requireText(id, "id");
+        this.documentId = requireText(documentId, "documentId");
+        this.chunkId = requireText(chunkId, "chunkId");
+        this.parentChunkId = normalize(parentChunkId);
+        this.contentHash = requireText(contentHash, "contentHash");
+        this.text = requireText(text, "text");
+        this.embedding = List.copyOf(Objects.requireNonNull(embedding, "embedding"));
+        if (this.embedding.isEmpty()) {
+            throw new IllegalArgumentException("embedding must not be empty");
+        }
+        if (embeddingDimension <= 0) {
+            throw new IllegalArgumentException("embeddingDimension must be greater than zero");
+        }
+        if (embeddingDimension != this.embedding.size()) {
+            throw new IllegalArgumentException("embeddingDimension must match embedding size");
+        }
+        this.embeddingModel = requireText(embeddingModel, "embeddingModel");
+        this.embeddingDimension = embeddingDimension;
+        this.chunkType = normalize(chunkType);
+        this.headingPath = normalize(headingPath);
+        this.sourceRef = normalize(sourceRef);
+        this.page = page;
+        this.slide = slide;
+        this.metadata = sanitize(metadata);
+    }
+
+    public String id() {
+        return id;
+    }
+
+    public String documentId() {
+        return documentId;
+    }
+
+    public String chunkId() {
+        return chunkId;
+    }
+
+    public String parentChunkId() {
+        return parentChunkId;
+    }
+
+    public String contentHash() {
+        return contentHash;
+    }
+
+    public String text() {
+        return text;
+    }
+
+    public List<Double> embedding() {
+        return embedding;
+    }
+
+    public String embeddingModel() {
+        return embeddingModel;
+    }
+
+    public int embeddingDimension() {
+        return embeddingDimension;
+    }
+
+    public String chunkType() {
+        return chunkType;
+    }
+
+    public String headingPath() {
+        return headingPath;
+    }
+
+    public String sourceRef() {
+        return sourceRef;
+    }
+
+    public Integer page() {
+        return page;
+    }
+
+    public Integer slide() {
+        return slide;
+    }
+
+    public Map<String, Object> metadata() {
+        return metadata;
+    }
+
+    public Map<String, Object> toMetadata() {
+        Map<String, Object> values = new LinkedHashMap<>(metadata);
+        put(values, KEY_DOCUMENT_ID, documentId);
+        put(values, KEY_CHUNK_ID, chunkId);
+        put(values, KEY_PARENT_CHUNK_ID, parentChunkId);
+        put(values, KEY_CHUNK_TYPE, chunkType);
+        put(values, KEY_HEADING_PATH, headingPath);
+        put(values, KEY_SOURCE_REF, sourceRef);
+        put(values, KEY_PAGE, page);
+        put(values, KEY_SLIDE, slide);
+        put(values, KEY_CONTENT_HASH, contentHash);
+        put(values, KEY_EMBEDDING_MODEL, embeddingModel);
+        put(values, KEY_EMBEDDING_DIMENSION, embeddingDimension);
+        return Map.copyOf(values);
+    }
+
+    public VectorDocument toVectorDocument() {
+        return new VectorDocument(id, text, toMetadata(), embedding);
+    }
+
+    private static void put(Map<String, Object> values, String key, Object value) {
+        if (value != null && (!(value instanceof String textValue) || !textValue.isBlank())) {
+            values.put(key, value);
+        }
+    }
+
+    private static Map<String, Object> sanitize(Map<String, Object> values) {
+        if (values == null || values.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, Object> sanitized = new LinkedHashMap<>();
+        values.forEach((key, value) -> {
+            String normalizedKey = normalize(key);
+            if (normalizedKey != null && value != null
+                    && (!(value instanceof String textValue) || !textValue.isBlank())) {
+                sanitized.put(normalizedKey, value instanceof String textValue ? textValue.trim() : value);
+            }
+        });
+        return Map.copyOf(sanitized);
+    }
+
+    private static String requireText(String value, String name) {
+        String normalized = normalize(value);
+        if (normalized == null) {
+            throw new IllegalArgumentException(name + " must not be blank");
+        }
+        return normalized;
+    }
+
+    private static String normalize(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.trim();
+    }
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorRecord.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorRecord.java
@@ -7,6 +7,13 @@ import java.util.Objects;
 
 /**
  * RAG chunk record persisted by a vector store.
+ * <p>
+ * Standard metadata keys such as {@link #KEY_CHUNK_INDEX},
+ * {@link #KEY_PREVIOUS_CHUNK_ID}, {@link #KEY_NEXT_CHUNK_ID},
+ * {@link #KEY_TENANT_ID}, {@link #KEY_CREATED_AT}, and {@link #KEY_INDEXED_AT}
+ * are pass-through metadata keys. They are intentionally not promoted to
+ * constructor fields until the core contract has a stable need for first-class
+ * accessors.
  */
 public final class VectorRecord {
 
@@ -46,6 +53,13 @@ public final class VectorRecord {
     private final Integer slide;
     private final Map<String, Object> metadata;
 
+    /**
+     * Creates a vector record.
+     * <p>
+     * Prefer {@link #builder()} for new call sites because this constructor has
+     * many adjacent {@link String} parameters and is retained for binary/source
+     * compatibility.
+     */
     public VectorRecord(
             String id,
             String documentId,
@@ -86,6 +100,10 @@ public final class VectorRecord {
         this.page = page;
         this.slide = slide;
         this.metadata = sanitize(metadata);
+    }
+
+    public static Builder builder() {
+        return new Builder();
     }
 
     public String id() {
@@ -166,6 +184,124 @@ public final class VectorRecord {
 
     public VectorDocument toVectorDocument() {
         return new VectorDocument(id, text, toMetadata(), embedding);
+    }
+
+    public static final class Builder {
+
+        private String id;
+        private String documentId;
+        private String chunkId;
+        private String parentChunkId;
+        private String contentHash;
+        private String text;
+        private List<Double> embedding;
+        private String embeddingModel;
+        private Integer embeddingDimension;
+        private String chunkType;
+        private String headingPath;
+        private String sourceRef;
+        private Integer page;
+        private Integer slide;
+        private Map<String, Object> metadata;
+
+        private Builder() {
+        }
+
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder documentId(String documentId) {
+            this.documentId = documentId;
+            return this;
+        }
+
+        public Builder chunkId(String chunkId) {
+            this.chunkId = chunkId;
+            return this;
+        }
+
+        public Builder parentChunkId(String parentChunkId) {
+            this.parentChunkId = parentChunkId;
+            return this;
+        }
+
+        public Builder contentHash(String contentHash) {
+            this.contentHash = contentHash;
+            return this;
+        }
+
+        public Builder text(String text) {
+            this.text = text;
+            return this;
+        }
+
+        public Builder embedding(List<Double> embedding) {
+            this.embedding = embedding;
+            return this;
+        }
+
+        public Builder embeddingModel(String embeddingModel) {
+            this.embeddingModel = embeddingModel;
+            return this;
+        }
+
+        public Builder embeddingDimension(int embeddingDimension) {
+            this.embeddingDimension = embeddingDimension;
+            return this;
+        }
+
+        public Builder chunkType(String chunkType) {
+            this.chunkType = chunkType;
+            return this;
+        }
+
+        public Builder headingPath(String headingPath) {
+            this.headingPath = headingPath;
+            return this;
+        }
+
+        public Builder sourceRef(String sourceRef) {
+            this.sourceRef = sourceRef;
+            return this;
+        }
+
+        public Builder page(Integer page) {
+            this.page = page;
+            return this;
+        }
+
+        public Builder slide(Integer slide) {
+            this.slide = slide;
+            return this;
+        }
+
+        public Builder metadata(Map<String, Object> metadata) {
+            this.metadata = metadata;
+            return this;
+        }
+
+        public VectorRecord build() {
+            List<Double> vector = Objects.requireNonNull(embedding, "embedding");
+            int dimension = embeddingDimension == null ? vector.size() : embeddingDimension;
+            return new VectorRecord(
+                    id,
+                    documentId,
+                    chunkId,
+                    parentChunkId,
+                    contentHash,
+                    text,
+                    vector,
+                    embeddingModel,
+                    dimension,
+                    chunkType,
+                    headingPath,
+                    sourceRef,
+                    page,
+                    slide,
+                    metadata);
+        }
     }
 
     private static void put(Map<String, Object> values, String key, Object value) {

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorSearchHit.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorSearchHit.java
@@ -1,0 +1,138 @@
+package studio.one.platform.ai.core.vector;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * RAG-oriented vector search hit with chunk provenance.
+ */
+public final class VectorSearchHit {
+
+    private final String id;
+    private final String documentId;
+    private final String chunkId;
+    private final String parentChunkId;
+    private final String text;
+    private final double score;
+    private final String chunkType;
+    private final String headingPath;
+    private final String sourceRef;
+    private final Integer page;
+    private final Integer slide;
+    private final Map<String, Object> metadata;
+
+    public VectorSearchHit(
+            String id,
+            String documentId,
+            String chunkId,
+            String parentChunkId,
+            String text,
+            double score,
+            String chunkType,
+            String headingPath,
+            String sourceRef,
+            Integer page,
+            Integer slide,
+            Map<String, Object> metadata) {
+        this.id = Objects.requireNonNull(id, "id");
+        this.documentId = Objects.requireNonNull(documentId, "documentId");
+        this.chunkId = chunkId;
+        this.parentChunkId = parentChunkId;
+        this.text = text;
+        this.score = score;
+        this.chunkType = chunkType;
+        this.headingPath = headingPath;
+        this.sourceRef = sourceRef;
+        this.page = page;
+        this.slide = slide;
+        this.metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+    }
+
+    public static VectorSearchHit from(VectorSearchResult result) {
+        Objects.requireNonNull(result, "result");
+        VectorDocument document = result.document();
+        Map<String, Object> metadata = document.metadata();
+        String documentId = stringMetadata(metadata, VectorRecord.KEY_DOCUMENT_ID, document.id());
+        return new VectorSearchHit(
+                document.id(),
+                documentId,
+                stringMetadata(metadata, VectorRecord.KEY_CHUNK_ID, document.id()),
+                stringMetadata(metadata, VectorRecord.KEY_PARENT_CHUNK_ID, null),
+                document.content(),
+                result.score(),
+                stringMetadata(metadata, VectorRecord.KEY_CHUNK_TYPE, null),
+                stringMetadata(metadata, VectorRecord.KEY_HEADING_PATH, null),
+                stringMetadata(metadata, VectorRecord.KEY_SOURCE_REF, null),
+                integerMetadata(metadata, VectorRecord.KEY_PAGE),
+                integerMetadata(metadata, VectorRecord.KEY_SLIDE),
+                metadata);
+    }
+
+    public String id() {
+        return id;
+    }
+
+    public String documentId() {
+        return documentId;
+    }
+
+    public String chunkId() {
+        return chunkId;
+    }
+
+    public String parentChunkId() {
+        return parentChunkId;
+    }
+
+    public String text() {
+        return text;
+    }
+
+    public double score() {
+        return score;
+    }
+
+    public String chunkType() {
+        return chunkType;
+    }
+
+    public String headingPath() {
+        return headingPath;
+    }
+
+    public String sourceRef() {
+        return sourceRef;
+    }
+
+    public Integer page() {
+        return page;
+    }
+
+    public Integer slide() {
+        return slide;
+    }
+
+    public Map<String, Object> metadata() {
+        return metadata;
+    }
+
+    private static String stringMetadata(Map<String, Object> metadata, String key, String fallback) {
+        Object value = metadata.get(key);
+        if (value == null) {
+            return fallback;
+        }
+        String text = value.toString().trim();
+        return text.isBlank() ? fallback : text;
+    }
+
+    private static Integer integerMetadata(Map<String, Object> metadata, String key) {
+        Object value = metadata.get(key);
+        if (value instanceof Integer integerValue) {
+            return integerValue;
+        }
+        if (value instanceof Number numberValue) {
+            return numberValue.intValue();
+        }
+        return null;
+    }
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorSearchHit.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorSearchHit.java
@@ -88,6 +88,12 @@ public final class VectorSearchHit {
         return parentChunkId;
     }
 
+    /**
+     * Returns chunk text when requested.
+     * <p>
+     * This value can be {@code null} when the originating
+     * {@link VectorSearchRequest#includeText()} is {@code false}.
+     */
     public String text() {
         return text;
     }

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorSearchHit.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorSearchHit.java
@@ -49,6 +49,10 @@ public final class VectorSearchHit {
     }
 
     public static VectorSearchHit from(VectorSearchResult result) {
+        return from(result, true, true);
+    }
+
+    public static VectorSearchHit from(VectorSearchResult result, boolean includeText, boolean includeMetadata) {
         Objects.requireNonNull(result, "result");
         VectorDocument document = result.document();
         Map<String, Object> metadata = document.metadata();
@@ -58,14 +62,14 @@ public final class VectorSearchHit {
                 documentId,
                 stringMetadata(metadata, VectorRecord.KEY_CHUNK_ID, document.id()),
                 stringMetadata(metadata, VectorRecord.KEY_PARENT_CHUNK_ID, null),
-                document.content(),
+                includeText ? document.content() : null,
                 result.score(),
                 stringMetadata(metadata, VectorRecord.KEY_CHUNK_TYPE, null),
                 stringMetadata(metadata, VectorRecord.KEY_HEADING_PATH, null),
                 stringMetadata(metadata, VectorRecord.KEY_SOURCE_REF, null),
                 integerMetadata(metadata, VectorRecord.KEY_PAGE),
                 integerMetadata(metadata, VectorRecord.KEY_SLIDE),
-                metadata);
+                includeMetadata ? metadata : Map.of());
     }
 
     public String id() {

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorSearchRequest.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorSearchRequest.java
@@ -11,19 +11,33 @@ import studio.one.platform.ai.core.MetadataFilter;
 public final class VectorSearchRequest {
 
     private final List<Double> embedding;
+    private final String queryText;
     private final int topK;
     private final MetadataFilter metadataFilter;
     private final Double minScore;
+    private final boolean includeText;
+    private final boolean includeMetadata;
 
     public VectorSearchRequest(List<Double> embedding, int topK) {
-        this(embedding, topK, MetadataFilter.empty(), null);
+        this(embedding, null, topK, MetadataFilter.empty(), null, true, true);
     }
 
     public VectorSearchRequest(List<Double> embedding, int topK, MetadataFilter metadataFilter) {
-        this(embedding, topK, metadataFilter, null);
+        this(embedding, null, topK, metadataFilter, null, true, true);
     }
 
     public VectorSearchRequest(List<Double> embedding, int topK, MetadataFilter metadataFilter, Double minScore) {
+        this(embedding, null, topK, metadataFilter, minScore, true, true);
+    }
+
+    public VectorSearchRequest(
+            List<Double> embedding,
+            String queryText,
+            int topK,
+            MetadataFilter metadataFilter,
+            Double minScore,
+            boolean includeText,
+            boolean includeMetadata) {
         this.embedding = List.copyOf(Objects.requireNonNull(embedding, "embedding"));
         if (embedding.isEmpty()) {
             throw new IllegalArgumentException("Search embedding must not be empty");
@@ -35,12 +49,27 @@ public final class VectorSearchRequest {
             throw new IllegalArgumentException("minScore must be greater than or equal to zero");
         }
         this.topK = topK;
+        this.queryText = queryText == null || queryText.isBlank() ? null : queryText.trim();
         this.metadataFilter = metadataFilter == null ? MetadataFilter.empty() : metadataFilter;
         this.minScore = minScore;
+        this.includeText = includeText;
+        this.includeMetadata = includeMetadata;
     }
 
+    /**
+     * @deprecated since 2026-04-25. Use {@link #queryVector()}.
+     */
+    @Deprecated(forRemoval = false)
     public List<Double> embedding() {
+        return queryVector();
+    }
+
+    public List<Double> queryVector() {
         return embedding;
+    }
+
+    public String queryText() {
+        return queryText;
     }
 
     public int topK() {
@@ -57,5 +86,13 @@ public final class VectorSearchRequest {
 
     public boolean hasMinScore() {
         return minScore != null;
+    }
+
+    public boolean includeText() {
+        return includeText;
+    }
+
+    public boolean includeMetadata() {
+        return includeMetadata;
     }
 }

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorSearchResults.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorSearchResults.java
@@ -1,0 +1,32 @@
+package studio.one.platform.ai.core.vector;
+
+import java.util.List;
+
+/**
+ * Aggregate RAG vector search response.
+ */
+public final class VectorSearchResults {
+
+    private final List<VectorSearchHit> hits;
+    private final long elapsedMs;
+
+    public VectorSearchResults(List<VectorSearchHit> hits, long elapsedMs) {
+        if (elapsedMs < 0L) {
+            throw new IllegalArgumentException("elapsedMs must not be negative");
+        }
+        this.hits = hits == null ? List.of() : List.copyOf(hits);
+        this.elapsedMs = elapsedMs;
+    }
+
+    public static VectorSearchResults of(List<VectorSearchHit> hits, long elapsedMs) {
+        return new VectorSearchResults(hits, elapsedMs);
+    }
+
+    public List<VectorSearchHit> hits() {
+        return hits;
+    }
+
+    public long elapsedMs() {
+        return elapsedMs;
+    }
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorStorePort.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorStorePort.java
@@ -11,6 +11,21 @@ public interface VectorStorePort {
 
     void upsert(List<VectorDocument> documents);
 
+    default void upsert(VectorRecord record) {
+        Objects.requireNonNull(record, "record");
+        upsertAll(List.of(record));
+    }
+
+    default void upsertAll(List<VectorRecord> records) {
+        Objects.requireNonNull(records, "records");
+        if (records.isEmpty()) {
+            return;
+        }
+        upsert(records.stream()
+                .map(VectorRecord::toVectorDocument)
+                .toList());
+    }
+
     default void deleteByObject(String objectType, String objectId) {
         throw new UnsupportedOperationException("deleteByObject is not implemented");
     }
@@ -29,6 +44,31 @@ public interface VectorStorePort {
     }
 
     List<VectorSearchResult> search(VectorSearchRequest request);
+
+    default VectorSearchResults searchRecords(VectorSearchRequest request) {
+        long startedAt = System.nanoTime();
+        List<VectorSearchHit> hits = search(request).stream()
+                .map(VectorSearchHit::from)
+                .toList();
+        long elapsedMs = (System.nanoTime() - startedAt) / 1_000_000L;
+        return new VectorSearchResults(hits, elapsedMs);
+    }
+
+    default VectorSearchResults searchWithFilter(VectorSearchRequest request) {
+        return searchRecords(request);
+    }
+
+    default void deleteByDocumentId(String documentId) {
+        throw new UnsupportedOperationException("deleteByDocumentId is not implemented");
+    }
+
+    default void deleteByChunkId(String chunkId) {
+        throw new UnsupportedOperationException("deleteByChunkId is not implemented");
+    }
+
+    default boolean existsByContentHash(String contentHash) {
+        return false;
+    }
 
     /**
      * 지정된 objectType/objectId 조합의 벡터가 존재하는지 여부를 반환한다.

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorStorePort.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorStorePort.java
@@ -45,6 +45,14 @@ public interface VectorStorePort {
 
     List<VectorSearchResult> search(VectorSearchRequest request);
 
+    /**
+     * Searches chunk records and adapts legacy {@link VectorSearchResult} hits to
+     * the aggregate RAG result contract.
+     * <p>
+     * The default implementation delegates to {@link #search(VectorSearchRequest)}
+     * for compatibility. Implementations that can execute metadata predicates
+     * natively should override this method or {@link #searchWithFilter(VectorSearchRequest)}.
+     */
     default VectorSearchResults searchRecords(VectorSearchRequest request) {
         long startedAt = System.nanoTime();
         List<VectorSearchHit> hits = search(request).stream()
@@ -54,6 +62,14 @@ public interface VectorStorePort {
         return new VectorSearchResults(hits, elapsedMs);
     }
 
+    /**
+     * Extension point for vector stores that have a distinct filtered search path.
+     * <p>
+     * By default this is an alias of {@link #searchRecords(VectorSearchRequest)} so
+     * existing stores keep working. Store adapters should override it when
+     * {@link VectorSearchRequest#metadataFilter()} can be pushed down to the
+     * backend.
+     */
     default VectorSearchResults searchWithFilter(VectorSearchRequest request) {
         return searchRecords(request);
     }
@@ -66,6 +82,13 @@ public interface VectorStorePort {
         throw new UnsupportedOperationException("deleteByChunkId is not implemented");
     }
 
+    /**
+     * Returns whether a record with the given content hash exists.
+     * <p>
+     * The default {@code false} means the adapter has not implemented the lookup;
+     * callers that rely on hash-based deduplication should require an adapter
+     * override rather than treating the default as authoritative absence.
+     */
     default boolean existsByContentHash(String contentHash) {
         return false;
     }

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorStorePort.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorStorePort.java
@@ -48,7 +48,7 @@ public interface VectorStorePort {
     default VectorSearchResults searchRecords(VectorSearchRequest request) {
         long startedAt = System.nanoTime();
         List<VectorSearchHit> hits = search(request).stream()
-                .map(VectorSearchHit::from)
+                .map(result -> VectorSearchHit.from(result, request.includeText(), request.includeMetadata()))
                 .toList();
         long elapsedMs = (System.nanoTime() - startedAt) / 1_000_000L;
         return new VectorSearchResults(hits, elapsedMs);

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/core/vector/VectorContractsTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/core/vector/VectorContractsTest.java
@@ -1,0 +1,375 @@
+package studio.one.platform.ai.core.vector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.ai.core.MetadataFilter;
+import studio.one.platform.ai.core.MetadataRange;
+
+class VectorContractsTest {
+
+    @Test
+    void vectorDocumentDefensivelyCopiesMetadataAndEmbedding() {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("objectType", "attachment");
+        List<Double> embedding = new ArrayList<>(List.of(0.1d, 0.2d));
+
+        VectorDocument document = new VectorDocument("doc-1", "content", metadata, embedding);
+        metadata.put("objectId", "42");
+        embedding.add(0.3d);
+
+        assertThat(document.metadata()).containsExactly(Map.entry("objectType", "attachment"));
+        assertThat(document.embedding()).containsExactly(0.1d, 0.2d);
+        assertThatThrownBy(() -> document.metadata().put("extra", "value"))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> document.embedding().add(0.4d))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void vectorSearchRequestKeepsCompatibilityWhileCarryingMetadataPredicates() {
+        MetadataRange<Integer> versionRange = MetadataRange.closed(1, 3);
+        List<Object> statuses = new ArrayList<>();
+        statuses.add(" READY ");
+        statuses.add("");
+        statuses.add("READY");
+        statuses.add(null);
+        MetadataFilter filter = MetadataFilter.of(
+                Map.of(" objectType ", " attachment "),
+                Map.of(" status ", statuses),
+                Map.of(" version ", versionRange));
+
+        VectorSearchRequest request = new VectorSearchRequest(
+                List.of(0.1d, 0.2d),
+                "semantic query",
+                5,
+                filter,
+                0.4d,
+                false,
+                false);
+
+        assertThat(legacyEmbedding(request)).containsExactly(0.1d, 0.2d);
+        assertThat(request.queryVector()).containsExactly(0.1d, 0.2d);
+        assertThat(request.queryText()).isEqualTo("semantic query");
+        assertThat(request.topK()).isEqualTo(5);
+        assertThat(request.metadataFilter().objectType()).isEqualTo("attachment");
+        assertThat(request.metadataFilter().equalsCriteria()).containsEntry("objectType", "attachment");
+        assertThat(request.metadataFilter().inCriteria()).containsEntry("status", List.of("READY"));
+        assertThat(request.metadataFilter().rangeCriteria()).containsEntry("version", versionRange);
+        assertThat(request.minScore()).isEqualTo(0.4d);
+        assertThat(request.hasMinScore()).isTrue();
+        assertThat(request.includeText()).isFalse();
+        assertThat(request.includeMetadata()).isFalse();
+    }
+
+    @SuppressWarnings("deprecation")
+    private static List<Double> legacyEmbedding(VectorSearchRequest request) {
+        return request.embedding();
+    }
+
+    @Test
+    void metadataRangeFactoriesExposeInclusiveAndExclusiveBounds() {
+        MetadataRange<Integer> closed = MetadataRange.closed(1, 3);
+        MetadataRange<Integer> open = MetadataRange.open(1, 3);
+
+        assertThat(closed.from()).isEqualTo(1);
+        assertThat(closed.to()).isEqualTo(3);
+        assertThat(closed.includeFrom()).isTrue();
+        assertThat(closed.includeTo()).isTrue();
+        assertThat(open.includeFrom()).isFalse();
+        assertThat(open.includeTo()).isFalse();
+        assertThat(MetadataRange.atLeast(2).to()).isNull();
+        assertThat(MetadataRange.atMost(4).from()).isNull();
+    }
+
+    @Test
+    void metadataRangeRejectsEmptyAndReversedBounds() {
+        assertThatThrownBy(() -> new MetadataRange<Integer>(null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("from or to");
+        assertThatThrownBy(() -> MetadataRange.closed(3, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("from must be less than or equal to to");
+    }
+
+    @Test
+    void vectorStoreDefaultSearchByObjectFiltersByScopeAndTopK() {
+        TestVectorStore store = new TestVectorStore(List.of(
+                result("doc-1", "ATTACHMENT", "42"),
+                result("doc-2", "attachment", "42"),
+                result("doc-3", "attachment", "99")));
+
+        List<VectorSearchResult> results = store.searchByObject(
+                "attachment",
+                "42",
+                new VectorSearchRequest(List.of(0.1d), 1));
+
+        assertThat(results)
+                .extracting(result -> result.document().id())
+                .containsExactly("doc-1");
+    }
+
+    @Test
+    void vectorStoreDefaultAdaptersDelegateToSearchPaths() {
+        TestVectorStore store = new TestVectorStore(List.of(result("doc-1", "attachment", "42")));
+        VectorSearchRequest request = new VectorSearchRequest(List.of(0.1d), 3);
+
+        assertThat(store.hybridSearch("hello", request, 0.7d, 0.3d)).hasSize(1);
+        assertThat(store.hybridSearchByObject("hello", "attachment", "42", request, 0.7d, 0.3d))
+                .hasSize(1);
+        assertThat(store.searchRequests()).containsExactly(request, request);
+    }
+
+    @Test
+    void vectorStoreUnsupportedDefaultsRemainExplicit() {
+        UnsupportedDefaultVectorStore store = new UnsupportedDefaultVectorStore();
+
+        assertThatThrownBy(() -> store.deleteByObject("attachment", "42"))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("deleteByObject");
+        assertThatThrownBy(() -> store.listByObject("attachment", "42", 10))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("listByObject");
+        assertThatThrownBy(() -> store.getMetadata("attachment", "42"))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("getMetadata");
+        assertThatThrownBy(() -> store.deleteByDocumentId("doc-1"))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("deleteByDocumentId");
+        assertThatThrownBy(() -> store.deleteByChunkId("chunk-1"))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("deleteByChunkId");
+        assertThat(store.existsByContentHash("hash")).isFalse();
+    }
+
+    @Test
+    void vectorStoreReplaceByObjectDeletesThenUpsertsByDefault() {
+        TestVectorStore store = new TestVectorStore(List.of());
+        List<VectorDocument> documents = List.of(new VectorDocument("doc-1", "content", Map.of(), List.of(0.1d)));
+
+        store.replaceByObject("attachment", "42", documents);
+
+        assertThat(store.operations()).containsExactly("delete:attachment:42", "upsert:1");
+    }
+
+    @Test
+    void vectorRecordPreservesChunkFieldsInVectorDocumentMetadata() {
+        VectorRecord record = record(Map.of(
+                VectorRecord.KEY_DOCUMENT_ID, "caller-doc",
+                VectorRecord.KEY_CHUNK_INDEX, 7,
+                VectorRecord.KEY_TENANT_ID, "tenant-a"));
+
+        VectorDocument document = record.toVectorDocument();
+
+        assertThat(document.id()).isEqualTo("record-1");
+        assertThat(document.content()).isEqualTo("chunk text");
+        assertThat(document.embedding()).containsExactly(0.1d, 0.2d);
+        assertThat(document.metadata())
+                .containsEntry(VectorRecord.KEY_DOCUMENT_ID, "doc-1")
+                .containsEntry(VectorRecord.KEY_CHUNK_ID, "chunk-1")
+                .containsEntry(VectorRecord.KEY_PARENT_CHUNK_ID, "parent-1")
+                .containsEntry(VectorRecord.KEY_CONTENT_HASH, "hash-1")
+                .containsEntry(VectorRecord.KEY_EMBEDDING_MODEL, "embedding-model")
+                .containsEntry(VectorRecord.KEY_EMBEDDING_DIMENSION, 2)
+                .containsEntry(VectorRecord.KEY_CHUNK_INDEX, 7)
+                .containsEntry(VectorRecord.KEY_TENANT_ID, "tenant-a");
+    }
+
+    @Test
+    void vectorRecordRejectsInvalidRequiredFields() {
+        assertThatThrownBy(() -> record("", List.of(0.1d), 1, Map.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("id");
+        assertThatThrownBy(() -> new VectorRecord(
+                "record-1",
+                "doc-1",
+                "chunk-1",
+                null,
+                "hash-1",
+                "text",
+                List.of(0.1d),
+                "model",
+                2,
+                null,
+                null,
+                null,
+                null,
+                null,
+                Map.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("embeddingDimension");
+        assertThatThrownBy(() -> record("record-1", List.of(), 0, Map.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("embedding must not be empty");
+    }
+
+    @Test
+    void vectorStoreDefaultRecordAdaptersAndAggregateSearchUseLegacyContract() {
+        TestVectorStore store = new TestVectorStore(List.of(new VectorSearchResult(record(Map.of()).toVectorDocument(), 0.8d)));
+
+        store.upsert(record(Map.of()));
+        store.upsertAll(List.of());
+        VectorSearchResults results = store.searchWithFilter(new VectorSearchRequest(List.of(0.1d), 3));
+
+        assertThat(store.operations()).containsExactly("upsert:1");
+        assertThat(store.upsertedDocuments())
+                .extracting(VectorDocument::id)
+                .containsExactly("record-1");
+        assertThat(results.elapsedMs()).isGreaterThanOrEqualTo(0L);
+        assertThat(results.hits()).hasSize(1);
+        assertThat(results.hits().get(0).documentId()).isEqualTo("doc-1");
+        assertThat(results.hits().get(0).chunkId()).isEqualTo("chunk-1");
+        assertThat(results.hits().get(0).parentChunkId()).isEqualTo("parent-1");
+        assertThat(results.hits().get(0).score()).isEqualTo(0.8d);
+    }
+
+    @Test
+    void vectorSearchHitAdaptsLegacySearchResultMetadata() {
+        VectorSearchHit hit = VectorSearchHit.from(new VectorSearchResult(
+                new VectorDocument("record-1", "chunk text", Map.of(
+                        VectorRecord.KEY_DOCUMENT_ID, " doc-1 ",
+                        VectorRecord.KEY_CHUNK_ID, " chunk-1 ",
+                        VectorRecord.KEY_PARENT_CHUNK_ID, "parent-1",
+                        VectorRecord.KEY_CHUNK_TYPE, "paragraph",
+                        VectorRecord.KEY_HEADING_PATH, "Intro > Body",
+                        VectorRecord.KEY_SOURCE_REF, "file.pdf",
+                        VectorRecord.KEY_PAGE, 3L,
+                        VectorRecord.KEY_SLIDE, 2), List.of()),
+                0.93d));
+
+        assertThat(hit.id()).isEqualTo("record-1");
+        assertThat(hit.documentId()).isEqualTo("doc-1");
+        assertThat(hit.chunkId()).isEqualTo("chunk-1");
+        assertThat(hit.parentChunkId()).isEqualTo("parent-1");
+        assertThat(hit.text()).isEqualTo("chunk text");
+        assertThat(hit.score()).isEqualTo(0.93d);
+        assertThat(hit.chunkType()).isEqualTo("paragraph");
+        assertThat(hit.headingPath()).isEqualTo("Intro > Body");
+        assertThat(hit.sourceRef()).isEqualTo("file.pdf");
+        assertThat(hit.page()).isEqualTo(3);
+        assertThat(hit.slide()).isEqualTo(2);
+        assertThat(hit.metadata()).containsEntry(VectorRecord.KEY_DOCUMENT_ID, " doc-1 ");
+    }
+
+    @Test
+    void vectorSearchResultsDefensivelyCopiesHitsAndRejectsNegativeElapsed() {
+        List<VectorSearchHit> hits = new ArrayList<>();
+        hits.add(VectorSearchHit.from(new VectorSearchResult(record(Map.of()).toVectorDocument(), 0.8d)));
+
+        VectorSearchResults results = VectorSearchResults.of(hits, 12L);
+        hits.clear();
+
+        assertThat(results.hits()).hasSize(1);
+        assertThat(results.elapsedMs()).isEqualTo(12L);
+        assertThatThrownBy(() -> results.hits().clear())
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> new VectorSearchResults(List.of(), -1L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("elapsedMs");
+    }
+
+    private static VectorSearchResult result(String id, String objectType, String objectId) {
+        return new VectorSearchResult(
+                new VectorDocument(id, "content", Map.of(
+                        "objectType", objectType,
+                        "objectId", objectId), List.of()),
+                0.9d);
+    }
+
+    private static VectorRecord record(Map<String, Object> metadata) {
+        return record("record-1", List.of(0.1d, 0.2d), 2, metadata);
+    }
+
+    private static VectorRecord record(
+            String id,
+            List<Double> embedding,
+            int embeddingDimension,
+            Map<String, Object> metadata) {
+        return new VectorRecord(
+                id,
+                "doc-1",
+                "chunk-1",
+                "parent-1",
+                "hash-1",
+                "chunk text",
+                embedding,
+                "embedding-model",
+                embeddingDimension,
+                "child",
+                "Intro",
+                "page[1]/p[0]",
+                1,
+                null,
+                metadata);
+    }
+
+    private static final class TestVectorStore implements VectorStorePort {
+
+        private final List<VectorSearchResult> results;
+        private final List<VectorSearchRequest> searchRequests = new ArrayList<>();
+        private final List<String> operations = new ArrayList<>();
+        private final List<VectorDocument> upsertedDocuments = new ArrayList<>();
+
+        private TestVectorStore(List<VectorSearchResult> results) {
+            this.results = results;
+        }
+
+        @Override
+        public void upsert(List<VectorDocument> documents) {
+            operations.add("upsert:" + documents.size());
+            upsertedDocuments.addAll(documents);
+        }
+
+        @Override
+        public void deleteByObject(String objectType, String objectId) {
+            operations.add("delete:" + objectType + ":" + objectId);
+        }
+
+        @Override
+        public List<VectorSearchResult> search(VectorSearchRequest request) {
+            searchRequests.add(request);
+            return results;
+        }
+
+        @Override
+        public boolean exists(String objectType, String objectId) {
+            return false;
+        }
+
+        private List<VectorSearchRequest> searchRequests() {
+            return searchRequests;
+        }
+
+        private List<String> operations() {
+            return operations;
+        }
+
+        private List<VectorDocument> upsertedDocuments() {
+            return upsertedDocuments;
+        }
+    }
+
+    private static final class UnsupportedDefaultVectorStore implements VectorStorePort {
+
+        @Override
+        public void upsert(List<VectorDocument> documents) {
+        }
+
+        @Override
+        public List<VectorSearchResult> search(VectorSearchRequest request) {
+            return List.of();
+        }
+
+        @Override
+        public boolean exists(String objectType, String objectId) {
+            return false;
+        }
+    }
+}

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/core/vector/VectorContractsTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/core/vector/VectorContractsTest.java
@@ -183,6 +183,31 @@ class VectorContractsTest {
     }
 
     @Test
+    void vectorRecordBuilderCreatesRecordWithoutLongConstructorOrderingRisk() {
+        VectorRecord record = VectorRecord.builder()
+                .id("record-1")
+                .documentId("doc-1")
+                .chunkId("chunk-1")
+                .parentChunkId("parent-1")
+                .contentHash("hash-1")
+                .text("chunk text")
+                .embedding(List.of(0.1d, 0.2d))
+                .embeddingModel("embedding-model")
+                .chunkType("child")
+                .headingPath("Intro")
+                .sourceRef("page[1]/p[0]")
+                .page(1)
+                .metadata(Map.of(VectorRecord.KEY_CHUNK_INDEX, 7))
+                .build();
+
+        assertThat(record.embeddingDimension()).isEqualTo(2);
+        assertThat(record.toMetadata())
+                .containsEntry(VectorRecord.KEY_DOCUMENT_ID, "doc-1")
+                .containsEntry(VectorRecord.KEY_CHUNK_ID, "chunk-1")
+                .containsEntry(VectorRecord.KEY_CHUNK_INDEX, 7);
+    }
+
+    @Test
     void vectorRecordRejectsInvalidRequiredFields() {
         assertThatThrownBy(() -> record("", List.of(0.1d), 1, Map.of()))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/core/vector/VectorContractsTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/core/vector/VectorContractsTest.java
@@ -231,6 +231,27 @@ class VectorContractsTest {
     }
 
     @Test
+    void vectorStoreDefaultAggregateSearchHonorsIncludeFlags() {
+        TestVectorStore store = new TestVectorStore(List.of(new VectorSearchResult(record(Map.of()).toVectorDocument(), 0.8d)));
+        VectorSearchRequest request = new VectorSearchRequest(
+                List.of(0.1d),
+                null,
+                3,
+                MetadataFilter.empty(),
+                null,
+                false,
+                false);
+
+        VectorSearchResults results = store.searchRecords(request);
+
+        assertThat(results.hits()).hasSize(1);
+        assertThat(results.hits().get(0).text()).isNull();
+        assertThat(results.hits().get(0).metadata()).isEmpty();
+        assertThat(results.hits().get(0).documentId()).isEqualTo("doc-1");
+        assertThat(results.hits().get(0).chunkId()).isEqualTo("chunk-1");
+    }
+
+    @Test
     void vectorSearchHitAdaptsLegacySearchResultMetadata() {
         VectorSearchHit hit = VectorSearchHit.from(new VectorSearchResult(
                 new VectorDocument("record-1", "chunk text", Map.of(


### PR DESCRIPTION
## Why

- RAG 구조화 색인과 context expansion을 안정적으로 연결하려면 `ai.core.vector`가 단순 vector document가 아니라 검색 가능한 chunk 저장소 계약을 표현해야 합니다.
- 기존 `VectorStorePort`, `VectorDocument`, `VectorSearchResult` 호출부는 유지하면서 `VectorRecord` 기반 계약을 additive하게 보강합니다.

## What

- `VectorRecord`, `VectorSearchHit`, `VectorSearchResults`, `MetadataRange`를 추가했습니다.
- `MetadataFilter`가 기존 `objectType`/`objectId` object scope API와 함께 equals/in/range 조건을 담을 수 있도록 확장했습니다.
- `VectorSearchRequest`에 `queryVector`, optional `queryText`, `includeText`, `includeMetadata`를 추가하고 기존 `embedding()`은 deprecated alias로 유지했습니다.
- `VectorStorePort`에 `VectorRecord` 기반 `upsert`, `upsertAll`, aggregate search, document/chunk delete, content hash existence default method를 추가했습니다.
- `VectorDocument`와 기존 `VectorSearchResult`는 호환 모델로 유지한다는 내용을 README에 명시했습니다.
- 새 overload로 인해 기존 Mockito `any()` 호출이 모호해진 starter-ai 테스트 한 곳은 기존 `List<VectorDocument>` 의도를 명시했습니다.

## Related Issues

- Closes #291

## Validation

- Command: `./gradlew :studio-platform-ai:test`
- Result: 성공
- Command: `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test`
- Result: 성공
- Command: `git diff --check`
- Result: 성공

## Risk / Rollback

- Risk: `VectorStorePort.upsert(VectorRecord)` overload 추가로 untyped Mockito `any()` 같은 일부 source-level 호출은 타입 명시가 필요할 수 있습니다.
- Rollback: 이 PR을 revert하면 기존 `VectorDocument`/`VectorSearchResult` 중심 vector 계약으로 돌아갑니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: Yes
- Delegated scope: vector contract test 검토와 README 문서 보강 검토
- Main author validation: Gradle core/starter tests와 `git diff --check`를 실행했습니다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
