### PR TITLE
refactor(ai): legacy chunk 계약 deprecated 처리

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2026-04-25
 
 ### 변경됨
+- 이슈 #293 대응으로 `studio-platform-ai`의 `TextChunk`/`TextChunker`와 `starter-ai`의 `OverlapTextChunker`를 deprecated legacy fallback으로 표시했다.
+- 신규 RAG chunking은 `studio-platform-chunking`의 `ChunkingOrchestrator`를 기준으로 사용하도록 README를 정리했다.
 - 이슈 #188 대응으로 PostgreSQL 그룹 멤버 summary 검색에 `pg_trgm` 기반 `lower(username|name|email)` GIN trigram index migration을 추가했다.
 - MySQL/MariaDB에는 PostgreSQL 전용 검색 최적화와 schema version 이력을 맞추기 위한 V301 schema-neutral migration을 추가했다.
 - 그룹 멤버 summary 검색에서 blank keyword를 null keyword와 동일하게 전체 조회로 처리하도록 service/JPA repository 경로를 정리했다.
@@ -12,6 +14,8 @@
 - README 예시와 실제 public API가 어긋나지 않도록 parent-child chunking, context expansion, text fallback 문서 시나리오 테스트를 추가했다.
 
 ### 검증
+- `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-chunking:test`
+- `git diff --check`
 - `./gradlew :studio-platform-user:test --tests 'studio.one.base.user.persistence.jpa.ApplicationGroupMembershipJpaRepositorySearchTest' --tests 'studio.one.base.user.persistence.jdbc.ApplicationGroupMembershipJdbcRepositoryTest'`
 - `./gradlew :studio-platform-chunking:test :starter:studio-platform-starter-chunking:test`
 - `git diff --check`

--- a/starter/studio-platform-starter-ai/README.md
+++ b/starter/studio-platform-starter-ai/README.md
@@ -213,6 +213,9 @@ HTTP `text/event-stream` endpoint 변환은 `starter-ai-web` 책임이다.
 
 `starter:studio-platform-starter-chunking`이 classpath에 있으면 `RagPipelineService`는 신규
 `ChunkingOrchestrator`를 사용한다. 없으면 기존 `TextChunker` 기반 fallback이 적용된다.
+`TextChunker`와 `OverlapTextChunker`는 deprecated legacy fallback이다. 신규 RAG indexing 또는
+구조화 chunking 확장은 `starter:studio-platform-starter-chunking`의 auto-configuration과
+`studio-platform-chunking`의 `ChunkingOrchestrator`를 기준으로 구현한다.
 
 ```yaml
 studio:
@@ -230,7 +233,7 @@ studio:
 | `studio.chunking.max-size` | `800` | chunk 최대 문자 수 |
 | `studio.chunking.overlap` | `100` | 이전 chunk tail을 다음 chunk에 포함할 문자 수 |
 
-기존 `studio.ai.pipeline.chunk-size`, `studio.ai.pipeline.chunk-overlap`는 legacy `TextChunker` fallback 설정이다.
+기존 `studio.ai.pipeline.chunk-size`, `studio.ai.pipeline.chunk-overlap`는 deprecated legacy `TextChunker` fallback 설정이다.
 신규 `ChunkingOrchestrator` 경로에서는 `studio.chunking.*`가 기준이다.
 
 ### RAG 파이프라인 튜닝

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfiguration.java
@@ -44,6 +44,7 @@ import studio.one.platform.util.LogUtils;
 @EnableConfigurationProperties(RagPipelineProperties.class)
 @RequiredArgsConstructor
 @Slf4j
+@SuppressWarnings("deprecation")
 public class RagPipelineConfiguration {
 
         private final ObjectProvider<I18n> i18nProvider;

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/chunk/OverlapTextChunker.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/chunk/OverlapTextChunker.java
@@ -52,6 +52,7 @@ import java.util.regex.Pattern;
  */
 
 @Deprecated(since = "2.x", forRemoval = false)
+@SuppressWarnings("deprecation")
 public class OverlapTextChunker implements TextChunker {
 
     private final int chunkSize;

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/chunk/OverlapTextChunker.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/chunk/OverlapTextChunker.java
@@ -33,6 +33,11 @@ import java.util.regex.Pattern;
  * <p>입력 텍스트를 정규화(CR/LF 통합, 과도한 빈줄 제거)한 뒤 문단 단위로 이어붙여
  * 지정된 길이(chunkSize)에 도달하면 청크를 생성하고, overlap 길이만큼 꼬리를 다음 청크에
  * 이어붙여 연속성을 유지한다. chunk_id는 문서 ID에 인덱스와 랜덤 UUID를 덧붙여 생성한다.
+ *
+ * @deprecated since 2.x. Use {@code starter:studio-platform-starter-chunking}
+ * and {@link studio.one.platform.chunking.core.ChunkingOrchestrator} for new RAG
+ * indexing code. This class is retained only as the legacy fallback when the
+ * chunking starter is not available.
  * 
  * @author  donghyuck, son
  * @since 2025-12-02
@@ -46,6 +51,7 @@ import java.util.regex.Pattern;
  * </pre>
  */
 
+@Deprecated(since = "2.x", forRemoval = false)
 public class OverlapTextChunker implements TextChunker {
 
     private final int chunkSize;

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagPipelineService.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagPipelineService.java
@@ -36,6 +36,7 @@ import studio.one.platform.chunking.core.ChunkingContext;
 import studio.one.platform.chunking.core.ChunkingOrchestrator;
 
 @Slf4j
+@SuppressWarnings("deprecation")
 public class DefaultRagPipelineService implements RagPipelineService {
 
     private final EmbeddingPort embeddingPort;

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/chunk/OverlapTextChunkerTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/chunk/OverlapTextChunkerTest.java
@@ -8,7 +8,17 @@ import org.junit.jupiter.api.Test;
 
 import studio.one.platform.ai.core.chunk.TextChunk;
 
+@SuppressWarnings("deprecation")
 public class OverlapTextChunkerTest {
+
+    @Test
+    public void legacyOverlapChunkerIsDeprecatedWithoutRemoval() {
+        Deprecated deprecated = OverlapTextChunker.class.getAnnotation(Deprecated.class);
+
+        assertThat(deprecated).isNotNull();
+        assertThat(deprecated.since()).isEqualTo("2.x");
+        assertThat(deprecated.forRemoval()).isFalse();
+    }
 
     @Test
     public void splitsLongSingleParagraphIntoBoundedChunks() {

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/chunk/OverlapTextChunkerTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/chunk/OverlapTextChunkerTest.java
@@ -12,7 +12,7 @@ import studio.one.platform.ai.core.chunk.TextChunk;
 public class OverlapTextChunkerTest {
 
     @Test
-    public void legacyOverlapChunkerIsDeprecatedWithoutRemoval() {
+    public void legacyOverlapChunkerStaysDeprecatedButNotScheduledForRemoval() {
         Deprecated deprecated = OverlapTextChunker.class.getAnnotation(Deprecated.class);
 
         assertThat(deprecated).isNotNull();

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
@@ -51,6 +51,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings("deprecation")
 class RagPipelineServiceTest {
 
     @Mock

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagQualitySmokeTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagQualitySmokeTest.java
@@ -36,6 +36,7 @@ import studio.one.platform.ai.core.vector.VectorSearchRequest;
 import studio.one.platform.ai.core.vector.VectorSearchResult;
 import studio.one.platform.ai.core.vector.VectorStorePort;
 
+@SuppressWarnings("deprecation")
 class RagQualitySmokeTest {
 
     private static final String ATTACHMENT = "attachment";

--- a/studio-platform-ai/README.md
+++ b/studio-platform-ai/README.md
@@ -14,7 +14,7 @@ RAG indexing용 chunking 계약과 구현은 `studio-platform-chunking`과 `stud
 - `ChatStreamEvent`: provider-neutral streaming event 계약 (`delta`, `usage`, `complete`, `error`)
 - `ConversationRepositoryPort`: conversation 저장소 구현을 위한 포트
 - `AiProviderRegistry`: 공급자 이름을 키로 ChatPort/EmbeddingPort를 관리하는 레지스트리
-- `TextChunker`: 긴 문서를 임베딩에 적합한 크기로 분할하는 전략 인터페이스
+- `TextChunker`: legacy fallback용 텍스트 chunking 인터페이스. 신규 RAG indexing은 `studio-platform-chunking`의 `ChunkingOrchestrator`를 사용한다.
 - `RagPipelineService`: 인덱싱(`index`)과 검색(`search`, `searchByObject`, `listByObject`)을 정의하는 RAG facade 계약
 - `TextCleaner` / `KeywordExtractor` / `PromptRenderer`: RAG 전처리와 프롬프트 확장점 계약
 - `RagPipelineOptions` 계열: 기본 RAG 구현을 대체하거나 테스트할 때 사용할 설정 계약
@@ -35,7 +35,7 @@ RAG indexing용 chunking 계약과 구현은 `studio-platform-chunking`과 `stud
 | `VectorRecord` | `core.vector` | RAG chunk 저장을 표현하는 core vector storage 모델 |
 | `VectorDocument` / `VectorSearchResult` | `core.vector` | 기존 vector 저장/검색 호출자 호환성을 위해 유지하는 모델 |
 | `AiProviderRegistry` | `core.registry` | 공급자별 ChatPort/EmbeddingPort 룩업 |
-| `TextChunker` | `core.chunk` | 문서를 TextChunk 리스트로 분할 |
+| `TextChunk` / `TextChunker` | `core.chunk` | deprecated legacy fallback 계약. 신규 코드는 `studio-platform-chunking` 사용 |
 | `RagPipelineService` | `service.pipeline` | 인덱싱/검색 RAG facade 계약 |
 | `TextCleaner` | `service.cleaning` | 색인 전 추출 텍스트 정제 계약 |
 | `KeywordExtractor` | `service.keyword` | 색인/검색 keyword 추출 계약 |
@@ -76,6 +76,7 @@ Keyword metadata는 trim, blank 제거, case-insensitive 중복 제거를 거친
 중복 계약은 만들지 않는다.
 
 - 새 `EmbeddingPort` 또는 `VectorStorePort` 대신 기존 포트를 확장한다.
+- 새 chunking 계약은 이 모듈에 추가하지 않는다. `core.chunk.TextChunk`와 `core.chunk.TextChunker`는 deprecated legacy fallback이며, 신규 구현은 `studio-platform-chunking`의 `Chunk`, `ChunkingContext`, `ChunkingOrchestrator`를 사용한다.
 - `VectorRecord`는 RAG chunk 저장을 표현하는 core vector storage 모델이다. 신규 호출자는 긴 생성자 대신 `VectorRecord.builder()`를 우선 사용한다.
 - `chunkIndex`, `previousChunkId`, `nextChunkId`, `tenantId`, `createdAt`, `indexedAt`은 표준 metadata key로만 정의한다. first-class field가 아니므로 `metadata` map을 통해 전달한다.
 - `embeddingDimension`은 `Number` metadata로 소비해야 한다. 현재 `VectorRecord.toMetadata()`는 Java `Integer` 값을 저장하지만 adapter는 DB/driver별 숫자 타입 차이를 고려해 `Number`로 읽어야 한다.

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chunk/TextChunk.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chunk/TextChunk.java
@@ -4,7 +4,13 @@ import java.util.Objects;
 
 /**
  * Represents a chunk of text prepared for embedding.
+ *
+ * @deprecated since 2.x. Use {@code studio.one.platform.chunking.core.Chunk}
+ * and {@code studio.one.platform.chunking.core.ChunkingOrchestrator} from
+ * {@code studio-platform-chunking} for new RAG indexing code. This type remains
+ * only for the legacy {@code starter-ai} fallback path.
  */
+@Deprecated(since = "2.x", forRemoval = false)
 public final class TextChunk {
 
     private final String id;

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chunk/TextChunker.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/chunk/TextChunker.java
@@ -4,7 +4,14 @@ import java.util.List;
 
 /**
  * Splits text into manageable chunks suitable for embedding.
+ *
+ * @deprecated since 2.x. Use
+ * {@code studio.one.platform.chunking.core.ChunkingOrchestrator} and
+ * {@code studio.one.platform.chunking.core.ChunkingContext} from
+ * {@code studio-platform-chunking} for new RAG indexing code. This interface is
+ * retained for legacy fallback compatibility in {@code starter-ai}.
  */
+@Deprecated(since = "2.x", forRemoval = false)
 public interface TextChunker {
 
     List<TextChunk> chunk(String documentId, String text);

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/core/chunk/TextChunkContractTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/core/chunk/TextChunkContractTest.java
@@ -1,0 +1,22 @@
+package studio.one.platform.ai.core.chunk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("deprecation")
+class TextChunkContractTest {
+
+    @Test
+    void legacyChunkContractsAreDeprecatedWithoutRemoval() {
+        Deprecated chunkDeprecated = TextChunk.class.getAnnotation(Deprecated.class);
+        Deprecated chunkerDeprecated = TextChunker.class.getAnnotation(Deprecated.class);
+
+        assertThat(chunkDeprecated).isNotNull();
+        assertThat(chunkDeprecated.since()).isEqualTo("2.x");
+        assertThat(chunkDeprecated.forRemoval()).isFalse();
+        assertThat(chunkerDeprecated).isNotNull();
+        assertThat(chunkerDeprecated.since()).isEqualTo("2.x");
+        assertThat(chunkerDeprecated.forRemoval()).isFalse();
+    }
+}

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/core/chunk/TextChunkContractTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/core/chunk/TextChunkContractTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 class TextChunkContractTest {
 
     @Test
-    void legacyChunkContractsAreDeprecatedWithoutRemoval() {
+    void legacyChunkContractsStayDeprecatedButNotScheduledForRemoval() {
         Deprecated chunkDeprecated = TextChunk.class.getAnnotation(Deprecated.class);
         Deprecated chunkerDeprecated = TextChunker.class.getAnnotation(Deprecated.class);
 


### PR DESCRIPTION
## Why

`studio-platform-chunking`과 `starter:studio-platform-starter-chunking`이 이미 공식 RAG chunking 계약과 auto-configuration을 제공한다. `studio-platform-ai`의 `core.chunk.TextChunk`/`TextChunker`는 현재 `starter-ai` legacy fallback으로만 남아 있어 신규 구현 기준으로는 중복 계약이다.

즉시 삭제하면 기존 `DefaultRagPipelineService` fallback과 사용자 정의 `TextChunker` 구현을 깨므로, 첫 단계는 deprecated 표시와 사용 방향 문서화로 제한한다.

## What

- `TextChunk`, `TextChunker`, `OverlapTextChunker`를 `@Deprecated(since = "2.x", forRemoval = false)`로 표시했다.
- 각 javadoc에 신규 RAG indexing은 `studio-platform-chunking`의 `ChunkingOrchestrator`를 사용하도록 안내했다.
- `studio-platform-ai`와 `starter-ai` README에 legacy fallback과 신규 chunking 기준을 명시했다.
- `CHANGELOG.md`에 이슈 #293 변경 사항과 검증 기록을 추가했다.
- deprecation 계약 테스트를 추가했다.

## Related Issues

- Closes #293

## Validation

- Command: `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-chunking:test`
- Result: PASS
- Command: `git diff --check`
- Result: PASS

## Risk / Rollback

- Risk: deprecation warning이 기존 legacy fallback 사용처에 표시될 수 있다. 런타임 동작과 public API 삭제는 포함하지 않았다.
- Rollback: 이 PR의 커밋을 revert하면 deprecation annotation, 문서, 테스트 추가만 제거된다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: 관련 세 모듈 테스트와 `git diff --check`를 실행했다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included
