### PR TITLE
refactor(rag): legacy chunker adapter 분리

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2026-04-25
 
 ### 변경됨
+- 이슈 #295 대응으로 `starter-ai`의 RAG indexing chunking 분기를 `RagChunker` adapter로 분리했다.
+- `DefaultRagPipelineService`는 `ChunkingOrchestrator` 우선 경로와 deprecated `TextChunker` fallback 변환을 직접 다루지 않고 adapter 결과만 사용하도록 정리했다.
 - 이슈 #293 대응으로 `studio-platform-ai`의 `TextChunk`/`TextChunker`와 `starter-ai`의 `OverlapTextChunker`를 deprecated legacy fallback으로 표시했다.
 - 신규 RAG chunking은 `studio-platform-chunking`의 `ChunkingOrchestrator`를 기준으로 사용하도록 README를 정리했다.
 - 이슈 #188 대응으로 PostgreSQL 그룹 멤버 summary 검색에 `pg_trgm` 기반 `lower(username|name|email)` GIN trigram index migration을 추가했다.
@@ -14,6 +16,9 @@
 - README 예시와 실제 public API가 어긋나지 않도록 parent-child chunking, context expansion, text fallback 문서 시나리오 테스트를 추가했다.
 
 ### 검증
+- `./gradlew :starter:studio-platform-starter-ai:test`
+- `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-chunking:test`
+- `git diff --check`
 - `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-chunking:test`
 - `git diff --check`
 - `./gradlew :studio-platform-user:test --tests 'studio.one.base.user.persistence.jpa.ApplicationGroupMembershipJpaRepositorySearchTest' --tests 'studio.one.base.user.persistence.jdbc.ApplicationGroupMembershipJdbcRepositoryTest'`

--- a/starter/studio-platform-starter-ai/README.md
+++ b/starter/studio-platform-starter-ai/README.md
@@ -216,6 +216,8 @@ HTTP `text/event-stream` endpoint 변환은 `starter-ai-web` 책임이다.
 `TextChunker`와 `OverlapTextChunker`는 deprecated legacy fallback이다. 신규 RAG indexing 또는
 구조화 chunking 확장은 `starter:studio-platform-starter-chunking`의 auto-configuration과
 `studio-platform-chunking`의 `ChunkingOrchestrator`를 기준으로 구현한다.
+`DefaultRagPipelineService` 내부에서는 `RagChunker` adapter가 `ChunkingOrchestrator` 우선 경로와
+legacy fallback 변환을 캡슐화한다.
 
 ```yaml
 studio:

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagPipelineService.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagPipelineService.java
@@ -177,11 +177,10 @@ public class DefaultRagPipelineService implements RagPipelineService {
     }
 
     private static RagChunker createChunker(TextChunker textChunker, ChunkingOrchestrator chunkingOrchestrator) {
-        RagChunker legacyChunker = new LegacyTextChunkerAdapter(textChunker);
-        if (chunkingOrchestrator == null) {
-            return legacyChunker;
+        if (chunkingOrchestrator != null) {
+            return new OrchestratedRagChunker(chunkingOrchestrator);
         }
-        return new OrchestratedRagChunker(chunkingOrchestrator);
+        return new LegacyTextChunkerAdapter(textChunker);
     }
 
     @Override
@@ -224,8 +223,8 @@ public class DefaultRagPipelineService implements RagPipelineService {
             metadata.put("chunkLength", chunk.content().length());
             documents.add(new VectorDocument(chunk.id(), chunk.content(), metadata, embedding));
         }
-        String objectType = normalizeObjectScope(baseMetadata.get("objectType"));
-        String objectId = normalizeObjectScope(baseMetadata.get("objectId"));
+        String objectType = RagChunkingMetadata.normalizeObjectScope(baseMetadata.get("objectType"));
+        String objectId = RagChunkingMetadata.normalizeObjectScope(baseMetadata.get("objectId"));
         if (objectType != null && objectId != null) {
             if (documents.isEmpty()) {
                 vectorStorePort.deleteByObject(objectType, objectId);
@@ -250,14 +249,6 @@ public class DefaultRagPipelineService implements RagPipelineService {
                 metadata.putIfAbsent(key, value);
             }
         });
-    }
-
-    private String normalizeObjectScope(Object value) {
-        if (value == null) {
-            return null;
-        }
-        String text = value.toString();
-        return text.isBlank() ? null : text;
     }
 
     @Override

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagPipelineService.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagPipelineService.java
@@ -14,7 +14,6 @@ import com.github.benmanes.caffeine.cache.Cache;
 import io.github.resilience4j.retry.Retry;
 import lombok.extern.slf4j.Slf4j;
 import studio.one.platform.ai.core.MetadataFilter;
-import studio.one.platform.ai.core.chunk.TextChunk;
 import studio.one.platform.ai.core.chunk.TextChunker;
 import studio.one.platform.ai.core.embedding.EmbeddingPort;
 import studio.one.platform.ai.core.embedding.EmbeddingRequest;
@@ -31,8 +30,6 @@ import studio.one.platform.ai.core.vector.VectorStorePort;
 import studio.one.platform.ai.service.cleaning.TextCleaner;
 import studio.one.platform.ai.service.cleaning.TextCleaningResult;
 import studio.one.platform.ai.service.keyword.KeywordExtractor;
-import studio.one.platform.chunking.core.Chunk;
-import studio.one.platform.chunking.core.ChunkingContext;
 import studio.one.platform.chunking.core.ChunkingOrchestrator;
 
 @Slf4j
@@ -41,8 +38,7 @@ public class DefaultRagPipelineService implements RagPipelineService {
 
     private final EmbeddingPort embeddingPort;
     private final VectorStorePort vectorStorePort;
-    private final TextChunker textChunker;
-    private final ChunkingOrchestrator chunkingOrchestrator;
+    private final RagChunker ragChunker;
     private final Cache<String, List<Double>> embeddingCache;
     private final Retry retry;
     private final KeywordExtractor keywordExtractor;
@@ -62,7 +58,7 @@ public class DefaultRagPipelineService implements RagPipelineService {
             RagPipelineOptions options,
             RagPipelineDiagnosticsOptions diagnosticsOptions,
             RagKeywordOptions keywordOptions) {
-        this(embeddingPort, vectorStorePort, textChunker, null, embeddingCache, retry, keywordExtractor, textCleaner,
+        this(embeddingPort, vectorStorePort, createChunker(textChunker, null), embeddingCache, retry, keywordExtractor, textCleaner,
                 options, diagnosticsOptions, keywordOptions);
     }
 
@@ -77,11 +73,24 @@ public class DefaultRagPipelineService implements RagPipelineService {
             RagPipelineOptions options,
             RagPipelineDiagnosticsOptions diagnosticsOptions,
             RagKeywordOptions keywordOptions) {
+        this(embeddingPort, vectorStorePort, createChunker(textChunker, chunkingOrchestrator), embeddingCache, retry,
+                keywordExtractor, textCleaner, options, diagnosticsOptions, keywordOptions);
+    }
+
+    private DefaultRagPipelineService(EmbeddingPort embeddingPort,
+            VectorStorePort vectorStorePort,
+            RagChunker ragChunker,
+            Cache<String, List<Double>> embeddingCache,
+            Retry retry,
+            KeywordExtractor keywordExtractor,
+            TextCleaner textCleaner,
+            RagPipelineOptions options,
+            RagPipelineDiagnosticsOptions diagnosticsOptions,
+            RagKeywordOptions keywordOptions) {
 
         this.embeddingPort = Objects.requireNonNull(embeddingPort, "embeddingPort");
         this.vectorStorePort = Objects.requireNonNull(vectorStorePort, "vectorStorePort");
-        this.textChunker = Objects.requireNonNull(textChunker, "textChunker");
-        this.chunkingOrchestrator = chunkingOrchestrator;
+        this.ragChunker = Objects.requireNonNull(ragChunker, "ragChunker");
         this.embeddingCache = Objects.requireNonNull(embeddingCache, "embeddingCache");
         this.retry = Objects.requireNonNull(retry, "retry");
         this.keywordExtractor = keywordExtractor;
@@ -167,6 +176,14 @@ public class DefaultRagPipelineService implements RagPipelineService {
                 embeddingCache, retry, keywordExtractor, textCleaner, options, diagnosticsOptions, keywordOptions);
     }
 
+    private static RagChunker createChunker(TextChunker textChunker, ChunkingOrchestrator chunkingOrchestrator) {
+        RagChunker legacyChunker = new LegacyTextChunkerAdapter(textChunker);
+        if (chunkingOrchestrator == null) {
+            return legacyChunker;
+        }
+        return new OrchestratedRagChunker(chunkingOrchestrator);
+    }
+
     @Override
     public void index(RagIndexRequest request) {
 
@@ -174,7 +191,7 @@ public class DefaultRagPipelineService implements RagPipelineService {
 
         TextCleaningResult cleaning = cleanText(request.text());
         String indexedText = cleaning.text() == null ? request.text() : cleaning.text();
-        List<IndexedChunk> chunks = chunk(indexedText, request);
+        List<RagPipelineChunk> chunks = chunk(indexedText, request);
         List<VectorDocument> documents = new ArrayList<>(chunks.size());
         List<String> documentKeywords = keywordOptions.scope().includesDocument()
                 ? resolveDocumentKeywords(request, indexedText)
@@ -190,7 +207,7 @@ public class DefaultRagPipelineService implements RagPipelineService {
             baseMetadata.put("keywordsText", String.join(" ", documentKeywords));
         }
         int order = 0;
-        for (IndexedChunk chunk : chunks) {
+        for (RagPipelineChunk chunk : chunks) {
             List<Double> embedding = embedWithCache(chunk.content());
             Map<String, Object> metadata = new HashMap<>(baseMetadata);
             mergeChunkMetadata(metadata, chunk.metadata());
@@ -220,31 +237,11 @@ public class DefaultRagPipelineService implements RagPipelineService {
         }
     }
 
-    private List<IndexedChunk> chunk(String indexedText, RagIndexRequest request) {
+    private List<RagPipelineChunk> chunk(String indexedText, RagIndexRequest request) {
         if (indexedText == null || indexedText.isBlank()) {
             return List.of();
         }
-        if (chunkingOrchestrator == null) {
-            return textChunker.chunk(request.documentId(), indexedText).stream()
-                    .map(chunk -> new IndexedChunk(chunk.id(), chunk.content(), Map.of()))
-                    .toList();
-        }
-        Map<String, Object> metadata = request.metadata();
-        ChunkingContext context = ChunkingContext.configuredDefaults(indexedText)
-                .sourceDocumentId(request.documentId())
-                .contentType(normalizeObjectScope(metadata.get("contentType")))
-                .filename(normalizeObjectScope(metadata.get("filename")))
-                .objectType(normalizeObjectScope(metadata.get("objectType")))
-                .objectId(normalizeObjectScope(metadata.get("objectId")))
-                .metadata(metadata)
-                .build();
-        return chunkingOrchestrator.chunk(context).stream()
-                .map(this::toIndexedChunk)
-                .toList();
-    }
-
-    private IndexedChunk toIndexedChunk(Chunk chunk) {
-        return new IndexedChunk(chunk.id(), chunk.content(), chunk.metadata().toMap());
+        return ragChunker.chunk(indexedText, request);
     }
 
     private void mergeChunkMetadata(Map<String, Object> metadata, Map<String, Object> chunkMetadata) {
@@ -262,8 +259,6 @@ public class DefaultRagPipelineService implements RagPipelineService {
         String text = value.toString();
         return text.isBlank() ? null : text;
     }
-
-    private record IndexedChunk(String id, String content, Map<String, Object> metadata) {}
 
     @Override
     public List<RagSearchResult> search(RagSearchRequest request) {

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/LegacyTextChunkerAdapter.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/LegacyTextChunkerAdapter.java
@@ -1,0 +1,25 @@
+package studio.one.platform.ai.service.pipeline;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import studio.one.platform.ai.core.chunk.TextChunker;
+import studio.one.platform.ai.core.rag.RagIndexRequest;
+
+@SuppressWarnings("deprecation")
+final class LegacyTextChunkerAdapter implements RagChunker {
+
+    private final TextChunker textChunker;
+
+    LegacyTextChunkerAdapter(TextChunker textChunker) {
+        this.textChunker = Objects.requireNonNull(textChunker, "textChunker");
+    }
+
+    @Override
+    public List<RagPipelineChunk> chunk(String indexedText, RagIndexRequest request) {
+        return textChunker.chunk(request.documentId(), indexedText).stream()
+                .map(chunk -> new RagPipelineChunk(chunk.id(), chunk.content(), Map.of()))
+                .toList();
+    }
+}

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/OrchestratedRagChunker.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/OrchestratedRagChunker.java
@@ -22,10 +22,10 @@ final class OrchestratedRagChunker implements RagChunker {
         Map<String, Object> metadata = request.metadata();
         ChunkingContext context = ChunkingContext.configuredDefaults(indexedText)
                 .sourceDocumentId(request.documentId())
-                .contentType(normalizeObjectScope(metadata.get("contentType")))
-                .filename(normalizeObjectScope(metadata.get("filename")))
-                .objectType(normalizeObjectScope(metadata.get("objectType")))
-                .objectId(normalizeObjectScope(metadata.get("objectId")))
+                .contentType(RagChunkingMetadata.normalizeObjectScope(metadata.get("contentType")))
+                .filename(RagChunkingMetadata.normalizeObjectScope(metadata.get("filename")))
+                .objectType(RagChunkingMetadata.normalizeObjectScope(metadata.get("objectType")))
+                .objectId(RagChunkingMetadata.normalizeObjectScope(metadata.get("objectId")))
                 .metadata(metadata)
                 .build();
         return chunkingOrchestrator.chunk(context).stream()
@@ -37,11 +37,4 @@ final class OrchestratedRagChunker implements RagChunker {
         return new RagPipelineChunk(chunk.id(), chunk.content(), chunk.metadata().toMap());
     }
 
-    private String normalizeObjectScope(Object value) {
-        if (value == null) {
-            return null;
-        }
-        String text = value.toString();
-        return text.isBlank() ? null : text;
-    }
 }

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/OrchestratedRagChunker.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/OrchestratedRagChunker.java
@@ -1,0 +1,47 @@
+package studio.one.platform.ai.service.pipeline;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import studio.one.platform.ai.core.rag.RagIndexRequest;
+import studio.one.platform.chunking.core.Chunk;
+import studio.one.platform.chunking.core.ChunkingContext;
+import studio.one.platform.chunking.core.ChunkingOrchestrator;
+
+final class OrchestratedRagChunker implements RagChunker {
+
+    private final ChunkingOrchestrator chunkingOrchestrator;
+
+    OrchestratedRagChunker(ChunkingOrchestrator chunkingOrchestrator) {
+        this.chunkingOrchestrator = Objects.requireNonNull(chunkingOrchestrator, "chunkingOrchestrator");
+    }
+
+    @Override
+    public List<RagPipelineChunk> chunk(String indexedText, RagIndexRequest request) {
+        Map<String, Object> metadata = request.metadata();
+        ChunkingContext context = ChunkingContext.configuredDefaults(indexedText)
+                .sourceDocumentId(request.documentId())
+                .contentType(normalizeObjectScope(metadata.get("contentType")))
+                .filename(normalizeObjectScope(metadata.get("filename")))
+                .objectType(normalizeObjectScope(metadata.get("objectType")))
+                .objectId(normalizeObjectScope(metadata.get("objectId")))
+                .metadata(metadata)
+                .build();
+        return chunkingOrchestrator.chunk(context).stream()
+                .map(this::toPipelineChunk)
+                .toList();
+    }
+
+    private RagPipelineChunk toPipelineChunk(Chunk chunk) {
+        return new RagPipelineChunk(chunk.id(), chunk.content(), chunk.metadata().toMap());
+    }
+
+    private String normalizeObjectScope(Object value) {
+        if (value == null) {
+            return null;
+        }
+        String text = value.toString();
+        return text.isBlank() ? null : text;
+    }
+}

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagChunker.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagChunker.java
@@ -1,0 +1,10 @@
+package studio.one.platform.ai.service.pipeline;
+
+import java.util.List;
+
+import studio.one.platform.ai.core.rag.RagIndexRequest;
+
+interface RagChunker {
+
+    List<RagPipelineChunk> chunk(String indexedText, RagIndexRequest request);
+}

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagChunkingMetadata.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagChunkingMetadata.java
@@ -1,0 +1,15 @@
+package studio.one.platform.ai.service.pipeline;
+
+final class RagChunkingMetadata {
+
+    private RagChunkingMetadata() {
+    }
+
+    static String normalizeObjectScope(Object value) {
+        if (value == null) {
+            return null;
+        }
+        String text = value.toString();
+        return text.isBlank() ? null : text;
+    }
+}

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineChunk.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineChunk.java
@@ -1,0 +1,10 @@
+package studio.one.platform.ai.service.pipeline;
+
+import java.util.Map;
+
+record RagPipelineChunk(String id, String content, Map<String, Object> metadata) {
+
+    RagPipelineChunk {
+        metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+    }
+}

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagChunkerAdapterTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagChunkerAdapterTest.java
@@ -1,0 +1,69 @@
+package studio.one.platform.ai.service.pipeline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.ai.core.chunk.TextChunk;
+import studio.one.platform.ai.core.rag.RagIndexRequest;
+import studio.one.platform.chunking.core.Chunk;
+import studio.one.platform.chunking.core.ChunkMetadata;
+import studio.one.platform.chunking.core.ChunkingContext;
+import studio.one.platform.chunking.core.ChunkingStrategyType;
+
+@SuppressWarnings("deprecation")
+class RagChunkerAdapterTest {
+
+    @Test
+    void legacyAdapterConvertsTextChunksWithoutMetadata() {
+        LegacyTextChunkerAdapter adapter = new LegacyTextChunkerAdapter(
+                (documentId, text) -> List.of(new TextChunk(documentId + "-0", text)));
+
+        List<RagPipelineChunk> chunks = adapter.chunk(
+                "hello world",
+                new RagIndexRequest("doc-1", "hello world", Map.of()));
+
+        assertThat(chunks).hasSize(1);
+        assertThat(chunks.get(0).id()).isEqualTo("doc-1-0");
+        assertThat(chunks.get(0).content()).isEqualTo("hello world");
+        assertThat(chunks.get(0).metadata()).isEmpty();
+    }
+
+    @Test
+    void orchestratedAdapterBuildsChunkingContextAndPreservesMetadata() {
+        AtomicReference<ChunkingContext> capturedContext = new AtomicReference<>();
+        OrchestratedRagChunker adapter = new OrchestratedRagChunker(context -> {
+            capturedContext.set(context);
+            return List.of(Chunk.of(
+                    "chunk-1",
+                    context.text(),
+                    ChunkMetadata.builder(ChunkingStrategyType.RECURSIVE, 3)
+                            .sourceDocumentId(context.sourceDocumentId())
+                            .objectType(context.objectType())
+                            .objectId(context.objectId())
+                            .build()));
+        });
+        RagIndexRequest request = new RagIndexRequest("doc-1", "ignored", Map.of(
+                "objectType", "attachment",
+                "objectId", "42",
+                "filename", "file.pdf"));
+
+        List<RagPipelineChunk> chunks = adapter.chunk("indexed text", request);
+
+        assertThat(capturedContext.get().sourceDocumentId()).isEqualTo("doc-1");
+        assertThat(capturedContext.get().objectType()).isEqualTo("attachment");
+        assertThat(capturedContext.get().objectId()).isEqualTo("42");
+        assertThat(capturedContext.get().filename()).isEqualTo("file.pdf");
+        assertThat(chunks).hasSize(1);
+        assertThat(chunks.get(0).metadata())
+                .containsEntry("sourceDocumentId", "doc-1")
+                .containsEntry("objectType", "attachment")
+                .containsEntry("objectId", "42")
+                .containsEntry("strategy", "recursive")
+                .containsEntry("chunkOrder", 3);
+    }
+}

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
@@ -232,6 +232,68 @@ class RagPipelineServiceTest {
     }
 
     @Test
+    void shouldRouteConstructorWithChunkingOrchestratorWithoutLegacyTextChunker() {
+        ragPipelineService = DefaultRagPipelineService.create(
+                embeddingPort,
+                vectorStorePort,
+                null,
+                chunkingOrchestrator,
+                cache,
+                retry,
+                keywordExtractor,
+                null,
+                RagPipelineOptions.defaults(),
+                RagPipelineDiagnosticsOptions.defaults(),
+                RagKeywordOptions.defaults());
+        RagIndexRequest request = new RagIndexRequest("doc-orchestrated-null-legacy", "alpha beta", Map.of(
+                "objectType", "attachment",
+                "objectId", "42"));
+        Chunk chunk = Chunk.of(
+                "doc-orchestrated-null-legacy-0",
+                "alpha beta",
+                ChunkMetadata.builder(ChunkingStrategyType.RECURSIVE, 0)
+                        .sourceDocumentId("doc-orchestrated-null-legacy")
+                        .objectType("attachment")
+                        .objectId("42")
+                        .build());
+        when(chunkingOrchestrator.chunk(any(ChunkingContext.class))).thenReturn(List.of(chunk));
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("chunk", List.of(0.1, 0.2)))));
+
+        ragPipelineService.index(request);
+
+        verify(vectorStorePort).replaceByObject(eq("attachment"), eq("42"), documentsCaptor.capture());
+        assertThat(documentsCaptor.getValue().get(0).id()).isEqualTo("doc-orchestrated-null-legacy-0");
+    }
+
+    @Test
+    void shouldRouteConstructorWithoutChunkingOrchestratorToLegacyTextChunker() {
+        ragPipelineService = DefaultRagPipelineService.create(
+                embeddingPort,
+                vectorStorePort,
+                textChunker,
+                null,
+                cache,
+                retry,
+                keywordExtractor,
+                null,
+                RagPipelineOptions.defaults(),
+                RagPipelineDiagnosticsOptions.defaults(),
+                RagKeywordOptions.defaults());
+        RagIndexRequest request = new RagIndexRequest("doc-legacy", "alpha beta", Map.of());
+        when(textChunker.chunk("doc-legacy", "alpha beta"))
+                .thenReturn(List.of(new TextChunk("doc-legacy-0", "alpha beta")));
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("chunk", List.of(0.1, 0.2)))));
+
+        ragPipelineService.index(request);
+
+        verify(textChunker).chunk("doc-legacy", "alpha beta");
+        verify(vectorStorePort).upsert(documentsCaptor.capture());
+        assertThat(documentsCaptor.getValue().get(0).id()).isEqualTo("doc-legacy-0");
+    }
+
+    @Test
     void shouldDeleteObjectScopedChunksWhenNewIndexHasNoChunks() {
         ragPipelineService = DefaultRagPipelineService.create(
                 embeddingPort,


### PR DESCRIPTION
## Why

이슈 #293에서 `TextChunk`/`TextChunker`/`OverlapTextChunker`를 deprecated legacy fallback으로 표시했지만, `DefaultRagPipelineService`는 여전히 deprecated `TextChunker` fallback 변환과 `ChunkingOrchestrator` 우선 분기를 직접 갖고 있었다.

신규 기준은 `studio-platform-chunking`의 `ChunkingOrchestrator`이므로, 첫 단계로 service 본문에서 chunking 선택/변환 로직을 내부 adapter로 분리해 deprecated 계약 접촉면을 줄인다.

## What

- `RagChunker` 내부 adapter 계약을 추가했다.
- `LegacyTextChunkerAdapter`가 deprecated `TextChunker` fallback 결과를 `RagPipelineChunk`로 변환하도록 분리했다.
- `OrchestratedRagChunker`가 `ChunkingOrchestrator` 기반 context 생성과 chunk metadata 변환을 담당하도록 분리했다.
- `DefaultRagPipelineService`는 `RagChunker` 결과만 사용하도록 정리하고 기존 public 생성자/factory는 유지했다.
- adapter 단위 테스트와 README/CHANGELOG를 추가했다.

## Related Issues

- Closes #295

## Validation

- Command: `./gradlew :starter:studio-platform-starter-ai:test`
- Result: PASS
- Command: `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-chunking:test`
- Result: PASS
- Command: `git diff --check`
- Result: PASS

## Risk / Rollback

- Risk: chunking 분기 위치가 바뀌었지만 public API와 런타임 우선순위는 유지된다. `ChunkingOrchestrator`가 있으면 기존처럼 우선 사용하고, 없으면 legacy `TextChunker` fallback을 사용한다.
- Rollback: 이 PR의 커밋을 revert하면 `DefaultRagPipelineService` 내부 분기 구조로 돌아간다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: 관련 테스트와 `git diff --check`를 실행했다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
