### PR TITLE
refactor(rag): legacy TextChunker bean 조건화

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 2026-04-25
 
 ### 변경됨
+- 이슈 #297 대응으로 `starter-ai`의 기본 `TextChunker` bean 생성을 `ChunkingOrchestrator`가 없을 때의 legacy fallback으로 제한했다.
+- `RagPipelineService` auto-configuration은 `TextChunker`를 optional로 받아 orchestrator-only 환경에서도 동작하도록 했다.
+- `AiAutoConfiguration`은 `ChunkingAutoConfiguration` 이후 평가되도록 정렬해 chunking starter가 제공하는 `ChunkingOrchestrator`를 우선 감지한다.
 - 이슈 #295 대응으로 `starter-ai`의 RAG indexing chunking 분기를 `RagChunker` adapter로 분리했다.
 - `DefaultRagPipelineService`는 `ChunkingOrchestrator` 우선 경로와 deprecated `TextChunker` fallback 변환을 직접 다루지 않고 adapter 결과만 사용하도록 정리했다.
 - 이슈 #293 대응으로 `studio-platform-ai`의 `TextChunk`/`TextChunker`와 `starter-ai`의 `OverlapTextChunker`를 deprecated legacy fallback으로 표시했다.
@@ -16,6 +19,9 @@
 - README 예시와 실제 public API가 어긋나지 않도록 parent-child chunking, context expansion, text fallback 문서 시나리오 테스트를 추가했다.
 
 ### 검증
+- `./gradlew :starter:studio-platform-starter-ai:test`
+- `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-chunking:test`
+- `git diff --check`
 - `./gradlew :starter:studio-platform-starter-ai:test`
 - `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-chunking:test`
 - `git diff --check`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,14 +22,8 @@
 - `./gradlew :starter:studio-platform-starter-ai:test`
 - `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-chunking:test`
 - `git diff --check`
-- `./gradlew :starter:studio-platform-starter-ai:test`
-- `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-chunking:test`
-- `git diff --check`
-- `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-chunking:test`
-- `git diff --check`
 - `./gradlew :studio-platform-user:test --tests 'studio.one.base.user.persistence.jpa.ApplicationGroupMembershipJpaRepositorySearchTest' --tests 'studio.one.base.user.persistence.jdbc.ApplicationGroupMembershipJdbcRepositoryTest'`
 - `./gradlew :studio-platform-chunking:test :starter:studio-platform-starter-chunking:test`
-- `git diff --check`
 
 ## 2026-04-24
 

--- a/starter/studio-platform-starter-ai/README.md
+++ b/starter/studio-platform-starter-ai/README.md
@@ -218,6 +218,8 @@ HTTP `text/event-stream` endpoint 변환은 `starter-ai-web` 책임이다.
 `studio-platform-chunking`의 `ChunkingOrchestrator`를 기준으로 구현한다.
 `DefaultRagPipelineService` 내부에서는 `RagChunker` adapter가 `ChunkingOrchestrator` 우선 경로와
 legacy fallback 변환을 캡슐화한다.
+auto-configuration도 같은 기준을 따른다. `ChunkingOrchestrator` bean이 있으면 기본
+`OverlapTextChunker` bean을 만들지 않고, 없을 때만 legacy fallback bean을 등록한다.
 
 ```yaml
 studio:

--- a/starter/studio-platform-starter-ai/build.gradle.kts
+++ b/starter/studio-platform-starter-ai/build.gradle.kts
@@ -45,4 +45,5 @@ dependencies {
     testImplementation("org.assertj:assertj-core")
     testImplementation("org.springframework:spring-jdbc")
     testImplementation(project(":studio-platform"))
+    testImplementation(project(":starter:studio-platform-starter-chunking"))
 } 

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/AiAutoConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/AiAutoConfiguration.java
@@ -1,5 +1,6 @@
 package studio.one.platform.ai.autoconfigure;
 
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
@@ -20,6 +21,7 @@ import studio.one.platform.ai.core.chat.ChatPort;
 import studio.one.platform.constant.PropertyKeys;
 
 @Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(name = "studio.one.platform.chunking.autoconfigure.ChunkingAutoConfiguration")
 @ConditionalOnClass(ChatPort.class)
 @ConditionalOnProperty(prefix = PropertyKeys.AI.PREFIX, name = "enabled", havingValue = "true", matchIfMissing = false)
 @Import({

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfiguration.java
@@ -5,12 +5,11 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -41,8 +40,7 @@ import studio.one.platform.service.I18n;
 import studio.one.platform.util.I18nUtils;
 import studio.one.platform.util.LogUtils;
 
-@Configuration
-@AutoConfigureAfter(name = "studio.one.platform.chunking.autoconfigure.ChunkingAutoConfiguration")
+@AutoConfiguration(afterName = "studio.one.platform.chunking.autoconfigure.ChunkingAutoConfiguration")
 @EnableConfigurationProperties(RagPipelineProperties.class)
 @RequiredArgsConstructor
 @Slf4j

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfiguration.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -41,6 +42,7 @@ import studio.one.platform.util.I18nUtils;
 import studio.one.platform.util.LogUtils;
 
 @Configuration
+@AutoConfigureAfter(name = "studio.one.platform.chunking.autoconfigure.ChunkingAutoConfiguration")
 @EnableConfigurationProperties(RagPipelineProperties.class)
 @RequiredArgsConstructor
 @Slf4j
@@ -50,6 +52,7 @@ public class RagPipelineConfiguration {
         private final ObjectProvider<I18n> i18nProvider;
 
         @Bean
+        @ConditionalOnMissingBean({ TextChunker.class, ChunkingOrchestrator.class })
         public TextChunker textChunker(RagPipelineProperties properties) {
 
                 I18n i18n = I18nUtils.resolve(i18nProvider);
@@ -99,7 +102,8 @@ public class RagPipelineConfiguration {
 
         @Bean(name = { RagPipelineService.SERVICE_NAME, RagPipelineService.LEGACY_SERVICE_NAME })
         RagPipelineService ragPipelineService(EmbeddingPort embeddingPort, VectorStorePort vectorStorePort,
-                        TextChunker textChunker, Cache<String, List<Double>> embeddingCache, Retry embeddingRetry,
+                        ObjectProvider<TextChunker> textChunkerProvider,
+                        Cache<String, List<Double>> embeddingCache, Retry embeddingRetry,
                         ObjectProvider<ChunkingOrchestrator> chunkingOrchestratorProvider,
                         ObjectProvider<KeywordExtractor> keywordExtractorProvider,
                         ObjectProvider<TextCleaner> textCleanerProvider,
@@ -110,7 +114,8 @@ public class RagPipelineConfiguration {
                                 AiProviderRegistryConfiguration.FEATURE_NAME,
                                 LogUtils.blue(RagPipelineService.class, true), LogUtils.red(State.CREATED.toString())));
 
-                return DefaultRagPipelineService.create(embeddingPort, vectorStorePort, textChunker,
+                return DefaultRagPipelineService.create(embeddingPort, vectorStorePort,
+                                textChunkerProvider.getIfAvailable(),
                                 chunkingOrchestratorProvider.getIfAvailable(), embeddingCache,
                                 embeddingRetry, keywordExtractorProvider.getIfAvailable(),
                                 textCleanerProvider.getIfAvailable(), ragPipelineOptions(properties),

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfigurationChunkingTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfigurationChunkingTest.java
@@ -1,0 +1,75 @@
+package studio.one.platform.ai.autoconfigure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import studio.one.platform.ai.core.chunk.TextChunker;
+import studio.one.platform.ai.core.embedding.EmbeddingPort;
+import studio.one.platform.ai.core.vector.VectorStorePort;
+import studio.one.platform.ai.service.chunk.OverlapTextChunker;
+import studio.one.platform.ai.service.pipeline.RagPipelineService;
+import studio.one.platform.chunking.autoconfigure.ChunkingAutoConfiguration;
+import studio.one.platform.chunking.core.ChunkingOrchestrator;
+
+@SuppressWarnings("deprecation")
+class RagPipelineConfigurationChunkingTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(RagPipelineConfiguration.class))
+            .withBean(EmbeddingPort.class, () -> mock(EmbeddingPort.class))
+            .withBean(VectorStorePort.class, () -> mock(VectorStorePort.class));
+
+    @Test
+    void createsLegacyTextChunkerFallbackWhenChunkingOrchestratorIsMissing() {
+        contextRunner.run(context -> assertThat(context)
+                .hasSingleBean(TextChunker.class)
+                .hasSingleBean(OverlapTextChunker.class)
+                .hasSingleBean(RagPipelineService.class));
+    }
+
+    @Test
+    void doesNotCreateLegacyTextChunkerWhenChunkingOrchestratorExists() {
+        contextRunner.withBean(ChunkingOrchestrator.class, () -> request -> List.of())
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(TextChunker.class);
+                    assertThat(context).doesNotHaveBean(OverlapTextChunker.class);
+                    assertThat(context).hasSingleBean(ChunkingOrchestrator.class);
+                    assertThat(context).hasSingleBean(RagPipelineService.class);
+                });
+    }
+
+    @Test
+    void doesNotCreateLegacyTextChunkerWhenChunkingAutoConfigurationProvidesOrchestrator() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        ChunkingAutoConfiguration.class,
+                        RagPipelineConfiguration.class))
+                .withBean(EmbeddingPort.class, () -> mock(EmbeddingPort.class))
+                .withBean(VectorStorePort.class, () -> mock(VectorStorePort.class))
+                .run(context -> {
+                    assertThat(context).hasSingleBean(ChunkingOrchestrator.class);
+                    assertThat(context).doesNotHaveBean(TextChunker.class);
+                    assertThat(context).doesNotHaveBean(OverlapTextChunker.class);
+                    assertThat(context).hasSingleBean(RagPipelineService.class);
+                });
+    }
+
+    @Test
+    void keepsUserDefinedTextChunkerWhenChunkingOrchestratorIsMissing() {
+        TextChunker customChunker = (documentId, text) -> List.of();
+
+        contextRunner.withBean(TextChunker.class, () -> customChunker)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(TextChunker.class);
+                    assertThat(context).doesNotHaveBean(OverlapTextChunker.class);
+                    assertThat(context.getBean(TextChunker.class)).isSameAs(customChunker);
+                    assertThat(context).hasSingleBean(RagPipelineService.class);
+                });
+    }
+}

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfigurationChunkingTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfigurationChunkingTest.java
@@ -72,4 +72,19 @@ class RagPipelineConfigurationChunkingTest {
                     assertThat(context).hasSingleBean(RagPipelineService.class);
                 });
     }
+
+    @Test
+    void keepsUserDefinedTextChunkerWithoutCreatingDefaultWhenChunkingOrchestratorAlsoExists() {
+        TextChunker customChunker = (documentId, text) -> List.of();
+
+        contextRunner.withBean(TextChunker.class, () -> customChunker)
+                .withBean(ChunkingOrchestrator.class, () -> request -> List.of())
+                .run(context -> {
+                    assertThat(context).hasSingleBean(TextChunker.class);
+                    assertThat(context).doesNotHaveBean(OverlapTextChunker.class);
+                    assertThat(context.getBean(TextChunker.class)).isSameAs(customChunker);
+                    assertThat(context).hasSingleBean(ChunkingOrchestrator.class);
+                    assertThat(context).hasSingleBean(RagPipelineService.class);
+                });
+    }
 }


### PR DESCRIPTION
## Why

`TextChunker`와 `OverlapTextChunker`는 이슈 #293에서 deprecated legacy fallback으로 표시됐다. 이슈 #295에서는 `DefaultRagPipelineService` 내부 chunking 분기도 `RagChunker` adapter로 분리했다.

하지만 `starter-ai` auto-configuration은 `ChunkingOrchestrator`가 있어도 기본 `TextChunker` bean을 항상 생성했다. deprecated fallback 접촉면을 줄이기 위해 기본 `TextChunker` bean은 `ChunkingOrchestrator`가 없는 경우에만 생성되어야 한다.

## What

- `RagPipelineConfiguration.textChunker(...)`에 `@ConditionalOnMissingBean({ TextChunker.class, ChunkingOrchestrator.class })`를 추가했다.
- `RagPipelineService` wiring에서 `TextChunker`를 `ObjectProvider<TextChunker>`로 optional 주입받도록 변경했다.
- `AiAutoConfiguration`과 `RagPipelineConfiguration`이 `ChunkingAutoConfiguration` 이후 평가되도록 ordering metadata를 추가했다.
- `ChunkingAutoConfiguration` 조합을 포함한 `ApplicationContextRunner` 테스트를 추가했다.
- README와 CHANGELOG를 갱신했다.

## Related Issues

- Closes #297

## Validation

- Command: `./gradlew :starter:studio-platform-starter-ai:test`
- Result: PASS
- Command: `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-chunking:test`
- Result: PASS
- Command: `git diff --check`
- Result: PASS

## Risk / Rollback

- Risk: `ChunkingOrchestrator`가 있는 환경에서는 기본 `OverlapTextChunker` bean이 더 이상 생성되지 않는다. 사용자 정의 `TextChunker` bean은 계속 존중되며, legacy fallback만 필요한 환경에서는 기존처럼 생성된다.
- Rollback: 이 PR의 커밋을 revert하면 `TextChunker` bean이 항상 생성되던 이전 wiring으로 돌아간다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: 관련 테스트와 `git diff --check`를 실행했다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included
