### PR TITLE
docs(rag): chunk 설정 migration guide 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2026-04-25
 
 ### 변경됨
+- 이슈 #299/#300 대응으로 `starter-ai` README에 legacy RAG chunk 설정 migration guide를 추가했다.
+- `studio.ai.pipeline.chunk-size`와 `studio.ai.pipeline.chunk-overlap`는 deprecated `TextChunker` fallback 전용 설정으로 표시하고, 기존 binding 호환성 테스트를 보강했다.
 - 이슈 #297 대응으로 `starter-ai`의 기본 `TextChunker` bean 생성을 `ChunkingOrchestrator`가 없을 때의 legacy fallback으로 제한했다.
 - `RagPipelineService` auto-configuration은 `TextChunker`를 optional로 받아 orchestrator-only 환경에서도 동작하도록 했다.
 - `AiAutoConfiguration`은 `ChunkingAutoConfiguration` 이후 평가되도록 정렬해 chunking starter가 제공하는 `ChunkingOrchestrator`를 우선 감지한다.
@@ -20,8 +22,8 @@
 
 ### 검증
 - `./gradlew :starter:studio-platform-starter-ai:test`
-- `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-chunking:test`
 - `git diff --check`
+- `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-chunking:test`
 - `./gradlew :studio-platform-user:test --tests 'studio.one.base.user.persistence.jpa.ApplicationGroupMembershipJpaRepositorySearchTest' --tests 'studio.one.base.user.persistence.jdbc.ApplicationGroupMembershipJdbcRepositoryTest'`
 - `./gradlew :studio-platform-chunking:test :starter:studio-platform-starter-chunking:test`
 

--- a/starter/studio-platform-starter-ai/README.md
+++ b/starter/studio-platform-starter-ai/README.md
@@ -240,6 +240,39 @@ studio:
 기존 `studio.ai.pipeline.chunk-size`, `studio.ai.pipeline.chunk-overlap`는 deprecated legacy `TextChunker` fallback 설정이다.
 신규 `ChunkingOrchestrator` 경로에서는 `studio.chunking.*`가 기준이다.
 
+#### legacy RAG chunk 설정 migration
+
+신규 RAG indexing에서는 `starter:studio-platform-starter-chunking`을 추가하고 `studio.chunking.*` 설정을 사용한다.
+`studio.ai.pipeline.*` chunk 설정은 `ChunkingOrchestrator` bean이 없어서 `starter-ai`가 deprecated
+`OverlapTextChunker` fallback을 생성하는 경우에만 적용된다.
+
+| legacy 설정 | 신규 설정 | 적용 조건 |
+|---|---|---|
+| `studio.ai.pipeline.chunk-size` | `studio.chunking.max-size` | legacy `TextChunker` fallback에서만 legacy key 적용 |
+| `studio.ai.pipeline.chunk-overlap` | `studio.chunking.overlap` | legacy `TextChunker` fallback에서만 legacy key 적용 |
+
+Migration 예시:
+
+```yaml
+# legacy fallback only
+studio:
+  ai:
+    pipeline:
+      chunk-size: 500
+      chunk-overlap: 50
+
+# recommended
+studio:
+  chunking:
+    max-size: 800
+    overlap: 100
+```
+
+`starter:studio-platform-starter-chunking`이 classpath에 있고 `ChunkingOrchestrator`가 등록되면
+기본 `OverlapTextChunker` bean은 생성되지 않는다. 이때 `studio.ai.pipeline.chunk-size`와
+`studio.ai.pipeline.chunk-overlap`은 신규 chunking 경로에 전달되지 않는다. 신규 경로의 chunk 크기와
+overlap은 `studio.chunking.max-size`, `studio.chunking.overlap`로 조정한다.
+
 ### RAG 파이프라인 튜닝
 
 이슈 #202부터 RAG 검색과 객체 범위 조회 제한은 운영 설정으로 조정할 수 있다. 기본값은 기존 동작과 유사하게 유지하되,

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineProperties.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineProperties.java
@@ -12,8 +12,8 @@ import java.time.Duration;
 @ConfigurationProperties(prefix = PropertyKeys.AI.PREFIX + ".pipeline")
 public class RagPipelineProperties {
 
-    public static final String LEGACY_CHUNK_SIZE_PROPERTY = PropertyKeys.AI.PREFIX + ".pipeline.chunk-size";
-    public static final String LEGACY_CHUNK_OVERLAP_PROPERTY = PropertyKeys.AI.PREFIX + ".pipeline.chunk-overlap";
+    static final String LEGACY_CHUNK_SIZE_PROPERTY = PropertyKeys.AI.PREFIX + ".pipeline.chunk-size";
+    static final String LEGACY_CHUNK_OVERLAP_PROPERTY = PropertyKeys.AI.PREFIX + ".pipeline.chunk-overlap";
 
     private int chunkSize = 500;
     private int chunkOverlap = 50;
@@ -40,11 +40,10 @@ public class RagPipelineProperties {
     }
 
     /**
-     * @deprecated Use {@code studio.chunking.max-size} from
-     *             {@code starter:studio-platform-starter-chunking} for new RAG
-     *             chunking.
+     * Binds the deprecated legacy fallback chunk size property. Kept non-deprecated
+     * so Spring Boot configuration binding does not report the setter itself as a
+     * deprecated invocation path.
      */
-    @Deprecated(since = "2.x", forRemoval = false)
     public void setChunkSize(int chunkSize) {
         this.chunkSize = chunkSize;
     }
@@ -64,11 +63,10 @@ public class RagPipelineProperties {
     }
 
     /**
-     * @deprecated Use {@code studio.chunking.overlap} from
-     *             {@code starter:studio-platform-starter-chunking} for new RAG
-     *             chunking.
+     * Binds the deprecated legacy fallback chunk overlap property. Kept
+     * non-deprecated so Spring Boot configuration binding does not report the
+     * setter itself as a deprecated invocation path.
      */
-    @Deprecated(since = "2.x", forRemoval = false)
     public void setChunkOverlap(int chunkOverlap) {
         this.chunkOverlap = chunkOverlap;
     }

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineProperties.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineProperties.java
@@ -12,6 +12,9 @@ import java.time.Duration;
 @ConfigurationProperties(prefix = PropertyKeys.AI.PREFIX + ".pipeline")
 public class RagPipelineProperties {
 
+    public static final String LEGACY_CHUNK_SIZE_PROPERTY = PropertyKeys.AI.PREFIX + ".pipeline.chunk-size";
+    public static final String LEGACY_CHUNK_OVERLAP_PROPERTY = PropertyKeys.AI.PREFIX + ".pipeline.chunk-overlap";
+
     private int chunkSize = 500;
     private int chunkOverlap = 50;
     private final CacheProperties cache = new CacheProperties();
@@ -22,18 +25,50 @@ public class RagPipelineProperties {
     private final DiagnosticsProperties diagnostics = new DiagnosticsProperties();
     private final KeywordsProperties keywords = new KeywordsProperties();
 
+    /**
+     * Deprecated legacy fallback chunk size. This property is only used when no
+     * {@code ChunkingOrchestrator} bean is available and starter-ai creates the
+     * deprecated {@code TextChunker} fallback.
+     *
+     * @deprecated Use {@code studio.chunking.max-size} from
+     *             {@code starter:studio-platform-starter-chunking} for new RAG
+     *             chunking.
+     */
+    @Deprecated(since = "2.x", forRemoval = false)
     public int getChunkSize() {
         return chunkSize;
     }
 
+    /**
+     * @deprecated Use {@code studio.chunking.max-size} from
+     *             {@code starter:studio-platform-starter-chunking} for new RAG
+     *             chunking.
+     */
+    @Deprecated(since = "2.x", forRemoval = false)
     public void setChunkSize(int chunkSize) {
         this.chunkSize = chunkSize;
     }
 
+    /**
+     * Deprecated legacy fallback chunk overlap. This property is only used when no
+     * {@code ChunkingOrchestrator} bean is available and starter-ai creates the
+     * deprecated {@code TextChunker} fallback.
+     *
+     * @deprecated Use {@code studio.chunking.overlap} from
+     *             {@code starter:studio-platform-starter-chunking} for new RAG
+     *             chunking.
+     */
+    @Deprecated(since = "2.x", forRemoval = false)
     public int getChunkOverlap() {
         return chunkOverlap;
     }
 
+    /**
+     * @deprecated Use {@code studio.chunking.overlap} from
+     *             {@code starter:studio-platform-starter-chunking} for new RAG
+     *             chunking.
+     */
+    @Deprecated(since = "2.x", forRemoval = false)
     public void setChunkOverlap(int chunkOverlap) {
         this.chunkOverlap = chunkOverlap;
     }

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/RagPipelinePropertiesTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/RagPipelinePropertiesTest.java
@@ -90,11 +90,6 @@ class RagPipelinePropertiesTest {
 
     @Test
     void shouldBindLegacyChunkFallbackDefaultsAndOverrides() {
-        RagPipelineProperties defaults = new RagPipelineProperties();
-
-        assertThat(defaults.getChunkSize()).isEqualTo(500);
-        assertThat(defaults.getChunkOverlap()).isEqualTo(50);
-
         StandardEnvironment environment = new StandardEnvironment();
         environment.getPropertySources().addFirst(new MapPropertySource("test", Map.of(
                 RagPipelineProperties.LEGACY_CHUNK_SIZE_PROPERTY, "900",
@@ -111,9 +106,12 @@ class RagPipelinePropertiesTest {
     @Test
     void shouldMarkLegacyChunkFallbackAccessorsAsDeprecated() throws NoSuchMethodException {
         assertDeprecatedFallbackAccessor(RagPipelineProperties.class.getMethod("getChunkSize"));
-        assertDeprecatedFallbackAccessor(RagPipelineProperties.class.getMethod("setChunkSize", int.class));
         assertDeprecatedFallbackAccessor(RagPipelineProperties.class.getMethod("getChunkOverlap"));
-        assertDeprecatedFallbackAccessor(RagPipelineProperties.class.getMethod("setChunkOverlap", int.class));
+
+        assertThat(RagPipelineProperties.class.getMethod("setChunkSize", int.class).getAnnotation(Deprecated.class))
+                .isNull();
+        assertThat(RagPipelineProperties.class.getMethod("setChunkOverlap", int.class).getAnnotation(Deprecated.class))
+                .isNull();
     }
 
     @Test

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/RagPipelinePropertiesTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/RagPipelinePropertiesTest.java
@@ -9,14 +9,18 @@ import org.springframework.boot.context.properties.source.ConfigurationPropertyS
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.StandardEnvironment;
 
+import java.lang.reflect.Method;
 import java.util.Map;
 
+@SuppressWarnings("deprecation")
 class RagPipelinePropertiesTest {
 
     @Test
     void shouldExposeRetrievalAndObjectScopeDefaults() {
         RagPipelineProperties properties = new RagPipelineProperties();
 
+        assertThat(properties.getChunkSize()).isEqualTo(500);
+        assertThat(properties.getChunkOverlap()).isEqualTo(50);
         assertThat(properties.getRetrieval().getVectorWeight()).isEqualTo(0.7d);
         assertThat(properties.getRetrieval().getLexicalWeight()).isEqualTo(0.3d);
         assertThat(properties.getRetrieval().getMinRelevanceScore()).isEqualTo(0.15d);
@@ -85,6 +89,34 @@ class RagPipelinePropertiesTest {
     }
 
     @Test
+    void shouldBindLegacyChunkFallbackDefaultsAndOverrides() {
+        RagPipelineProperties defaults = new RagPipelineProperties();
+
+        assertThat(defaults.getChunkSize()).isEqualTo(500);
+        assertThat(defaults.getChunkOverlap()).isEqualTo(50);
+
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().addFirst(new MapPropertySource("test", Map.of(
+                RagPipelineProperties.LEGACY_CHUNK_SIZE_PROPERTY, "900",
+                RagPipelineProperties.LEGACY_CHUNK_OVERLAP_PROPERTY, "90")));
+
+        RagPipelineProperties properties = new Binder(ConfigurationPropertySources.get(environment))
+                .bind("studio.ai.pipeline", Bindable.of(RagPipelineProperties.class))
+                .orElseThrow(() -> new AssertionError("RagPipelineProperties binding failed"));
+
+        assertThat(properties.getChunkSize()).isEqualTo(900);
+        assertThat(properties.getChunkOverlap()).isEqualTo(90);
+    }
+
+    @Test
+    void shouldMarkLegacyChunkFallbackAccessorsAsDeprecated() throws NoSuchMethodException {
+        assertDeprecatedFallbackAccessor(RagPipelineProperties.class.getMethod("getChunkSize"));
+        assertDeprecatedFallbackAccessor(RagPipelineProperties.class.getMethod("setChunkSize", int.class));
+        assertDeprecatedFallbackAccessor(RagPipelineProperties.class.getMethod("getChunkOverlap"));
+        assertDeprecatedFallbackAccessor(RagPipelineProperties.class.getMethod("setChunkOverlap", int.class));
+    }
+
+    @Test
     void shouldExposeVectorStoreDefaultsAndOverrides() {
         VectorStoreProperties defaults = new VectorStoreProperties();
         assertThat(defaults.getPostgres().getTextSearchConfig()).isEqualTo("simple");
@@ -98,5 +130,13 @@ class RagPipelinePropertiesTest {
                 .orElseThrow(() -> new AssertionError("VectorStoreProperties binding failed"));
 
         assertThat(properties.getPostgres().getTextSearchConfig()).isEqualTo("simple");
+    }
+
+    private void assertDeprecatedFallbackAccessor(Method method) {
+        Deprecated deprecated = method.getAnnotation(Deprecated.class);
+
+        assertThat(deprecated).isNotNull();
+        assertThat(deprecated.since()).isEqualTo("2.x");
+        assertThat(deprecated.forRemoval()).isFalse();
     }
 }


### PR DESCRIPTION
## Why

legacy `TextChunker` fallback 설정과 신규 `ChunkingOrchestrator` 기반 chunking 설정의 적용 범위가 README와 설정 계약에서 더 명확해야 합니다.

## What

- `starter-ai` README에 legacy RAG chunk 설정 migration guide를 추가했습니다.
- `studio.ai.pipeline.chunk-size` → `studio.chunking.max-size`, `studio.ai.pipeline.chunk-overlap` → `studio.chunking.overlap` mapping을 문서화했습니다.
- `RagPipelineProperties`의 chunk fallback accessor를 deprecated legacy 설정으로 표시했습니다.
- 기존 binding 기본값/override 호환성과 deprecation annotation을 테스트로 고정했습니다.
- `CHANGELOG.md`에 변경과 검증을 기록했습니다.

## Related Issues

- Closes #299
- Closes #300

## Validation

- Command: `./gradlew :starter:studio-platform-starter-ai:test`
- Result: PASS
- Command: `git diff --check`
- Result: PASS

## Risk / Rollback

- Risk: 동작 변경은 없고 문서 및 deprecation 표시 중심입니다. `@Deprecated`로 내부 사용처에 경고가 생길 수 있으나 기존 `RagPipelineConfiguration`은 deprecation warning suppress 상태입니다.
- Rollback: README와 `RagPipelineProperties` deprecation 표시, 관련 테스트 변경을 되돌리면 됩니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: `./gradlew :starter:studio-platform-starter-ai:test`, `git diff --check`

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included