### PR TITLE
feat(rag): web RAG 문맥 확장 연결

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2026-04-25
 
 ### 변경됨
+- 이슈 #290 대응으로 `starter-ai-web`의 `RagContextBuilder`가 optional `ChunkContextExpander`를 사용해 object-scoped RAG 검색 결과의 parent/neighbor/table 문맥을 확장할 수 있도록 했다.
+- RAG chat context 확장 후에도 기존 `max-chunks`, `max-chars`, `include-scores` 제한을 유지하고, expander 또는 metadata가 없으면 기존 retrieval hit content 조립 경로를 유지한다.
 - 이슈 #299/#300 대응으로 `starter-ai` README에 legacy RAG chunk 설정 migration guide를 추가했다.
 - `studio.ai.pipeline.chunk-size`와 `studio.ai.pipeline.chunk-overlap`는 deprecated `TextChunker` fallback 전용 설정으로 표시하고, 기존 binding 호환성 테스트를 보강했다.
 - 이슈 #297 대응으로 `starter-ai`의 기본 `TextChunker` bean 생성을 `ChunkingOrchestrator`가 없을 때의 legacy fallback으로 제한했다.
@@ -21,6 +23,9 @@
 - README 예시와 실제 public API가 어긋나지 않도록 parent-child chunking, context expansion, text fallback 문서 시나리오 테스트를 추가했다.
 
 ### 검증
+- `./gradlew :starter:studio-platform-starter-ai-web:test`
+- `./gradlew :studio-platform-chunking:test`
+- `git diff --check`
 - `./gradlew :starter:studio-platform-starter-ai:test`
 - `git diff --check`
 - `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-chunking:test`

--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -282,7 +282,11 @@ Content-Type: application/json
 RAG context는 이슈 #202부터 설정된 chunk 수와 문자 수를 넘지 않도록 제한된다.
 문자 수 한도는 context header를 포함해 계산하며, 한도를 초과하는 chunk는 문장 중간에서 자르지 않고 통째로 제외한다.
 현재 context assembly 구현은 web starter 내부의 `RagContextBuilder`가 담당한다.
-별도 core `ContextAssembler` 계약은 만들지 않고, chunk 주변 문맥 확장은 `studio-platform-chunking`의 `ChunkContextExpander`를 우선 사용한다.
+별도 core `ContextAssembler` 계약은 만들지 않고, `ChunkContextExpander` bean이 있으면 object-scoped
+검색 결과의 chunk metadata를 기준으로 parent/neighbor/table 주변 문맥을 선택적으로 확장한다.
+`ChunkContextExpander`가 없거나 `objectType`/`objectId` 또는 `chunkId` metadata가 부족하면 기존처럼
+retrieval hit content만 사용한다. 확장 후에도 아래 `max-chunks`, `max-chars`, `include-scores`
+설정은 그대로 적용된다.
 
 ```yaml
 studio:

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
@@ -2,6 +2,7 @@ package studio.one.platform.ai.autoconfigure;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -34,6 +35,7 @@ import studio.one.platform.ai.web.service.ConversationChatService;
 import studio.one.platform.ai.web.service.InMemoryConversationRepository;
 import studio.one.platform.ai.web.service.InMemoryChatMemoryStore;
 import studio.one.platform.constant.PropertyKeys;
+import studio.one.platform.chunking.core.ChunkContextExpander;
 
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(ChatPort.class)
@@ -42,8 +44,10 @@ import studio.one.platform.constant.PropertyKeys;
 public class AiWebAutoConfiguration {
 
     @Bean
-    RagContextBuilder ragContextBuilder(AiWebRagProperties properties) {
-        return new RagContextBuilder(properties);
+    RagContextBuilder ragContextBuilder(
+            AiWebRagProperties properties,
+            ObjectProvider<ChunkContextExpander> contextExpanders) {
+        return new RagContextBuilder(properties, contextExpanders.stream().toList());
     }
 
     @Bean

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
@@ -291,7 +291,13 @@ public class ChatController {
         }
         RagRetrievalDiagnostics diagnostics = ragPipelineService.latestDiagnostics().orElse(null);
 
-        String context = ragContextBuilder.build(ragResults);
+        List<RagSearchResult> expansionCandidates = contextExpansionCandidates(
+                ragResults,
+                objectType,
+                objectId,
+                ragTopK,
+                ragQuery == null || ragQuery.isBlank());
+        String context = ragContextBuilder.build(ragResults, expansionCandidates);
 
         List<ChatMessageDto> augmentedMessages = new ArrayList<>();
         augmentedMessages.add(new ChatMessageDto("system", context));
@@ -551,6 +557,29 @@ public class ChatController {
             }
         }
         throw new IllegalArgumentException("RAG query is empty");
+    }
+
+    private List<RagSearchResult> contextExpansionCandidates(
+            List<RagSearchResult> ragResults,
+            String objectType,
+            String objectId,
+            int ragTopK,
+            boolean resultsAlreadyObjectCandidates) {
+        if (!ragContextBuilder.supportsExpansion()
+                || objectType == null || objectId == null
+                || objectType.isBlank() || objectId.isBlank()) {
+            return ragResults;
+        }
+        if (resultsAlreadyObjectCandidates) {
+            return ragResults;
+        }
+        int limit = Math.max(ragTopK, 1) * 4;
+        try {
+            List<RagSearchResult> candidates = ragPipelineService.listByObject(objectType, objectId, limit);
+            return candidates == null || candidates.isEmpty() ? ragResults : candidates;
+        } catch (RuntimeException ignored) {
+            return ragResults;
+        }
     }
 
     private ChatMemoryContext resolveMemory(ChatRequestDto request, Principal principal) {

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
@@ -38,6 +38,8 @@ import jakarta.validation.Valid;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -95,6 +97,7 @@ import studio.one.platform.web.dto.ApiResponse;
 @Validated
 public class ChatController {
 
+    private static final Logger log = LoggerFactory.getLogger(ChatController.class);
     private static final String OBJECT_TYPE_ATTACHMENT = "attachment";
 
     private final AiProviderRegistry providerRegistry;
@@ -577,7 +580,9 @@ public class ChatController {
         try {
             List<RagSearchResult> candidates = ragPipelineService.listByObject(objectType, objectId, limit);
             return candidates == null || candidates.isEmpty() ? ragResults : candidates;
-        } catch (RuntimeException ignored) {
+        } catch (RuntimeException ex) {
+            log.warn("RAG context expansion candidate fetch failed for objectType={}, objectId={}: {}",
+                    objectType, objectId, ex.getMessage());
             return ragResults;
         }
     }

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagContextBuilder.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagContextBuilder.java
@@ -25,7 +25,7 @@ public class RagContextBuilder {
 
     private static final String NO_CONTEXT_MESSAGE = "참고할 문서가 없습니다. 일반적으로 답변하세요.";
     private static final String HEADER = "다음 문서 내용을 참고해 답변하세요:\n";
-    private static final String KEY_CHUNK_ID = "chunkId";
+    static final String KEY_CHUNK_ID = "chunkId";
     private static final String KEY_DOCUMENT_ID = "documentId";
 
     private final int maxChunks;
@@ -161,6 +161,8 @@ public class RagContextBuilder {
         return contextExpanders.stream()
                 .filter(expander -> expander.strategy() == preferred)
                 .findFirst()
+                // Fall back to WINDOW because it preserves the seed chunk and only
+                // adds explicitly linked neighbors when a specialized expander is absent.
                 .or(() -> contextExpanders.stream()
                         .filter(expander -> expander.strategy() == ChunkContextExpansionStrategy.WINDOW)
                         .findFirst());
@@ -196,7 +198,7 @@ public class RagContextBuilder {
         ChunkMetadata chunkMetadata = ChunkMetadata.builder(strategy(metadata), order)
                 .sourceDocumentId(firstText(metadata, ChunkMetadata.KEY_SOURCE_DOCUMENT_ID, KEY_DOCUMENT_ID))
                 .parentId(text(metadata.get(ChunkMetadata.KEY_PARENT_ID)))
-                .chunkType(ChunkType.from(text(metadata.get(ChunkMetadata.KEY_CHUNK_TYPE))))
+                .chunkType(chunkType(metadata))
                 .parentChunkId(text(metadata.get(ChunkMetadata.KEY_PARENT_CHUNK_ID)))
                 .previousChunkId(text(metadata.get(ChunkMetadata.KEY_PREVIOUS_CHUNK_ID)))
                 .nextChunkId(text(metadata.get(ChunkMetadata.KEY_NEXT_CHUNK_ID)))
@@ -207,6 +209,14 @@ public class RagContextBuilder {
                 .attributes(metadata)
                 .build();
         return Optional.of(Chunk.of(chunkId, result.content(), chunkMetadata));
+    }
+
+    private ChunkType chunkType(Map<String, Object> metadata) {
+        try {
+            return ChunkType.from(text(metadata.get(ChunkMetadata.KEY_CHUNK_TYPE)));
+        } catch (IllegalArgumentException ignored) {
+            return ChunkType.CHILD;
+        }
     }
 
     private ChunkingStrategyType strategy(Map<String, Object> metadata) {

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagContextBuilder.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagContextBuilder.java
@@ -1,9 +1,22 @@
 package studio.one.platform.ai.web.controller;
 
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 import studio.one.platform.ai.autoconfigure.AiWebRagProperties;
 import studio.one.platform.ai.core.rag.RagSearchResult;
+import studio.one.platform.chunking.core.Chunk;
+import studio.one.platform.chunking.core.ChunkContextExpander;
+import studio.one.platform.chunking.core.ChunkContextExpansion;
+import studio.one.platform.chunking.core.ChunkContextExpansionRequest;
+import studio.one.platform.chunking.core.ChunkContextExpansionStrategy;
+import studio.one.platform.chunking.core.ChunkMetadata;
+import studio.one.platform.chunking.core.ChunkType;
+import studio.one.platform.chunking.core.ChunkingStrategyType;
 
 /**
  * Builds bounded RAG context prompts for chat completion requests.
@@ -12,28 +25,54 @@ public class RagContextBuilder {
 
     private static final String NO_CONTEXT_MESSAGE = "참고할 문서가 없습니다. 일반적으로 답변하세요.";
     private static final String HEADER = "다음 문서 내용을 참고해 답변하세요:\n";
+    private static final String KEY_CHUNK_ID = "chunkId";
+    private static final String KEY_DOCUMENT_ID = "documentId";
 
     private final int maxChunks;
     private final int maxChars;
     private final boolean includeScores;
+    private final List<ChunkContextExpander> contextExpanders;
 
     public RagContextBuilder(AiWebRagProperties properties) {
+        this(properties, List.of());
+    }
+
+    public RagContextBuilder(AiWebRagProperties properties, List<ChunkContextExpander> contextExpanders) {
         this(properties.getContext().getMaxChunks(),
                 properties.getContext().getMaxChars(),
-                properties.getContext().isIncludeScores());
+                properties.getContext().isIncludeScores(),
+                contextExpanders);
     }
 
     public RagContextBuilder(int maxChunks, int maxChars, boolean includeScores) {
+        this(maxChunks, maxChars, includeScores, List.of());
+    }
+
+    public RagContextBuilder(
+            int maxChunks,
+            int maxChars,
+            boolean includeScores,
+            List<ChunkContextExpander> contextExpanders) {
         this.maxChunks = Math.max(0, maxChunks);
         this.maxChars = Math.max(0, maxChars);
         this.includeScores = includeScores;
+        this.contextExpanders = contextExpanders == null ? List.of()
+                : contextExpanders.stream().filter(Objects::nonNull).toList();
     }
 
     public static RagContextBuilder defaults() {
         return new RagContextBuilder(8, 12_000, true);
     }
 
+    public boolean supportsExpansion() {
+        return !contextExpanders.isEmpty();
+    }
+
     public String build(List<RagSearchResult> results) {
+        return build(results, results);
+    }
+
+    public String build(List<RagSearchResult> results, List<RagSearchResult> expansionCandidates) {
         if (results == null || results.isEmpty() || maxChunks == 0 || maxChars == 0) {
             return NO_CONTEXT_MESSAGE;
         }
@@ -43,7 +82,7 @@ public class RagContextBuilder {
         }
         int count = Math.min(maxChunks, results.size());
         for (int i = 0; i < count; i++) {
-            RagSearchResult result = results.get(i);
+            RagSearchResult result = expandResult(results.get(i), expansionCandidates);
             String chunk = formatChunk(i + 1, result);
             if (!appendWithinLimit(sb, chunk)) {
                 break;
@@ -69,5 +108,153 @@ public class RagContextBuilder {
         }
         sb.append("\n").append(result.content()).append("\n\n");
         return sb.toString();
+    }
+
+    private RagSearchResult expandResult(RagSearchResult result, List<RagSearchResult> expansionCandidates) {
+        if (result == null || contextExpanders.isEmpty()) {
+            return result;
+        }
+        Optional<Chunk> seed = toChunk(result);
+        if (seed.isEmpty() || !hasObjectScope(seed.get())) {
+            return result;
+        }
+        List<Chunk> availableChunks = availableChunks(seed.get(), expansionCandidates);
+        if (availableChunks.isEmpty()) {
+            return result;
+        }
+        Optional<ChunkContextExpander> expander = selectExpander(seed.get());
+        if (expander.isEmpty()) {
+            return result;
+        }
+        ChunkContextExpansionRequest request = ChunkContextExpansionRequest.builder(seed.get())
+                .availableChunks(availableChunks)
+                .previousWindow(1)
+                .nextWindow(1)
+                .includeParentContent(true)
+                .build();
+        try {
+            ChunkContextExpansion expansion = expander.get().expand(request);
+            return new RagSearchResult(result.documentId(), expansion.content(), result.metadata(), result.score());
+        } catch (RuntimeException ignored) {
+            return result;
+        }
+    }
+
+    private List<Chunk> availableChunks(Chunk seed, List<RagSearchResult> candidates) {
+        if (candidates == null || candidates.isEmpty()) {
+            return List.of(seed);
+        }
+        Map<String, Chunk> chunks = new LinkedHashMap<>();
+        candidates.stream()
+                .filter(Objects::nonNull)
+                .map(this::toChunk)
+                .flatMap(Optional::stream)
+                .filter(candidate -> sameObjectScope(seed, candidate))
+                .sorted(Comparator.comparingInt(chunk -> chunk.metadata().order()))
+                .forEach(chunk -> chunks.putIfAbsent(chunk.id(), chunk));
+        chunks.putIfAbsent(seed.id(), seed);
+        return List.copyOf(chunks.values());
+    }
+
+    private Optional<ChunkContextExpander> selectExpander(Chunk seed) {
+        ChunkContextExpansionStrategy preferred = preferredStrategy(seed);
+        return contextExpanders.stream()
+                .filter(expander -> expander.strategy() == preferred)
+                .findFirst()
+                .or(() -> contextExpanders.stream()
+                        .filter(expander -> expander.strategy() == ChunkContextExpansionStrategy.WINDOW)
+                        .findFirst());
+    }
+
+    private ChunkContextExpansionStrategy preferredStrategy(Chunk seed) {
+        if (seed.metadata().chunkType() == ChunkType.TABLE) {
+            return ChunkContextExpansionStrategy.TABLE;
+        }
+        if (hasText(seed.metadata().parentChunkId())
+                || seed.metadata().toMap().containsKey(ChunkMetadata.KEY_PARENT_CHUNK_CONTENT)) {
+            return ChunkContextExpansionStrategy.PARENT_CHILD;
+        }
+        if (hasText(seed.metadata().section())) {
+            return ChunkContextExpansionStrategy.HEADING;
+        }
+        return ChunkContextExpansionStrategy.WINDOW;
+    }
+
+    private Optional<Chunk> toChunk(RagSearchResult result) {
+        if (result == null || !hasText(result.content())) {
+            return Optional.empty();
+        }
+        Map<String, Object> metadata = result.metadata();
+        String chunkId = text(metadata.get(KEY_CHUNK_ID));
+        if (!hasText(chunkId)) {
+            chunkId = result.documentId();
+        }
+        if (!hasText(chunkId)) {
+            return Optional.empty();
+        }
+        int order = intValue(metadata.get(ChunkMetadata.KEY_CHUNK_ORDER), 0);
+        ChunkMetadata chunkMetadata = ChunkMetadata.builder(strategy(metadata), order)
+                .sourceDocumentId(firstText(metadata, ChunkMetadata.KEY_SOURCE_DOCUMENT_ID, KEY_DOCUMENT_ID))
+                .parentId(text(metadata.get(ChunkMetadata.KEY_PARENT_ID)))
+                .chunkType(ChunkType.from(text(metadata.get(ChunkMetadata.KEY_CHUNK_TYPE))))
+                .parentChunkId(text(metadata.get(ChunkMetadata.KEY_PARENT_CHUNK_ID)))
+                .previousChunkId(text(metadata.get(ChunkMetadata.KEY_PREVIOUS_CHUNK_ID)))
+                .nextChunkId(text(metadata.get(ChunkMetadata.KEY_NEXT_CHUNK_ID)))
+                .section(firstText(metadata, ChunkMetadata.KEY_SECTION, ChunkMetadata.KEY_HEADING_PATH))
+                .objectType(text(metadata.get(ChunkMetadata.KEY_OBJECT_TYPE)))
+                .objectId(text(metadata.get(ChunkMetadata.KEY_OBJECT_ID)))
+                .charCount(result.content().length())
+                .attributes(metadata)
+                .build();
+        return Optional.of(Chunk.of(chunkId, result.content(), chunkMetadata));
+    }
+
+    private ChunkingStrategyType strategy(Map<String, Object> metadata) {
+        try {
+            return ChunkingStrategyType.from(text(metadata.get(ChunkMetadata.KEY_STRATEGY)));
+        } catch (IllegalArgumentException ignored) {
+            return ChunkingStrategyType.RECURSIVE;
+        }
+    }
+
+    private boolean hasObjectScope(Chunk chunk) {
+        return hasText(chunk.metadata().objectType()) && hasText(chunk.metadata().objectId());
+    }
+
+    private boolean sameObjectScope(Chunk left, Chunk right) {
+        return Objects.equals(left.metadata().objectType(), right.metadata().objectType())
+                && Objects.equals(left.metadata().objectId(), right.metadata().objectId());
+    }
+
+    private String firstText(Map<String, Object> metadata, String... keys) {
+        for (String key : keys) {
+            String value = text(metadata.get(key));
+            if (hasText(value)) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private int intValue(Object value, int fallback) {
+        if (value instanceof Number number) {
+            return Math.max(0, number.intValue());
+        }
+        if (value instanceof String stringValue) {
+            try {
+                return Math.max(0, Integer.parseInt(stringValue.trim()));
+            } catch (NumberFormatException ignored) {
+                return fallback;
+            }
+        }
+        return fallback;
+    }
+
+    private String text(Object value) {
+        return value instanceof String stringValue && !stringValue.isBlank() ? stringValue.trim() : null;
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
     }
 }

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
@@ -48,9 +48,17 @@ import studio.one.platform.ai.web.dto.ConversationSummaryDto;
 import studio.one.platform.ai.web.service.ConversationChatService;
 import studio.one.platform.ai.web.service.InMemoryChatMemoryStore;
 import studio.one.platform.ai.web.service.InMemoryConversationRepository;
+import studio.one.platform.chunking.core.Chunk;
+import studio.one.platform.chunking.core.ChunkContextExpander;
+import studio.one.platform.chunking.core.ChunkContextExpansion;
+import studio.one.platform.chunking.core.ChunkContextExpansionRequest;
+import studio.one.platform.chunking.core.ChunkContextExpansionStrategy;
+import studio.one.platform.chunking.core.ChunkMetadata;
 import studio.one.platform.web.dto.ApiResponse;
 
 class ChatControllerTest {
+
+    private static final String KEY_CHUNK_ID = "chunkId";
 
     @Mock
     private AiProviderRegistry providerRegistry;
@@ -544,6 +552,46 @@ class ChatControllerTest {
     }
 
     @Test
+    void ragChatUsesObjectScopedCandidatesForContextExpansion() {
+        controller = new ChatController(providerRegistry, ragPipelineService,
+                new RagContextBuilder(8, 12_000, true, List.of(new TestWindowExpander())));
+        ArgumentCaptor<ChatRequest> chatCaptor = ArgumentCaptor.forClass(ChatRequest.class);
+        when(ragPipelineService.search(any(RagSearchRequest.class)))
+                .thenReturn(List.of(new RagSearchResult("chunk-2", "seed", chunkMetadata("chunk-2"), 0.9d)));
+        when(ragPipelineService.listByObject("attachment", "123", 12))
+                .thenReturn(List.of(
+                        new RagSearchResult("chunk-1", "previous",
+                                chunkMetadata("chunk-1", null, "chunk-2", 0), 1.0d),
+                        new RagSearchResult("chunk-2", "seed",
+                                chunkMetadata("chunk-2", "chunk-1", "chunk-3", 1), 1.0d),
+                        new RagSearchResult("chunk-3", "next",
+                                chunkMetadata("chunk-3", "chunk-2", null, 2), 1.0d)));
+
+        controller.chatWithRag(new ChatRagRequestDto(
+                new ChatRequestDto(
+                        null,
+                        null,
+                        List.of(new ChatMessageDto("user", "summarize")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null),
+                "summary",
+                3,
+                "attachment",
+                "123"));
+
+        verify(ragPipelineService).listByObject("attachment", "123", 12);
+        verify(defaultChatPort).chat(chatCaptor.capture());
+        assertThat(chatCaptor.getValue().messages().get(0).content())
+                .contains("previous\nseed\nnext")
+                .contains("docId=chunk-2")
+                .contains("score=0.900");
+    }
+
+    @Test
     void ragChatLimitsContextChunks() {
         controller = new ChatController(providerRegistry, ragPipelineService, new RagContextBuilder(2, 12_000, true));
         ArgumentCaptor<ChatRequest> chatCaptor = ArgumentCaptor.forClass(ChatRequest.class);
@@ -866,5 +914,41 @@ class ChatControllerTest {
                 null,
                 null,
                 3);
+    }
+
+    private Map<String, Object> chunkMetadata(String chunkId) {
+        return chunkMetadata(chunkId, "chunk-1", "chunk-3", 1);
+    }
+
+    private Map<String, Object> chunkMetadata(String chunkId, String previousChunkId, String nextChunkId, int order) {
+        return Map.ofEntries(
+                Map.entry(ChunkMetadata.KEY_OBJECT_TYPE, "attachment"),
+                Map.entry(ChunkMetadata.KEY_OBJECT_ID, "123"),
+                Map.entry(KEY_CHUNK_ID, chunkId),
+                Map.entry(ChunkMetadata.KEY_CHUNK_ORDER, order),
+                Map.entry(ChunkMetadata.KEY_PREVIOUS_CHUNK_ID, previousChunkId == null ? "" : previousChunkId),
+                Map.entry(ChunkMetadata.KEY_NEXT_CHUNK_ID, nextChunkId == null ? "" : nextChunkId));
+    }
+
+    private static final class TestWindowExpander implements ChunkContextExpander {
+
+        @Override
+        public ChunkContextExpansionStrategy strategy() {
+            return ChunkContextExpansionStrategy.WINDOW;
+        }
+
+        @Override
+        public ChunkContextExpansion expand(ChunkContextExpansionRequest request) {
+            String content = request.availableChunks().stream()
+                    .map(Chunk::content)
+                    .reduce((left, right) -> left + "\n" + right)
+                    .orElse(request.seedChunk().content());
+            return new ChunkContextExpansion(
+                    request.seedChunk(),
+                    request.availableChunks(),
+                    content,
+                    strategy(),
+                    Map.of());
+        }
     }
 }

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
@@ -48,17 +48,10 @@ import studio.one.platform.ai.web.dto.ConversationSummaryDto;
 import studio.one.platform.ai.web.service.ConversationChatService;
 import studio.one.platform.ai.web.service.InMemoryChatMemoryStore;
 import studio.one.platform.ai.web.service.InMemoryConversationRepository;
-import studio.one.platform.chunking.core.Chunk;
-import studio.one.platform.chunking.core.ChunkContextExpander;
-import studio.one.platform.chunking.core.ChunkContextExpansion;
-import studio.one.platform.chunking.core.ChunkContextExpansionRequest;
-import studio.one.platform.chunking.core.ChunkContextExpansionStrategy;
 import studio.one.platform.chunking.core.ChunkMetadata;
 import studio.one.platform.web.dto.ApiResponse;
 
 class ChatControllerTest {
-
-    private static final String KEY_CHUNK_ID = "chunkId";
 
     @Mock
     private AiProviderRegistry providerRegistry;
@@ -554,7 +547,7 @@ class ChatControllerTest {
     @Test
     void ragChatUsesObjectScopedCandidatesForContextExpansion() {
         controller = new ChatController(providerRegistry, ragPipelineService,
-                new RagContextBuilder(8, 12_000, true, List.of(new TestWindowExpander())));
+                new RagContextBuilder(8, 12_000, true, TestWindowChunkContextExpander.asList()));
         ArgumentCaptor<ChatRequest> chatCaptor = ArgumentCaptor.forClass(ChatRequest.class);
         when(ragPipelineService.search(any(RagSearchRequest.class)))
                 .thenReturn(List.of(new RagSearchResult("chunk-2", "seed", chunkMetadata("chunk-2"), 0.9d)));
@@ -924,31 +917,9 @@ class ChatControllerTest {
         return Map.ofEntries(
                 Map.entry(ChunkMetadata.KEY_OBJECT_TYPE, "attachment"),
                 Map.entry(ChunkMetadata.KEY_OBJECT_ID, "123"),
-                Map.entry(KEY_CHUNK_ID, chunkId),
+                Map.entry(RagContextBuilder.KEY_CHUNK_ID, chunkId),
                 Map.entry(ChunkMetadata.KEY_CHUNK_ORDER, order),
                 Map.entry(ChunkMetadata.KEY_PREVIOUS_CHUNK_ID, previousChunkId == null ? "" : previousChunkId),
                 Map.entry(ChunkMetadata.KEY_NEXT_CHUNK_ID, nextChunkId == null ? "" : nextChunkId));
-    }
-
-    private static final class TestWindowExpander implements ChunkContextExpander {
-
-        @Override
-        public ChunkContextExpansionStrategy strategy() {
-            return ChunkContextExpansionStrategy.WINDOW;
-        }
-
-        @Override
-        public ChunkContextExpansion expand(ChunkContextExpansionRequest request) {
-            String content = request.availableChunks().stream()
-                    .map(Chunk::content)
-                    .reduce((left, right) -> left + "\n" + right)
-                    .orElse(request.seedChunk().content());
-            return new ChunkContextExpansion(
-                    request.seedChunk(),
-                    request.availableChunks(),
-                    content,
-                    strategy(),
-                    Map.of());
-        }
     }
 }

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagContextBuilderTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagContextBuilderTest.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import studio.one.platform.ai.core.rag.RagSearchResult;
-import studio.one.platform.chunking.core.Chunk;
 import studio.one.platform.chunking.core.ChunkContextExpander;
 import studio.one.platform.chunking.core.ChunkContextExpansion;
 import studio.one.platform.chunking.core.ChunkContextExpansionRequest;
@@ -16,8 +15,6 @@ import studio.one.platform.chunking.core.ChunkContextExpansionStrategy;
 import studio.one.platform.chunking.core.ChunkMetadata;
 
 class RagContextBuilderTest {
-
-    private static final String KEY_CHUNK_ID = "chunkId";
 
     @Test
     void keepsExistingContextWhenNoExpanderIsConfigured() {
@@ -33,7 +30,7 @@ class RagContextBuilderTest {
 
     @Test
     void expandsChunkContextWhenObjectScopedMetadataIsAvailable() {
-        RagContextBuilder builder = new RagContextBuilder(8, 12_000, true, List.of(new JoiningWindowExpander()));
+        RagContextBuilder builder = new RagContextBuilder(8, 12_000, true, TestWindowChunkContextExpander.asList());
 
         String context = builder.build(
                 List.of(result("chunk-2", "seed", metadata("chunk-2"))),
@@ -56,7 +53,7 @@ class RagContextBuilderTest {
         String context = builder.build(List.of(new RagSearchResult(
                 "chunk-1",
                 "seed",
-                Map.of(KEY_CHUNK_ID, "chunk-1"),
+                Map.of(RagContextBuilder.KEY_CHUNK_ID, "chunk-1"),
                 0.9d)));
 
         assertThat(context).contains("seed");
@@ -65,7 +62,7 @@ class RagContextBuilderTest {
 
     @Test
     void keepsCharacterBudgetAfterExpansion() {
-        RagContextBuilder builder = new RagContextBuilder(8, 80, true, List.of(new JoiningWindowExpander()));
+        RagContextBuilder builder = new RagContextBuilder(8, 80, true, TestWindowChunkContextExpander.asList());
 
         String context = builder.build(
                 List.of(result("chunk-2", "seed", metadata("chunk-2"))),
@@ -91,32 +88,10 @@ class RagContextBuilderTest {
         return Map.ofEntries(
                 Map.entry(ChunkMetadata.KEY_OBJECT_TYPE, "attachment"),
                 Map.entry(ChunkMetadata.KEY_OBJECT_ID, "123"),
-                Map.entry(KEY_CHUNK_ID, chunkId),
+                Map.entry(RagContextBuilder.KEY_CHUNK_ID, chunkId),
                 Map.entry(ChunkMetadata.KEY_CHUNK_ORDER, order),
                 Map.entry(ChunkMetadata.KEY_PREVIOUS_CHUNK_ID, previousChunkId == null ? "" : previousChunkId),
                 Map.entry(ChunkMetadata.KEY_NEXT_CHUNK_ID, nextChunkId == null ? "" : nextChunkId));
-    }
-
-    private static final class JoiningWindowExpander implements ChunkContextExpander {
-
-        @Override
-        public ChunkContextExpansionStrategy strategy() {
-            return ChunkContextExpansionStrategy.WINDOW;
-        }
-
-        @Override
-        public ChunkContextExpansion expand(ChunkContextExpansionRequest request) {
-            String content = request.availableChunks().stream()
-                    .map(Chunk::content)
-                    .reduce((left, right) -> left + "\n" + right)
-                    .orElse(request.seedChunk().content());
-            return new ChunkContextExpansion(
-                    request.seedChunk(),
-                    request.availableChunks(),
-                    content,
-                    strategy(),
-                    Map.of());
-        }
     }
 
     private static final class CountingExpander implements ChunkContextExpander {

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagContextBuilderTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagContextBuilderTest.java
@@ -1,0 +1,136 @@
+package studio.one.platform.ai.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.ai.core.rag.RagSearchResult;
+import studio.one.platform.chunking.core.Chunk;
+import studio.one.platform.chunking.core.ChunkContextExpander;
+import studio.one.platform.chunking.core.ChunkContextExpansion;
+import studio.one.platform.chunking.core.ChunkContextExpansionRequest;
+import studio.one.platform.chunking.core.ChunkContextExpansionStrategy;
+import studio.one.platform.chunking.core.ChunkMetadata;
+
+class RagContextBuilderTest {
+
+    private static final String KEY_CHUNK_ID = "chunkId";
+
+    @Test
+    void keepsExistingContextWhenNoExpanderIsConfigured() {
+        RagContextBuilder builder = new RagContextBuilder(8, 12_000, true);
+
+        String context = builder.build(List.of(result("chunk-1", "seed", metadata("chunk-1"))));
+
+        assertThat(context)
+                .contains("docId=chunk-1")
+                .contains("score=0.900")
+                .contains("seed");
+    }
+
+    @Test
+    void expandsChunkContextWhenObjectScopedMetadataIsAvailable() {
+        RagContextBuilder builder = new RagContextBuilder(8, 12_000, true, List.of(new JoiningWindowExpander()));
+
+        String context = builder.build(
+                List.of(result("chunk-2", "seed", metadata("chunk-2"))),
+                List.of(
+                        result("chunk-1", "previous", metadata("chunk-1", null, "chunk-2", 0)),
+                        result("chunk-2", "seed", metadata("chunk-2", "chunk-1", "chunk-3", 1)),
+                        result("chunk-3", "next", metadata("chunk-3", "chunk-2", null, 2))));
+
+        assertThat(context)
+                .contains("docId=chunk-2")
+                .contains("score=0.900")
+                .contains("previous\nseed\nnext");
+    }
+
+    @Test
+    void doesNotExpandWhenObjectScopeIsMissing() {
+        CountingExpander expander = new CountingExpander();
+        RagContextBuilder builder = new RagContextBuilder(8, 12_000, true, List.of(expander));
+
+        String context = builder.build(List.of(new RagSearchResult(
+                "chunk-1",
+                "seed",
+                Map.of(KEY_CHUNK_ID, "chunk-1"),
+                0.9d)));
+
+        assertThat(context).contains("seed");
+        assertThat(expander.calls).isZero();
+    }
+
+    @Test
+    void keepsCharacterBudgetAfterExpansion() {
+        RagContextBuilder builder = new RagContextBuilder(8, 80, true, List.of(new JoiningWindowExpander()));
+
+        String context = builder.build(
+                List.of(result("chunk-2", "seed", metadata("chunk-2"))),
+                List.of(
+                        result("chunk-1", "previous text that makes the expanded content too long",
+                                metadata("chunk-1", null, "chunk-2", 0)),
+                        result("chunk-2", "seed", metadata("chunk-2", "chunk-1", "chunk-3", 1)),
+                        result("chunk-3", "next text that makes the expanded content too long",
+                                metadata("chunk-3", "chunk-2", null, 2))));
+
+        assertThat(context).isEqualTo("참고할 문서가 없습니다. 일반적으로 답변하세요.");
+    }
+
+    private RagSearchResult result(String chunkId, String content, Map<String, Object> metadata) {
+        return new RagSearchResult(chunkId, content, metadata, 0.9d);
+    }
+
+    private Map<String, Object> metadata(String chunkId) {
+        return metadata(chunkId, "chunk-1", "chunk-3", 1);
+    }
+
+    private Map<String, Object> metadata(String chunkId, String previousChunkId, String nextChunkId, int order) {
+        return Map.ofEntries(
+                Map.entry(ChunkMetadata.KEY_OBJECT_TYPE, "attachment"),
+                Map.entry(ChunkMetadata.KEY_OBJECT_ID, "123"),
+                Map.entry(KEY_CHUNK_ID, chunkId),
+                Map.entry(ChunkMetadata.KEY_CHUNK_ORDER, order),
+                Map.entry(ChunkMetadata.KEY_PREVIOUS_CHUNK_ID, previousChunkId == null ? "" : previousChunkId),
+                Map.entry(ChunkMetadata.KEY_NEXT_CHUNK_ID, nextChunkId == null ? "" : nextChunkId));
+    }
+
+    private static final class JoiningWindowExpander implements ChunkContextExpander {
+
+        @Override
+        public ChunkContextExpansionStrategy strategy() {
+            return ChunkContextExpansionStrategy.WINDOW;
+        }
+
+        @Override
+        public ChunkContextExpansion expand(ChunkContextExpansionRequest request) {
+            String content = request.availableChunks().stream()
+                    .map(Chunk::content)
+                    .reduce((left, right) -> left + "\n" + right)
+                    .orElse(request.seedChunk().content());
+            return new ChunkContextExpansion(
+                    request.seedChunk(),
+                    request.availableChunks(),
+                    content,
+                    strategy(),
+                    Map.of());
+        }
+    }
+
+    private static final class CountingExpander implements ChunkContextExpander {
+        private int calls;
+
+        @Override
+        public ChunkContextExpansionStrategy strategy() {
+            return ChunkContextExpansionStrategy.WINDOW;
+        }
+
+        @Override
+        public ChunkContextExpansion expand(ChunkContextExpansionRequest request) {
+            calls++;
+            return ChunkContextExpansion.of(request.seedChunk(), List.of(request.seedChunk()), strategy());
+        }
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/TestWindowChunkContextExpander.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/TestWindowChunkContextExpander.java
@@ -1,0 +1,36 @@
+package studio.one.platform.ai.web.controller;
+
+import java.util.List;
+import java.util.Map;
+
+import studio.one.platform.chunking.core.Chunk;
+import studio.one.platform.chunking.core.ChunkContextExpander;
+import studio.one.platform.chunking.core.ChunkContextExpansion;
+import studio.one.platform.chunking.core.ChunkContextExpansionRequest;
+import studio.one.platform.chunking.core.ChunkContextExpansionStrategy;
+
+final class TestWindowChunkContextExpander implements ChunkContextExpander {
+
+    @Override
+    public ChunkContextExpansionStrategy strategy() {
+        return ChunkContextExpansionStrategy.WINDOW;
+    }
+
+    @Override
+    public ChunkContextExpansion expand(ChunkContextExpansionRequest request) {
+        String content = request.availableChunks().stream()
+                .map(Chunk::content)
+                .reduce((left, right) -> left + "\n" + right)
+                .orElse(request.seedChunk().content());
+        return new ChunkContextExpansion(
+                request.seedChunk(),
+                request.availableChunks(),
+                content,
+                strategy(),
+                Map.of());
+    }
+
+    static List<ChunkContextExpander> asList() {
+        return List.of(new TestWindowChunkContextExpander());
+    }
+}


### PR DESCRIPTION
## Why

구조화 RAG 색인과 chunk metadata가 준비됐지만 web RAG chat context 조립은 retrieval hit 본문만 사용하고 있었습니다. 새 core `ContextAssembler`를 만들지 않고 기존 `RagContextBuilder`와 `ChunkContextExpander` 계약을 연결합니다.

## What

- `RagContextBuilder`가 optional `ChunkContextExpander` 목록을 받아 object-scoped RAG hit를 `Chunk`로 변환하고 parent/neighbor/table 문맥을 확장하도록 했습니다.
- `ChatController`는 object-scoped 검색에서 `listByObject(objectType, objectId, ragTopK * 4)` 후보를 context expansion에 전달합니다.
- expander가 없거나 object/chunk metadata가 부족하거나 후보 조회/확장이 실패하면 기존 retrieval hit content 조립으로 fallback합니다.
- 확장 후에도 기존 `max-chunks`, `max-chars`, `include-scores` 제한을 유지합니다.
- README와 controller/builder 테스트를 보강했습니다.

## Related Issues

- Closes #290

## Validation

- Command: `./gradlew :starter:studio-platform-starter-ai-web:test`
- Result: PASS
- Command: `./gradlew :studio-platform-chunking:test`
- Result: PASS
- Command: `git diff --check`
- Result: PASS

## Risk / Rollback

- Risk: object-scoped RAG chat에서 expander가 있을 때 후보 chunk 조회가 추가됩니다. 조회 실패나 metadata 부족 시 기존 context 조립으로 fallback하도록 제한했습니다.
- Rollback: `RagContextBuilder`의 expander 연결과 `ChatController` 후보 조회 변경을 되돌리면 기존 retrieval hit content 조립으로 복귀합니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: `./gradlew :starter:studio-platform-starter-ai-web:test`, `./gradlew :studio-platform-chunking:test`, `git diff --check`

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included