### PR TITLE
feat(rag): context expansion 설정 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
 # Changelog
 
-## 2026-04-25
+## 2026-04-26
 
 ### 변경됨
 - 이슈 #303 대응으로 `starter-ai-web`의 RAG context expansion을 `studio.ai.endpoints.rag.context.expansion.*` 설정으로 제어할 수 있도록 했다.
 - context expansion candidate 조회 배수, previous/next window, parent content 포함 여부를 설정으로 분리하고 기본값은 기존 동작과 호환되게 유지했다.
+
+### 검증
+- `./gradlew :starter:studio-platform-starter-ai-web:test`
+- `git diff --check`
+
+## 2026-04-25
+
+### 변경됨
 - 이슈 #290 대응으로 `starter-ai-web`의 `RagContextBuilder`가 optional `ChunkContextExpander`를 사용해 object-scoped RAG 검색 결과의 parent/neighbor/table 문맥을 확장할 수 있도록 했다.
 - RAG chat context 확장 후에도 기존 `max-chunks`, `max-chars`, `include-scores` 제한을 유지하고, expander 또는 metadata가 없으면 기존 retrieval hit content 조립 경로를 유지한다.
 - 이슈 #299/#300 대응으로 `starter-ai` README에 legacy RAG chunk 설정 migration guide를 추가했다.
@@ -25,8 +33,6 @@
 - README 예시와 실제 public API가 어긋나지 않도록 parent-child chunking, context expansion, text fallback 문서 시나리오 테스트를 추가했다.
 
 ### 검증
-- `./gradlew :starter:studio-platform-starter-ai-web:test`
-- `git diff --check`
 - `./gradlew :studio-platform-chunking:test`
 - `./gradlew :starter:studio-platform-starter-ai:test`
 - `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-chunking:test`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 변경됨
 - 이슈 #303 대응으로 `starter-ai-web`의 RAG context expansion을 `studio.ai.endpoints.rag.context.expansion.*` 설정으로 제어할 수 있도록 했다.
-- context expansion candidate 조회 배수, previous/next window, parent content 포함 여부를 설정으로 분리하고 기본값은 기존 동작과 호환되게 유지했다.
+- context expansion candidate 조회 배수, previous/next window, parent content 포함 여부를 설정으로 분리하고 후보 조회 limit 상한을 적용했다.
 
 ### 검증
 - `./gradlew :starter:studio-platform-starter-ai-web:test`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 변경됨
 - 이슈 #303 대응으로 `starter-ai-web`의 RAG context expansion을 `studio.ai.endpoints.rag.context.expansion.*` 설정으로 제어할 수 있도록 했다.
-- context expansion candidate 조회 배수, previous/next window, parent content 포함 여부를 설정으로 분리하고 후보 조회 limit 상한을 적용했다.
+- context expansion candidate 조회 배수, 후보 조회 상한, previous/next window, parent content 포함 여부를 설정으로 분리했다.
 
 ### 검증
 - `./gradlew :starter:studio-platform-starter-ai-web:test`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2026-04-25
 
 ### 변경됨
+- 이슈 #303 대응으로 `starter-ai-web`의 RAG context expansion을 `studio.ai.endpoints.rag.context.expansion.*` 설정으로 제어할 수 있도록 했다.
+- context expansion candidate 조회 배수, previous/next window, parent content 포함 여부를 설정으로 분리하고 기본값은 기존 동작과 호환되게 유지했다.
 - 이슈 #290 대응으로 `starter-ai-web`의 `RagContextBuilder`가 optional `ChunkContextExpander`를 사용해 object-scoped RAG 검색 결과의 parent/neighbor/table 문맥을 확장할 수 있도록 했다.
 - RAG chat context 확장 후에도 기존 `max-chunks`, `max-chars`, `include-scores` 제한을 유지하고, expander 또는 metadata가 없으면 기존 retrieval hit content 조립 경로를 유지한다.
 - 이슈 #299/#300 대응으로 `starter-ai` README에 legacy RAG chunk 설정 migration guide를 추가했다.
@@ -24,10 +26,9 @@
 
 ### 검증
 - `./gradlew :starter:studio-platform-starter-ai-web:test`
+- `git diff --check`
 - `./gradlew :studio-platform-chunking:test`
-- `git diff --check`
 - `./gradlew :starter:studio-platform-starter-ai:test`
-- `git diff --check`
 - `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-chunking:test`
 - `./gradlew :studio-platform-user:test --tests 'studio.one.base.user.persistence.jpa.ApplicationGroupMembershipJpaRepositorySearchTest' --tests 'studio.one.base.user.persistence.jdbc.ApplicationGroupMembershipJdbcRepositoryTest'`
 - `./gradlew :studio-platform-chunking:test :starter:studio-platform-starter-chunking:test`

--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -297,6 +297,12 @@ studio:
           max-chunks: 8
           max-chars: 12000
           include-scores: true
+          expansion:
+            enabled: true
+            candidate-multiplier: 4
+            previous-window: 1
+            next-window: 1
+            include-parent-content: true
         diagnostics:
           allow-client-debug: false
 ```
@@ -306,6 +312,11 @@ studio:
 | `studio.ai.endpoints.rag.context.max-chunks` | `8` | chat system context에 포함할 최대 RAG chunk 수 |
 | `studio.ai.endpoints.rag.context.max-chars` | `12000` | header 포함 chat system context 최대 문자 수 |
 | `studio.ai.endpoints.rag.context.include-scores` | `true` | context에 retrieval score를 포함할지 여부 |
+| `studio.ai.endpoints.rag.context.expansion.enabled` | `true` | `ChunkContextExpander` 기반 주변 문맥 확장 사용 여부 |
+| `studio.ai.endpoints.rag.context.expansion.candidate-multiplier` | `4` | object-scoped 검색 시 `ragTopK` 대비 후보 chunk 조회 배수 |
+| `studio.ai.endpoints.rag.context.expansion.previous-window` | `1` | neighbor expansion에 전달할 이전 chunk window |
+| `studio.ai.endpoints.rag.context.expansion.next-window` | `1` | neighbor expansion에 전달할 다음 chunk window |
+| `studio.ai.endpoints.rag.context.expansion.include-parent-content` | `true` | parent/table expansion에서 parent content metadata를 사용할지 여부 |
 | `studio.ai.endpoints.rag.diagnostics.allow-client-debug` | `false` | client `debug=true` 요청에 `metadata.ragDiagnostics` 노출 허용 여부 |
 
 이슈 #205부터 RAG retrieval diagnostics를 선택적으로 사용할 수 있다. 서버의

--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -276,7 +276,7 @@ Content-Type: application/json
 }
 ```
 
-`objectType`/`objectId`를 지정하면 해당 객체 범위의 RAG 인덱스에서 검색한다. `ragQuery`가 없고
+`ragTopK`는 `1` 이상 `100` 이하만 허용한다. `objectType`/`objectId`를 지정하면 해당 객체 범위의 RAG 인덱스에서 검색한다. `ragQuery`가 없고
 객체 범위만 있으면 저장된 chunk를 순서대로 가져와 컨텍스트로 사용한다.
 
 RAG context는 이슈 #202부터 설정된 chunk 수와 문자 수를 넘지 않도록 제한된다.
@@ -300,6 +300,7 @@ studio:
           expansion:
             enabled: true
             candidate-multiplier: 4
+            max-candidates: 100
             previous-window: 1
             next-window: 1
             include-parent-content: true
@@ -313,7 +314,8 @@ studio:
 | `studio.ai.endpoints.rag.context.max-chars` | `12000` | header 포함 chat system context 최대 문자 수 |
 | `studio.ai.endpoints.rag.context.include-scores` | `true` | context에 retrieval score를 포함할지 여부 |
 | `studio.ai.endpoints.rag.context.expansion.enabled` | `true` | `ChunkContextExpander` 기반 주변 문맥 확장 사용 여부 |
-| `studio.ai.endpoints.rag.context.expansion.candidate-multiplier` | `4` | object-scoped 검색 시 `ragTopK` 대비 후보 chunk 조회 배수. 실제 후보 조회 limit은 최대 `100`으로 제한 |
+| `studio.ai.endpoints.rag.context.expansion.candidate-multiplier` | `4` | object-scoped 검색 시 `ragTopK` 대비 후보 chunk 조회 배수 |
+| `studio.ai.endpoints.rag.context.expansion.max-candidates` | `100` | context expansion 후보 chunk 조회 limit 상한 |
 | `studio.ai.endpoints.rag.context.expansion.previous-window` | `1` | neighbor expansion에 전달할 이전 chunk window |
 | `studio.ai.endpoints.rag.context.expansion.next-window` | `1` | neighbor expansion에 전달할 다음 chunk window |
 | `studio.ai.endpoints.rag.context.expansion.include-parent-content` | `true` | parent/table expansion에서 parent content metadata를 사용할지 여부 |

--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -313,7 +313,7 @@ studio:
 | `studio.ai.endpoints.rag.context.max-chars` | `12000` | header 포함 chat system context 최대 문자 수 |
 | `studio.ai.endpoints.rag.context.include-scores` | `true` | context에 retrieval score를 포함할지 여부 |
 | `studio.ai.endpoints.rag.context.expansion.enabled` | `true` | `ChunkContextExpander` 기반 주변 문맥 확장 사용 여부 |
-| `studio.ai.endpoints.rag.context.expansion.candidate-multiplier` | `4` | object-scoped 검색 시 `ragTopK` 대비 후보 chunk 조회 배수 |
+| `studio.ai.endpoints.rag.context.expansion.candidate-multiplier` | `4` | object-scoped 검색 시 `ragTopK` 대비 후보 chunk 조회 배수. 실제 후보 조회 limit은 최대 `100`으로 제한 |
 | `studio.ai.endpoints.rag.context.expansion.previous-window` | `1` | neighbor expansion에 전달할 이전 chunk window |
 | `studio.ai.endpoints.rag.context.expansion.next-window` | `1` | neighbor expansion에 전달할 다음 chunk window |
 | `studio.ai.endpoints.rag.context.expansion.include-parent-content` | `true` | parent/table expansion에서 parent content metadata를 사용할지 여부 |

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
@@ -89,7 +89,8 @@ public class AiWebAutoConfiguration {
                 chatMemoryStore,
                 chatProperties.getMemory().isEnabled(),
                 conversationChatService,
-                objectMapper);
+                objectMapper,
+                ragProperties.getContext().getExpansion());
     }
 
     @Bean

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
@@ -90,7 +90,8 @@ public class AiWebAutoConfiguration {
                 chatProperties.getMemory().isEnabled(),
                 conversationChatService,
                 objectMapper,
-                ragProperties.getContext().getExpansion().getCandidateMultiplier());
+                ragProperties.getContext().getExpansion().getCandidateMultiplier(),
+                ragProperties.getContext().getExpansion().getMaxCandidates());
     }
 
     @Bean

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
@@ -90,7 +90,7 @@ public class AiWebAutoConfiguration {
                 chatProperties.getMemory().isEnabled(),
                 conversationChatService,
                 objectMapper,
-                ragProperties.getContext().getExpansion());
+                ragProperties.getContext().getExpansion().getCandidateMultiplier());
     }
 
     @Bean

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebRagProperties.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebRagProperties.java
@@ -56,6 +56,7 @@ public class AiWebRagProperties {
     public static class ExpansionProperties {
         private boolean enabled = true;
         private int candidateMultiplier = 4;
+        private int maxCandidates = 100;
         private int previousWindow = 1;
         private int nextWindow = 1;
         private boolean includeParentContent = true;
@@ -74,6 +75,14 @@ public class AiWebRagProperties {
 
         public void setCandidateMultiplier(int candidateMultiplier) {
             this.candidateMultiplier = Math.max(1, candidateMultiplier);
+        }
+
+        public int getMaxCandidates() {
+            return maxCandidates;
+        }
+
+        public void setMaxCandidates(int maxCandidates) {
+            this.maxCandidates = Math.max(1, maxCandidates);
         }
 
         public int getPreviousWindow() {

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebRagProperties.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebRagProperties.java
@@ -22,6 +22,7 @@ public class AiWebRagProperties {
         private int maxChunks = 8;
         private int maxChars = 12_000;
         private boolean includeScores = true;
+        private final ExpansionProperties expansion = new ExpansionProperties();
 
         public int getMaxChunks() {
             return maxChunks;
@@ -45,6 +46,58 @@ public class AiWebRagProperties {
 
         public void setIncludeScores(boolean includeScores) {
             this.includeScores = includeScores;
+        }
+
+        public ExpansionProperties getExpansion() {
+            return expansion;
+        }
+    }
+
+    public static class ExpansionProperties {
+        private boolean enabled = true;
+        private int candidateMultiplier = 4;
+        private int previousWindow = 1;
+        private int nextWindow = 1;
+        private boolean includeParentContent = true;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public int getCandidateMultiplier() {
+            return candidateMultiplier;
+        }
+
+        public void setCandidateMultiplier(int candidateMultiplier) {
+            this.candidateMultiplier = Math.max(1, candidateMultiplier);
+        }
+
+        public int getPreviousWindow() {
+            return previousWindow;
+        }
+
+        public void setPreviousWindow(int previousWindow) {
+            this.previousWindow = Math.max(0, previousWindow);
+        }
+
+        public int getNextWindow() {
+            return nextWindow;
+        }
+
+        public void setNextWindow(int nextWindow) {
+            this.nextWindow = Math.max(0, nextWindow);
+        }
+
+        public boolean isIncludeParentContent() {
+            return includeParentContent;
+        }
+
+        public void setIncludeParentContent(boolean includeParentContent) {
+            this.includeParentContent = includeParentContent;
         }
     }
 

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
@@ -71,6 +71,7 @@ import studio.one.platform.ai.core.registry.AiProviderRegistry;
 import studio.one.platform.ai.core.rag.RagRetrievalDiagnostics;
 import studio.one.platform.ai.core.rag.RagSearchRequest;
 import studio.one.platform.ai.core.rag.RagSearchResult;
+import studio.one.platform.ai.autoconfigure.AiWebRagProperties;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
 import studio.one.platform.ai.web.dto.ChatMemoryOptionsDto;
 import studio.one.platform.ai.web.dto.ChatMessageDto;
@@ -100,12 +101,13 @@ public class ChatController {
     private static final Logger log = LoggerFactory.getLogger(ChatController.class);
     private static final String OBJECT_TYPE_ATTACHMENT = "attachment";
     private static final int DEFAULT_CONTEXT_EXPANSION_CANDIDATE_MULTIPLIER = 4;
-    private static final int MAX_CONTEXT_EXPANSION_CANDIDATES = 100;
+    private static final int DEFAULT_CONTEXT_EXPANSION_MAX_CANDIDATES = 100;
 
     private final AiProviderRegistry providerRegistry;
     private final RagPipelineService ragPipelineService;
     private final RagContextBuilder ragContextBuilder;
     private final int ragContextCandidateMultiplier;
+    private final int ragContextMaxCandidates;
     private final boolean allowClientDebug;
     private final ChatMemoryStore chatMemoryStore;
     private final boolean chatMemoryEnabled;
@@ -164,16 +166,58 @@ public class ChatController {
             boolean chatMemoryEnabled,
             ConversationChatService conversationChatService,
             ObjectMapper objectMapper,
-            int ragContextCandidateMultiplier) {
+            int ragContextCandidateMultiplier,
+            int ragContextMaxCandidates) {
         this.providerRegistry = Objects.requireNonNull(providerRegistry, "providerRegistry");
         this.ragPipelineService = Objects.requireNonNull(ragPipelineService, "ragPipelineService");
         this.ragContextBuilder = Objects.requireNonNull(ragContextBuilder, "ragContextBuilder");
         this.ragContextCandidateMultiplier = Math.max(1, ragContextCandidateMultiplier);
+        this.ragContextMaxCandidates = Math.max(1, ragContextMaxCandidates);
         this.allowClientDebug = allowClientDebug;
         this.chatMemoryStore = chatMemoryStore;
         this.chatMemoryEnabled = chatMemoryEnabled;
         this.conversationChatService = conversationChatService;
         this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
+    }
+
+    public ChatController(
+            AiProviderRegistry providerRegistry,
+            RagPipelineService ragPipelineService,
+            RagContextBuilder ragContextBuilder,
+            boolean allowClientDebug,
+            ChatMemoryStore chatMemoryStore,
+            boolean chatMemoryEnabled,
+            ConversationChatService conversationChatService,
+            ObjectMapper objectMapper,
+            int ragContextCandidateMultiplier) {
+        this(providerRegistry, ragPipelineService, ragContextBuilder, allowClientDebug, chatMemoryStore,
+                chatMemoryEnabled, conversationChatService, objectMapper,
+                ragContextCandidateMultiplier, DEFAULT_CONTEXT_EXPANSION_MAX_CANDIDATES);
+    }
+
+    /**
+     * @deprecated Since 2.x. Pass scalar candidate settings to this controller and keep window/parent expansion
+     * options on {@link RagContextBuilder}.
+     */
+    @Deprecated(since = "2.x", forRemoval = false)
+    public ChatController(
+            AiProviderRegistry providerRegistry,
+            RagPipelineService ragPipelineService,
+            RagContextBuilder ragContextBuilder,
+            boolean allowClientDebug,
+            ChatMemoryStore chatMemoryStore,
+            boolean chatMemoryEnabled,
+            ConversationChatService conversationChatService,
+            ObjectMapper objectMapper,
+            AiWebRagProperties.ExpansionProperties ragContextExpansion) {
+        this(providerRegistry, ragPipelineService, ragContextBuilder, allowClientDebug, chatMemoryStore,
+                chatMemoryEnabled, conversationChatService, objectMapper,
+                ragContextExpansion == null
+                        ? DEFAULT_CONTEXT_EXPANSION_CANDIDATE_MULTIPLIER
+                        : ragContextExpansion.getCandidateMultiplier(),
+                ragContextExpansion == null
+                        ? DEFAULT_CONTEXT_EXPANSION_MAX_CANDIDATES
+                        : ragContextExpansion.getMaxCandidates());
     }
 
     public ChatController(
@@ -608,7 +652,7 @@ public class ChatController {
 
     private int contextExpansionCandidateLimit(int ragTopK) {
         long requestedLimit = (long) Math.max(ragTopK, 1) * ragContextCandidateMultiplier;
-        return (int) Math.min(MAX_CONTEXT_EXPANSION_CANDIDATES, requestedLimit);
+        return (int) Math.min(ragContextMaxCandidates, requestedLimit);
     }
 
     private ChatMemoryContext resolveMemory(ChatRequestDto request, Principal principal) {

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
@@ -71,7 +71,6 @@ import studio.one.platform.ai.core.registry.AiProviderRegistry;
 import studio.one.platform.ai.core.rag.RagRetrievalDiagnostics;
 import studio.one.platform.ai.core.rag.RagSearchRequest;
 import studio.one.platform.ai.core.rag.RagSearchResult;
-import studio.one.platform.ai.autoconfigure.AiWebRagProperties;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
 import studio.one.platform.ai.web.dto.ChatMemoryOptionsDto;
 import studio.one.platform.ai.web.dto.ChatMessageDto;
@@ -100,11 +99,13 @@ public class ChatController {
 
     private static final Logger log = LoggerFactory.getLogger(ChatController.class);
     private static final String OBJECT_TYPE_ATTACHMENT = "attachment";
+    private static final int DEFAULT_CONTEXT_EXPANSION_CANDIDATE_MULTIPLIER = 4;
+    private static final int MAX_CONTEXT_EXPANSION_CANDIDATES = 100;
 
     private final AiProviderRegistry providerRegistry;
     private final RagPipelineService ragPipelineService;
     private final RagContextBuilder ragContextBuilder;
-    private final AiWebRagProperties.ExpansionProperties ragContextExpansion;
+    private final int ragContextCandidateMultiplier;
     private final boolean allowClientDebug;
     private final ChatMemoryStore chatMemoryStore;
     private final boolean chatMemoryEnabled;
@@ -163,13 +164,11 @@ public class ChatController {
             boolean chatMemoryEnabled,
             ConversationChatService conversationChatService,
             ObjectMapper objectMapper,
-            AiWebRagProperties.ExpansionProperties ragContextExpansion) {
+            int ragContextCandidateMultiplier) {
         this.providerRegistry = Objects.requireNonNull(providerRegistry, "providerRegistry");
         this.ragPipelineService = Objects.requireNonNull(ragPipelineService, "ragPipelineService");
         this.ragContextBuilder = Objects.requireNonNull(ragContextBuilder, "ragContextBuilder");
-        this.ragContextExpansion = ragContextExpansion == null
-                ? new AiWebRagProperties.ExpansionProperties()
-                : ragContextExpansion;
+        this.ragContextCandidateMultiplier = Math.max(1, ragContextCandidateMultiplier);
         this.allowClientDebug = allowClientDebug;
         this.chatMemoryStore = chatMemoryStore;
         this.chatMemoryEnabled = chatMemoryEnabled;
@@ -188,7 +187,7 @@ public class ChatController {
             ObjectMapper objectMapper) {
         this(providerRegistry, ragPipelineService, ragContextBuilder, allowClientDebug, chatMemoryStore,
                 chatMemoryEnabled, conversationChatService, objectMapper,
-                new AiWebRagProperties.ExpansionProperties());
+                DEFAULT_CONTEXT_EXPANSION_CANDIDATE_MULTIPLIER);
     }
 
     /**
@@ -596,7 +595,7 @@ public class ChatController {
         if (resultsAlreadyObjectCandidates) {
             return ragResults;
         }
-        int limit = Math.max(ragTopK, 1) * ragContextExpansion.getCandidateMultiplier();
+        int limit = contextExpansionCandidateLimit(ragTopK);
         try {
             List<RagSearchResult> candidates = ragPipelineService.listByObject(objectType, objectId, limit);
             return candidates == null || candidates.isEmpty() ? ragResults : candidates;
@@ -605,6 +604,11 @@ public class ChatController {
                     objectType, objectId, ex.getMessage());
             return ragResults;
         }
+    }
+
+    private int contextExpansionCandidateLimit(int ragTopK) {
+        long requestedLimit = (long) Math.max(ragTopK, 1) * ragContextCandidateMultiplier;
+        return (int) Math.min(MAX_CONTEXT_EXPANSION_CANDIDATES, requestedLimit);
     }
 
     private ChatMemoryContext resolveMemory(ChatRequestDto request, Principal principal) {

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
@@ -71,6 +71,7 @@ import studio.one.platform.ai.core.registry.AiProviderRegistry;
 import studio.one.platform.ai.core.rag.RagRetrievalDiagnostics;
 import studio.one.platform.ai.core.rag.RagSearchRequest;
 import studio.one.platform.ai.core.rag.RagSearchResult;
+import studio.one.platform.ai.autoconfigure.AiWebRagProperties;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
 import studio.one.platform.ai.web.dto.ChatMemoryOptionsDto;
 import studio.one.platform.ai.web.dto.ChatMessageDto;
@@ -103,6 +104,7 @@ public class ChatController {
     private final AiProviderRegistry providerRegistry;
     private final RagPipelineService ragPipelineService;
     private final RagContextBuilder ragContextBuilder;
+    private final AiWebRagProperties.ExpansionProperties ragContextExpansion;
     private final boolean allowClientDebug;
     private final ChatMemoryStore chatMemoryStore;
     private final boolean chatMemoryEnabled;
@@ -160,15 +162,33 @@ public class ChatController {
             ChatMemoryStore chatMemoryStore,
             boolean chatMemoryEnabled,
             ConversationChatService conversationChatService,
-            ObjectMapper objectMapper) {
+            ObjectMapper objectMapper,
+            AiWebRagProperties.ExpansionProperties ragContextExpansion) {
         this.providerRegistry = Objects.requireNonNull(providerRegistry, "providerRegistry");
         this.ragPipelineService = Objects.requireNonNull(ragPipelineService, "ragPipelineService");
         this.ragContextBuilder = Objects.requireNonNull(ragContextBuilder, "ragContextBuilder");
+        this.ragContextExpansion = ragContextExpansion == null
+                ? new AiWebRagProperties.ExpansionProperties()
+                : ragContextExpansion;
         this.allowClientDebug = allowClientDebug;
         this.chatMemoryStore = chatMemoryStore;
         this.chatMemoryEnabled = chatMemoryEnabled;
         this.conversationChatService = conversationChatService;
         this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
+    }
+
+    public ChatController(
+            AiProviderRegistry providerRegistry,
+            RagPipelineService ragPipelineService,
+            RagContextBuilder ragContextBuilder,
+            boolean allowClientDebug,
+            ChatMemoryStore chatMemoryStore,
+            boolean chatMemoryEnabled,
+            ConversationChatService conversationChatService,
+            ObjectMapper objectMapper) {
+        this(providerRegistry, ragPipelineService, ragContextBuilder, allowClientDebug, chatMemoryStore,
+                chatMemoryEnabled, conversationChatService, objectMapper,
+                new AiWebRagProperties.ExpansionProperties());
     }
 
     /**
@@ -576,7 +596,7 @@ public class ChatController {
         if (resultsAlreadyObjectCandidates) {
             return ragResults;
         }
-        int limit = Math.max(ragTopK, 1) * 4;
+        int limit = Math.max(ragTopK, 1) * ragContextExpansion.getCandidateMultiplier();
         try {
             List<RagSearchResult> candidates = ragPipelineService.listByObject(objectType, objectId, limit);
             return candidates == null || candidates.isEmpty() ? ragResults : candidates;

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagContextBuilder.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagContextBuilder.java
@@ -31,6 +31,7 @@ public class RagContextBuilder {
     private final int maxChunks;
     private final int maxChars;
     private final boolean includeScores;
+    private final AiWebRagProperties.ExpansionProperties expansion;
     private final List<ChunkContextExpander> contextExpanders;
 
     public RagContextBuilder(AiWebRagProperties properties) {
@@ -41,11 +42,12 @@ public class RagContextBuilder {
         this(properties.getContext().getMaxChunks(),
                 properties.getContext().getMaxChars(),
                 properties.getContext().isIncludeScores(),
+                properties.getContext().getExpansion(),
                 contextExpanders);
     }
 
     public RagContextBuilder(int maxChunks, int maxChars, boolean includeScores) {
-        this(maxChunks, maxChars, includeScores, List.of());
+        this(maxChunks, maxChars, includeScores, new AiWebRagProperties.ExpansionProperties(), List.of());
     }
 
     public RagContextBuilder(
@@ -53,9 +55,19 @@ public class RagContextBuilder {
             int maxChars,
             boolean includeScores,
             List<ChunkContextExpander> contextExpanders) {
+        this(maxChunks, maxChars, includeScores, new AiWebRagProperties.ExpansionProperties(), contextExpanders);
+    }
+
+    public RagContextBuilder(
+            int maxChunks,
+            int maxChars,
+            boolean includeScores,
+            AiWebRagProperties.ExpansionProperties expansion,
+            List<ChunkContextExpander> contextExpanders) {
         this.maxChunks = Math.max(0, maxChunks);
         this.maxChars = Math.max(0, maxChars);
         this.includeScores = includeScores;
+        this.expansion = expansion == null ? new AiWebRagProperties.ExpansionProperties() : expansion;
         this.contextExpanders = contextExpanders == null ? List.of()
                 : contextExpanders.stream().filter(Objects::nonNull).toList();
     }
@@ -65,7 +77,7 @@ public class RagContextBuilder {
     }
 
     public boolean supportsExpansion() {
-        return !contextExpanders.isEmpty();
+        return expansion.isEnabled() && !contextExpanders.isEmpty();
     }
 
     public String build(List<RagSearchResult> results) {
@@ -111,7 +123,7 @@ public class RagContextBuilder {
     }
 
     private RagSearchResult expandResult(RagSearchResult result, List<RagSearchResult> expansionCandidates) {
-        if (result == null || contextExpanders.isEmpty()) {
+        if (result == null || !supportsExpansion()) {
             return result;
         }
         Optional<Chunk> seed = toChunk(result);
@@ -128,9 +140,9 @@ public class RagContextBuilder {
         }
         ChunkContextExpansionRequest request = ChunkContextExpansionRequest.builder(seed.get())
                 .availableChunks(availableChunks)
-                .previousWindow(1)
-                .nextWindow(1)
-                .includeParentContent(true)
+                .previousWindow(expansion.getPreviousWindow())
+                .nextWindow(expansion.getNextWindow())
+                .includeParentContent(expansion.isIncludeParentContent())
                 .build();
         try {
             ChunkContextExpansion expansion = expander.get().expand(request);

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/ChatRagRequestDto.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/ChatRagRequestDto.java
@@ -1,6 +1,8 @@
 package studio.one.platform.ai.web.dto;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 /**
@@ -9,6 +11,8 @@ import jakarta.validation.constraints.NotNull;
 public record ChatRagRequestDto(
         @NotNull @Valid ChatRequestDto chat,
         String ragQuery,
+        @Min(value = 1, message = "ragTopK must be at least 1")
+        @Max(value = 100, message = "ragTopK must be at most 100")
         Integer ragTopK,
         String objectType,
         String objectId,

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/AiWebChatPropertiesTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/AiWebChatPropertiesTest.java
@@ -1,0 +1,45 @@
+package studio.one.platform.ai.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+class AiWebChatPropertiesTest {
+
+    @Test
+    void shouldExposeChatMemoryDefaults() {
+        AiWebChatProperties properties = new AiWebChatProperties();
+
+        assertThat(properties.getMemory().isEnabled()).isFalse();
+        assertThat(properties.getMemory().getMaxMessages()).isEqualTo(20);
+        assertThat(properties.getMemory().getMaxConversations()).isEqualTo(1_000);
+        assertThat(properties.getMemory().getTtl()).isEqualTo(Duration.ofMinutes(30));
+    }
+
+    @Test
+    void shouldBindChatMemoryOverrides() {
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().addFirst(new MapPropertySource("test", Map.of(
+                "studio.ai.endpoints.chat.memory.enabled", "true",
+                "studio.ai.endpoints.chat.memory.max-messages", "12",
+                "studio.ai.endpoints.chat.memory.max-conversations", "200",
+                "studio.ai.endpoints.chat.memory.ttl", "5m")));
+
+        AiWebChatProperties properties = new Binder(ConfigurationPropertySources.get(environment))
+                .bind("studio.ai.endpoints.chat", Bindable.of(AiWebChatProperties.class))
+                .orElseThrow(() -> new AssertionError("AiWebChatProperties binding failed"));
+
+        assertThat(properties.getMemory().isEnabled()).isTrue();
+        assertThat(properties.getMemory().getMaxMessages()).isEqualTo(12);
+        assertThat(properties.getMemory().getMaxConversations()).isEqualTo(200);
+        assertThat(properties.getMemory().getTtl()).isEqualTo(Duration.ofMinutes(5));
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/AiWebRagPropertiesTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/AiWebRagPropertiesTest.java
@@ -43,7 +43,7 @@ class AiWebRagPropertiesTest {
     }
 
     @Test
-    void shouldExposeDiagnosticsDefaults() {
+    void shouldExposeContextExpansionAndDiagnosticsDefaults() {
         AiWebRagProperties properties = new AiWebRagProperties();
 
         assertThat(properties.getContext().getExpansion().isEnabled()).isTrue();
@@ -55,7 +55,7 @@ class AiWebRagPropertiesTest {
     }
 
     @Test
-    void shouldBindDiagnosticsOverrides() {
+    void shouldBindContextExpansionAndDiagnosticsOverrides() {
         StandardEnvironment environment = new StandardEnvironment();
         environment.getPropertySources().addFirst(new MapPropertySource("test", Map.ofEntries(
                 Map.entry("studio.ai.endpoints.rag.context.expansion.enabled", "false"),

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/AiWebRagPropertiesTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/AiWebRagPropertiesTest.java
@@ -14,40 +14,12 @@ import org.springframework.core.env.StandardEnvironment;
 class AiWebRagPropertiesTest {
 
     @Test
-    void shouldExposeChatMemoryDefaults() {
-        AiWebChatProperties properties = new AiWebChatProperties();
-
-        assertThat(properties.getMemory().isEnabled()).isFalse();
-        assertThat(properties.getMemory().getMaxMessages()).isEqualTo(20);
-        assertThat(properties.getMemory().getMaxConversations()).isEqualTo(1_000);
-        assertThat(properties.getMemory().getTtl()).isEqualTo(java.time.Duration.ofMinutes(30));
-    }
-
-    @Test
-    void shouldBindChatMemoryOverrides() {
-        StandardEnvironment environment = new StandardEnvironment();
-        environment.getPropertySources().addFirst(new MapPropertySource("test", Map.of(
-                "studio.ai.endpoints.chat.memory.enabled", "true",
-                "studio.ai.endpoints.chat.memory.max-messages", "12",
-                "studio.ai.endpoints.chat.memory.max-conversations", "200",
-                "studio.ai.endpoints.chat.memory.ttl", "5m")));
-
-        AiWebChatProperties properties = new Binder(ConfigurationPropertySources.get(environment))
-                .bind("studio.ai.endpoints.chat", Bindable.of(AiWebChatProperties.class))
-                .orElseThrow(() -> new AssertionError("AiWebChatProperties binding failed"));
-
-        assertThat(properties.getMemory().isEnabled()).isTrue();
-        assertThat(properties.getMemory().getMaxMessages()).isEqualTo(12);
-        assertThat(properties.getMemory().getMaxConversations()).isEqualTo(200);
-        assertThat(properties.getMemory().getTtl()).isEqualTo(java.time.Duration.ofMinutes(5));
-    }
-
-    @Test
     void shouldExposeContextExpansionAndDiagnosticsDefaults() {
         AiWebRagProperties properties = new AiWebRagProperties();
 
         assertThat(properties.getContext().getExpansion().isEnabled()).isTrue();
         assertThat(properties.getContext().getExpansion().getCandidateMultiplier()).isEqualTo(4);
+        assertThat(properties.getContext().getExpansion().getMaxCandidates()).isEqualTo(100);
         assertThat(properties.getContext().getExpansion().getPreviousWindow()).isEqualTo(1);
         assertThat(properties.getContext().getExpansion().getNextWindow()).isEqualTo(1);
         assertThat(properties.getContext().getExpansion().isIncludeParentContent()).isTrue();
@@ -60,6 +32,7 @@ class AiWebRagPropertiesTest {
         environment.getPropertySources().addFirst(new MapPropertySource("test", Map.ofEntries(
                 Map.entry("studio.ai.endpoints.rag.context.expansion.enabled", "false"),
                 Map.entry("studio.ai.endpoints.rag.context.expansion.candidate-multiplier", "6"),
+                Map.entry("studio.ai.endpoints.rag.context.expansion.max-candidates", "30"),
                 Map.entry("studio.ai.endpoints.rag.context.expansion.previous-window", "2"),
                 Map.entry("studio.ai.endpoints.rag.context.expansion.next-window", "3"),
                 Map.entry("studio.ai.endpoints.rag.context.expansion.include-parent-content", "false"),
@@ -71,6 +44,7 @@ class AiWebRagPropertiesTest {
 
         assertThat(properties.getContext().getExpansion().isEnabled()).isFalse();
         assertThat(properties.getContext().getExpansion().getCandidateMultiplier()).isEqualTo(6);
+        assertThat(properties.getContext().getExpansion().getMaxCandidates()).isEqualTo(30);
         assertThat(properties.getContext().getExpansion().getPreviousWindow()).isEqualTo(2);
         assertThat(properties.getContext().getExpansion().getNextWindow()).isEqualTo(3);
         assertThat(properties.getContext().getExpansion().isIncludeParentContent()).isFalse();

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/AiWebRagPropertiesTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/AiWebRagPropertiesTest.java
@@ -46,19 +46,34 @@ class AiWebRagPropertiesTest {
     void shouldExposeDiagnosticsDefaults() {
         AiWebRagProperties properties = new AiWebRagProperties();
 
+        assertThat(properties.getContext().getExpansion().isEnabled()).isTrue();
+        assertThat(properties.getContext().getExpansion().getCandidateMultiplier()).isEqualTo(4);
+        assertThat(properties.getContext().getExpansion().getPreviousWindow()).isEqualTo(1);
+        assertThat(properties.getContext().getExpansion().getNextWindow()).isEqualTo(1);
+        assertThat(properties.getContext().getExpansion().isIncludeParentContent()).isTrue();
         assertThat(properties.getDiagnostics().isAllowClientDebug()).isFalse();
     }
 
     @Test
     void shouldBindDiagnosticsOverrides() {
         StandardEnvironment environment = new StandardEnvironment();
-        environment.getPropertySources().addFirst(new MapPropertySource("test", Map.of(
-                "studio.ai.endpoints.rag.diagnostics.allow-client-debug", "true")));
+        environment.getPropertySources().addFirst(new MapPropertySource("test", Map.ofEntries(
+                Map.entry("studio.ai.endpoints.rag.context.expansion.enabled", "false"),
+                Map.entry("studio.ai.endpoints.rag.context.expansion.candidate-multiplier", "6"),
+                Map.entry("studio.ai.endpoints.rag.context.expansion.previous-window", "2"),
+                Map.entry("studio.ai.endpoints.rag.context.expansion.next-window", "3"),
+                Map.entry("studio.ai.endpoints.rag.context.expansion.include-parent-content", "false"),
+                Map.entry("studio.ai.endpoints.rag.diagnostics.allow-client-debug", "true"))));
 
         AiWebRagProperties properties = new Binder(ConfigurationPropertySources.get(environment))
                 .bind("studio.ai.endpoints.rag", Bindable.of(AiWebRagProperties.class))
                 .orElseThrow(() -> new AssertionError("AiWebRagProperties binding failed"));
 
+        assertThat(properties.getContext().getExpansion().isEnabled()).isFalse();
+        assertThat(properties.getContext().getExpansion().getCandidateMultiplier()).isEqualTo(6);
+        assertThat(properties.getContext().getExpansion().getPreviousWindow()).isEqualTo(2);
+        assertThat(properties.getContext().getExpansion().getNextWindow()).isEqualTo(3);
+        assertThat(properties.getContext().getExpansion().isIncludeParentContent()).isFalse();
         assertThat(properties.getDiagnostics().isAllowClientDebug()).isTrue();
     }
 }

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
@@ -597,7 +597,7 @@ class ChatControllerTest {
                 false,
                 new ConversationChatService(new InMemoryConversationRepository()),
                 Jackson2ObjectMapperBuilder.json().build(),
-                expansion);
+                expansion.getCandidateMultiplier());
         when(ragPipelineService.search(any(RagSearchRequest.class)))
                 .thenReturn(List.of(new RagSearchResult("chunk-2", "seed", chunkMetadata("chunk-2"), 0.9d)));
         when(ragPipelineService.listByObject("attachment", "123", 6))
@@ -620,6 +620,41 @@ class ChatControllerTest {
                 "123"));
 
         verify(ragPipelineService).listByObject("attachment", "123", 6);
+    }
+
+    @Test
+    void ragChatCapsContextExpansionCandidateLimit() {
+        AiWebRagProperties.ExpansionProperties expansion = new AiWebRagProperties.ExpansionProperties();
+        controller = new ChatController(providerRegistry, ragPipelineService,
+                new RagContextBuilder(8, 12_000, true, expansion, TestWindowChunkContextExpander.asList()),
+                false,
+                null,
+                false,
+                new ConversationChatService(new InMemoryConversationRepository()),
+                Jackson2ObjectMapperBuilder.json().build(),
+                1_000);
+        when(ragPipelineService.search(any(RagSearchRequest.class)))
+                .thenReturn(List.of(new RagSearchResult("chunk-2", "seed", chunkMetadata("chunk-2"), 0.9d)));
+        when(ragPipelineService.listByObject("attachment", "123", 100))
+                .thenReturn(List.of(new RagSearchResult("chunk-2", "seed", chunkMetadata("chunk-2"), 1.0d)));
+
+        controller.chatWithRag(new ChatRagRequestDto(
+                new ChatRequestDto(
+                        null,
+                        null,
+                        List.of(new ChatMessageDto("user", "summarize")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null),
+                "summary",
+                1_000,
+                "attachment",
+                "123"));
+
+        verify(ragPipelineService).listByObject("attachment", "123", 100);
     }
 
     @Test

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
@@ -22,8 +22,10 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.web.server.ResponseStatusException;
 
+import studio.one.platform.ai.autoconfigure.AiWebRagProperties;
 import studio.one.platform.ai.autoconfigure.AiWebChatProperties;
 import studio.one.platform.ai.core.chat.ChatMemoryStore;
 import studio.one.platform.ai.core.chat.ChatPort;
@@ -582,6 +584,42 @@ class ChatControllerTest {
                 .contains("previous\nseed\nnext")
                 .contains("docId=chunk-2")
                 .contains("score=0.900");
+    }
+
+    @Test
+    void ragChatUsesConfiguredCandidateMultiplierForContextExpansion() {
+        AiWebRagProperties.ExpansionProperties expansion = new AiWebRagProperties.ExpansionProperties();
+        expansion.setCandidateMultiplier(2);
+        controller = new ChatController(providerRegistry, ragPipelineService,
+                new RagContextBuilder(8, 12_000, true, expansion, TestWindowChunkContextExpander.asList()),
+                false,
+                null,
+                false,
+                new ConversationChatService(new InMemoryConversationRepository()),
+                Jackson2ObjectMapperBuilder.json().build(),
+                expansion);
+        when(ragPipelineService.search(any(RagSearchRequest.class)))
+                .thenReturn(List.of(new RagSearchResult("chunk-2", "seed", chunkMetadata("chunk-2"), 0.9d)));
+        when(ragPipelineService.listByObject("attachment", "123", 6))
+                .thenReturn(List.of(new RagSearchResult("chunk-2", "seed", chunkMetadata("chunk-2"), 1.0d)));
+
+        controller.chatWithRag(new ChatRagRequestDto(
+                new ChatRequestDto(
+                        null,
+                        null,
+                        List.of(new ChatMessageDto("user", "summarize")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null),
+                "summary",
+                3,
+                "attachment",
+                "123"));
+
+        verify(ragPipelineService).listByObject("attachment", "123", 6);
     }
 
     @Test

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
@@ -632,10 +632,11 @@ class ChatControllerTest {
                 false,
                 new ConversationChatService(new InMemoryConversationRepository()),
                 Jackson2ObjectMapperBuilder.json().build(),
-                1_000);
+                1_000,
+                25);
         when(ragPipelineService.search(any(RagSearchRequest.class)))
                 .thenReturn(List.of(new RagSearchResult("chunk-2", "seed", chunkMetadata("chunk-2"), 0.9d)));
-        when(ragPipelineService.listByObject("attachment", "123", 100))
+        when(ragPipelineService.listByObject("attachment", "123", 25))
                 .thenReturn(List.of(new RagSearchResult("chunk-2", "seed", chunkMetadata("chunk-2"), 1.0d)));
 
         controller.chatWithRag(new ChatRagRequestDto(
@@ -650,11 +651,49 @@ class ChatControllerTest {
                         null,
                         null),
                 "summary",
-                1_000,
+                100,
                 "attachment",
                 "123"));
 
-        verify(ragPipelineService).listByObject("attachment", "123", 100);
+        verify(ragPipelineService).listByObject("attachment", "123", 25);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void ragChatKeepsExpansionPropertiesConstructorForCompatibility() {
+        AiWebRagProperties.ExpansionProperties expansion = new AiWebRagProperties.ExpansionProperties();
+        expansion.setCandidateMultiplier(5);
+        expansion.setMaxCandidates(7);
+        controller = new ChatController(providerRegistry, ragPipelineService,
+                new RagContextBuilder(8, 12_000, true, expansion, TestWindowChunkContextExpander.asList()),
+                false,
+                null,
+                false,
+                new ConversationChatService(new InMemoryConversationRepository()),
+                Jackson2ObjectMapperBuilder.json().build(),
+                expansion);
+        when(ragPipelineService.search(any(RagSearchRequest.class)))
+                .thenReturn(List.of(new RagSearchResult("chunk-2", "seed", chunkMetadata("chunk-2"), 0.9d)));
+        when(ragPipelineService.listByObject("attachment", "123", 7))
+                .thenReturn(List.of(new RagSearchResult("chunk-2", "seed", chunkMetadata("chunk-2"), 1.0d)));
+
+        controller.chatWithRag(new ChatRagRequestDto(
+                new ChatRequestDto(
+                        null,
+                        null,
+                        List.of(new ChatMessageDto("user", "summarize")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null),
+                "summary",
+                3,
+                "attachment",
+                "123"));
+
+        verify(ragPipelineService).listByObject("attachment", "123", 7);
     }
 
     @Test

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagContextBuilderTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagContextBuilderTest.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import studio.one.platform.ai.autoconfigure.AiWebRagProperties;
 import studio.one.platform.ai.core.rag.RagSearchResult;
 import studio.one.platform.chunking.core.ChunkContextExpander;
 import studio.one.platform.chunking.core.ChunkContextExpansion;
@@ -61,6 +62,36 @@ class RagContextBuilderTest {
     }
 
     @Test
+    void doesNotExpandWhenExpansionIsDisabled() {
+        CountingExpander expander = new CountingExpander();
+        AiWebRagProperties.ExpansionProperties expansion = new AiWebRagProperties.ExpansionProperties();
+        expansion.setEnabled(false);
+        RagContextBuilder builder = new RagContextBuilder(8, 12_000, true, expansion, List.of(expander));
+
+        String context = builder.build(List.of(result("chunk-1", "seed", metadata("chunk-1"))));
+
+        assertThat(context).contains("seed");
+        assertThat(expander.calls).isZero();
+        assertThat(builder.supportsExpansion()).isFalse();
+    }
+
+    @Test
+    void passesExpansionWindowOptionsToExpander() {
+        RecordingExpander expander = new RecordingExpander();
+        AiWebRagProperties.ExpansionProperties expansion = new AiWebRagProperties.ExpansionProperties();
+        expansion.setPreviousWindow(2);
+        expansion.setNextWindow(3);
+        expansion.setIncludeParentContent(false);
+        RagContextBuilder builder = new RagContextBuilder(8, 12_000, true, expansion, List.of(expander));
+
+        builder.build(List.of(result("chunk-1", "seed", metadata("chunk-1"))));
+
+        assertThat(expander.previousWindow).isEqualTo(2);
+        assertThat(expander.nextWindow).isEqualTo(3);
+        assertThat(expander.includeParentContent).isFalse();
+    }
+
+    @Test
     void keepsCharacterBudgetAfterExpansion() {
         RagContextBuilder builder = new RagContextBuilder(8, 80, true, TestWindowChunkContextExpander.asList());
 
@@ -105,6 +136,25 @@ class RagContextBuilderTest {
         @Override
         public ChunkContextExpansion expand(ChunkContextExpansionRequest request) {
             calls++;
+            return ChunkContextExpansion.of(request.seedChunk(), List.of(request.seedChunk()), strategy());
+        }
+    }
+
+    private static final class RecordingExpander implements ChunkContextExpander {
+        private int previousWindow;
+        private int nextWindow;
+        private boolean includeParentContent = true;
+
+        @Override
+        public ChunkContextExpansionStrategy strategy() {
+            return ChunkContextExpansionStrategy.WINDOW;
+        }
+
+        @Override
+        public ChunkContextExpansion expand(ChunkContextExpansionRequest request) {
+            previousWindow = request.previousWindow();
+            nextWindow = request.nextWindow();
+            includeParentContent = request.includeParentContent();
             return ChunkContextExpansion.of(request.seedChunk(), List.of(request.seedChunk()), strategy());
         }
     }


### PR DESCRIPTION
## Why

RAG context expansion은 expander bean 존재만으로 자동 적용되고 있어 운영 환경에서 성능과 답변 품질 tradeoff를 조정하기 어렵습니다.

## What

- `AiWebRagProperties`에 `context.expansion.*` 설정을 추가했습니다.
- `enabled`, `candidate-multiplier`, `previous-window`, `next-window`, `include-parent-content`를 `RagContextBuilder`와 `ChatController`에 연결했습니다.
- 기본값은 PR #302 동작과 호환되도록 유지했습니다.
- expansion disabled 시 기존 retrieval hit context 조립으로 fallback합니다.
- README와 설정 binding, builder, controller 테스트를 보강했습니다.

## Related Issues

- Closes #303

## Validation

- Command: `./gradlew :starter:studio-platform-starter-ai-web:test`
- Result: PASS
- Command: `git diff --check`
- Result: PASS

## Risk / Rollback

- Risk: 기본값은 기존 동작과 호환되며, 설정을 잘못 낮추거나 끄면 확장 문맥 품질이 줄어들 수 있습니다.
- Rollback: `AiWebRagProperties`의 expansion 설정과 builder/controller 연결을 되돌리면 PR #302의 자동 expansion 동작으로 복귀합니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: `./gradlew :starter:studio-platform-starter-ai-web:test`, `git diff --check`

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included