### PR TITLE
[ai-assisted] refactor(rag): 구조화 색인 VectorRecord 사용

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@
 - 이슈 #305 대응으로 첨부 RAG 색인과 web RAG context expansion에 opt-in diagnostics를 추가했다.
 - `POST /api/mgmt/attachments/{id}/rag/index`는 서버 `allow-client-debug=true`와 요청 `debug=true`가 모두 만족될 때 안전한 `X-RAG-Index-*` 헤더로 구조화/fallback 경로와 count 정보를 노출한다.
 - `POST /api/ai/chat/rag`는 서버 `allow-client-debug=true`와 요청 `debug=true`가 모두 만족될 때 `metadata.ragContextDiagnostics`에 context expansion 적용 상태를 노출한다.
+- 이슈 #304 대응으로 `content-embedding-pipeline`의 구조화 attachment RAG 색인 경로가 `VectorRecord.builder()`와 `VectorStorePort.replaceRecordsByObject(...)`를 사용하도록 전환됐다.
+- `VectorStorePort`에 record 기반 object-scope replace default adapter를 추가해 기존 `VectorDocument` 기반 store 구현과 호환되도록 했다.
 - 이슈 #303 대응으로 `starter-ai-web`의 RAG context expansion을 `studio.ai.endpoints.rag.context.expansion.*` 설정으로 제어할 수 있도록 했다.
 - context expansion candidate 조회 배수, 후보 조회 상한, previous/next window, parent content 포함 여부를 설정으로 분리했다.
 
 ### 검증
 - `./gradlew :starter:studio-platform-starter-ai-web:test :studio-application-modules:content-embedding-pipeline:test`
 - `git diff --check`
+- `./gradlew :studio-platform-ai:test :studio-application-modules:content-embedding-pipeline:test`
 - `./gradlew :starter:studio-platform-starter-ai-web:test`
 - `git diff --check`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,7 @@
 
 ### 검증
 - `./gradlew :starter:studio-platform-starter-ai-web:test :studio-application-modules:content-embedding-pipeline:test`
-- `git diff --check`
-- `./gradlew :studio-platform-ai:test :studio-application-modules:content-embedding-pipeline:test`
+- `./gradlew :studio-platform-ai:test :studio-application-modules:content-embedding-pipeline:test :starter:studio-platform-starter-ai:test`
 - `./gradlew :starter:studio-platform-starter-ai-web:test`
 - `git diff --check`
 

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/adapters/vector/PgVectorStoreAdapterV2.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/adapters/vector/PgVectorStoreAdapterV2.java
@@ -245,7 +245,7 @@ public class PgVectorStoreAdapterV2 implements VectorStorePort {
     }
 
     private static int resolveChunkIndex(Map<String, Object> metadata) {
-        Object value = metadata.getOrDefault("chunkOrder", 0);
+        Object value = metadata.getOrDefault("chunkOrder", metadata.getOrDefault("chunkIndex", 0));
         if (value instanceof Number number) {
             return number.intValue();
         }

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/adapters/vector/PgVectorStoreAdapterV2Test.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/adapters/vector/PgVectorStoreAdapterV2Test.java
@@ -24,6 +24,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import com.pgvector.PGvector;
 
 import studio.one.platform.ai.core.vector.VectorDocument;
+import studio.one.platform.ai.core.vector.VectorRecord;
 import studio.one.platform.ai.core.vector.VectorSearchRequest;
 import studio.one.platform.ai.core.vector.VectorSearchResult;
 
@@ -82,6 +83,34 @@ class PgVectorStoreAdapterV2Test {
     }
 
     @Test
+    void upsertRecordAdaptsChunkIndexForPgVectorBinding() {
+        VectorRecord record = VectorRecord.builder()
+                .id("record-1")
+                .documentId("doc-1")
+                .chunkId("chunk-1")
+                .contentHash("hash-1")
+                .text("record text")
+                .embedding(List.of(0.1d, 0.2d))
+                .embeddingModel("test-embedding")
+                .metadata(Map.of(
+                        VectorRecord.KEY_OBJECT_TYPE, "ARTICLE",
+                        VectorRecord.KEY_OBJECT_ID, "article-1",
+                        VectorRecord.KEY_CHUNK_INDEX, 7))
+                .build();
+
+        adapter.upsert(record);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<MapSqlParameterSource[]> batchCaptor = ArgumentCaptor.forClass(MapSqlParameterSource[].class);
+        verify(namedParameterJdbcTemplate).batchUpdate(org.mockito.Mockito.eq(UPSERT_SQL), batchCaptor.capture());
+        MapSqlParameterSource params = batchCaptor.getValue()[0];
+        assertThat(params.getValue("objectType")).isEqualTo("ARTICLE");
+        assertThat(params.getValue("objectId")).isEqualTo("article-1");
+        assertThat(params.getValue("chunkIndex")).isEqualTo(7);
+        assertThat(String.valueOf(params.getValue("metadata"))).contains("\"chunkOrder\":7");
+    }
+
+    @Test
     void searchUsesSqlSetQueryAndMapsMetadataDocumentId() throws SQLException {
         when(namedParameterJdbcTemplate.query(anyString(), any(MapSqlParameterSource.class), any(RowMapper.class)))
                 .thenAnswer(invocation -> {
@@ -130,6 +159,35 @@ class PgVectorStoreAdapterV2Test {
 
         verify(namedParameterJdbcTemplate).update(org.mockito.Mockito.eq(DELETE_BY_OBJECT_SQL), any(MapSqlParameterSource.class));
         verify(namedParameterJdbcTemplate).batchUpdate(org.mockito.Mockito.eq(UPSERT_SQL), any(MapSqlParameterSource[].class));
+    }
+
+    @Test
+    void replaceRecordsByObjectAdaptsScopeAndChunkIndexForPgVectorBinding() {
+        VectorRecord record = VectorRecord.builder()
+                .id("record-1")
+                .documentId("doc-1")
+                .chunkId("chunk-1")
+                .contentHash("hash-1")
+                .text("record text")
+                .embedding(List.of(0.1d, 0.2d))
+                .embeddingModel("test-embedding")
+                .metadata(Map.of(VectorRecord.KEY_CHUNK_INDEX, 7))
+                .build();
+
+        adapter.replaceRecordsByObject("ARTICLE", "article-1", List.of(record));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<MapSqlParameterSource[]> batchCaptor = ArgumentCaptor.forClass(MapSqlParameterSource[].class);
+        verify(namedParameterJdbcTemplate).update(org.mockito.Mockito.eq(DELETE_BY_OBJECT_SQL), any(MapSqlParameterSource.class));
+        verify(namedParameterJdbcTemplate).batchUpdate(org.mockito.Mockito.eq(UPSERT_SQL), batchCaptor.capture());
+        MapSqlParameterSource params = batchCaptor.getValue()[0];
+        assertThat(params.getValue("objectType")).isEqualTo("ARTICLE");
+        assertThat(params.getValue("objectId")).isEqualTo("article-1");
+        assertThat(params.getValue("chunkIndex")).isEqualTo(7);
+        assertThat(String.valueOf(params.getValue("metadata")))
+                .contains("\"objectType\":\"ARTICLE\"")
+                .contains("\"objectId\":\"article-1\"")
+                .contains("\"chunkOrder\":7");
     }
 
     @Test

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/adapters/vector/PgVectorStoreAdapterV2Test.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/adapters/vector/PgVectorStoreAdapterV2Test.java
@@ -111,6 +111,22 @@ class PgVectorStoreAdapterV2Test {
     }
 
     @Test
+    void upsertDocumentReadsChunkIndexWhenChunkOrderIsMissing() {
+        VectorDocument document = new VectorDocument(
+                "doc-1",
+                "hello world",
+                Map.of("objectType", "ARTICLE", "objectId", "article-1", "chunkIndex", 9),
+                List.of(0.1d, 0.2d, 0.3d));
+
+        adapter.upsert(List.of(document));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<MapSqlParameterSource[]> batchCaptor = ArgumentCaptor.forClass(MapSqlParameterSource[].class);
+        verify(namedParameterJdbcTemplate).batchUpdate(anyString(), batchCaptor.capture());
+        assertThat(batchCaptor.getValue()[0].getValue("chunkIndex")).isEqualTo(9);
+    }
+
+    @Test
     void searchUsesSqlSetQueryAndMapsMetadataDocumentId() throws SQLException {
         when(namedParameterJdbcTemplate.query(anyString(), any(MapSqlParameterSource.class), any(RowMapper.class)))
                 .thenAnswer(invocation -> {

--- a/studio-application-modules/content-embedding-pipeline/README.md
+++ b/studio-application-modules/content-embedding-pipeline/README.md
@@ -35,7 +35,8 @@ EmbeddingPort.embed()                 ← studio-platform-ai 어댑터 제공
 ```
 
 RAG 색인은 `TextractNormalizedDocumentAdapter`, `ChunkingOrchestrator`, `EmbeddingPort`, `VectorStorePort`가 모두 있으면
-구조화 문서 청킹 경로를 자동 사용한다. 하나라도 없으면 기존 `RagPipelineService.index()` 경로로 fallback한다.
+구조화 문서 청킹 경로를 자동 사용한다. 구조화 경로는 `VectorRecord.builder()`로 chunk 저장 단위를 만든 뒤
+`VectorStorePort.replaceRecordsByObject()`를 호출한다. 하나라도 없으면 기존 `RagPipelineService.index()` 경로로 fallback한다.
 `studio.ai.pipeline.cleaner.enabled=true`이면 `RagPipelineService`가 chunking 전에 추출 텍스트를 정제한다.
 
 ## 주요 서비스 클래스와 역할

--- a/studio-application-modules/content-embedding-pipeline/README.md
+++ b/studio-application-modules/content-embedding-pipeline/README.md
@@ -30,7 +30,7 @@ EmbeddingPort.embed()                 ← studio-platform-ai 어댑터 제공
     ├─ [storeVector=true] VectorStorePort.upsert()    ← 선택적 벡터 저장
     │
     └─ [RAG 인덱싱]
-        ├─ [구조화 빈 사용 가능] ChunkingOrchestrator + VectorStorePort.replaceByObject()
+        ├─ [구조화 빈 사용 가능] ChunkingOrchestrator + VectorStorePort.replaceRecordsByObject()
         └─ [fallback] RagPipelineService.index()
 ```
 

--- a/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/DefaultAttachmentStructuredRagIndexer.java
+++ b/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/DefaultAttachmentStructuredRagIndexer.java
@@ -2,11 +2,16 @@ package studio.one.application.web.service;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.HexFormat;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Objects;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -19,7 +24,7 @@ import studio.one.platform.ai.core.embedding.EmbeddingPort;
 import studio.one.platform.ai.core.embedding.EmbeddingRequest;
 import studio.one.platform.ai.core.embedding.EmbeddingResponse;
 import studio.one.platform.ai.core.embedding.EmbeddingVector;
-import studio.one.platform.ai.core.vector.VectorDocument;
+import studio.one.platform.ai.core.vector.VectorRecord;
 import studio.one.platform.ai.core.vector.VectorStorePort;
 import studio.one.platform.chunking.core.Chunk;
 import studio.one.platform.chunking.core.ChunkMetadata;
@@ -69,8 +74,8 @@ public class DefaultAttachmentStructuredRagIndexer implements AttachmentStructur
         NormalizedDocument document = enrichMetadata(documentId, normalizedDocument, metadata);
         List<Chunk> chunks = chunkingOrchestrator.chunk(document);
         if (chunks.isEmpty()) {
-            vectorStore.replaceByObject(objectType, objectId, List.of());
             latestDiagnostics.set(AttachmentRagIndexDiagnostics.structured(parsedFile.blocks().size(), 0, 0));
+            vectorStore.replaceRecordsByObject(objectType, objectId, List.of());
             return true;
         }
 
@@ -81,22 +86,44 @@ public class DefaultAttachmentStructuredRagIndexer implements AttachmentStructur
             throw new IllegalStateException("Embedding response size does not match chunk count");
         }
 
-        List<VectorDocument> documents = new ArrayList<>(chunks.size());
+        List<VectorRecord> records = new ArrayList<>(chunks.size());
         for (int i = 0; i < chunks.size(); i++) {
             Chunk chunk = chunks.get(i);
             Map<String, Object> chunkMetadata = new HashMap<>(metadata);
             chunkMetadata.remove(ChunkMetadata.KEY_CHUNK_ORDER);
             mergeChunkMetadata(chunkMetadata, chunk.metadata().toMap());
-            chunkMetadata.put("documentId", documentId);
-            chunkMetadata.put("chunkId", chunk.id());
+            chunkMetadata.put(VectorRecord.KEY_DOCUMENT_ID, documentId);
+            chunkMetadata.put(VectorRecord.KEY_CHUNK_ID, chunk.id());
             chunkMetadata.put("chunkLength", chunk.content().length());
-            documents.add(new VectorDocument(
-                    chunk.id(),
-                    chunk.content(),
-                    chunkMetadata,
-                    List.copyOf(vectors.get(i).values())));
+            Object chunkOrder = chunkMetadata.get(ChunkMetadata.KEY_CHUNK_ORDER);
+            if (chunkOrder != null) {
+                chunkMetadata.putIfAbsent(VectorRecord.KEY_CHUNK_INDEX, chunkOrder);
+            }
+            chunkMetadata.putIfAbsent(VectorRecord.KEY_OBJECT_TYPE, objectType);
+            chunkMetadata.putIfAbsent(VectorRecord.KEY_OBJECT_ID, objectId);
+            List<Double> embedding = List.copyOf(vectors.get(i).values());
+            records.add(VectorRecord.builder()
+                    .id(chunk.id())
+                    .documentId(documentId)
+                    .chunkId(chunk.id())
+                    .parentChunkId(text(chunkMetadata.get(VectorRecord.KEY_PARENT_CHUNK_ID)))
+                    .contentHash(contentHash(chunk.content()))
+                    .text(chunk.content())
+                    .embedding(embedding)
+                    .embeddingModel(embeddingModel(chunkMetadata))
+                    .embeddingDimension(embedding.size())
+                    .chunkType(text(chunkMetadata.get(VectorRecord.KEY_CHUNK_TYPE)))
+                    .headingPath(text(chunkMetadata.get(VectorRecord.KEY_HEADING_PATH)))
+                    .sourceRef(text(firstPresent(chunkMetadata,
+                            VectorRecord.KEY_SOURCE_REF,
+                            ChunkMetadata.KEY_SOURCE_REF,
+                            ChunkMetadata.KEY_SOURCE_REFS)))
+                    .page(integer(chunkMetadata.get(VectorRecord.KEY_PAGE)))
+                    .slide(integer(chunkMetadata.get(VectorRecord.KEY_SLIDE)))
+                    .metadata(chunkMetadata)
+                    .build());
         }
-        vectorStore.replaceByObject(objectType, objectId, documents);
+        vectorStore.replaceRecordsByObject(objectType, objectId, records);
         latestDiagnostics.set(AttachmentRagIndexDiagnostics.structured(
                 parsedFile.blocks().size(),
                 chunks.size(),
@@ -165,5 +192,64 @@ public class DefaultAttachmentStructuredRagIndexer implements AttachmentStructur
                 metadata.putIfAbsent(key, value);
             }
         });
+    }
+
+    private Object firstPresent(Map<String, Object> metadata, String... keys) {
+        for (String key : keys) {
+            Object value = metadata.get(key);
+            if (value != null && (!(value instanceof String textValue) || !textValue.isBlank())) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private String embeddingModel(Map<String, Object> metadata) {
+        String embeddingModel = text(metadata.get(VectorRecord.KEY_EMBEDDING_MODEL));
+        return embeddingModel == null ? "unknown" : embeddingModel;
+    }
+
+    private String text(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Iterable<?> iterable) {
+            return join(iterable);
+        }
+        String text = Objects.toString(value, null);
+        return text == null || text.isBlank() ? null : text;
+    }
+
+    private String join(Iterable<?> values) {
+        String joined = java.util.stream.StreamSupport.stream(values.spliterator(), false)
+                .filter(Objects::nonNull)
+                .map(Objects::toString)
+                .filter(value -> !value.isBlank())
+                .reduce((left, right) -> left + " > " + right)
+                .orElse(null);
+        return joined == null || joined.isBlank() ? null : joined;
+    }
+
+    private Integer integer(Object value) {
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        if (value instanceof String text && !text.isBlank()) {
+            try {
+                return Integer.valueOf(text);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private String contentHash(String content) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(content.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("SHA-256 digest is not available", ex);
+        }
     }
 }

--- a/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/DefaultAttachmentStructuredRagIndexer.java
+++ b/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/DefaultAttachmentStructuredRagIndexer.java
@@ -98,10 +98,10 @@ public class DefaultAttachmentStructuredRagIndexer implements AttachmentStructur
             chunkMetadata.put("chunkLength", chunk.content().length());
             Object chunkOrder = standardChunkMetadata.get(ChunkMetadata.KEY_CHUNK_ORDER);
             if (chunkOrder != null) {
-                chunkMetadata.putIfAbsent(VectorRecord.KEY_CHUNK_INDEX, chunkOrder);
+                chunkMetadata.put(VectorRecord.KEY_CHUNK_INDEX, chunkOrder);
             }
-            chunkMetadata.putIfAbsent(VectorRecord.KEY_OBJECT_TYPE, objectType);
-            chunkMetadata.putIfAbsent(VectorRecord.KEY_OBJECT_ID, objectId);
+            chunkMetadata.put(VectorRecord.KEY_OBJECT_TYPE, objectType);
+            chunkMetadata.put(VectorRecord.KEY_OBJECT_ID, objectId);
             List<Double> embedding = List.copyOf(vectors.get(i).values());
             records.add(VectorRecord.builder()
                     .id(chunk.id())

--- a/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/DefaultAttachmentStructuredRagIndexer.java
+++ b/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/DefaultAttachmentStructuredRagIndexer.java
@@ -89,13 +89,14 @@ public class DefaultAttachmentStructuredRagIndexer implements AttachmentStructur
         List<VectorRecord> records = new ArrayList<>(chunks.size());
         for (int i = 0; i < chunks.size(); i++) {
             Chunk chunk = chunks.get(i);
+            Map<String, Object> standardChunkMetadata = chunk.metadata().toMap();
             Map<String, Object> chunkMetadata = new HashMap<>(metadata);
             chunkMetadata.remove(ChunkMetadata.KEY_CHUNK_ORDER);
-            mergeChunkMetadata(chunkMetadata, chunk.metadata().toMap());
+            mergeChunkMetadata(chunkMetadata, standardChunkMetadata);
             chunkMetadata.put(VectorRecord.KEY_DOCUMENT_ID, documentId);
             chunkMetadata.put(VectorRecord.KEY_CHUNK_ID, chunk.id());
             chunkMetadata.put("chunkLength", chunk.content().length());
-            Object chunkOrder = chunkMetadata.get(ChunkMetadata.KEY_CHUNK_ORDER);
+            Object chunkOrder = standardChunkMetadata.get(ChunkMetadata.KEY_CHUNK_ORDER);
             if (chunkOrder != null) {
                 chunkMetadata.putIfAbsent(VectorRecord.KEY_CHUNK_INDEX, chunkOrder);
             }
@@ -112,14 +113,14 @@ public class DefaultAttachmentStructuredRagIndexer implements AttachmentStructur
                     .embedding(embedding)
                     .embeddingModel(embeddingModel(chunkMetadata))
                     .embeddingDimension(embedding.size())
-                    .chunkType(text(chunkMetadata.get(VectorRecord.KEY_CHUNK_TYPE)))
-                    .headingPath(text(chunkMetadata.get(VectorRecord.KEY_HEADING_PATH)))
-                    .sourceRef(text(firstPresent(chunkMetadata,
+                    .chunkType(text(standardChunkMetadata.get(VectorRecord.KEY_CHUNK_TYPE)))
+                    .headingPath(text(firstPresent(standardChunkMetadata, chunkMetadata, VectorRecord.KEY_HEADING_PATH)))
+                    .sourceRef(text(firstPresent(standardChunkMetadata, chunkMetadata,
                             VectorRecord.KEY_SOURCE_REF,
                             ChunkMetadata.KEY_SOURCE_REF,
                             ChunkMetadata.KEY_SOURCE_REFS)))
-                    .page(integer(chunkMetadata.get(VectorRecord.KEY_PAGE)))
-                    .slide(integer(chunkMetadata.get(VectorRecord.KEY_SLIDE)))
+                    .page(integer(firstPresent(standardChunkMetadata, chunkMetadata, VectorRecord.KEY_PAGE)))
+                    .slide(integer(firstPresent(standardChunkMetadata, chunkMetadata, VectorRecord.KEY_SLIDE)))
                     .metadata(chunkMetadata)
                     .build());
         }
@@ -194,14 +195,37 @@ public class DefaultAttachmentStructuredRagIndexer implements AttachmentStructur
         });
     }
 
-    private Object firstPresent(Map<String, Object> metadata, String... keys) {
+    private Object firstPresent(Map<String, Object> preferred, Map<String, Object> fallback, String key) {
+        Object value = value(preferred, key);
+        return value == null ? value(fallback, key) : value;
+    }
+
+    private Object firstPresent(Map<String, Object> preferred, Map<String, Object> fallback, String... keys) {
         for (String key : keys) {
-            Object value = metadata.get(key);
-            if (value != null && (!(value instanceof String textValue) || !textValue.isBlank())) {
+            Object value = firstPresent(preferred, fallback, key);
+            if (value != null) {
                 return value;
             }
         }
         return null;
+    }
+
+    private Object firstPresent(Map<String, Object> metadata, String... keys) {
+        for (String key : keys) {
+            Object value = value(metadata, key);
+            if (value != null) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private Object value(Map<String, Object> metadata, String key) {
+        Object value = metadata.get(key);
+        if (value == null || (value instanceof String textValue && textValue.isBlank())) {
+            return null;
+        }
+        return value;
     }
 
     private String embeddingModel(Map<String, Object> metadata) {

--- a/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineControllerTest.java
+++ b/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineControllerTest.java
@@ -43,11 +43,12 @@ import studio.one.platform.ai.core.embedding.EmbeddingVector;
 import studio.one.platform.ai.core.rag.RagIndexRequest;
 import studio.one.platform.ai.core.rag.RagSearchRequest;
 import studio.one.platform.ai.core.rag.RagSearchResult;
-import studio.one.platform.ai.core.vector.VectorDocument;
+import studio.one.platform.ai.core.vector.VectorRecord;
 import studio.one.platform.ai.core.vector.VectorStorePort;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
 import studio.one.platform.chunking.core.Chunk;
 import studio.one.platform.chunking.core.ChunkMetadata;
+import studio.one.platform.chunking.core.ChunkType;
 import studio.one.platform.chunking.core.ChunkingOrchestrator;
 import studio.one.platform.chunking.core.ChunkingStrategyType;
 import studio.one.platform.chunking.core.NormalizedDocument;
@@ -225,9 +226,19 @@ class AttachmentEmbeddingPipelineControllerTest {
                 "structured text",
                 ChunkMetadata.builder(ChunkingStrategyType.STRUCTURE_BASED, 7)
                         .sourceDocumentId("doc-1")
+                        .chunkType(ChunkType.TABLE)
+                        .parentChunkId("parent-1")
+                        .previousChunkId("prev-1")
+                        .nextChunkId("next-1")
                         .objectType("attachment")
                         .objectId("1")
                         .section("Intro")
+                        .attributes(Map.of(
+                                "headingPath", List.of("Intro", "Table"),
+                                "sourceRef", "sample.txt#page=3",
+                                "page", 3,
+                                "slide", 2,
+                                "embeddingModel", "test-embedding"))
                         .build());
 
         when(attachmentService.getAttachmentById(1L)).thenReturn(attachment);
@@ -265,17 +276,28 @@ class AttachmentEmbeddingPipelineControllerTest {
         verify(extractionService).parseStructured(any(), any(), any(InputStream.class));
         verify(extractionService, never()).extractText(any(), any(), any(InputStream.class));
         verifyNoInteractions(ragPipelineService);
-        verify(vectorStore).replaceByObject(
+        verify(vectorStore).replaceRecordsByObject(
                 argThat("attachment"::equals),
                 argThat("1"::equals),
-                argThat((List<VectorDocument> documents) -> {
-                    if (documents.size() != 1) {
+                argThat((List<VectorRecord> records) -> {
+                    if (records.size() != 1) {
                         return false;
                     }
-                    VectorDocument document = documents.get(0);
-                    Map<String, Object> metadata = document.metadata();
-                    return "doc-1#0".equals(document.id())
-                            && "structured text".equals(document.content())
+                    VectorRecord record = records.get(0);
+                    Map<String, Object> metadata = record.toMetadata();
+                    return "doc-1#0".equals(record.id())
+                            && "doc-1".equals(record.documentId())
+                            && "doc-1#0".equals(record.chunkId())
+                            && "structured text".equals(record.text())
+                            && "parent-1".equals(record.parentChunkId())
+                            && "test-embedding".equals(record.embeddingModel())
+                            && record.embeddingDimension() == 2
+                            && "table".equals(record.chunkType())
+                            && "Intro > Table".equals(record.headingPath())
+                            && "sample.txt#page=3".equals(record.sourceRef())
+                            && Integer.valueOf(3).equals(record.page())
+                            && Integer.valueOf(2).equals(record.slide())
+                            && record.contentHash() != null
                             && metadata.containsKey("documentId")
                             && "doc-1".equals(metadata.get("documentId"))
                             && "attachment".equals(metadata.get("objectType"))
@@ -283,6 +305,17 @@ class AttachmentEmbeddingPipelineControllerTest {
                             && "manual".equals(metadata.get("category"))
                             && "Intro".equals(metadata.get("section"))
                             && Integer.valueOf(7).equals(metadata.get("chunkOrder"))
+                            && Integer.valueOf(7).equals(metadata.get("chunkIndex"))
+                            && "table".equals(metadata.get("chunkType"))
+                            && "parent-1".equals(metadata.get("parentChunkId"))
+                            && "prev-1".equals(metadata.get("previousChunkId"))
+                            && "next-1".equals(metadata.get("nextChunkId"))
+                            && "Intro > Table".equals(metadata.get("headingPath"))
+                            && "sample.txt#page=3".equals(metadata.get("sourceRef"))
+                            && Integer.valueOf(3).equals(metadata.get("page"))
+                            && Integer.valueOf(2).equals(metadata.get("slide"))
+                            && "test-embedding".equals(metadata.get("embeddingModel"))
+                            && Integer.valueOf(2).equals(metadata.get("embeddingDimension"))
                             && metadata.containsKey("strategy");
                 }));
     }

--- a/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineControllerTest.java
+++ b/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineControllerTest.java
@@ -434,6 +434,41 @@ class AttachmentEmbeddingPipelineControllerTest {
     }
 
     @Test
+    void structuredIndexerClearsObjectScopeWhenChunkingProducesNoChunks() throws Exception {
+        VectorStorePort vectorStore = mock(VectorStorePort.class);
+        ChunkingOrchestrator chunkingOrchestrator = mock(ChunkingOrchestrator.class);
+        TextractNormalizedDocumentAdapter adapter = mock(TextractNormalizedDocumentAdapter.class);
+        DefaultAttachmentStructuredRagIndexer indexer = new DefaultAttachmentStructuredRagIndexer(
+                provider(adapter),
+                provider(chunkingOrchestrator),
+                provider(embeddingPort),
+                provider(vectorStore));
+        Attachment attachment = mock(Attachment.class);
+        ParsedFile parsedFile = ParsedFile.textOnly(DocumentFormat.TEXT, "structured text", "sample.txt");
+        NormalizedDocument normalizedDocument = NormalizedDocument.builder("doc-1")
+                .plainText("structured text")
+                .build();
+        when(attachment.getContentType()).thenReturn("text/plain");
+        when(attachment.getName()).thenReturn("sample.txt");
+        when(extractionService.parseStructured(any(), any(), any(InputStream.class))).thenReturn(parsedFile);
+        when(adapter.adapt("doc-1", parsedFile)).thenReturn(normalizedDocument);
+        when(chunkingOrchestrator.chunk(any(NormalizedDocument.class))).thenReturn(List.of());
+
+        boolean indexed = indexer.index(
+                attachment,
+                "doc-1",
+                "attachment",
+                "1",
+                Map.of("category", "manual"),
+                extractionService,
+                new ByteArrayInputStream("content".getBytes(StandardCharsets.UTF_8)));
+
+        org.assertj.core.api.Assertions.assertThat(indexed).isTrue();
+        verify(vectorStore).replaceRecordsByObject("attachment", "1", List.of());
+        verifyNoInteractions(embeddingPort);
+    }
+
+    @Test
     void structuredIndexerFallsBackWithoutReplacingWhenObjectScopeIsMissing() throws Exception {
         VectorStorePort vectorStore = mock(VectorStorePort.class);
         ChunkingOrchestrator chunkingOrchestrator = mock(ChunkingOrchestrator.class);

--- a/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineControllerTest.java
+++ b/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineControllerTest.java
@@ -261,7 +261,10 @@ class AttachmentEmbeddingPipelineControllerTest {
                                   "documentId": "doc-1",
                                   "debug": true,
                                   "metadata": {
-                                    "category": "manual"
+                                    "category": "manual",
+                                    "objectType": "caller-object",
+                                    "objectId": "caller-id",
+                                    "chunkIndex": 99
                                   }
                                 }
                                 """))

--- a/studio-platform-ai/README.md
+++ b/studio-platform-ai/README.md
@@ -78,6 +78,7 @@ Keyword metadata는 trim, blank 제거, case-insensitive 중복 제거를 거친
 - 새 `EmbeddingPort` 또는 `VectorStorePort` 대신 기존 포트를 확장한다.
 - 새 chunking 계약은 이 모듈에 추가하지 않는다. `core.chunk.TextChunk`와 `core.chunk.TextChunker`는 deprecated legacy fallback이며, 신규 구현은 `studio-platform-chunking`의 `Chunk`, `ChunkingContext`, `ChunkingOrchestrator`를 사용한다.
 - `VectorRecord`는 RAG chunk 저장을 표현하는 core vector storage 모델이다. 신규 호출자는 긴 생성자 대신 `VectorRecord.builder()`를 우선 사용한다.
+- object-scoped RAG chunk 교체는 신규 호출자에서 `VectorStorePort.replaceRecordsByObject(...)`를 우선 사용한다. 기본 구현은 `VectorRecord.toVectorDocument()`로 변환해 기존 `replaceByObject(...)`에 위임한다.
 - `chunkIndex`, `previousChunkId`, `nextChunkId`, `tenantId`, `createdAt`, `indexedAt`은 표준 metadata key로만 정의한다. first-class field가 아니므로 `metadata` map을 통해 전달한다.
 - `embeddingDimension`은 `Number` metadata로 소비해야 한다. 현재 `VectorRecord.toMetadata()`는 Java `Integer` 값을 저장하지만 adapter는 DB/driver별 숫자 타입 차이를 고려해 `Number`로 읽어야 한다.
 - `VectorSearchRequest.includeText=false`이면 `VectorSearchHit.text()`는 `null`일 수 있고, `includeMetadata=false`이면 `metadata()`는 empty map일 수 있다.

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorStorePort.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorStorePort.java
@@ -1,6 +1,7 @@
 package studio.one.platform.ai.core.vector;
 
 import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -22,7 +23,7 @@ public interface VectorStorePort {
             return;
         }
         upsert(records.stream()
-                .map(VectorRecord::toVectorDocument)
+                .map(VectorStorePort::toLegacyDocument)
                 .toList());
     }
 
@@ -53,8 +54,26 @@ public interface VectorStorePort {
     default void replaceRecordsByObject(String objectType, String objectId, List<VectorRecord> records) {
         Objects.requireNonNull(records, "records");
         replaceByObject(objectType, objectId, records.stream()
-                .map(VectorRecord::toVectorDocument)
+                .map(record -> toObjectScopedDocument(objectType, objectId, record))
                 .toList());
+    }
+
+    private static VectorDocument toObjectScopedDocument(String objectType, String objectId, VectorRecord record) {
+        VectorDocument document = toLegacyDocument(record);
+        Map<String, Object> metadata = new LinkedHashMap<>(document.metadata());
+        metadata.put(VectorRecord.KEY_OBJECT_TYPE, objectType);
+        metadata.put(VectorRecord.KEY_OBJECT_ID, objectId);
+        return new VectorDocument(document.id(), document.content(), metadata, document.embedding());
+    }
+
+    private static VectorDocument toLegacyDocument(VectorRecord record) {
+        Objects.requireNonNull(record, "record");
+        Map<String, Object> metadata = new LinkedHashMap<>(record.toMetadata());
+        Object chunkIndex = metadata.get(VectorRecord.KEY_CHUNK_INDEX);
+        if (chunkIndex != null) {
+            metadata.putIfAbsent("chunkOrder", chunkIndex);
+        }
+        return new VectorDocument(record.id(), record.text(), metadata, record.embedding());
     }
 
     List<VectorSearchResult> search(VectorSearchRequest request);

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorStorePort.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorStorePort.java
@@ -1,8 +1,8 @@
 package studio.one.platform.ai.core.vector;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.List;
 
 /**
  * Contract for persisting and querying vectors.
@@ -41,6 +41,20 @@ public interface VectorStorePort {
     default void replaceByObject(String objectType, String objectId, List<VectorDocument> documents) {
         deleteByObject(objectType, objectId);
         upsert(documents);
+    }
+
+    /**
+     * Replaces all RAG chunk records for an object scope.
+     * <p>
+     * Default implementation adapts records to legacy {@link VectorDocument}
+     * values and delegates to {@link #replaceByObject(String, String, List)} so
+     * existing store adapters keep their current atomic replacement behavior.
+     */
+    default void replaceRecordsByObject(String objectType, String objectId, List<VectorRecord> records) {
+        Objects.requireNonNull(records, "records");
+        replaceByObject(objectType, objectId, records.stream()
+                .map(VectorRecord::toVectorDocument)
+                .toList());
     }
 
     List<VectorSearchResult> search(VectorSearchRequest request);

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/core/vector/VectorContractsTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/core/vector/VectorContractsTest.java
@@ -241,12 +241,13 @@ class VectorContractsTest {
 
         store.upsert(record(Map.of()));
         store.upsertAll(List.of());
+        store.replaceRecordsByObject("attachment", "42", List.of(record("record-2", List.of(0.3d, 0.4d), 2, Map.of())));
         VectorSearchResults results = store.searchWithFilter(new VectorSearchRequest(List.of(0.1d), 3));
 
-        assertThat(store.operations()).containsExactly("upsert:1");
+        assertThat(store.operations()).containsExactly("upsert:1", "delete:attachment:42", "upsert:1");
         assertThat(store.upsertedDocuments())
                 .extracting(VectorDocument::id)
-                .containsExactly("record-1");
+                .containsExactly("record-1", "record-2");
         assertThat(results.elapsedMs()).isGreaterThanOrEqualTo(0L);
         assertThat(results.hits()).hasSize(1);
         assertThat(results.hits().get(0).documentId()).isEqualTo("doc-1");

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/core/vector/VectorContractsTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/core/vector/VectorContractsTest.java
@@ -239,15 +239,24 @@ class VectorContractsTest {
     void vectorStoreDefaultRecordAdaptersAndAggregateSearchUseLegacyContract() {
         TestVectorStore store = new TestVectorStore(List.of(new VectorSearchResult(record(Map.of()).toVectorDocument(), 0.8d)));
 
-        store.upsert(record(Map.of()));
+        store.upsert(record(Map.of(VectorRecord.KEY_CHUNK_INDEX, 3)));
         store.upsertAll(List.of());
-        store.replaceRecordsByObject("attachment", "42", List.of(record("record-2", List.of(0.3d, 0.4d), 2, Map.of())));
+        store.replaceRecordsByObject("attachment", "42", List.of(record("record-2", List.of(0.3d, 0.4d), 2,
+                Map.of(VectorRecord.KEY_CHUNK_INDEX, 7))));
         VectorSearchResults results = store.searchWithFilter(new VectorSearchRequest(List.of(0.1d), 3));
 
         assertThat(store.operations()).containsExactly("upsert:1", "delete:attachment:42", "upsert:1");
         assertThat(store.upsertedDocuments())
                 .extracting(VectorDocument::id)
                 .containsExactly("record-1", "record-2");
+        assertThat(store.upsertedDocuments().get(0).metadata())
+                .containsEntry(VectorRecord.KEY_CHUNK_INDEX, 3)
+                .containsEntry("chunkOrder", 3);
+        assertThat(store.upsertedDocuments().get(1).metadata())
+                .containsEntry(VectorRecord.KEY_OBJECT_TYPE, "attachment")
+                .containsEntry(VectorRecord.KEY_OBJECT_ID, "42")
+                .containsEntry(VectorRecord.KEY_CHUNK_INDEX, 7)
+                .containsEntry("chunkOrder", 7);
         assertThat(results.elapsedMs()).isGreaterThanOrEqualTo(0L);
         assertThat(results.hits()).hasSize(1);
         assertThat(results.hits().get(0).documentId()).isEqualTo("doc-1");


### PR DESCRIPTION
## Why

- RAG chunk 저장 표준 모델인 `VectorRecord`가 추가됐지만, 구조화 attachment RAG 색인 경로는 여전히 `VectorDocument`를 직접 생성하고 있었다.
- 신규 RAG indexing 경로부터 `VectorRecord.builder()` 사용 기준을 적용해 core vector 계약 사용처를 확산한다.

## What

- `VectorStorePort.replaceRecordsByObject(...)` default adapter를 추가해 record 기반 object-scope 교체를 기존 `replaceByObject(...)` 구현으로 위임했다.
- `DefaultAttachmentStructuredRagIndexer`가 구조화 chunk를 `VectorRecord.builder()`로 생성하고 `replaceRecordsByObject(...)`를 호출하도록 전환했다.
- PR #308 병합분 위로 rebase하면서 structured indexing diagnostics(`AttachmentRagIndexDiagnostics`)와 VectorRecord 저장 경로가 함께 유지되도록 충돌을 정리했다.
- 서브에이전트 리뷰 후 indexer가 `objectType`, `objectId`, `chunkIndex` reserved metadata를 직접 정규화하도록 보강했다.
- `PgVectorStoreAdapterV2`가 legacy `VectorDocument` 입력에서도 `chunkIndex` key를 직접 읽도록 보강했다.
- `documentId`, `chunkId`, `parentChunkId`, `chunkType`, `headingPath`, `sourceRef`, `page`, `slide`, `contentHash`, `embeddingModel`, `embeddingDimension`, `chunkIndex` metadata 보존 테스트를 보강했다.
- `studio-platform-ai`와 `content-embedding-pipeline` README 및 CHANGELOG를 갱신했다.

## Related Issues

- Closes #304

## Validation

- Command: `./gradlew :studio-platform-ai:test :studio-application-modules:content-embedding-pipeline:test :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test`
- Result: PASS
- Command: `git diff --check`
- Result: PASS

## Risk / Rollback

- Risk: `VectorStorePort` default method가 추가됐지만 기존 구현체의 필수 구현은 늘어나지 않는다. 구조화 색인 경로의 저장 호출이 `replaceRecordsByObject(...)`로 바뀌며, 기본 구현은 기존 `replaceByObject(...)`로 변환 위임한다.
- Rollback: 이 PR을 revert하면 구조화 색인 경로는 기존 `VectorDocument` 직접 생성과 `replaceByObject(...)` 호출로 돌아간다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: Yes
- Delegated scope: PR #307 코드 리뷰 및 reserved metadata/pgvector chunkIndex 호환성 검토
- Main author validation: 서브에이전트 Low findings 2건을 보완한 뒤 관련 모듈 테스트, web starter 회귀 테스트, `git diff --check`를 실행했다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
