### PR TITLE
feat(rag): indexing/search observability 보강

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,15 @@
 ## 2026-04-26
 
 ### 변경됨
+- 이슈 #305 대응으로 첨부 RAG 색인과 web RAG context expansion에 opt-in diagnostics를 추가했다.
+- `POST /api/mgmt/attachments/{id}/rag/index`는 서버 `allow-client-debug=true`와 요청 `debug=true`가 모두 만족될 때 안전한 `X-RAG-Index-*` 헤더로 구조화/fallback 경로와 count 정보를 노출한다.
+- `POST /api/ai/chat/rag`는 서버 `allow-client-debug=true`와 요청 `debug=true`가 모두 만족될 때 `metadata.ragContextDiagnostics`에 context expansion 적용 상태를 노출한다.
 - 이슈 #303 대응으로 `starter-ai-web`의 RAG context expansion을 `studio.ai.endpoints.rag.context.expansion.*` 설정으로 제어할 수 있도록 했다.
 - context expansion candidate 조회 배수, 후보 조회 상한, previous/next window, parent content 포함 여부를 설정으로 분리했다.
 
 ### 검증
+- `./gradlew :starter:studio-platform-starter-ai-web:test :studio-application-modules:content-embedding-pipeline:test`
+- `git diff --check`
 - `./gradlew :starter:studio-platform-starter-ai-web:test`
 - `git diff --check`
 

--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -327,6 +327,10 @@ studio:
 `ragDiagnostics`를 추가한다. diagnostics metadata에는 chunk 본문이나 snippet을 포함하지 않는다.
 result snippet 로그는 `studio.ai.pipeline.diagnostics.log-results=true`일 때만 debug level로 제한 길이만 출력한다.
 
+이슈 #305부터 같은 opt-in 조건에서 RAG context expansion diagnostics도
+`ChatResponseDto.metadata.ragContextDiagnostics`로 노출한다. 이 값은 확장 지원 여부, 적용 여부, 전략,
+후보/결과/확장 hit 수, fallback reason만 포함하며 chunk 본문, snippet, embedding vector는 포함하지 않는다.
+
 ### 임베딩 요청 예시
 
 ```http

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
@@ -363,7 +363,8 @@ public class ChatController {
                 objectId,
                 ragTopK,
                 ragQuery == null || ragQuery.isBlank());
-        String context = ragContextBuilder.build(ragResults, expansionCandidates);
+        RagContextBuilder.BuildResult contextResult = ragContextBuilder.buildWithDiagnostics(ragResults, expansionCandidates);
+        String context = contextResult.context();
 
         List<ChatMessageDto> augmentedMessages = new ArrayList<>();
         augmentedMessages.add(new ChatMessageDto("system", context));
@@ -389,11 +390,16 @@ public class ChatController {
         ChatResponse response = chatPort(chat.provider()).chat(toDomainChatRequest(augmented));
         int memoryMessageCount = appendMemory(memory, chat.messages(), response);
         appendConversation(principal, memory, chat.messages().stream().map(this::toDomainMessage).toList(), response);
+        boolean exposeDiagnostics = shouldExposeDiagnostics(request);
+        Map<String, Object> extraMetadata = memoryMetadata(memory, memoryMessageCount);
+        if (exposeDiagnostics && contextResult.diagnostics() != null) {
+            extraMetadata.put("ragContextDiagnostics", contextResult.diagnostics().toMetadata());
+        }
         return ResponseEntity.ok(ApiResponse.ok(toDto(
                 response,
                 diagnostics,
-                shouldExposeDiagnostics(request),
-                memoryMetadata(memory, memoryMessageCount))));
+                exposeDiagnostics,
+                extraMetadata)));
     }
 
     @GetMapping("/conversations")

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagContextBuilder.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagContextBuilder.java
@@ -85,23 +85,59 @@ public class RagContextBuilder {
     }
 
     public String build(List<RagSearchResult> results, List<RagSearchResult> expansionCandidates) {
+        return buildWithDiagnostics(results, expansionCandidates).context();
+    }
+
+    public BuildResult buildWithDiagnostics(List<RagSearchResult> results, List<RagSearchResult> expansionCandidates) {
+        int resultCount = results == null ? 0 : results.size();
+        int candidateCount = expansionCandidates == null ? 0 : expansionCandidates.size();
+        boolean expansionSupported = supportsExpansion();
         if (results == null || results.isEmpty() || maxChunks == 0 || maxChars == 0) {
-            return NO_CONTEXT_MESSAGE;
+            return new BuildResult(NO_CONTEXT_MESSAGE, new Diagnostics(
+                    expansionSupported, false, null, 0, 0, candidateCount, resultCount, "no_context"));
         }
         StringBuilder sb = new StringBuilder(HEADER);
         if (sb.length() > maxChars) {
-            return NO_CONTEXT_MESSAGE;
+            return new BuildResult(NO_CONTEXT_MESSAGE, new Diagnostics(
+                    expansionSupported, false, null, 0, 0, candidateCount, resultCount, "context_limit"));
         }
         int count = Math.min(maxChunks, results.size());
+        int expandedHitCount = 0;
+        int fallbackHitCount = 0;
+        String strategy = null;
+        String fallbackReason = expansionSupported ? null : "disabled";
         for (int i = 0; i < count; i++) {
-            RagSearchResult result = expandResult(results.get(i), expansionCandidates);
-            String chunk = formatChunk(i + 1, result);
+            ExpansionAttempt attempt = expandResultWithDiagnostics(results.get(i), expansionCandidates);
+            String chunk = formatChunk(i + 1, attempt.result());
             if (!appendWithinLimit(sb, chunk)) {
                 break;
             }
+            if (attempt.expanded()) {
+                expandedHitCount++;
+                if (strategy == null) {
+                    strategy = attempt.strategy();
+                }
+            } else if (fallbackReason == null) {
+                fallbackHitCount++;
+                fallbackReason = attempt.fallbackReason();
+            } else {
+                fallbackHitCount++;
+            }
         }
         String context = sb.toString().trim();
-        return HEADER.trim().equals(context) ? NO_CONTEXT_MESSAGE : context;
+        if (HEADER.trim().equals(context)) {
+            return new BuildResult(NO_CONTEXT_MESSAGE, new Diagnostics(
+                    expansionSupported, false, null, 0, 0, candidateCount, resultCount, "no_context"));
+        }
+        return new BuildResult(context, new Diagnostics(
+                expansionSupported,
+                expandedHitCount > 0,
+                strategy,
+                expandedHitCount,
+                fallbackHitCount,
+                candidateCount,
+                resultCount,
+                fallbackReason));
     }
 
     private boolean appendWithinLimit(StringBuilder sb, String chunk) {
@@ -123,21 +159,26 @@ public class RagContextBuilder {
     }
 
     private RagSearchResult expandResult(RagSearchResult result, List<RagSearchResult> expansionCandidates) {
+        return expandResultWithDiagnostics(result, expansionCandidates).result();
+    }
+
+    private ExpansionAttempt expandResultWithDiagnostics(RagSearchResult result, List<RagSearchResult> expansionCandidates) {
         if (result == null || !supportsExpansion()) {
-            return result;
+            return new ExpansionAttempt(result, false, null, "disabled");
         }
         Optional<Chunk> seed = toChunk(result);
         if (seed.isEmpty() || !hasObjectScope(seed.get())) {
-            return result;
+            return new ExpansionAttempt(result, false, null, "missing_object_scope");
         }
         List<Chunk> availableChunks = availableChunks(seed.get(), expansionCandidates);
         if (availableChunks.isEmpty()) {
-            return result;
+            return new ExpansionAttempt(result, false, null, "no_candidates");
         }
         Optional<ChunkContextExpander> expander = selectExpander(seed.get());
         if (expander.isEmpty()) {
-            return result;
+            return new ExpansionAttempt(result, false, null, "no_expander");
         }
+        String strategy = expander.get().strategy().name().toLowerCase(java.util.Locale.ROOT);
         ChunkContextExpansionRequest request = ChunkContextExpansionRequest.builder(seed.get())
                 .availableChunks(availableChunks)
                 .previousWindow(expansion.getPreviousWindow())
@@ -146,9 +187,13 @@ public class RagContextBuilder {
                 .build();
         try {
             ChunkContextExpansion expansion = expander.get().expand(request);
-            return new RagSearchResult(result.documentId(), expansion.content(), result.metadata(), result.score());
+            return new ExpansionAttempt(
+                    new RagSearchResult(result.documentId(), expansion.content(), result.metadata(), result.score()),
+                    true,
+                    strategy,
+                    null);
         } catch (RuntimeException ignored) {
-            return result;
+            return new ExpansionAttempt(result, false, strategy, "expander_failed");
         }
     }
 
@@ -278,5 +323,45 @@ public class RagContextBuilder {
 
     private boolean hasText(String value) {
         return value != null && !value.isBlank();
+    }
+
+    public record BuildResult(String context, Diagnostics diagnostics) {
+    }
+
+    public record Diagnostics(
+            boolean expansionSupported,
+            boolean applied,
+            String strategy,
+            int expandedHitCount,
+            int fallbackHitCount,
+            int candidateCount,
+            int resultCount,
+            String fallbackReason) {
+
+        public Map<String, Object> toMetadata() {
+            Map<String, Object> metadata = new LinkedHashMap<>();
+            metadata.put("expansionSupported", expansionSupported);
+            metadata.put("applied", applied);
+            put(metadata, "strategy", strategy);
+            metadata.put("expandedHitCount", expandedHitCount);
+            metadata.put("fallbackHitCount", fallbackHitCount);
+            metadata.put("candidateCount", candidateCount);
+            metadata.put("resultCount", resultCount);
+            put(metadata, "fallbackReason", fallbackReason);
+            return Map.copyOf(metadata);
+        }
+
+        private static void put(Map<String, Object> metadata, String key, Object value) {
+            if (value != null && (!(value instanceof String text) || !text.isBlank())) {
+                metadata.put(key, value);
+            }
+        }
+    }
+
+    private record ExpansionAttempt(
+            RagSearchResult result,
+            boolean expanded,
+            String strategy,
+            String fallbackReason) {
     }
 }

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
@@ -814,6 +814,7 @@ class ChatControllerTest {
                 false)).getBody().getData();
 
         assertThat(response.metadata()).doesNotContainKey("ragDiagnostics");
+        assertThat(response.metadata()).doesNotContainKey("ragContextDiagnostics");
     }
 
     @Test
@@ -840,6 +841,7 @@ class ChatControllerTest {
                 true)).getBody().getData();
 
         assertThat(response.metadata()).doesNotContainKey("ragDiagnostics");
+        assertThat(response.metadata()).doesNotContainKey("ragContextDiagnostics");
     }
 
     @Test
@@ -878,6 +880,53 @@ class ChatControllerTest {
                 .containsEntry("topK", 3)
                 .doesNotContainKeys("content", "snippet", "text", "chunk");
         assertThat(ragDiagnostics.values()).doesNotContain("sensitive file body");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void ragChatExposesSafeContextExpansionDiagnosticsWhenDebugIsAllowed() {
+        controller = new ChatController(providerRegistry, ragPipelineService,
+                new RagContextBuilder(8, 12_000, true, TestWindowChunkContextExpander.asList()), true);
+        when(ragPipelineService.search(any(RagSearchRequest.class)))
+                .thenReturn(List.of(new RagSearchResult("chunk-2", "seed sensitive body",
+                        chunkMetadata("chunk-2"), 0.9d)));
+        when(ragPipelineService.listByObject("attachment", "123", 12))
+                .thenReturn(List.of(
+                        new RagSearchResult("chunk-1", "previous sensitive body",
+                                chunkMetadata("chunk-1", null, "chunk-2", 0), 1.0d),
+                        new RagSearchResult("chunk-2", "seed sensitive body",
+                                chunkMetadata("chunk-2", "chunk-1", "chunk-3", 1), 1.0d),
+                        new RagSearchResult("chunk-3", "next sensitive body",
+                                chunkMetadata("chunk-3", "chunk-2", null, 2), 1.0d)));
+
+        ChatResponseDto response = controller.chatWithRag(new ChatRagRequestDto(
+                new ChatRequestDto(
+                        null,
+                        null,
+                        List.of(new ChatMessageDto("user", "summarize")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null),
+                "summary",
+                3,
+                "attachment",
+                "123",
+                true)).getBody().getData();
+
+        Map<String, Object> contextDiagnostics = (Map<String, Object>) response.metadata()
+                .get("ragContextDiagnostics");
+        assertThat(contextDiagnostics)
+                .containsEntry("expansionSupported", true)
+                .containsEntry("applied", true)
+                .containsEntry("strategy", "window")
+                .containsEntry("expandedHitCount", 1)
+                .containsEntry("candidateCount", 3)
+                .containsEntry("resultCount", 1)
+                .doesNotContainKeys("content", "snippet", "text", "chunk");
+        assertThat(contextDiagnostics.values()).doesNotContain("seed sensitive body", "previous sensitive body");
     }
 
     @Test

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagContextBuilderTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagContextBuilderTest.java
@@ -92,6 +92,26 @@ class RagContextBuilderTest {
     }
 
     @Test
+    void diagnosticsPreservePartialExpansionFallbacks() {
+        RagContextBuilder builder = new RagContextBuilder(8, 12_000, true, TestWindowChunkContextExpander.asList());
+
+        RagContextBuilder.BuildResult result = builder.buildWithDiagnostics(
+                List.of(
+                        result("chunk-2", "seed", metadata("chunk-2")),
+                        new RagSearchResult("legacy", "legacy", Map.of(RagContextBuilder.KEY_CHUNK_ID, "legacy"), 0.7d)),
+                List.of(
+                        result("chunk-1", "previous", metadata("chunk-1", null, "chunk-2", 0)),
+                        result("chunk-2", "seed", metadata("chunk-2", "chunk-1", "chunk-3", 1)),
+                        result("chunk-3", "next", metadata("chunk-3", "chunk-2", null, 2))));
+
+        assertThat(result.diagnostics().toMetadata())
+                .containsEntry("applied", true)
+                .containsEntry("expandedHitCount", 1)
+                .containsEntry("fallbackHitCount", 1)
+                .containsEntry("fallbackReason", "missing_object_scope");
+    }
+
+    @Test
     void keepsCharacterBudgetAfterExpansion() {
         RagContextBuilder builder = new RagContextBuilder(8, 80, true, TestWindowChunkContextExpander.asList());
 

--- a/studio-application-modules/content-embedding-pipeline/README.md
+++ b/studio-application-modules/content-embedding-pipeline/README.md
@@ -101,6 +101,7 @@ Content-Type: application/json
   "documentId": "doc-101",
   "objectType": "forums-post",
   "objectId": "42",
+  "debug": true,
   "keywords": ["spring", "java"],
   "useLlmKeywordExtraction": false,
   "metadata": {
@@ -108,6 +109,12 @@ Content-Type: application/json
   }
 }
 ```
+
+서버 `studio.ai.endpoints.rag.diagnostics.allow-client-debug=true`와 요청 `debug=true`가 모두 설정되면
+`202 Accepted` 응답 헤더에 안전한 색인 diagnostics를 추가한다.
+헤더는 `X-RAG-Index-Path`, `X-RAG-Index-Structured`, `X-RAG-Index-Fallback-Reason`,
+`X-RAG-Index-Parsed-Block-Count`, `X-RAG-Index-Chunk-Count`, `X-RAG-Index-Vector-Count`만 사용한다.
+본문 텍스트, snippet, embedding vector, 사용자 metadata 값은 diagnostics 헤더에 포함하지 않는다.
 
 첨부 RAG 인덱싱은 metadata에 아래 값을 `putIfAbsent`로 보강한다. 요청 metadata에 같은 key가 있으면 요청 값을 유지한다.
 

--- a/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineController.java
+++ b/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineController.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -50,6 +51,7 @@ import studio.one.application.web.dto.EmbeddingVectorDto;
 import studio.one.application.web.dto.SearchRequest;
 import studio.one.application.web.dto.SearchResponse;
 import studio.one.application.web.dto.SearchResult;
+import studio.one.application.web.service.AttachmentRagIndexDiagnostics;
 import studio.one.application.web.service.AttachmentStructuredRagIndexer;
 import studio.one.platform.ai.core.MetadataFilter;
 import studio.one.platform.ai.core.embedding.EmbeddingPort;
@@ -90,6 +92,12 @@ import studio.one.platform.web.dto.ApiResponse;
 @Slf4j
 @Validated
 public class AttachmentEmbeddingPipelineController {
+    private static final String HEADER_RAG_INDEX_PATH = "X-RAG-Index-Path";
+    private static final String HEADER_RAG_INDEX_STRUCTURED = "X-RAG-Index-Structured";
+    private static final String HEADER_RAG_INDEX_FALLBACK_REASON = "X-RAG-Index-Fallback-Reason";
+    private static final String HEADER_RAG_INDEX_PARSED_BLOCK_COUNT = "X-RAG-Index-Parsed-Block-Count";
+    private static final String HEADER_RAG_INDEX_CHUNK_COUNT = "X-RAG-Index-Chunk-Count";
+    private static final String HEADER_RAG_INDEX_VECTOR_COUNT = "X-RAG-Index-Vector-Count";
 
     private final AttachmentService attachmentService;
     private final ObjectProvider<FileContentExtractionService> textExtractionProvider;
@@ -98,6 +106,9 @@ public class AttachmentEmbeddingPipelineController {
     private final ObjectProvider<RagPipelineService> ragPipelineProvider;
     private final ObjectProvider<AttachmentStructuredRagIndexer> structuredRagIndexerProvider;
     private final ObjectProvider<I18n> i18nProvider;
+
+    @Value("${studio.ai.endpoints.rag.diagnostics.allow-client-debug:false}")
+    private boolean allowClientDebug;
 
     /**
      * 첨부파일 텍스트를 추출해 임베딩을 생성하고, 구성된 경우 벡터 스토어에 업서트한다.
@@ -253,11 +264,21 @@ public class AttachmentEmbeddingPipelineController {
         String objectId = resolveObjectId(request, attachmentId);
         Map<String, Object> metadata = buildMetadata(request, attachment, objectType, objectId);
         AttachmentStructuredRagIndexer structuredIndexer = structuredRagIndexerProvider.getIfAvailable();
+        AttachmentRagIndexDiagnostics structuredDiagnostics = structuredIndexer == null
+                ? AttachmentRagIndexDiagnostics.fallback("missing_structured_indexer")
+                : null;
         if (structuredIndexer != null) {
-            try (InputStream in = attachmentService.getInputStream(attachment)) {
-                if (structuredIndexer.index(attachment, documentId, objectType, objectId, metadata, extractor, in)) {
-                    return ResponseEntity.accepted().build();
+            try {
+                try (InputStream in = attachmentService.getInputStream(attachment)) {
+                    if (structuredIndexer.index(attachment, documentId, objectType, objectId, metadata, extractor, in)) {
+                        return accepted(request, structuredIndexer.latestDiagnostics()
+                                .orElse(AttachmentRagIndexDiagnostics.structuredUnknown()));
+                    }
+                    structuredDiagnostics = structuredIndexer.latestDiagnostics()
+                            .orElse(AttachmentRagIndexDiagnostics.fallback("structured_not_handled"));
                 }
+            } finally {
+                structuredIndexer.clearDiagnostics();
             }
         }
         RagPipelineService ragPipeline = ragPipelineProvider.getIfAvailable();
@@ -270,7 +291,35 @@ public class AttachmentEmbeddingPipelineController {
             boolean useLlmKeywords = request != null && Boolean.TRUE.equals(request.useLlmKeywordExtraction());
             ragPipeline.index(new RagIndexRequest(documentId, text, metadata, keywords, useLlmKeywords));
         }
-        return ResponseEntity.accepted().build();
+        return accepted(request, AttachmentRagIndexDiagnostics.fallback(
+                structuredDiagnostics == null ? "structured_not_attempted" : structuredDiagnostics.fallbackReason()));
+    }
+
+    private ResponseEntity<Void> accepted(
+            AttachmentRagIndexRequestDto request,
+            AttachmentRagIndexDiagnostics diagnostics) {
+        ResponseEntity.BodyBuilder builder = ResponseEntity.accepted();
+        if (allowClientDebug && request != null && Boolean.TRUE.equals(request.debug()) && diagnostics != null) {
+            builder.header(HEADER_RAG_INDEX_PATH, diagnostics.path());
+            builder.header(HEADER_RAG_INDEX_STRUCTURED, Boolean.toString(diagnostics.structured()));
+            putHeader(builder, HEADER_RAG_INDEX_FALLBACK_REASON, diagnostics.fallbackReason());
+            putCountHeader(builder, HEADER_RAG_INDEX_PARSED_BLOCK_COUNT, diagnostics.parsedBlockCount());
+            putCountHeader(builder, HEADER_RAG_INDEX_CHUNK_COUNT, diagnostics.chunkCount());
+            putCountHeader(builder, HEADER_RAG_INDEX_VECTOR_COUNT, diagnostics.vectorCount());
+        }
+        return builder.build();
+    }
+
+    private void putHeader(ResponseEntity.BodyBuilder builder, String name, String value) {
+        if (value != null && !value.isBlank()) {
+            builder.header(name, value);
+        }
+    }
+
+    private void putCountHeader(ResponseEntity.BodyBuilder builder, String name, int value) {
+        if (value >= 0) {
+            builder.header(name, Integer.toString(value));
+        }
     }
 
     /**

--- a/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/controller/AttachmentRagIndexRequestDto.java
+++ b/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/controller/AttachmentRagIndexRequestDto.java
@@ -12,6 +12,16 @@ public record AttachmentRagIndexRequestDto(
         String objectId,
         Map<String, Object> metadata,
         List<String> keywords,
-        Boolean useLlmKeywordExtraction
+        Boolean useLlmKeywordExtraction,
+        Boolean debug
 ) {
+    public AttachmentRagIndexRequestDto(
+            String documentId,
+            String objectType,
+            String objectId,
+            Map<String, Object> metadata,
+            List<String> keywords,
+            Boolean useLlmKeywordExtraction) {
+        this(documentId, objectType, objectId, metadata, keywords, useLlmKeywordExtraction, null);
+    }
 }

--- a/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/AttachmentRagIndexDiagnostics.java
+++ b/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/AttachmentRagIndexDiagnostics.java
@@ -1,0 +1,56 @@
+package studio.one.application.web.service;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Debug-safe diagnostics for attachment RAG indexing.
+ */
+public record AttachmentRagIndexDiagnostics(
+        String path,
+        boolean structured,
+        String fallbackReason,
+        int parsedBlockCount,
+        int chunkCount,
+        int vectorCount) {
+
+    public static AttachmentRagIndexDiagnostics structured(int parsedBlockCount, int chunkCount, int vectorCount) {
+        return new AttachmentRagIndexDiagnostics("structured", true, null,
+                Math.max(0, parsedBlockCount), Math.max(0, chunkCount), Math.max(0, vectorCount));
+    }
+
+    public static AttachmentRagIndexDiagnostics structuredUnknown() {
+        return new AttachmentRagIndexDiagnostics("structured", true, null, -1, -1, -1);
+    }
+
+    public static AttachmentRagIndexDiagnostics fallback(String reason) {
+        return new AttachmentRagIndexDiagnostics("fallback", false, normalize(reason), 0, 0, 0);
+    }
+
+    public Map<String, Object> toMetadata() {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("path", path);
+        metadata.put("structured", structured);
+        put(metadata, "fallbackReason", fallbackReason);
+        putCount(metadata, "parsedBlockCount", parsedBlockCount);
+        putCount(metadata, "chunkCount", chunkCount);
+        putCount(metadata, "vectorCount", vectorCount);
+        return Map.copyOf(metadata);
+    }
+
+    private static String normalize(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+
+    private static void put(Map<String, Object> metadata, String key, Object value) {
+        if (value != null && (!(value instanceof String text) || !text.isBlank())) {
+            metadata.put(key, value);
+        }
+    }
+
+    private static void putCount(Map<String, Object> metadata, String key, int value) {
+        if (value >= 0) {
+            metadata.put(key, value);
+        }
+    }
+}

--- a/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/AttachmentStructuredRagIndexer.java
+++ b/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/AttachmentStructuredRagIndexer.java
@@ -3,6 +3,7 @@ package studio.one.application.web.service;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
+import java.util.Optional;
 
 import studio.one.application.attachment.domain.model.Attachment;
 import studio.one.platform.textract.service.FileContentExtractionService;
@@ -23,4 +24,11 @@ public interface AttachmentStructuredRagIndexer {
             Map<String, Object> metadata,
             FileContentExtractionService extractor,
             InputStream inputStream) throws IOException;
+
+    default Optional<AttachmentRagIndexDiagnostics> latestDiagnostics() {
+        return Optional.empty();
+    }
+
+    default void clearDiagnostics() {
+    }
 }

--- a/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/DefaultAttachmentStructuredRagIndexer.java
+++ b/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/DefaultAttachmentStructuredRagIndexer.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -42,6 +43,7 @@ public class DefaultAttachmentStructuredRagIndexer implements AttachmentStructur
     private final ObjectProvider<ChunkingOrchestrator> chunkingOrchestratorProvider;
     private final ObjectProvider<EmbeddingPort> embeddingPortProvider;
     private final ObjectProvider<VectorStorePort> vectorStoreProvider;
+    private final ThreadLocal<AttachmentRagIndexDiagnostics> latestDiagnostics = new ThreadLocal<>();
 
     @Override
     public boolean index(Attachment attachment,
@@ -51,15 +53,14 @@ public class DefaultAttachmentStructuredRagIndexer implements AttachmentStructur
             Map<String, Object> metadata,
             FileContentExtractionService extractor,
             InputStream inputStream) throws IOException {
+        latestDiagnostics.remove();
         TextractNormalizedDocumentAdapter adapter = normalizedDocumentAdapterProvider.getIfAvailable();
         ChunkingOrchestrator chunkingOrchestrator = chunkingOrchestratorProvider.getIfAvailable();
         EmbeddingPort embeddingPort = embeddingPortProvider.getIfAvailable();
         VectorStorePort vectorStore = vectorStoreProvider.getIfAvailable();
-        if (adapter == null
-                || chunkingOrchestrator == null
-                || embeddingPort == null
-                || vectorStore == null
-                || !hasObjectScope(objectType, objectId)) {
+        String fallbackReason = fallbackReason(adapter, chunkingOrchestrator, embeddingPort, vectorStore, objectType, objectId);
+        if (fallbackReason != null) {
+            latestDiagnostics.set(AttachmentRagIndexDiagnostics.fallback(fallbackReason));
             return false;
         }
 
@@ -69,6 +70,7 @@ public class DefaultAttachmentStructuredRagIndexer implements AttachmentStructur
         List<Chunk> chunks = chunkingOrchestrator.chunk(document);
         if (chunks.isEmpty()) {
             vectorStore.replaceByObject(objectType, objectId, List.of());
+            latestDiagnostics.set(AttachmentRagIndexDiagnostics.structured(parsedFile.blocks().size(), 0, 0));
             return true;
         }
 
@@ -95,12 +97,51 @@ public class DefaultAttachmentStructuredRagIndexer implements AttachmentStructur
                     List.copyOf(vectors.get(i).values())));
         }
         vectorStore.replaceByObject(objectType, objectId, documents);
+        latestDiagnostics.set(AttachmentRagIndexDiagnostics.structured(
+                parsedFile.blocks().size(),
+                chunks.size(),
+                vectors.size()));
         return true;
+    }
+
+    @Override
+    public Optional<AttachmentRagIndexDiagnostics> latestDiagnostics() {
+        return Optional.ofNullable(latestDiagnostics.get());
+    }
+
+    @Override
+    public void clearDiagnostics() {
+        latestDiagnostics.remove();
     }
 
     private boolean hasObjectScope(String objectType, String objectId) {
         return objectType != null && !objectType.isBlank()
                 && objectId != null && !objectId.isBlank();
+    }
+
+    private String fallbackReason(
+            TextractNormalizedDocumentAdapter adapter,
+            ChunkingOrchestrator chunkingOrchestrator,
+            EmbeddingPort embeddingPort,
+            VectorStorePort vectorStore,
+            String objectType,
+            String objectId) {
+        if (adapter == null) {
+            return "missing_normalized_document_adapter";
+        }
+        if (chunkingOrchestrator == null) {
+            return "missing_chunking_orchestrator";
+        }
+        if (embeddingPort == null) {
+            return "missing_embedding_port";
+        }
+        if (vectorStore == null) {
+            return "missing_vector_store";
+        }
+        if (!hasObjectScope(objectType, objectId)) {
+            return "missing_object_scope";
+        }
+        return null;
     }
 
     private NormalizedDocument enrichMetadata(

--- a/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineControllerTest.java
+++ b/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineControllerTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -26,6 +27,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -77,6 +79,10 @@ class AttachmentEmbeddingPipelineControllerTest {
     }
 
     private void configureMockMvc(AttachmentStructuredRagIndexer structuredRagIndexer) {
+        configureMockMvc(structuredRagIndexer, false);
+    }
+
+    private void configureMockMvc(AttachmentStructuredRagIndexer structuredRagIndexer, boolean allowClientDebug) {
         AttachmentEmbeddingPipelineController controller = new AttachmentEmbeddingPipelineController(
                 attachmentService,
                 provider(extractionService),
@@ -85,6 +91,7 @@ class AttachmentEmbeddingPipelineControllerTest {
                 provider(ragPipelineService),
                 provider(structuredRagIndexer),
                 provider((I18n) null));
+        ReflectionTestUtils.setField(controller, "allowClientDebug", allowClientDebug);
 
         LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
         validator.afterPropertiesSet();
@@ -205,7 +212,7 @@ class AttachmentEmbeddingPipelineControllerTest {
                 provider(chunkingOrchestrator),
                 provider(embeddingPort),
                 provider(vectorStore));
-        configureMockMvc(structuredRagIndexer);
+        configureMockMvc(structuredRagIndexer, true);
 
         Attachment attachment = mock(Attachment.class);
         ParsedFile parsedFile = ParsedFile.textOnly(DocumentFormat.TEXT, "structured text", "sample.txt");
@@ -241,12 +248,19 @@ class AttachmentEmbeddingPipelineControllerTest {
                         .content("""
                                 {
                                   "documentId": "doc-1",
+                                  "debug": true,
                                   "metadata": {
                                     "category": "manual"
                                   }
                                 }
                                 """))
-                .andExpect(status().isAccepted());
+                .andExpect(status().isAccepted())
+                .andExpect(header().string("X-RAG-Index-Path", "structured"))
+                .andExpect(header().string("X-RAG-Index-Structured", "true"))
+                .andExpect(header().string("X-RAG-Index-Parsed-Block-Count", "1"))
+                .andExpect(header().string("X-RAG-Index-Chunk-Count", "1"))
+                .andExpect(header().string("X-RAG-Index-Vector-Count", "1"))
+                .andExpect(header().doesNotExist("X-RAG-Index-Fallback-Reason"));
 
         verify(extractionService).parseStructured(any(), any(), any(InputStream.class));
         verify(extractionService, never()).extractText(any(), any(), any(InputStream.class));
@@ -280,7 +294,7 @@ class AttachmentEmbeddingPipelineControllerTest {
             inputStream.readAllBytes();
             return false;
         };
-        configureMockMvc(structuredRagIndexer);
+        configureMockMvc(structuredRagIndexer, true);
 
         Attachment attachment = mock(Attachment.class);
         when(attachmentService.getAttachmentById(1L)).thenReturn(attachment);
@@ -295,12 +309,95 @@ class AttachmentEmbeddingPipelineControllerTest {
 
         mockMvc.perform(post(BASE_PATH + "/1/rag/index")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{}"))
-                .andExpect(status().isAccepted());
+                        .content("""
+                                {
+                                  "debug": true
+                                }
+                                """))
+                .andExpect(status().isAccepted())
+                .andExpect(header().string("X-RAG-Index-Path", "fallback"))
+                .andExpect(header().string("X-RAG-Index-Structured", "false"))
+                .andExpect(header().string("X-RAG-Index-Fallback-Reason", "structured_not_handled"))
+                .andExpect(header().string("X-RAG-Index-Chunk-Count", "0"));
 
         verify(attachmentService, times(2)).getInputStream(attachment);
         verify(ragPipelineService).index(argThat((RagIndexRequest request) ->
                 "fallback text".equals(request.text())));
+    }
+
+    @Test
+    void ragIndexDoesNotExposeDiagnosticsHeadersUnlessDebugIsRequested() throws Exception {
+        configureMockMvc(null, true);
+        Attachment attachment = mock(Attachment.class);
+        when(attachmentService.getAttachmentById(1L)).thenReturn(attachment);
+        when(attachmentService.getInputStream(attachment))
+                .thenReturn(new ByteArrayInputStream("hello".getBytes(StandardCharsets.UTF_8)));
+        when(attachment.getAttachmentId()).thenReturn(1L);
+        when(attachment.getContentType()).thenReturn("text/plain");
+        when(attachment.getName()).thenReturn("sample.txt");
+        when(attachment.getSize()).thenReturn(5L);
+        when(extractionService.extractText(any(), any(), any(InputStream.class))).thenReturn("hello");
+
+        mockMvc.perform(post(BASE_PATH + "/1/rag/index")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isAccepted())
+                .andExpect(header().doesNotExist("X-RAG-Index-Path"))
+                .andExpect(header().doesNotExist("X-RAG-Index-Fallback-Reason"));
+    }
+
+    @Test
+    void ragIndexDoesNotExposeDiagnosticsHeadersUnlessServerAllowsDebug() throws Exception {
+        Attachment attachment = mock(Attachment.class);
+        when(attachmentService.getAttachmentById(1L)).thenReturn(attachment);
+        when(attachmentService.getInputStream(attachment))
+                .thenReturn(new ByteArrayInputStream("hello".getBytes(StandardCharsets.UTF_8)));
+        when(attachment.getAttachmentId()).thenReturn(1L);
+        when(attachment.getContentType()).thenReturn("text/plain");
+        when(attachment.getName()).thenReturn("sample.txt");
+        when(attachment.getSize()).thenReturn(5L);
+        when(extractionService.extractText(any(), any(), any(InputStream.class))).thenReturn("hello");
+
+        mockMvc.perform(post(BASE_PATH + "/1/rag/index")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "debug": true
+                                }
+                                """))
+                .andExpect(status().isAccepted())
+                .andExpect(header().doesNotExist("X-RAG-Index-Path"))
+                .andExpect(header().doesNotExist("X-RAG-Index-Fallback-Reason"));
+    }
+
+    @Test
+    void ragIndexDoesNotEmitFakeCountsWhenCustomStructuredIndexerHasNoDiagnostics() throws Exception {
+        AttachmentStructuredRagIndexer structuredRagIndexer = (attachment, documentId, objectType, objectId,
+                metadata, extractor, inputStream) -> true;
+        configureMockMvc(structuredRagIndexer, true);
+
+        Attachment attachment = mock(Attachment.class);
+        when(attachmentService.getAttachmentById(1L)).thenReturn(attachment);
+        when(attachmentService.getInputStream(attachment))
+                .thenReturn(new ByteArrayInputStream("hello".getBytes(StandardCharsets.UTF_8)));
+        when(attachment.getAttachmentId()).thenReturn(1L);
+        when(attachment.getContentType()).thenReturn("text/plain");
+        when(attachment.getName()).thenReturn("sample.txt");
+        when(attachment.getSize()).thenReturn(5L);
+
+        mockMvc.perform(post(BASE_PATH + "/1/rag/index")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "debug": true
+                                }
+                                """))
+                .andExpect(status().isAccepted())
+                .andExpect(header().string("X-RAG-Index-Path", "structured"))
+                .andExpect(header().string("X-RAG-Index-Structured", "true"))
+                .andExpect(header().doesNotExist("X-RAG-Index-Parsed-Block-Count"))
+                .andExpect(header().doesNotExist("X-RAG-Index-Chunk-Count"))
+                .andExpect(header().doesNotExist("X-RAG-Index-Vector-Count"));
     }
 
     @Test


### PR DESCRIPTION
## Why

- RAG 색인과 검색 문맥 확장 경로에서 운영자가 구조화/fallback 여부와 확장 적용 상태를 안전하게 확인할 수 있어야 한다.
- diagnostics는 본문, snippet, embedding vector, 사용자 metadata 값을 노출하지 않고 opt-in 조건에서만 제공해야 한다.

## What

- 첨부 RAG 색인에 `AttachmentRagIndexDiagnostics`를 추가하고, `allow-client-debug=true`와 요청 `debug=true`가 모두 만족될 때만 `X-RAG-Index-*` 헤더를 노출했다.
- `RagContextBuilder`에 `buildWithDiagnostics(...)`를 추가해 context expansion 지원/적용 여부, 전략, 후보/결과/확장/fallback hit 수를 `ragContextDiagnostics`로 전달한다.
- 커스텀 `AttachmentStructuredRagIndexer`가 diagnostics를 제공하지 않는 경우 0 count를 꾸며내지 않고 unknown structured 결과로 처리한다.
- 서브에이전트 리뷰 결과에 따라 서버 opt-in 가드, ThreadLocal 정리, 부분 확장 실패 요약, 문서/테스트를 보완했다.

## Related Issues

- Closes #305

## Validation

- Command: `./gradlew :starter:studio-platform-starter-ai-web:test :studio-application-modules:content-embedding-pipeline:test`
- Result: PASS
- Command: `git diff --check`
- Result: PASS

## Risk / Rollback

- Risk: diagnostics 키/헤더가 새로 추가되지만 기본값은 비노출이며 기존 요청/응답 경로는 유지된다.
- Rollback: 이 PR revert 시 기존 RAG 색인/search 동작으로 돌아간다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: Yes
- Delegated scope: `code-reviewer` 에이전트가 RAG observability 변경분의 보안/정확성/운영 안정성을 독립 리뷰했다.
- Main author validation: 리뷰 지적 사항을 보완한 뒤 대상 모듈 테스트와 `git diff --check`를 재실행했다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
