### PR TITLE
[ai-assisted] fix(rag): VectorSearchHit metadata 변환 보강

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2026-04-26
 
 ### 변경됨
+- 이슈 #309 대응으로 `VectorSearchHit.from(...)`이 문자열 숫자 `page`/`slide`와 iterable `headingPath`/`sourceRef` metadata를 안정적으로 변환하도록 보강했다.
 - 이슈 #305 대응으로 첨부 RAG 색인과 web RAG context expansion에 opt-in diagnostics를 추가했다.
 - `POST /api/mgmt/attachments/{id}/rag/index`는 서버 `allow-client-debug=true`와 요청 `debug=true`가 모두 만족될 때 안전한 `X-RAG-Index-*` 헤더로 구조화/fallback 경로와 count 정보를 노출한다.
 - `POST /api/ai/chat/rag`는 서버 `allow-client-debug=true`와 요청 `debug=true`가 모두 만족될 때 `metadata.ragContextDiagnostics`에 context expansion 적용 상태를 노출한다.

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorSearchHit.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorSearchHit.java
@@ -2,6 +2,7 @@ package studio.one.platform.ai.core.vector;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.StreamSupport;
 
 /**
  * RAG-oriented vector search hit with chunk provenance.
@@ -131,7 +132,7 @@ public final class VectorSearchHit {
         if (value == null) {
             return fallback;
         }
-        String text = value.toString().trim();
+        String text = value instanceof Iterable<?> iterable ? join(iterable) : value.toString().trim();
         return text.isBlank() ? fallback : text;
     }
 
@@ -143,6 +144,23 @@ public final class VectorSearchHit {
         if (value instanceof Number numberValue) {
             return numberValue.intValue();
         }
+        if (value instanceof String textValue && !textValue.isBlank()) {
+            try {
+                return Integer.valueOf(textValue.trim());
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
         return null;
+    }
+
+    private static String join(Iterable<?> values) {
+        return StreamSupport.stream(values.spliterator(), false)
+                .filter(Objects::nonNull)
+                .map(Object::toString)
+                .map(String::trim)
+                .filter(value -> !value.isBlank())
+                .reduce((left, right) -> left + " > " + right)
+                .orElse("");
     }
 }

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/core/vector/VectorContractsTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/core/vector/VectorContractsTest.java
@@ -294,10 +294,10 @@ class VectorContractsTest {
                         VectorRecord.KEY_CHUNK_ID, " chunk-1 ",
                         VectorRecord.KEY_PARENT_CHUNK_ID, "parent-1",
                         VectorRecord.KEY_CHUNK_TYPE, "paragraph",
-                        VectorRecord.KEY_HEADING_PATH, "Intro > Body",
-                        VectorRecord.KEY_SOURCE_REF, "file.pdf",
-                        VectorRecord.KEY_PAGE, 3L,
-                        VectorRecord.KEY_SLIDE, 2), List.of()),
+                        VectorRecord.KEY_HEADING_PATH, List.of("Intro", "Body"),
+                        VectorRecord.KEY_SOURCE_REF, List.of("file.pdf", "page=3"),
+                        VectorRecord.KEY_PAGE, "3",
+                        VectorRecord.KEY_SLIDE, " 2 "), List.of()),
                 0.93d));
 
         assertThat(hit.id()).isEqualTo("record-1");
@@ -308,10 +308,26 @@ class VectorContractsTest {
         assertThat(hit.score()).isEqualTo(0.93d);
         assertThat(hit.chunkType()).isEqualTo("paragraph");
         assertThat(hit.headingPath()).isEqualTo("Intro > Body");
-        assertThat(hit.sourceRef()).isEqualTo("file.pdf");
+        assertThat(hit.sourceRef()).isEqualTo("file.pdf > page=3");
         assertThat(hit.page()).isEqualTo(3);
         assertThat(hit.slide()).isEqualTo(2);
         assertThat(hit.metadata()).containsEntry(VectorRecord.KEY_DOCUMENT_ID, " doc-1 ");
+    }
+
+    @Test
+    void vectorSearchHitIgnoresBlankAndInvalidStructuredMetadataValues() {
+        VectorSearchHit hit = VectorSearchHit.from(new VectorSearchResult(
+                new VectorDocument("record-1", "chunk text", Map.of(
+                        VectorRecord.KEY_HEADING_PATH, List.of("", "  "),
+                        VectorRecord.KEY_SOURCE_REF, "  ",
+                        VectorRecord.KEY_PAGE, "three",
+                        VectorRecord.KEY_SLIDE, "  "), List.of()),
+                0.93d));
+
+        assertThat(hit.headingPath()).isNull();
+        assertThat(hit.sourceRef()).isNull();
+        assertThat(hit.page()).isNull();
+        assertThat(hit.slide()).isNull();
     }
 
     @Test

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/core/vector/VectorContractsTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/core/vector/VectorContractsTest.java
@@ -284,6 +284,10 @@ class VectorContractsTest {
         assertThat(results.hits().get(0).metadata()).isEmpty();
         assertThat(results.hits().get(0).documentId()).isEqualTo("doc-1");
         assertThat(results.hits().get(0).chunkId()).isEqualTo("chunk-1");
+        assertThat(results.hits().get(0).headingPath()).isEqualTo("Intro");
+        assertThat(results.hits().get(0).sourceRef()).isEqualTo("page[1]/p[0]");
+        assertThat(results.hits().get(0).page()).isEqualTo(1);
+        assertThat(results.hits().get(0).slide()).isNull();
     }
 
     @Test
@@ -312,6 +316,22 @@ class VectorContractsTest {
         assertThat(hit.page()).isEqualTo(3);
         assertThat(hit.slide()).isEqualTo(2);
         assertThat(hit.metadata()).containsEntry(VectorRecord.KEY_DOCUMENT_ID, " doc-1 ");
+    }
+
+    @Test
+    void vectorSearchHitKeepsLegacyScalarMetadataContract() {
+        VectorSearchHit hit = VectorSearchHit.from(new VectorSearchResult(
+                new VectorDocument("record-1", "chunk text", Map.of(
+                        VectorRecord.KEY_HEADING_PATH, "Intro > Body",
+                        VectorRecord.KEY_SOURCE_REF, "file.pdf",
+                        VectorRecord.KEY_PAGE, 3L,
+                        VectorRecord.KEY_SLIDE, 2), List.of()),
+                0.93d));
+
+        assertThat(hit.headingPath()).isEqualTo("Intro > Body");
+        assertThat(hit.sourceRef()).isEqualTo("file.pdf");
+        assertThat(hit.page()).isEqualTo(3);
+        assertThat(hit.slide()).isEqualTo(2);
     }
 
     @Test


### PR DESCRIPTION
## Why

- `VectorRecord` 기반 색인 metadata가 검색 hit로 변환될 때 adapter/JSON 경로에 따라 숫자와 provenance 값 표현이 달라질 수 있다.
- `VectorSearchHit` 계약은 기존 필드를 유지하면서 다양한 metadata 표현을 안정적으로 받아야 한다.

## What

- `VectorSearchHit.from(...)`이 문자열 숫자 `page`/`slide`를 `Integer`로 변환하도록 보강했다.
- iterable `headingPath`/`sourceRef` 값을 ` > ` 구분 문자열로 변환하도록 했다.
- blank 또는 invalid 값은 기존 fallback/null 동작을 유지한다.
- 서브에이전트 리뷰 결과에 따라 legacy scalar metadata와 `includeMetadata=false` first-class provenance 보존 회귀 테스트를 추가했다.
- 계약 테스트와 CHANGELOG를 갱신했다.

## Related Issues

- Closes #309

## Validation

- Command: `./gradlew :studio-platform-ai:test`
- Result: PASS
- Command: `git diff --check`
- Result: PASS

## Risk / Rollback

- Risk: public API 필드 변경 없이 metadata 변환 허용 범위만 넓힌다. 기존 문자열/숫자 입력 동작은 유지된다.
- Rollback: 이 PR revert 시 기존 단순 문자열/숫자 변환 동작으로 돌아간다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: Yes
- Delegated scope: PR #310 코드 리뷰 및 public API 호환성/테스트 충분성 검토
- Main author validation: 서브에이전트 Low findings 2건을 테스트로 보강한 뒤 `./gradlew :studio-platform-ai:test`와 `git diff --check`를 실행했다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
