### PR TITLE
[ai-assisted] refactor(rag): RagPipeline VectorRecord 색인 전환

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2026-04-26
 
 ### 변경됨
+- 이슈 #311 대응으로 `DefaultRagPipelineService`의 기본 RAG indexing 저장 경로를 `VectorRecord.builder()`와 `VectorStorePort.upsertAll(...)`/`replaceRecordsByObject(...)` 사용으로 전환했다.
+- `VectorRecord` metadata pass-through가 blank string 값을 보존하도록 해 기존 `cleanerPrompt=""` metadata 호환성을 유지했다.
 - 이슈 #309 대응으로 `VectorSearchHit.from(...)`이 문자열 숫자 `page`/`slide`와 iterable `headingPath`/`sourceRef` metadata를 안정적으로 변환하도록 보강했다.
 - 이슈 #305 대응으로 첨부 RAG 색인과 web RAG context expansion에 opt-in diagnostics를 추가했다.
 - `POST /api/mgmt/attachments/{id}/rag/index`는 서버 `allow-client-debug=true`와 요청 `debug=true`가 모두 만족될 때 안전한 `X-RAG-Index-*` 헤더로 구조화/fallback 경로와 count 정보를 노출한다.
@@ -13,6 +15,7 @@
 - context expansion candidate 조회 배수, 후보 조회 상한, previous/next window, parent content 포함 여부를 설정으로 분리했다.
 
 ### 검증
+- `./gradlew :starter:studio-platform-starter-ai:test :studio-platform-ai:test`
 - `./gradlew :starter:studio-platform-starter-ai-web:test :studio-application-modules:content-embedding-pipeline:test`
 - `./gradlew :studio-platform-ai:test :studio-application-modules:content-embedding-pipeline:test :starter:studio-platform-starter-ai:test`
 - `./gradlew :starter:studio-platform-starter-ai-web:test`

--- a/starter/studio-platform-starter-ai/README.md
+++ b/starter/studio-platform-starter-ai/README.md
@@ -178,6 +178,9 @@ studio:
 | `TextCleaner` | `studio.ai.pipeline.cleaner.enabled=true`일 때 색인 전 텍스트 정제 |
 
 `RagPipelineService`는 문서/파일/도메인 객체별 텍스트를 chunk로 나누고, 임베딩과 메타데이터를 벡터 스토어에 저장한다.
+기본 구현은 RAG chunk 저장 모델로 `VectorRecord.builder()`를 사용하고, 기존 `VectorDocument` 기반
+store 구현은 `VectorStorePort`의 default adapter를 통해 계속 호환된다.
+`embeddingModel` metadata가 없으면 core 필수 필드 호환을 위해 `unknown` placeholder가 기록된다.
 `objectType`/`objectId` 메타데이터를 함께 저장하면 AI web starter의 RAG chat API에서 특정 파일이나 객체 범위에 한정해 답변할 수 있다.
 같은 `objectType`/`objectId`를 재색인하면 기존 chunk를 삭제한 뒤 새 chunk를 저장해 stale chunk가 남지 않도록 한다.
 검색 요청은 기존 `searchByObject(...)`와 함께 `RagSearchRequest`의 `MetadataFilter.objectScope(...)` 경로도 지원한다.

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagPipelineService.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagPipelineService.java
@@ -1,6 +1,10 @@
 package studio.one.platform.ai.service.pipeline;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.HexFormat;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,13 +27,14 @@ import studio.one.platform.ai.core.rag.RagIndexRequest;
 import studio.one.platform.ai.core.rag.RagRetrievalDiagnostics;
 import studio.one.platform.ai.core.rag.RagSearchRequest;
 import studio.one.platform.ai.core.rag.RagSearchResult;
-import studio.one.platform.ai.core.vector.VectorDocument;
+import studio.one.platform.ai.core.vector.VectorRecord;
 import studio.one.platform.ai.core.vector.VectorSearchRequest;
 import studio.one.platform.ai.core.vector.VectorSearchResult;
 import studio.one.platform.ai.core.vector.VectorStorePort;
 import studio.one.platform.ai.service.cleaning.TextCleaner;
 import studio.one.platform.ai.service.cleaning.TextCleaningResult;
 import studio.one.platform.ai.service.keyword.KeywordExtractor;
+import studio.one.platform.chunking.core.ChunkMetadata;
 import studio.one.platform.chunking.core.ChunkingOrchestrator;
 
 @Slf4j
@@ -191,7 +196,7 @@ public class DefaultRagPipelineService implements RagPipelineService {
         TextCleaningResult cleaning = cleanText(request.text());
         String indexedText = cleaning.text() == null ? request.text() : cleaning.text();
         List<RagPipelineChunk> chunks = chunk(indexedText, request);
-        List<VectorDocument> documents = new ArrayList<>(chunks.size());
+        List<VectorRecord> records = new ArrayList<>(chunks.size());
         List<String> documentKeywords = keywordOptions.scope().includesDocument()
                 ? resolveDocumentKeywords(request, indexedText)
                 : List.of();
@@ -219,21 +224,50 @@ public class DefaultRagPipelineService implements RagPipelineService {
             }
             metadata.put("documentId", request.documentId());
             metadata.put("chunkId", chunk.id());
-            metadata.put("chunkOrder", order++);
+            metadata.put("chunkOrder", order);
+            metadata.put(VectorRecord.KEY_CHUNK_INDEX, order);
             metadata.put("chunkLength", chunk.content().length());
-            documents.add(new VectorDocument(chunk.id(), chunk.content(), metadata, embedding));
+            records.add(vectorRecord(request.documentId(), chunk, metadata, embedding));
+            order++;
         }
         String objectType = RagChunkingMetadata.normalizeObjectScope(baseMetadata.get("objectType"));
         String objectId = RagChunkingMetadata.normalizeObjectScope(baseMetadata.get("objectId"));
         if (objectType != null && objectId != null) {
-            if (documents.isEmpty()) {
+            if (records.isEmpty()) {
                 vectorStorePort.deleteByObject(objectType, objectId);
             } else {
-                vectorStorePort.replaceByObject(objectType, objectId, documents);
+                vectorStorePort.replaceRecordsByObject(objectType, objectId, records);
             }
-        } else if (!documents.isEmpty()) {
-            vectorStorePort.upsert(documents);
+        } else if (!records.isEmpty()) {
+            vectorStorePort.upsertAll(records);
         }
+    }
+
+    private VectorRecord vectorRecord(
+            String documentId,
+            RagPipelineChunk chunk,
+            Map<String, Object> metadata,
+            List<Double> embedding) {
+        return VectorRecord.builder()
+                .id(chunk.id())
+                .documentId(documentId)
+                .chunkId(chunk.id())
+                .parentChunkId(text(metadata.get(VectorRecord.KEY_PARENT_CHUNK_ID)))
+                .contentHash(contentHash(chunk.content()))
+                .text(chunk.content())
+                .embedding(embedding)
+                .embeddingModel(embeddingModel(metadata))
+                .embeddingDimension(embedding.size())
+                .chunkType(text(metadata.get(VectorRecord.KEY_CHUNK_TYPE)))
+                .headingPath(text(firstPresent(metadata, VectorRecord.KEY_HEADING_PATH, ChunkMetadata.KEY_SECTION)))
+                .sourceRef(text(firstPresent(metadata,
+                        VectorRecord.KEY_SOURCE_REF,
+                        ChunkMetadata.KEY_SOURCE_REF,
+                        ChunkMetadata.KEY_SOURCE_REFS)))
+                .page(integer(metadata.get(VectorRecord.KEY_PAGE)))
+                .slide(integer(metadata.get(VectorRecord.KEY_SLIDE)))
+                .metadata(metadata)
+                .build();
     }
 
     private List<RagPipelineChunk> chunk(String indexedText, RagIndexRequest request) {
@@ -249,6 +283,60 @@ public class DefaultRagPipelineService implements RagPipelineService {
                 metadata.putIfAbsent(key, value);
             }
         });
+    }
+
+    private Object firstPresent(Map<String, Object> metadata, String... keys) {
+        for (String key : keys) {
+            Object value = metadata.get(key);
+            if (value != null && (!(value instanceof String text) || !text.isBlank())) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private String embeddingModel(Map<String, Object> metadata) {
+        String embeddingModel = text(metadata.get(VectorRecord.KEY_EMBEDDING_MODEL));
+        return embeddingModel == null ? "unknown" : embeddingModel;
+    }
+
+    private String text(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Iterable<?> iterable) {
+            return java.util.stream.StreamSupport.stream(iterable.spliterator(), false)
+                    .filter(Objects::nonNull)
+                    .map(Objects::toString)
+                    .filter(text -> !text.isBlank())
+                    .reduce((left, right) -> left + " > " + right)
+                    .orElse(null);
+        }
+        String text = Objects.toString(value, null);
+        return text == null || text.isBlank() ? null : text;
+    }
+
+    private Integer integer(Object value) {
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        if (value instanceof String text && !text.isBlank()) {
+            try {
+                return Integer.valueOf(text.trim());
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private String contentHash(String content) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(content.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("SHA-256 digest is not available", ex);
+        }
     }
 
     @Override

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
@@ -23,6 +23,7 @@ import studio.one.platform.ai.core.rag.RagRetrievalDiagnostics;
 import studio.one.platform.ai.core.rag.RagSearchRequest;
 import studio.one.platform.ai.core.rag.RagSearchResult;
 import studio.one.platform.ai.core.vector.VectorDocument;
+import studio.one.platform.ai.core.vector.VectorRecord;
 import studio.one.platform.ai.core.vector.VectorSearchRequest;
 import studio.one.platform.ai.core.vector.VectorSearchResult;
 import studio.one.platform.ai.core.vector.VectorStorePort;
@@ -36,6 +37,7 @@ import studio.one.platform.chunking.core.ChunkingOrchestrator;
 import studio.one.platform.chunking.core.ChunkingStrategyType;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -78,7 +80,7 @@ class RagPipelineServiceTest {
     private RagPipelineService ragPipelineService;
 
     @Captor
-    private ArgumentCaptor<List<VectorDocument>> documentsCaptor;
+    private ArgumentCaptor<List<VectorRecord>> recordsCaptor;
 
     @Captor
     private ArgumentCaptor<Integer> limitCaptor;
@@ -100,20 +102,53 @@ class RagPipelineServiceTest {
 
         ragPipelineService.index(request);
 
-        verify(vectorStorePort).upsert(documentsCaptor.capture());
-        List<VectorDocument> documents = documentsCaptor.getValue();
-        assertThat(documents).hasSize(1);
-        VectorDocument document = documents.get(0);
-        assertThat(document.id()).isEqualTo("doc-1-0");
-        assertThat(document.metadata()).containsEntry("author", "test");
-        assertThat(document.metadata()).containsEntry("cleaned", false);
-        assertThat(document.metadata()).containsEntry("cleanerPrompt", "");
-        assertThat(document.metadata()).containsEntry("originalTextLength", 11);
-        assertThat(document.metadata()).containsEntry("indexedTextLength", 11);
-        assertThat(document.metadata()).containsEntry("chunkCount", 1);
-        assertThat(document.metadata()).containsEntry("chunkOrder", 0);
-        assertThat(document.metadata()).containsEntry("chunkLength", 11);
-        assertThat(document.embedding()).containsExactly(0.1, 0.2, 0.3);
+        verify(vectorStorePort).upsertAll(recordsCaptor.capture());
+        List<VectorRecord> records = recordsCaptor.getValue();
+        assertThat(records).hasSize(1);
+        VectorRecord record = records.get(0);
+        assertThat(record.id()).isEqualTo("doc-1-0");
+        assertThat(record.documentId()).isEqualTo("doc-1");
+        assertThat(record.chunkId()).isEqualTo("doc-1-0");
+        assertThat(record.contentHash()).isNotBlank();
+        assertThat(record.embeddingModel()).isEqualTo("unknown");
+        assertThat(record.embeddingDimension()).isEqualTo(3);
+        assertThat(record.metadata()).containsEntry("author", "test");
+        assertThat(record.metadata()).containsEntry("cleaned", false);
+        assertThat(record.metadata()).containsEntry("cleanerPrompt", "");
+        assertThat(record.metadata()).containsEntry("originalTextLength", 11);
+        assertThat(record.metadata()).containsEntry("indexedTextLength", 11);
+        assertThat(record.metadata()).containsEntry("chunkCount", 1);
+        assertThat(record.metadata()).containsEntry("chunkOrder", 0);
+        assertThat(record.metadata()).containsEntry("chunkIndex", 0);
+        assertThat(record.metadata()).containsEntry("chunkLength", 11);
+        assertThat(record.embedding()).containsExactly(0.1, 0.2, 0.3);
+    }
+
+    @Test
+    void shouldPersistVectorRecordMetadataThroughDefaultLegacyAdapter() {
+        CapturingVectorStore store = new CapturingVectorStore();
+        ragPipelineService = DefaultRagPipelineService.create(embeddingPort, store, textChunker, cache, retry,
+                keywordExtractor);
+        RagIndexRequest request = new RagIndexRequest("doc-adapter", "hello world", Map.of(
+                "embeddingModel", "test-embedding"));
+        when(textChunker.chunk("doc-adapter", "hello world"))
+                .thenReturn(List.of(new TextChunk("doc-adapter-0", "hello world")));
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("doc-adapter-0", List.of(0.1, 0.2)))));
+
+        ragPipelineService.index(request);
+
+        assertThat(store.upsertedDocuments()).hasSize(1);
+        VectorDocument document = store.upsertedDocuments().get(0);
+        assertThat(document.id()).isEqualTo("doc-adapter-0");
+        assertThat(document.content()).isEqualTo("hello world");
+        assertThat(document.embedding()).containsExactly(0.1, 0.2);
+        assertThat(document.metadata())
+                .containsEntry("cleanerPrompt", "")
+                .containsEntry("chunkIndex", 0)
+                .containsEntry("chunkOrder", 0)
+                .containsEntry("embeddingModel", "test-embedding")
+                .containsEntry("embeddingDimension", 2);
     }
 
     @Test
@@ -132,15 +167,15 @@ class RagPipelineServiceTest {
 
         verify(textCleaner).clean("noisy text");
         verify(textChunker).chunk("doc-clean", "clean text");
-        verify(vectorStorePort).upsert(documentsCaptor.capture());
-        VectorDocument document = documentsCaptor.getValue().get(0);
-        assertThat(document.content()).isEqualTo("clean text");
-        assertThat(document.metadata()).containsEntry("cleaned", true);
-        assertThat(document.metadata()).containsEntry("cleanerPrompt", "rag-cleaner");
-        assertThat(document.metadata()).containsEntry("originalTextLength", 10);
-        assertThat(document.metadata()).containsEntry("indexedTextLength", 10);
-        assertThat(document.metadata()).containsEntry("chunkCount", 1);
-        assertThat(document.metadata()).containsEntry("chunkLength", 10);
+        verify(vectorStorePort).upsertAll(recordsCaptor.capture());
+        VectorRecord record = recordsCaptor.getValue().get(0);
+        assertThat(record.text()).isEqualTo("clean text");
+        assertThat(record.metadata()).containsEntry("cleaned", true);
+        assertThat(record.metadata()).containsEntry("cleanerPrompt", "rag-cleaner");
+        assertThat(record.metadata()).containsEntry("originalTextLength", 10);
+        assertThat(record.metadata()).containsEntry("indexedTextLength", 10);
+        assertThat(record.metadata()).containsEntry("chunkCount", 1);
+        assertThat(record.metadata()).containsEntry("chunkLength", 10);
     }
 
     @Test
@@ -158,14 +193,14 @@ class RagPipelineServiceTest {
 
         ragPipelineService.index(request);
 
-        verify(vectorStorePort).upsert(documentsCaptor.capture());
-        VectorDocument document = documentsCaptor.getValue().get(0);
-        assertThat(document.metadata()).containsEntry("cleaned", "caller-cleaned");
-        assertThat(document.metadata()).containsEntry("cleanerPrompt", "caller-prompt");
-        assertThat(document.metadata()).containsEntry("originalTextLength", 999);
-        assertThat(document.metadata()).containsEntry("indexedTextLength", 888);
-        assertThat(document.metadata()).containsEntry("chunkCount", 777);
-        assertThat(document.metadata()).containsEntry("chunkLength", 11);
+        verify(vectorStorePort).upsertAll(recordsCaptor.capture());
+        VectorRecord record = recordsCaptor.getValue().get(0);
+        assertThat(record.metadata()).containsEntry("cleaned", "caller-cleaned");
+        assertThat(record.metadata()).containsEntry("cleanerPrompt", "caller-prompt");
+        assertThat(record.metadata()).containsEntry("originalTextLength", 999);
+        assertThat(record.metadata()).containsEntry("indexedTextLength", 888);
+        assertThat(record.metadata()).containsEntry("chunkCount", 777);
+        assertThat(record.metadata()).containsEntry("chunkLength", 11);
     }
 
     @Test
@@ -180,11 +215,11 @@ class RagPipelineServiceTest {
         ragPipelineService.index(request);
 
         verify(keywordExtractor).extract("hello world");
-        verify(vectorStorePort).upsert(documentsCaptor.capture());
-        VectorDocument document = documentsCaptor.getValue().get(0);
-        assertThat(document.metadata()).containsEntry("keywords", List.of("hello", "world"));
-        assertThat(document.metadata()).containsEntry("keywordsText", "hello world");
-        assertThat(document.metadata()).doesNotContainKeys("chunkKeywords", "chunkKeywordsText");
+        verify(vectorStorePort).upsertAll(recordsCaptor.capture());
+        VectorRecord record = recordsCaptor.getValue().get(0);
+        assertThat(record.metadata()).containsEntry("keywords", List.of("hello", "world"));
+        assertThat(record.metadata()).containsEntry("keywordsText", "hello world");
+        assertThat(record.metadata()).doesNotContainKeys("chunkKeywords", "chunkKeywordsText");
     }
 
     @Test
@@ -220,15 +255,19 @@ class RagPipelineServiceTest {
         ragPipelineService.index(request);
 
         verify(textChunker, never()).chunk(anyString(), anyString());
-        verify(vectorStorePort).replaceByObject(eq("attachment"), eq("42"), documentsCaptor.capture());
-        VectorDocument document = documentsCaptor.getValue().get(0);
-        assertThat(document.id()).isEqualTo("doc-orchestrated-0");
-        assertThat(document.metadata())
+        verify(vectorStorePort).replaceRecordsByObject(eq("attachment"), eq("42"), recordsCaptor.capture());
+        VectorRecord record = recordsCaptor.getValue().get(0);
+        assertThat(record.id()).isEqualTo("doc-orchestrated-0");
+        assertThat(record.documentId()).isEqualTo("doc-orchestrated");
+        assertThat(record.chunkId()).isEqualTo("doc-orchestrated-0");
+        assertThat(record.embeddingDimension()).isEqualTo(2);
+        assertThat(record.metadata())
                 .containsEntry("sourceDocumentId", "doc-orchestrated")
                 .containsEntry("strategy", "recursive")
                 .containsEntry("objectType", "attachment")
                 .containsEntry("objectId", "42")
-                .containsEntry("chunkOrder", 0);
+                .containsEntry("chunkOrder", 0)
+                .containsEntry("chunkIndex", 0);
     }
 
     @Test
@@ -262,8 +301,8 @@ class RagPipelineServiceTest {
 
         ragPipelineService.index(request);
 
-        verify(vectorStorePort).replaceByObject(eq("attachment"), eq("42"), documentsCaptor.capture());
-        assertThat(documentsCaptor.getValue().get(0).id()).isEqualTo("doc-orchestrated-null-legacy-0");
+        verify(vectorStorePort).replaceRecordsByObject(eq("attachment"), eq("42"), recordsCaptor.capture());
+        assertThat(recordsCaptor.getValue().get(0).id()).isEqualTo("doc-orchestrated-null-legacy-0");
     }
 
     @Test
@@ -289,8 +328,8 @@ class RagPipelineServiceTest {
         ragPipelineService.index(request);
 
         verify(textChunker).chunk("doc-legacy", "alpha beta");
-        verify(vectorStorePort).upsert(documentsCaptor.capture());
-        assertThat(documentsCaptor.getValue().get(0).id()).isEqualTo("doc-legacy-0");
+        verify(vectorStorePort).upsertAll(recordsCaptor.capture());
+        assertThat(recordsCaptor.getValue().get(0).id()).isEqualTo("doc-legacy-0");
     }
 
     @Test
@@ -315,7 +354,9 @@ class RagPipelineServiceTest {
 
         verify(vectorStorePort).deleteByObject("attachment", "42");
         verify(vectorStorePort, never()).upsert(org.mockito.ArgumentMatchers.<List<VectorDocument>>any());
+        verify(vectorStorePort, never()).upsertAll(org.mockito.ArgumentMatchers.<List<VectorRecord>>any());
         verify(vectorStorePort, never()).replaceByObject(anyString(), anyString(), any());
+        verify(vectorStorePort, never()).replaceRecordsByObject(anyString(), anyString(), any());
     }
 
     @Test
@@ -346,13 +387,13 @@ class RagPipelineServiceTest {
         verify(keywordExtractor).extract("alpha");
         verify(keywordExtractor).extract("beta");
         verify(keywordExtractor, never()).extract("alpha beta");
-        verify(vectorStorePort).upsert(documentsCaptor.capture());
-        List<VectorDocument> documents = documentsCaptor.getValue();
-        assertThat(documents.get(0).metadata())
+        verify(vectorStorePort).upsertAll(recordsCaptor.capture());
+        List<VectorRecord> records = recordsCaptor.getValue();
+        assertThat(records.get(0).metadata())
                 .containsEntry("chunkKeywords", List.of("Alpha", "first"))
                 .containsEntry("chunkKeywordsText", "Alpha first")
                 .doesNotContainKeys("keywords", "keywordsText");
-        assertThat(documents.get(1).metadata())
+        assertThat(records.get(1).metadata())
                 .containsEntry("chunkKeywords", List.of("Beta", "second"))
                 .containsEntry("chunkKeywordsText", "Beta second")
                 .doesNotContainKeys("keywords", "keywordsText");
@@ -385,8 +426,8 @@ class RagPipelineServiceTest {
         ragPipelineService.index(request);
 
         verify(keywordExtractor, never()).extract(anyString());
-        verify(vectorStorePort).upsert(documentsCaptor.capture());
-        assertThat(documentsCaptor.getValue().get(0).metadata())
+        verify(vectorStorePort).upsertAll(recordsCaptor.capture());
+        assertThat(recordsCaptor.getValue().get(0).metadata())
                 .doesNotContainKeys("keywords", "keywordsText", "chunkKeywords", "chunkKeywordsText");
     }
 
@@ -415,12 +456,12 @@ class RagPipelineServiceTest {
         ragPipelineService.index(request);
 
         verify(keywordExtractor, times(2)).extract("alpha");
-        verify(vectorStorePort).upsert(documentsCaptor.capture());
-        VectorDocument document = documentsCaptor.getValue().get(0);
-        assertThat(document.metadata()).containsEntry("keywords", List.of("document"));
-        assertThat(document.metadata()).containsEntry("keywordsText", "document");
-        assertThat(document.metadata()).containsEntry("chunkKeywords", List.of("chunk"));
-        assertThat(document.metadata()).containsEntry("chunkKeywordsText", "chunk");
+        verify(vectorStorePort).upsertAll(recordsCaptor.capture());
+        VectorRecord record = recordsCaptor.getValue().get(0);
+        assertThat(record.metadata()).containsEntry("keywords", List.of("document"));
+        assertThat(record.metadata()).containsEntry("keywordsText", "document");
+        assertThat(record.metadata()).containsEntry("chunkKeywords", List.of("chunk"));
+        assertThat(record.metadata()).containsEntry("chunkKeywordsText", "chunk");
     }
 
     @Test
@@ -931,5 +972,29 @@ class RagPipelineServiceTest {
         assertThat(diagnostics.toMetadata())
                 .containsEntry("strategy", "hybrid")
                 .doesNotContainKeys("content", "snippet", "text", "chunk");
+    }
+
+    private static final class CapturingVectorStore implements VectorStorePort {
+
+        private final List<VectorDocument> upsertedDocuments = new ArrayList<>();
+
+        @Override
+        public void upsert(List<VectorDocument> documents) {
+            upsertedDocuments.addAll(documents);
+        }
+
+        @Override
+        public List<VectorSearchResult> search(VectorSearchRequest request) {
+            return List.of();
+        }
+
+        @Override
+        public boolean exists(String id, String contentHash) {
+            return false;
+        }
+
+        private List<VectorDocument> upsertedDocuments() {
+            return upsertedDocuments;
+        }
     }
 }

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorRecord.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorRecord.java
@@ -317,9 +317,8 @@ public final class VectorRecord {
         Map<String, Object> sanitized = new LinkedHashMap<>();
         values.forEach((key, value) -> {
             String normalizedKey = normalize(key);
-            if (normalizedKey != null && value != null
-                    && (!(value instanceof String textValue) || !textValue.isBlank())) {
-                sanitized.put(normalizedKey, value instanceof String textValue ? textValue.trim() : value);
+            if (normalizedKey != null && value != null) {
+                sanitized.put(normalizedKey, value);
             }
         });
         return Map.copyOf(sanitized);

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/core/vector/VectorContractsTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/core/vector/VectorContractsTest.java
@@ -164,7 +164,9 @@ class VectorContractsTest {
         VectorRecord record = record(Map.of(
                 VectorRecord.KEY_DOCUMENT_ID, "caller-doc",
                 VectorRecord.KEY_CHUNK_INDEX, 7,
-                VectorRecord.KEY_TENANT_ID, "tenant-a"));
+                VectorRecord.KEY_TENANT_ID, "tenant-a",
+                "cleanerPrompt", "",
+                "rawLabel", "  keep spacing  "));
 
         VectorDocument document = record.toVectorDocument();
 
@@ -179,7 +181,9 @@ class VectorContractsTest {
                 .containsEntry(VectorRecord.KEY_EMBEDDING_MODEL, "embedding-model")
                 .containsEntry(VectorRecord.KEY_EMBEDDING_DIMENSION, 2)
                 .containsEntry(VectorRecord.KEY_CHUNK_INDEX, 7)
-                .containsEntry(VectorRecord.KEY_TENANT_ID, "tenant-a");
+                .containsEntry(VectorRecord.KEY_TENANT_ID, "tenant-a")
+                .containsEntry("cleanerPrompt", "")
+                .containsEntry("rawLabel", "  keep spacing  ");
     }
 
     @Test


### PR DESCRIPTION
## Why

- `DefaultRagPipelineService`의 기본 RAG indexing 저장 경로가 legacy `VectorDocument` 중심이라, ai core의 RAG chunk 저장 표준 모델인 `VectorRecord` 계약이 실제 pipeline에서 사용되지 못했다.
- 기존 `VectorDocument` store 구현과 metadata shape 호환성은 유지해야 한다.

## What

- `DefaultRagPipelineService.index(...)` 저장 경로를 `VectorRecord.builder()` 기반으로 전환했다.
- non-object scope 색인은 `VectorStorePort.upsertAll(...)`, object scope 재색인은 `replaceRecordsByObject(...)`를 사용하도록 변경했다.
- `VectorRecord` metadata pass-through가 blank string 값을 보존하도록 해 기존 `cleanerPrompt=""` metadata 호환성을 유지했다.
- legacy `VectorDocument` store adapter 경유 시 `cleanerPrompt`, `chunkIndex`, `chunkOrder`, `embeddingModel`, `embeddingDimension` metadata shape가 유지되는 테스트를 추가했다.
- `embeddingModel` metadata가 없을 때 core 필수 필드 호환을 위해 `unknown` placeholder가 기록되는 현재 계약을 README에 명시했다.

## Related Issues

- Closes #311

## Validation

- Command: `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-ai:test`
- Result: PASS
- Command: `git diff --check`
- Result: PASS
- Subagent review: PASS, no findings

## Risk / Rollback

- Risk: RAG indexing 저장 호출이 `VectorRecord` default adapter 경로를 타므로 custom `VectorStorePort` 구현이 `upsertAll(...)`/`replaceRecordsByObject(...)`를 override하지 않아도 legacy adapter 동작에 의존한다.
- Rollback: `DefaultRagPipelineService.index(...)` 저장 경로를 기존 `VectorDocument` 생성과 `upsert(...)`/`replaceByObject(...)` 호출로 되돌린다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: Yes
- Delegated scope: 워킹트리 변경 리뷰, cleanerPrompt metadata 호환성, default adapter round-trip 테스트 검토
- Main author validation: `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-ai:test`, `git diff --check`

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
