### PR TITLE
[ai-assisted] feat(rag): web vector aggregate 검색 연결

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2026-04-26
 
 ### 변경됨
+- 이슈 #312 대응으로 AI web vector 검색 경로가 내부적으로 `VectorSearchResults`/`VectorSearchHit` aggregate 계약을 사용하도록 연결했다.
+- `POST /api/mgmt/ai/vectors/search` 요청에서 `includeText`/`includeMetadata`를 optional field로 받아 core `VectorSearchRequest`에 전달한다.
 - 이슈 #311 대응으로 `DefaultRagPipelineService`의 기본 RAG indexing 저장 경로를 `VectorRecord.builder()`와 `VectorStorePort.upsertAll(...)`/`replaceRecordsByObject(...)` 사용으로 전환했다.
 - `VectorRecord` metadata pass-through가 blank string 값을 보존하도록 해 기존 `cleanerPrompt=""` metadata 호환성을 유지했다.
 - 이슈 #309 대응으로 `VectorSearchHit.from(...)`이 문자열 숫자 `page`/`slide`와 iterable `headingPath`/`sourceRef` metadata를 안정적으로 변환하도록 보강했다.

--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -391,6 +391,10 @@ Content-Type: application/json
 ### 벡터 검색 응답
 
 `POST /api/mgmt/ai/vectors/search` 응답 항목은 기존 `documentId`와 클라이언트 grid 호환용 `id`를 함께 반환한다.
+내부 검색 결과는 core `VectorSearchResults`/`VectorSearchHit` aggregate 계약으로 정규화하지만,
+HTTP 응답 shape는 기존 `List<VectorSearchResultDto>`를 유지한다.
+요청에 `includeText=false` 또는 `includeMetadata=false`를 전달하면 core `VectorSearchRequest`에 그대로 전달되어
+응답 항목의 `content`가 `null`이거나 `metadata`가 빈 객체일 수 있다.
 
 ```json
 {

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/VectorController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/VectorController.java
@@ -1,7 +1,6 @@
 package studio.one.platform.ai.web.controller;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,8 +25,10 @@ import studio.one.platform.ai.core.embedding.EmbeddingPort;
 import studio.one.platform.ai.core.embedding.EmbeddingRequest;
 import studio.one.platform.ai.core.embedding.EmbeddingResponse;
 import studio.one.platform.ai.core.vector.VectorDocument;
+import studio.one.platform.ai.core.vector.VectorSearchHit;
 import studio.one.platform.ai.core.vector.VectorSearchRequest;
 import studio.one.platform.ai.core.vector.VectorSearchResult;
+import studio.one.platform.ai.core.vector.VectorSearchResults;
 import studio.one.platform.ai.core.vector.VectorStorePort;
 import studio.one.platform.ai.web.dto.VectorDocumentDto;
 import studio.one.platform.ai.web.dto.VectorSearchRequestDto;
@@ -133,11 +134,14 @@ public class VectorController {
         List<Double> queryEmbedding = resolveEmbedding(request);
         VectorSearchRequest searchRequest = new VectorSearchRequest(
                 queryEmbedding,
+                request.query(),
                 request.topK(),
                 MetadataFilter.objectScope(request.objectType(), request.objectId()),
-                request.minScore());
-        List<VectorSearchResult> results = executeSearch(store, request, searchRequest);
-        List<VectorSearchResultDto> payload = results.stream()
+                request.minScore(),
+                request.includeText(),
+                request.includeMetadata());
+        VectorSearchResults results = executeSearch(store, request, searchRequest);
+        List<VectorSearchResultDto> payload = results.hits().stream()
                 .map(this::toVectorSearchResultDto)
                 .toList();
         return ResponseEntity.ok(ApiResponse.ok(payload));
@@ -166,22 +170,23 @@ public class VectorController {
         return List.copyOf(response.vectors().get(0).values());
     }
 
-    private List<VectorSearchResult> executeSearch(VectorStorePort store, VectorSearchRequestDto request,
+    private VectorSearchResults executeSearch(VectorStorePort store, VectorSearchRequestDto request,
             VectorSearchRequest searchRequest) {
         boolean useHybrid = Boolean.TRUE.equals(request.hybrid());
         MetadataFilter filter = searchRequest.metadataFilter();
         boolean hasObjectFilter = filter.hasObjectScope();
-        List<VectorSearchResult> results;
         if (!useHybrid) {
-            results = hasObjectFilter
-                    ? store.searchByObject(filter.objectType(), filter.objectId(), searchRequest)
-                    : store.search(searchRequest);
-            return applyMinScore(results, searchRequest.minScore());
+            if (hasObjectFilter) {
+                return toSearchResults(
+                        store.searchByObject(filter.objectType(), filter.objectId(), searchRequest),
+                        searchRequest);
+            }
+            return applyMinScore(store.searchWithFilter(searchRequest), searchRequest.minScore());
         }
         if (request.query() == null || request.query().isBlank()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "hybrid search requires a query string");
         }
-        results = hasObjectFilter
+        List<VectorSearchResult> results = hasObjectFilter
                 ? store.hybridSearchByObject(
                         request.query(),
                         filter.objectType(),
@@ -190,7 +195,7 @@ public class VectorController {
                         HYBRID_VECTOR_WEIGHT,
                         HYBRID_LEXICAL_WEIGHT)
                 : store.hybridSearch(request.query(), searchRequest, HYBRID_VECTOR_WEIGHT, HYBRID_LEXICAL_WEIGHT);
-        return applyMinScore(results, searchRequest.minScore());
+        return toSearchResults(results, searchRequest);
     }
 
     private List<Double> normalizeEmbedding(List<Double> embedding, int expectedDim) {
@@ -217,28 +222,32 @@ public class VectorController {
         return normalized;
     }
 
-    private VectorSearchResultDto toVectorSearchResultDto(VectorSearchResult result) {
-        VectorDocument document = result.document();
-        Map<String, Object> metadata = document.metadata();
+    private VectorSearchResultDto toVectorSearchResultDto(VectorSearchHit hit) {
         return new VectorSearchResultDto(
-                document.id(),
-                document.id(),
-                document.content(),
-                metadata == null ? Collections.emptyMap() : Map.copyOf(metadata),
-                result.score());
+                hit.id(),
+                hit.documentId(),
+                hit.text(),
+                hit.metadata(),
+                hit.score());
     }
 
-    private List<VectorSearchResult> applyMinScore(List<VectorSearchResult> results, Double minScore) {
+    private VectorSearchResults toSearchResults(List<VectorSearchResult> results, VectorSearchRequest request) {
+        long startedAt = System.nanoTime();
+        List<VectorSearchHit> hits = results.stream()
+                .map(result -> VectorSearchHit.from(result, request.includeText(), request.includeMetadata()))
+                .toList();
+        long elapsedMs = (System.nanoTime() - startedAt) / 1_000_000L;
+        return applyMinScore(VectorSearchResults.of(hits, elapsedMs), request.minScore());
+    }
+
+    private VectorSearchResults applyMinScore(VectorSearchResults results, Double minScore) {
         if (minScore == null) {
             return results;
         }
-        return results.stream()
+        List<VectorSearchHit> hits = results.hits().stream()
                 .filter(result -> result.score() >= minScore)
                 .toList();
-    }
-
-    private boolean hasText(String value) {
-        return value != null && !value.isBlank();
+        return VectorSearchResults.of(hits, results.elapsedMs());
     }
 
     private VectorStorePort requireVectorStore() {

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/VectorSearchRequestDto.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/VectorSearchRequestDto.java
@@ -17,14 +17,33 @@ public record VectorSearchRequestDto(
         String objectId,
         @DecimalMin(value = "0.0", message = "minScore must be at least 0.0")
         @DecimalMax(value = "1.0", message = "minScore must be at most 1.0")
-        Double minScore
+        Double minScore,
+        Boolean includeText,
+        Boolean includeMetadata
 ) {
+    public VectorSearchRequestDto(
+            String query,
+            List<Double> embedding,
+            Integer topK,
+            Boolean hybrid,
+            String objectType,
+            String objectId,
+            Double minScore) {
+        this(query, embedding, topK, hybrid, objectType, objectId, minScore, null, null);
+    }
+
     public VectorSearchRequestDto {
         if (topK == null) {
             topK = 5;
         }
         if (hybrid == null) {
             hybrid = Boolean.FALSE;
+        }
+        if (includeText == null) {
+            includeText = Boolean.TRUE;
+        }
+        if (includeMetadata == null) {
+            includeMetadata = Boolean.TRUE;
         }
     }
 }

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/VectorControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/VectorControllerTest.java
@@ -21,8 +21,11 @@ import studio.one.platform.ai.core.embedding.EmbeddingPort;
 import studio.one.platform.ai.core.embedding.EmbeddingResponse;
 import studio.one.platform.ai.core.embedding.EmbeddingVector;
 import studio.one.platform.ai.core.vector.VectorDocument;
+import studio.one.platform.ai.core.vector.VectorRecord;
+import studio.one.platform.ai.core.vector.VectorSearchHit;
 import studio.one.platform.ai.core.vector.VectorSearchRequest;
 import studio.one.platform.ai.core.vector.VectorSearchResult;
+import studio.one.platform.ai.core.vector.VectorSearchResults;
 import studio.one.platform.ai.core.vector.VectorStorePort;
 import studio.one.platform.ai.web.dto.VectorSearchRequestDto;
 import studio.one.platform.ai.web.dto.VectorSearchResultDto;
@@ -57,6 +60,60 @@ class VectorControllerTest {
         assertThat(response.getBody().getData().get(0).id()).isEqualTo("doc-1");
         assertThat(response.getBody().getData().get(0).documentId()).isEqualTo("doc-1");
         verify(vectorStorePort).searchByObject(eq("attachment"), eq("42"), any(VectorSearchRequest.class));
+    }
+
+    @Test
+    void mapsVectorSearchHitProvenanceToLegacyResponseShape() {
+        when(embeddingPort.embed(any()))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("query", List.of(1.0, 0.0)))));
+        when(vectorStorePort.searchByObject(eq("attachment"), eq("42"), any(VectorSearchRequest.class)))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("chunk-1", "chunk", Map.of(
+                                VectorRecord.KEY_DOCUMENT_ID, "doc-1",
+                                VectorRecord.KEY_CHUNK_ID, "chunk-1",
+                                VectorRecord.KEY_SOURCE_REF, "page[1]/p[0]"), List.of()),
+                        0.8d)));
+
+        ResponseEntity<ApiResponse<List<VectorSearchResultDto>>> response = controller.search(
+                new VectorSearchRequestDto("hello", null, 3, false, "attachment", "42", null));
+
+        VectorSearchResultDto result = response.getBody().getData().get(0);
+        assertThat(result.id()).isEqualTo("chunk-1");
+        assertThat(result.documentId()).isEqualTo("doc-1");
+        assertThat(result.content()).isEqualTo("chunk");
+        assertThat(result.metadata()).containsEntry(VectorRecord.KEY_SOURCE_REF, "page[1]/p[0]");
+    }
+
+    @Test
+    void usesAggregateVectorSearchForGlobalSearch() {
+        ArgumentCaptor<VectorSearchRequest> captor = ArgumentCaptor.forClass(VectorSearchRequest.class);
+        when(embeddingPort.embed(any()))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("query", List.of(1.0, 0.0)))));
+        when(vectorStorePort.searchWithFilter(any(VectorSearchRequest.class)))
+                .thenReturn(VectorSearchResults.of(List.of(new VectorSearchHit(
+                        "chunk-1",
+                        "doc-1",
+                        "chunk-1",
+                        null,
+                        "chunk",
+                        0.8d,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        Map.of("topic", "alpha"))), 2L));
+
+        ResponseEntity<ApiResponse<List<VectorSearchResultDto>>> response = controller.search(
+                new VectorSearchRequestDto("hello", null, 3, false, null, null, null));
+
+        assertThat(response.getBody().getData()).hasSize(1);
+        assertThat(response.getBody().getData().get(0).documentId()).isEqualTo("doc-1");
+        assertThat(response.getBody().getData().get(0).metadata()).containsEntry("topic", "alpha");
+        verify(vectorStorePort).searchWithFilter(captor.capture());
+        assertThat(captor.getValue().queryText()).isEqualTo("hello");
+        assertThat(captor.getValue().includeText()).isTrue();
+        assertThat(captor.getValue().includeMetadata()).isTrue();
     }
 
     @Test
@@ -98,10 +155,12 @@ class VectorControllerTest {
     void filtersResultsByMinScore() {
         when(embeddingPort.embed(any()))
                 .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("query", List.of(1.0, 0.0)))));
-        when(vectorStorePort.search(any(VectorSearchRequest.class)))
-                .thenReturn(List.of(
-                        new VectorSearchResult(new VectorDocument("doc-low", "low", Map.of(), List.of()), 0.39d),
-                        new VectorSearchResult(new VectorDocument("doc-high", "high", Map.of(), List.of()), 0.61d)));
+        when(vectorStorePort.searchWithFilter(any(VectorSearchRequest.class)))
+                .thenReturn(VectorSearchResults.of(List.of(
+                        new VectorSearchHit("doc-low", "doc-low", "doc-low", null, "low", 0.39d,
+                                null, null, null, null, null, Map.of()),
+                        new VectorSearchHit("doc-high", "doc-high", "doc-high", null, "high", 0.61d,
+                                null, null, null, null, null, Map.of())), 1L));
 
         ResponseEntity<ApiResponse<List<VectorSearchResultDto>>> response = controller.search(
                 new VectorSearchRequestDto("hello", null, 3, false, null, null, 0.4d));
@@ -109,6 +168,36 @@ class VectorControllerTest {
         assertThat(response.getBody().getData())
                 .extracting(VectorSearchResultDto::documentId)
                 .containsExactly("doc-high");
+    }
+
+    @Test
+    void passesIncludeTextAndIncludeMetadataThroughCoreSearchRequest() {
+        ArgumentCaptor<VectorSearchRequest> captor = ArgumentCaptor.forClass(VectorSearchRequest.class);
+        when(embeddingPort.embed(any()))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("query", List.of(1.0, 0.0)))));
+        when(vectorStorePort.searchWithFilter(any(VectorSearchRequest.class)))
+                .thenReturn(VectorSearchResults.of(List.of(new VectorSearchHit(
+                        "chunk-1",
+                        "doc-1",
+                        "chunk-1",
+                        null,
+                        null,
+                        0.8d,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        Map.of())), 1L));
+
+        ResponseEntity<ApiResponse<List<VectorSearchResultDto>>> response = controller.search(
+                new VectorSearchRequestDto("hello", null, 3, false, null, null, null, false, false));
+
+        verify(vectorStorePort).searchWithFilter(captor.capture());
+        assertThat(captor.getValue().includeText()).isFalse();
+        assertThat(captor.getValue().includeMetadata()).isFalse();
+        assertThat(response.getBody().getData().get(0).content()).isNull();
+        assertThat(response.getBody().getData().get(0).metadata()).isEmpty();
     }
 
     @Test
@@ -151,10 +240,20 @@ class VectorControllerTest {
     void treatsBlankObjectFiltersAsAbsent() {
         when(embeddingPort.embed(any()))
                 .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("query", List.of(1.0, 0.0)))));
-        when(vectorStorePort.search(any(VectorSearchRequest.class)))
-                .thenReturn(List.of(new VectorSearchResult(
-                        new VectorDocument("doc-global", "chunk", Map.of(), List.of()),
-                        0.7d)));
+        when(vectorStorePort.searchWithFilter(any(VectorSearchRequest.class)))
+                .thenReturn(VectorSearchResults.of(List.of(new VectorSearchHit(
+                        "doc-global",
+                        "doc-global",
+                        "doc-global",
+                        null,
+                        "chunk",
+                        0.7d,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        Map.of())), 1L));
 
         ResponseEntity<ApiResponse<List<VectorSearchResultDto>>> response = controller.search(
                 new VectorSearchRequestDto("hello", null, 3, false, "   ", "", null));
@@ -162,7 +261,7 @@ class VectorControllerTest {
         assertThat(response.getBody().getData())
                 .extracting(VectorSearchResultDto::documentId)
                 .containsExactly("doc-global");
-        verify(vectorStorePort).search(any(VectorSearchRequest.class));
+        verify(vectorStorePort).searchWithFilter(any(VectorSearchRequest.class));
     }
 
     @Test


### PR DESCRIPTION
## Why

- `studio-platform-ai`는 `VectorSearchResults`/`VectorSearchHit` aggregate 검색 계약을 제공하지만 AI web vector 검색 경로는 legacy hit list 중심으로만 동작했다.
- 기존 HTTP 응답 shape는 유지하면서 web 검색 경로에서 core aggregate 계약을 사용해야 한다.

## What

- `VectorController`의 vector search 내부 결과를 `VectorSearchResults`/`VectorSearchHit`으로 정규화했다.
- 기존 `/api/mgmt/ai/vectors/search` 응답 shape인 `List<VectorSearchResultDto>`는 유지했다.
- `VectorSearchRequestDto`에 optional `includeText`/`includeMetadata` field를 추가하고 기존 7-argument Java 생성자 호환성을 유지했다.
- global vector search는 `VectorStorePort.searchWithFilter(...)` aggregate 확장점을 사용하도록 연결했다.
- provenance metadata 기반 `documentId` 매핑과 `includeText`/`includeMetadata` 전달 테스트를 추가했다.

## Related Issues

- Closes #312

## Validation

- Command: `./gradlew :starter:studio-platform-starter-ai-web:test`
- Result: PASS
- Command: `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-ai-web:test`
- Result: PASS
- Command: `git diff --check`
- Result: PASS

## Risk / Rollback

- Risk: global vector search가 `searchWithFilter(...)` 경로를 사용하므로 custom `VectorStorePort`가 이 메서드를 override하지 않은 경우 default adapter를 통해 기존 `search(...)`로 위임된다.
- Rollback: `VectorController` 내부 검색 결과를 기존 `List<VectorSearchResult>` 기반 처리로 되돌리고 `includeText`/`includeMetadata` request field를 제거한다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: `./gradlew :starter:studio-platform-starter-ai-web:test`, `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-ai-web:test`, `git diff --check`

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
