### PR TITLE
feat(rag): attachment source job executor 연결

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2026-04-26
 
 ### 변경됨
+- 이슈 #319 대응으로 `RagIndexJobSourceExecutor` 계약을 추가하고, `sourceType=attachment` RAG job이 기존 attachment RAG 색인 흐름을 비동기로 실행하도록 연결했다.
+- `POST /api/mgmt/ai/rag/jobs`는 raw `text` 없이 source 기반 요청을 받을 수 있으며, `content-embedding-pipeline`은 attachment source executor를 제공한다.
 - 이슈 #317 대응으로 RAG 색인 작업 management API와 in-memory job repository/service 계약을 추가했다.
 - `POST /api/mgmt/ai/rag/index`와 attachment RAG index API는 기존 empty `202 Accepted` 응답을 유지하면서 `X-RAG-Job-Id` 헤더를 additive하게 반환한다.
 - RAG 색인 진행 단계(`EXTRACTING`, `CHUNKING`, `EMBEDDING`, `INDEXING`, `COMPLETED`)와 chunk/embedding/index count, warning/error log를 조회할 수 있도록 했다.
@@ -21,6 +23,7 @@
 - context expansion candidate 조회 배수, 후보 조회 상한, previous/next window, parent content 포함 여부를 설정으로 분리했다.
 
 ### 검증
+- `./gradlew :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test :studio-application-modules:content-embedding-pipeline:test`
 - `./gradlew :studio-platform-ai:compileJava :starter:studio-platform-starter-ai:compileJava :starter:studio-platform-starter-ai-web:compileJava :studio-application-modules:content-embedding-pipeline:compileJava`
 - `./gradlew :studio-platform-ai:testClasses :starter:studio-platform-starter-ai:testClasses :starter:studio-platform-starter-ai-web:testClasses :studio-application-modules:content-embedding-pipeline:testClasses`
 - `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test :studio-application-modules:content-embedding-pipeline:test`

--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -97,9 +97,32 @@ studio:
 RAG 운영 화면은 신규 job API를 사용해 색인 실행 상태, 단계별 로그, 색인된 chunk를 조회할 수 있다.
 기존 `POST {mgmtBasePath}/rag/index` 테스트 API는 응답 body 없이 `202 Accepted`를 유지하며,
 job 추적이 활성화된 경우 `X-RAG-Job-Id` 헤더만 추가한다. 신규 `POST {mgmtBasePath}/rag/jobs`는
-raw `text`를 필수로 받아 같은 `RagPipelineService`를 in-memory job service로 감싸 비동기 실행하고,
-응답 body에 생성된 job을 반환한다. attachment 같은 source 기반 실행은 이번 범위에서는 기존
-attachment RAG index API를 사용한다.
+raw `text`가 있으면 같은 `RagPipelineService`를 in-memory job service로 감싸 비동기 실행하고,
+응답 body에 생성된 job을 반환한다. `text`가 없고 `sourceType`이 있으면 등록된
+`RagIndexJobSourceExecutor`가 해당 source를 실행한다. `content-embedding-pipeline`은
+`sourceType=attachment` job executor를 제공하며 기존 attachment RAG index 경로를 재사용한다.
+attachment source job 생성과 retry는 기존 attachment 색인 API와 동일하게 `features:attachment write`
+권한도 필요하다.
+
+attachment source job 예시:
+
+```http
+POST /api/mgmt/ai/rag/jobs
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "objectType": "attachment",
+  "objectId": "101",
+  "documentId": "doc-101",
+  "sourceType": "attachment",
+  "metadata": {
+    "category": "manual"
+  },
+  "keywords": ["spring", "java"],
+  "useLlmKeywordExtraction": false
+}
+```
 
 Job `status`는 `PENDING`, `RUNNING`, `SUCCEEDED`, `WARNING`, `FAILED`, `CANCELLED`이며,
 `currentStep`은 `EXTRACTING`, `CHUNKING`, `EMBEDDING`, `INDEXING`, `COMPLETED`이다.

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagIndexJobController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagIndexJobController.java
@@ -32,6 +32,7 @@ import studio.one.platform.ai.core.rag.RagIndexJobCreateRequest;
 import studio.one.platform.ai.core.rag.RagIndexJobFilter;
 import studio.one.platform.ai.core.rag.RagIndexJobPage;
 import studio.one.platform.ai.core.rag.RagIndexJobPageRequest;
+import studio.one.platform.ai.core.rag.RagIndexJobSourceRequest;
 import studio.one.platform.ai.core.rag.RagIndexJobStatus;
 import studio.one.platform.ai.core.rag.RagIndexRequest;
 import studio.one.platform.ai.core.rag.RagSearchResult;
@@ -110,7 +111,10 @@ public class RagIndexJobController {
             + " or @endpointAuthz.can('features:attachment','write'))")
     public ResponseEntity<ApiResponse<RagIndexJobDto>> createJob(
             @Valid @RequestBody RagIndexJobCreateRequestDto request) {
-        RagIndexJob job = jobService.createJob(toCreateRequest(request));
+        CreateJobCommand command = toCreateRequest(request);
+        RagIndexJob job = command.sourceRequest() == null
+                ? jobService.createJob(command.request())
+                : jobService.createJob(command.request(), command.sourceRequest());
         dispatch(job.jobId(), () -> jobService.startJob(job.jobId()));
         return ResponseEntity.accepted().body(ApiResponse.ok(RagIndexJobDto.from(job)));
     }
@@ -129,7 +133,9 @@ public class RagIndexJobController {
     }
 
     @GetMapping("/jobs/{jobId}/logs")
-    @PreAuthorize("@endpointAuthz.can('services:ai_rag','read')")
+    @PreAuthorize("@endpointAuthz.can('services:ai_rag','read')"
+            + " and (!@ragIndexJobEndpointSecurity.isAttachmentJob(#jobId)"
+            + " or @endpointAuthz.can('features:attachment','read'))")
     public ResponseEntity<ApiResponse<List<RagIndexJobLogDto>>> getLogs(@PathVariable("jobId") String jobId) {
         requireJob(jobId);
         return ResponseEntity.ok(ApiResponse.ok(jobService.getLogs(jobId).stream()
@@ -138,7 +144,9 @@ public class RagIndexJobController {
     }
 
     @GetMapping("/jobs/{jobId}/chunks")
-    @PreAuthorize("@endpointAuthz.can('services:ai_rag','read')")
+    @PreAuthorize("@endpointAuthz.can('services:ai_rag','read')"
+            + " and (!@ragIndexJobEndpointSecurity.isAttachmentJob(#jobId)"
+            + " or @endpointAuthz.can('features:attachment','read'))")
     public ResponseEntity<ApiResponse<List<RagIndexChunkDto>>> getJobChunks(
             @PathVariable("jobId") String jobId,
             @RequestParam(name = "limit", required = false, defaultValue = "200") int limit) {
@@ -150,7 +158,9 @@ public class RagIndexJobController {
     }
 
     @GetMapping("/objects/{objectType}/{objectId}/chunks")
-    @PreAuthorize("@endpointAuthz.can('services:ai_rag','read')")
+    @PreAuthorize("@endpointAuthz.can('services:ai_rag','read')"
+            + " and (!@ragIndexJobEndpointSecurity.isAttachmentObject(#objectType)"
+            + " or @endpointAuthz.can('features:attachment','read'))")
     public ResponseEntity<ApiResponse<List<RagIndexChunkDto>>> objectChunks(
             @PathVariable("objectType") String objectType,
             @PathVariable("objectId") String objectId,
@@ -163,7 +173,9 @@ public class RagIndexJobController {
     }
 
     @GetMapping("/objects/{objectType}/{objectId}/metadata")
-    @PreAuthorize("@endpointAuthz.can('services:ai_rag','read')")
+    @PreAuthorize("@endpointAuthz.can('services:ai_rag','read')"
+            + " and (!@ragIndexJobEndpointSecurity.isAttachmentObject(#objectType)"
+            + " or @endpointAuthz.can('features:attachment','read'))")
     public ResponseEntity<ApiResponse<Map<String, Object>>> objectMetadata(
             @PathVariable("objectType") String objectType,
             @PathVariable("objectId") String objectId) {
@@ -173,7 +185,7 @@ public class RagIndexJobController {
         return ResponseEntity.ok(ApiResponse.ok(vectorStorePort.getMetadata(objectType, objectId)));
     }
 
-    private RagIndexJobCreateRequest toCreateRequest(RagIndexJobCreateRequestDto request) {
+    private CreateJobCommand toCreateRequest(RagIndexJobCreateRequestDto request) {
         if (!hasText(request.text()) && !hasText(request.sourceType())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "text or sourceType is required for /rag/jobs");
         }
@@ -185,25 +197,37 @@ public class RagIndexJobController {
         if (hasText(request.sourceType())) {
             metadata.put("sourceType", request.sourceType().trim());
         }
+        String documentId = hasText(request.documentId()) ? request.documentId().trim() : null;
+        if (isAttachmentSource(request) && documentId == null) {
+            documentId = request.objectId().trim();
+            metadata.putIfAbsent("attachmentId", request.objectId().trim());
+        }
         RagIndexRequest indexRequest = null;
         if (hasText(request.text())) {
             indexRequest = new RagIndexRequest(
-                    hasText(request.documentId()) ? request.documentId().trim() : request.objectId().trim(),
+                    documentId == null ? request.objectId().trim() : documentId,
                     request.text(),
                     metadata,
                     request.keywords() == null ? List.of() : request.keywords(),
                     Boolean.TRUE.equals(request.useLlmKeywordExtraction()));
         }
-        return new RagIndexJobCreateRequest(
+        RagIndexJobSourceRequest sourceRequest = indexRequest == null
+                ? new RagIndexJobSourceRequest(
+                        metadata,
+                        request.keywords() == null ? List.of() : request.keywords(),
+                        Boolean.TRUE.equals(request.useLlmKeywordExtraction()))
+                : null;
+        return new CreateJobCommand(new RagIndexJobCreateRequest(
                 request.objectType(),
                 request.objectId(),
-                request.documentId(),
+                documentId,
                 request.sourceType(),
                 Boolean.TRUE.equals(request.forceReindex()),
-                indexRequest,
-                metadata,
-                request.keywords() == null ? List.of() : request.keywords(),
-                Boolean.TRUE.equals(request.useLlmKeywordExtraction()));
+                indexRequest), sourceRequest);
+    }
+
+    private boolean isAttachmentSource(RagIndexJobCreateRequestDto request) {
+        return "attachment".equalsIgnoreCase(request.sourceType());
     }
 
     private void dispatch(String jobId, Runnable task) {
@@ -309,5 +333,8 @@ public class RagIndexJobController {
             }
         }
         return null;
+    }
+
+    private record CreateJobCommand(RagIndexJobCreateRequest request, RagIndexJobSourceRequest sourceRequest) {
     }
 }

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagIndexJobController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagIndexJobController.java
@@ -105,7 +105,9 @@ public class RagIndexJobController {
     }
 
     @PostMapping("/jobs")
-    @PreAuthorize("@endpointAuthz.can('services:ai_rag','read')")
+    @PreAuthorize("@endpointAuthz.can('services:ai_rag','read')"
+            + " and (!@ragIndexJobEndpointSecurity.isAttachmentSource(#request)"
+            + " or @endpointAuthz.can('features:attachment','write'))")
     public ResponseEntity<ApiResponse<RagIndexJobDto>> createJob(
             @Valid @RequestBody RagIndexJobCreateRequestDto request) {
         RagIndexJob job = jobService.createJob(toCreateRequest(request));
@@ -114,7 +116,9 @@ public class RagIndexJobController {
     }
 
     @PostMapping("/jobs/{jobId}/retry")
-    @PreAuthorize("@endpointAuthz.can('services:ai_rag','read')")
+    @PreAuthorize("@endpointAuthz.can('services:ai_rag','read')"
+            + " and (!@ragIndexJobEndpointSecurity.isAttachmentJob(#jobId)"
+            + " or @endpointAuthz.can('features:attachment','write'))")
     public ResponseEntity<ApiResponse<RagIndexJobDto>> retryJob(@PathVariable("jobId") String jobId) {
         RagIndexJob job = requireJob(jobId);
         if (job.status() == RagIndexJobStatus.PENDING || job.status() == RagIndexJobStatus.RUNNING) {
@@ -170,8 +174,8 @@ public class RagIndexJobController {
     }
 
     private RagIndexJobCreateRequest toCreateRequest(RagIndexJobCreateRequestDto request) {
-        if (!hasText(request.text())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "text is required for /rag/jobs");
+        if (!hasText(request.text()) && !hasText(request.sourceType())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "text or sourceType is required for /rag/jobs");
         }
         Map<String, Object> metadata = request.metadata() == null
                 ? new HashMap<>()
@@ -196,7 +200,10 @@ public class RagIndexJobController {
                 request.documentId(),
                 request.sourceType(),
                 Boolean.TRUE.equals(request.forceReindex()),
-                indexRequest);
+                indexRequest,
+                metadata,
+                request.keywords() == null ? List.of() : request.keywords(),
+                Boolean.TRUE.equals(request.useLlmKeywordExtraction()));
     }
 
     private void dispatch(String jobId, Runnable task) {

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagIndexJobEndpointSecurity.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagIndexJobEndpointSecurity.java
@@ -18,6 +18,10 @@ public class RagIndexJobEndpointSecurity {
         return request != null && ATTACHMENT.equalsIgnoreCase(request.sourceType());
     }
 
+    public boolean isAttachmentObject(String objectType) {
+        return ATTACHMENT.equalsIgnoreCase(objectType);
+    }
+
     public boolean isAttachmentJob(String jobId) {
         return jobService.getJob(jobId)
                 .map(job -> ATTACHMENT.equalsIgnoreCase(job.sourceType()))

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagIndexJobEndpointSecurity.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagIndexJobEndpointSecurity.java
@@ -1,0 +1,26 @@
+package studio.one.platform.ai.web.controller;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import studio.one.platform.ai.service.pipeline.RagIndexJobService;
+import studio.one.platform.ai.web.dto.RagIndexJobCreateRequestDto;
+
+@Component("ragIndexJobEndpointSecurity")
+@RequiredArgsConstructor
+public class RagIndexJobEndpointSecurity {
+
+    private static final String ATTACHMENT = "attachment";
+
+    private final RagIndexJobService jobService;
+
+    public boolean isAttachmentSource(RagIndexJobCreateRequestDto request) {
+        return request != null && ATTACHMENT.equalsIgnoreCase(request.sourceType());
+    }
+
+    public boolean isAttachmentJob(String jobId) {
+        return jobService.getJob(jobId)
+                .map(job -> ATTACHMENT.equalsIgnoreCase(job.sourceType()))
+                .orElse(false);
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagIndexJobControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagIndexJobControllerTest.java
@@ -68,7 +68,32 @@ class RagIndexJobControllerTest {
     }
 
     @Test
-    void createJobRejectsMissingTextForDefaultExecutor() {
+    void createJobAcceptsSourceRequestWithoutText() {
+        CapturingJobService jobService = new CapturingJobService();
+        RagIndexJobController controller = new RagIndexJobController(
+                jobService,
+                mock(RagPipelineService.class),
+                null);
+
+        ResponseEntity<ApiResponse<RagIndexJobDto>> response = controller.createJob(new RagIndexJobCreateRequestDto(
+                "attachment",
+                "42",
+                "doc-1",
+                "attachment",
+                false,
+                null,
+                Map.of("attachmentId", "42"),
+                List.of("alpha"),
+                false));
+
+        assertThat(response.getStatusCode().value()).isEqualTo(202);
+        assertThat(jobService.createdRequest.indexRequest()).isNull();
+        assertThat(jobService.createdRequest.sourceType()).isEqualTo("attachment");
+        assertThat(jobService.createdRequest.metadata()).containsEntry("attachmentId", "42");
+    }
+
+    @Test
+    void createJobRejectsMissingTextAndSourceType() {
         RagIndexJobController controller = new RagIndexJobController(
                 new CapturingJobService(),
                 mock(RagPipelineService.class),
@@ -78,7 +103,7 @@ class RagIndexJobControllerTest {
                 "attachment",
                 "42",
                 "doc-1",
-                "attachment",
+                null,
                 false,
                 null,
                 Map.of(),

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagIndexJobControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagIndexJobControllerTest.java
@@ -22,6 +22,7 @@ import studio.one.platform.ai.core.rag.RagIndexJobLogCode;
 import studio.one.platform.ai.core.rag.RagIndexJobLogLevel;
 import studio.one.platform.ai.core.rag.RagIndexJobPage;
 import studio.one.platform.ai.core.rag.RagIndexJobPageRequest;
+import studio.one.platform.ai.core.rag.RagIndexJobSourceRequest;
 import studio.one.platform.ai.core.rag.RagIndexJobStatus;
 import studio.one.platform.ai.core.rag.RagIndexJobStep;
 import studio.one.platform.ai.core.rag.RagSearchResult;
@@ -89,7 +90,31 @@ class RagIndexJobControllerTest {
         assertThat(response.getStatusCode().value()).isEqualTo(202);
         assertThat(jobService.createdRequest.indexRequest()).isNull();
         assertThat(jobService.createdRequest.sourceType()).isEqualTo("attachment");
-        assertThat(jobService.createdRequest.metadata()).containsEntry("attachmentId", "42");
+        assertThat(jobService.createdRequest.documentId()).isEqualTo("doc-1");
+        assertThat(jobService.createdSourceRequest.metadata()).containsEntry("attachmentId", "42");
+    }
+
+    @Test
+    void createAttachmentSourceJobDefaultsDocumentIdBeforePersistingJob() {
+        CapturingJobService jobService = new CapturingJobService();
+        RagIndexJobController controller = new RagIndexJobController(
+                jobService,
+                mock(RagPipelineService.class),
+                null);
+
+        controller.createJob(new RagIndexJobCreateRequestDto(
+                "attachment",
+                "42",
+                null,
+                "attachment",
+                false,
+                null,
+                Map.of(),
+                List.of(),
+                false));
+
+        assertThat(jobService.createdRequest.documentId()).isEqualTo("42");
+        assertThat(jobService.createdSourceRequest.metadata()).containsEntry("attachmentId", "42");
     }
 
     @Test
@@ -194,6 +219,7 @@ class RagIndexJobControllerTest {
 
         private final RagIndexJob job;
         private RagIndexJobCreateRequest createdRequest;
+        private RagIndexJobSourceRequest createdSourceRequest;
 
         CapturingJobService() {
             this(RagIndexJobStatus.SUCCEEDED);
@@ -214,6 +240,13 @@ class RagIndexJobControllerTest {
         @Override
         public RagIndexJob createJob(RagIndexJobCreateRequest request) {
             this.createdRequest = request;
+            return job;
+        }
+
+        @Override
+        public RagIndexJob createJob(RagIndexJobCreateRequest request, RagIndexJobSourceRequest sourceRequest) {
+            this.createdRequest = request;
+            this.createdSourceRequest = sourceRequest;
             return job;
         }
 

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagIndexJobEndpointSecurityTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagIndexJobEndpointSecurityTest.java
@@ -51,6 +51,14 @@ class RagIndexJobEndpointSecurityTest {
         assertThat(security.isAttachmentJob("job-1")).isTrue();
     }
 
+    @Test
+    void detectsAttachmentObjectScopesForReadAuthorization() {
+        RagIndexJobEndpointSecurity security = new RagIndexJobEndpointSecurity(new StubJobService(null));
+
+        assertThat(security.isAttachmentObject("attachment")).isTrue();
+        assertThat(security.isAttachmentObject("article")).isFalse();
+    }
+
     private record StubJobService(RagIndexJob job) implements RagIndexJobService {
 
         @Override

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagIndexJobEndpointSecurityTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagIndexJobEndpointSecurityTest.java
@@ -1,0 +1,91 @@
+package studio.one.platform.ai.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.ai.core.rag.RagIndexJob;
+import studio.one.platform.ai.core.rag.RagIndexJobCreateRequest;
+import studio.one.platform.ai.core.rag.RagIndexJobFilter;
+import studio.one.platform.ai.core.rag.RagIndexJobLog;
+import studio.one.platform.ai.core.rag.RagIndexJobPage;
+import studio.one.platform.ai.core.rag.RagIndexJobPageRequest;
+import studio.one.platform.ai.service.pipeline.RagIndexJobService;
+import studio.one.platform.ai.service.pipeline.RagIndexProgressListener;
+import studio.one.platform.ai.web.dto.RagIndexJobCreateRequestDto;
+
+class RagIndexJobEndpointSecurityTest {
+
+    @Test
+    void detectsAttachmentSourceRequests() {
+        RagIndexJobEndpointSecurity security = new RagIndexJobEndpointSecurity(new StubJobService(null));
+
+        assertThat(security.isAttachmentSource(new RagIndexJobCreateRequestDto(
+                "attachment",
+                "42",
+                "doc-1",
+                "attachment",
+                false,
+                null,
+                Map.of(),
+                List.of(),
+                false))).isTrue();
+    }
+
+    @Test
+    void detectsAttachmentJobsForRetryAuthorization() {
+        RagIndexJob job = RagIndexJob.pending(
+                "job-1",
+                "attachment",
+                "42",
+                "doc-1",
+                "attachment",
+                Instant.parse("2026-04-26T00:00:00Z"));
+        RagIndexJobEndpointSecurity security = new RagIndexJobEndpointSecurity(new StubJobService(job));
+
+        assertThat(security.isAttachmentJob("job-1")).isTrue();
+    }
+
+    private record StubJobService(RagIndexJob job) implements RagIndexJobService {
+
+        @Override
+        public RagIndexJob createJob(RagIndexJobCreateRequest request) {
+            return job;
+        }
+
+        @Override
+        public RagIndexJob startJob(String jobId) {
+            return job;
+        }
+
+        @Override
+        public RagIndexJob retryJob(String jobId) {
+            return job;
+        }
+
+        @Override
+        public Optional<RagIndexJob> getJob(String jobId) {
+            return Optional.ofNullable(job);
+        }
+
+        @Override
+        public RagIndexJobPage listJobs(RagIndexJobFilter filter, RagIndexJobPageRequest pageable) {
+            return new RagIndexJobPage(List.of(), 0, pageable.offset(), pageable.limit());
+        }
+
+        @Override
+        public List<RagIndexJobLog> getLogs(String jobId) {
+            return List.of();
+        }
+
+        @Override
+        public RagIndexProgressListener progressListener(String jobId) {
+            return RagIndexProgressListener.noop();
+        }
+    }
+}

--- a/starter/studio-platform-starter-ai/README.md
+++ b/starter/studio-platform-starter-ai/README.md
@@ -175,6 +175,7 @@ studio:
 | `RagPipelineService` | RAG 인덱싱/검색 facade 계약. 기본 구현은 `DefaultRagPipelineService` |
 | `RagIndexJobRepository` | RAG 색인 작업 상태/로그 저장소. 기본 구현은 단일 인스턴스용 in-memory repository |
 | `RagIndexJobService` | RAG 색인 작업 생성/조회/재시도와 progress listener 연결 |
+| `RagIndexJobSourceExecutor` | source 기반 RAG job 실행 확장점. 등록된 Bean은 job service가 ordered stream으로 조회 |
 | `ChunkingOrchestrator` | `starter-chunking`이 있을 때 RAG indexing chunk 생성에 사용 |
 | `PromptManager` | Mustache 템플릿 기반 프롬프트 렌더러 |
 | `TextCleaner` | `studio.ai.pipeline.cleaner.enabled=true`일 때 색인 전 텍스트 정제 |
@@ -192,6 +193,9 @@ RAG metadata key의 표준 의미와 legacy alias 기준은
 
 `RagIndexJobService`는 `RagPipelineService.index(request, listener)` overload를 사용해
 `CHUNKING`, `EMBEDDING`, `INDEXING`, `COMPLETED` 단계와 chunk/embedding/index count를 기록한다.
+raw text가 없는 source 기반 job은 등록된 `RagIndexJobSourceExecutor`가 `supports(...)`로 선택되면
+해당 executor가 실행한다. 기본 starter는 source 구현을 포함하지 않으며, attachment 같은 application module이
+자기 source executor를 별도 Bean으로 제공한다.
 기본 `InMemoryRagIndexJobRepository`는 운영 화면 개발 및 단일 인스턴스 smoke 용도이며, 외부 queue나
 분산 worker를 포함하지 않는다. 재시도를 위해 최근 raw text 요청을 메모리에 보관하되 저장 request 수는
 bounded eviction으로 제한한다. 영구 이력, 다중 인스턴스 공유, 감사 로그가 필요하면 같은

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfiguration.java
@@ -31,6 +31,7 @@ import studio.one.platform.ai.service.pipeline.DefaultRagIndexJobService;
 import studio.one.platform.ai.service.pipeline.InMemoryRagIndexJobRepository;
 import studio.one.platform.ai.service.pipeline.RagIndexJobRepository;
 import studio.one.platform.ai.service.pipeline.RagIndexJobService;
+import studio.one.platform.ai.service.pipeline.RagIndexJobSourceExecutor;
 import studio.one.platform.ai.service.pipeline.RagKeywordOptions;
 import studio.one.platform.ai.service.pipeline.RagPipelineDiagnosticsOptions;
 import studio.one.platform.ai.service.pipeline.RagPipelineOptions;
@@ -135,8 +136,12 @@ public class RagPipelineConfiguration {
         @ConditionalOnMissingBean(RagIndexJobService.class)
         RagIndexJobService ragIndexJobService(
                         RagIndexJobRepository ragIndexJobRepository,
-                        RagPipelineService ragPipelineService) {
-                return new DefaultRagIndexJobService(ragIndexJobRepository, ragPipelineService);
+                        RagPipelineService ragPipelineService,
+                        ObjectProvider<RagIndexJobSourceExecutor> sourceExecutors) {
+                return new DefaultRagIndexJobService(
+                                ragIndexJobRepository,
+                                ragPipelineService,
+                                sourceExecutors.orderedStream().toList());
         }
 
         @Bean

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagIndexJobService.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagIndexJobService.java
@@ -20,6 +20,7 @@ import studio.one.platform.ai.core.rag.RagIndexJobLogCode;
 import studio.one.platform.ai.core.rag.RagIndexJobLogLevel;
 import studio.one.platform.ai.core.rag.RagIndexJobPage;
 import studio.one.platform.ai.core.rag.RagIndexJobPageRequest;
+import studio.one.platform.ai.core.rag.RagIndexJobSourceRequest;
 import studio.one.platform.ai.core.rag.RagIndexJobStatus;
 import studio.one.platform.ai.core.rag.RagIndexJobStep;
 
@@ -30,7 +31,7 @@ public class DefaultRagIndexJobService implements RagIndexJobService {
     private final RagIndexJobRepository repository;
     private final RagPipelineService ragPipelineService;
     private final List<RagIndexJobSourceExecutor> sourceExecutors;
-    private final ConcurrentMap<String, RagIndexJobCreateRequest> requests = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, StoredRequest> requests = new ConcurrentHashMap<>();
     private final Queue<String> requestOrder = new ConcurrentLinkedQueue<>();
     private final Set<String> runningJobs = ConcurrentHashMap.newKeySet();
 
@@ -51,6 +52,11 @@ public class DefaultRagIndexJobService implements RagIndexJobService {
 
     @Override
     public RagIndexJob createJob(RagIndexJobCreateRequest request) {
+        return createJob(request, null);
+    }
+
+    @Override
+    public RagIndexJob createJob(RagIndexJobCreateRequest request, RagIndexJobSourceRequest sourceRequest) {
         Objects.requireNonNull(request, "request");
         String jobId = UUID.randomUUID().toString();
         RagIndexJob job = RagIndexJob.pending(
@@ -60,7 +66,7 @@ public class DefaultRagIndexJobService implements RagIndexJobService {
                 request.documentId(),
                 request.sourceType(),
                 Instant.now());
-        requests.put(jobId, request);
+        requests.put(jobId, new StoredRequest(request, sourceRequest));
         requestOrder.add(jobId);
         evictStoredRequests();
         return repository.save(job);
@@ -83,10 +89,10 @@ public class DefaultRagIndexJobService implements RagIndexJobService {
     }
 
     private RagIndexJob runJob(String jobId) {
-        RagIndexJobCreateRequest request = requests.get(jobId);
+        StoredRequest storedRequest = requests.get(jobId);
         RagIndexProgressListener listener = progressListener(jobId);
         listener.onStarted();
-        if (request == null) {
+        if (storedRequest == null) {
             listener.onError(
                     RagIndexJobStep.EXTRACTING,
                     RagIndexJobLogCode.SOURCE_UNSUPPORTED,
@@ -95,10 +101,12 @@ public class DefaultRagIndexJobService implements RagIndexJobService {
             return requireJob(jobId);
         }
         try {
+            RagIndexJobCreateRequest request = storedRequest.request();
             if (request.indexRequest() != null) {
                 ragPipelineService.index(request.indexRequest(), listener);
             } else {
-                Optional<RagIndexJobSourceExecutor> sourceExecutor = sourceExecutor(request);
+                RagIndexJobSourceRequest sourceRequest = storedRequest.sourceRequest();
+                Optional<RagIndexJobSourceExecutor> sourceExecutor = sourceExecutor(request, sourceRequest);
                 if (sourceExecutor.isEmpty()) {
                     listener.onError(
                             RagIndexJobStep.EXTRACTING,
@@ -107,7 +115,7 @@ public class DefaultRagIndexJobService implements RagIndexJobService {
                             request.sourceType());
                     return requireJob(jobId);
                 }
-                sourceExecutor.get().execute(requireJob(jobId), request, listener);
+                sourceExecutor.get().execute(requireJob(jobId), request, sourceRequest, listener);
             }
             listener.onCompleted();
         } catch (RuntimeException ex) {
@@ -120,9 +128,11 @@ public class DefaultRagIndexJobService implements RagIndexJobService {
         return requireJob(jobId);
     }
 
-    private Optional<RagIndexJobSourceExecutor> sourceExecutor(RagIndexJobCreateRequest request) {
+    private Optional<RagIndexJobSourceExecutor> sourceExecutor(
+            RagIndexJobCreateRequest request,
+            RagIndexJobSourceRequest sourceRequest) {
         return sourceExecutors.stream()
-                .filter(executor -> executor.supports(request))
+                .filter(executor -> executor.supports(request, sourceRequest))
                 .findFirst();
     }
 
@@ -224,6 +234,9 @@ public class DefaultRagIndexJobService implements RagIndexJobService {
                 return;
             }
         }
+    }
+
+    private record StoredRequest(RagIndexJobCreateRequest request, RagIndexJobSourceRequest sourceRequest) {
     }
 
     private class RepositoryBackedProgressListener implements RagIndexProgressListener {

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagIndexJobService.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagIndexJobService.java
@@ -29,6 +29,7 @@ public class DefaultRagIndexJobService implements RagIndexJobService {
 
     private final RagIndexJobRepository repository;
     private final RagPipelineService ragPipelineService;
+    private final List<RagIndexJobSourceExecutor> sourceExecutors;
     private final ConcurrentMap<String, RagIndexJobCreateRequest> requests = new ConcurrentHashMap<>();
     private final Queue<String> requestOrder = new ConcurrentLinkedQueue<>();
     private final Set<String> runningJobs = ConcurrentHashMap.newKeySet();
@@ -36,8 +37,16 @@ public class DefaultRagIndexJobService implements RagIndexJobService {
     public DefaultRagIndexJobService(
             RagIndexJobRepository repository,
             RagPipelineService ragPipelineService) {
+        this(repository, ragPipelineService, List.of());
+    }
+
+    public DefaultRagIndexJobService(
+            RagIndexJobRepository repository,
+            RagPipelineService ragPipelineService,
+            List<RagIndexJobSourceExecutor> sourceExecutors) {
         this.repository = repository;
         this.ragPipelineService = ragPipelineService;
+        this.sourceExecutors = sourceExecutors == null ? List.of() : List.copyOf(sourceExecutors);
     }
 
     @Override
@@ -77,7 +86,7 @@ public class DefaultRagIndexJobService implements RagIndexJobService {
         RagIndexJobCreateRequest request = requests.get(jobId);
         RagIndexProgressListener listener = progressListener(jobId);
         listener.onStarted();
-        if (request == null || request.indexRequest() == null) {
+        if (request == null) {
             listener.onError(
                     RagIndexJobStep.EXTRACTING,
                     RagIndexJobLogCode.SOURCE_UNSUPPORTED,
@@ -86,13 +95,35 @@ public class DefaultRagIndexJobService implements RagIndexJobService {
             return requireJob(jobId);
         }
         try {
-            ragPipelineService.index(request.indexRequest(), listener);
+            if (request.indexRequest() != null) {
+                ragPipelineService.index(request.indexRequest(), listener);
+            } else {
+                Optional<RagIndexJobSourceExecutor> sourceExecutor = sourceExecutor(request);
+                if (sourceExecutor.isEmpty()) {
+                    listener.onError(
+                            RagIndexJobStep.EXTRACTING,
+                            RagIndexJobLogCode.SOURCE_UNSUPPORTED,
+                            "RAG index source is not executable by the default job service",
+                            request.sourceType());
+                    return requireJob(jobId);
+                }
+                sourceExecutor.get().execute(requireJob(jobId), request, listener);
+            }
             listener.onCompleted();
         } catch (RuntimeException ex) {
-            RagIndexJobStep step = requireJob(jobId).currentStep();
-            listener.onError(step, codeFor(step), "RAG index failed", ex.getMessage());
+            RagIndexJob current = requireJob(jobId);
+            if (current.status() != RagIndexJobStatus.FAILED) {
+                RagIndexJobStep step = current.currentStep();
+                listener.onError(step, codeFor(step), "RAG index failed", ex.getMessage());
+            }
         }
         return requireJob(jobId);
+    }
+
+    private Optional<RagIndexJobSourceExecutor> sourceExecutor(RagIndexJobCreateRequest request) {
+        return sourceExecutors.stream()
+                .filter(executor -> executor.supports(request))
+                .findFirst();
     }
 
     @Override

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/DefaultRagIndexJobServiceTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/DefaultRagIndexJobServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import studio.one.platform.ai.core.rag.RagIndexJob;
 import studio.one.platform.ai.core.rag.RagIndexJobCreateRequest;
 import studio.one.platform.ai.core.rag.RagIndexJobLogLevel;
+import studio.one.platform.ai.core.rag.RagIndexJobSourceRequest;
 import studio.one.platform.ai.core.rag.RagIndexJobStatus;
 import studio.one.platform.ai.core.rag.RagIndexJobStep;
 import studio.one.platform.ai.core.rag.RagIndexRequest;
@@ -118,17 +119,15 @@ class DefaultRagIndexJobServiceTest {
                 "doc-1",
                 "attachment",
                 false,
-                null,
-                Map.of("attachmentId", "42"),
-                List.of("alpha"),
-                true));
+                null),
+                new RagIndexJobSourceRequest(Map.of("attachmentId", "42"), List.of("alpha"), true));
 
         RagIndexJob completed = service.startJob(job.jobId());
 
         assertThat(completed.status()).isEqualTo(RagIndexJobStatus.SUCCEEDED);
         assertThat(completed.chunkCount()).isEqualTo(3);
-        assertThat(executor.request.metadata()).containsEntry("attachmentId", "42");
-        assertThat(executor.request.keywords()).containsExactly("alpha");
+        assertThat(executor.sourceRequest.metadata()).containsEntry("attachmentId", "42");
+        assertThat(executor.sourceRequest.keywords()).containsExactly("alpha");
     }
 
     @Test
@@ -187,15 +186,21 @@ class DefaultRagIndexJobServiceTest {
     private static class CapturingSourceExecutor implements RagIndexJobSourceExecutor {
 
         private RagIndexJobCreateRequest request;
+        private RagIndexJobSourceRequest sourceRequest;
 
         @Override
-        public boolean supports(RagIndexJobCreateRequest request) {
+        public boolean supports(RagIndexJobCreateRequest request, RagIndexJobSourceRequest sourceRequest) {
             return "attachment".equals(request.sourceType());
         }
 
         @Override
-        public void execute(RagIndexJob job, RagIndexJobCreateRequest request, RagIndexProgressListener listener) {
+        public void execute(
+                RagIndexJob job,
+                RagIndexJobCreateRequest request,
+                RagIndexJobSourceRequest sourceRequest,
+                RagIndexProgressListener listener) {
             this.request = request;
+            this.sourceRequest = sourceRequest;
             listener.onStep(RagIndexJobStep.CHUNKING);
             listener.onChunkCount(3);
             listener.onStep(RagIndexJobStep.EMBEDDING);

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/DefaultRagIndexJobServiceTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/DefaultRagIndexJobServiceTest.java
@@ -105,6 +105,51 @@ class DefaultRagIndexJobServiceTest {
                 .hasMessageContaining("cannot be retried");
     }
 
+    @Test
+    void delegatesNonTextSourceToMatchingExecutor() {
+        CapturingSourceExecutor executor = new CapturingSourceExecutor();
+        DefaultRagIndexJobService service = new DefaultRagIndexJobService(
+                repository,
+                new SuccessfulPipeline(),
+                List.of(executor));
+        RagIndexJob job = service.createJob(new RagIndexJobCreateRequest(
+                "attachment",
+                "42",
+                "doc-1",
+                "attachment",
+                false,
+                null,
+                Map.of("attachmentId", "42"),
+                List.of("alpha"),
+                true));
+
+        RagIndexJob completed = service.startJob(job.jobId());
+
+        assertThat(completed.status()).isEqualTo(RagIndexJobStatus.SUCCEEDED);
+        assertThat(completed.chunkCount()).isEqualTo(3);
+        assertThat(executor.request.metadata()).containsEntry("attachmentId", "42");
+        assertThat(executor.request.keywords()).containsExactly("alpha");
+    }
+
+    @Test
+    void marksUnsupportedNonTextSourceAsFailed() {
+        DefaultRagIndexJobService service = new DefaultRagIndexJobService(repository, new SuccessfulPipeline());
+        RagIndexJob job = service.createJob(new RagIndexJobCreateRequest(
+                "attachment",
+                "42",
+                "doc-1",
+                "attachment",
+                false,
+                null));
+
+        RagIndexJob failed = service.startJob(job.jobId());
+
+        assertThat(failed.status()).isEqualTo(RagIndexJobStatus.FAILED);
+        assertThat(service.getLogs(job.jobId()))
+                .anySatisfy(log -> assertThat(log.code()).isEqualTo(
+                        studio.one.platform.ai.core.rag.RagIndexJobLogCode.SOURCE_UNSUPPORTED));
+    }
+
     private static class SuccessfulPipeline extends BasePipeline {
 
         @Override
@@ -136,6 +181,27 @@ class DefaultRagIndexJobServiceTest {
             calls++;
             listener.onStep(RagIndexJobStep.CHUNKING);
             listener.onChunkCount(1);
+        }
+    }
+
+    private static class CapturingSourceExecutor implements RagIndexJobSourceExecutor {
+
+        private RagIndexJobCreateRequest request;
+
+        @Override
+        public boolean supports(RagIndexJobCreateRequest request) {
+            return "attachment".equals(request.sourceType());
+        }
+
+        @Override
+        public void execute(RagIndexJob job, RagIndexJobCreateRequest request, RagIndexProgressListener listener) {
+            this.request = request;
+            listener.onStep(RagIndexJobStep.CHUNKING);
+            listener.onChunkCount(3);
+            listener.onStep(RagIndexJobStep.EMBEDDING);
+            listener.onEmbeddedCount(3);
+            listener.onStep(RagIndexJobStep.INDEXING);
+            listener.onIndexedCount(3);
         }
     }
 

--- a/studio-application-modules/content-embedding-pipeline/README.md
+++ b/studio-application-modules/content-embedding-pipeline/README.md
@@ -44,6 +44,8 @@ RAG 색인은 `TextractNormalizedDocumentAdapter`, `ChunkingOrchestrator`, `Embe
 | 클래스 | 역할 |
 |--------|------|
 | `AttachmentEmbeddingPipelineController` | 임베딩 생성/저장, 벡터 존재 여부 확인, RAG 인덱싱/검색 REST 엔드포인트 제공 |
+| `AttachmentRagIndexService` | attachment RAG 색인 실행 흐름을 controller와 job executor가 함께 재사용하는 service |
+| `AttachmentRagIndexJobSourceExecutor` | `sourceType=attachment` RAG index job을 기존 attachment 색인 흐름으로 실행 |
 | `FileContentExtractionService` | 파일 MIME 타입과 이름을 기반으로 텍스트 추출. 구현체는 `studio-platform-textract-starter`가 제공한다 |
 | `TextractNormalizedDocumentAdapter` | `ParsedFile`을 structure-based chunking 입력인 `NormalizedDocument`로 변환한다 |
 | `EmbeddingPort` | 텍스트 리스트를 받아 임베딩 벡터 반환. `studio-platform-ai` AI 어댑터(OpenAI 등)가 구현체를 제공한다 |
@@ -115,6 +117,8 @@ Content-Type: application/json
 `202 Accepted` 응답 헤더에 안전한 색인 diagnostics를 추가한다.
 `RagIndexJobService`가 있으면 기존 응답 body 없이 `X-RAG-Job-Id` 헤더도 함께 반환해
 `starter-ai-web`의 RAG job management API에서 상태와 로그를 추적할 수 있다.
+`starter-ai-web`의 `POST /api/mgmt/ai/rag/jobs`에서도 `sourceType=attachment`, `objectType=attachment`,
+`objectId=<attachmentId>`를 보내면 동일한 attachment RAG 색인 흐름을 비동기 job으로 실행한다.
 헤더는 `X-RAG-Index-Path`, `X-RAG-Index-Structured`, `X-RAG-Index-Fallback-Reason`,
 `X-RAG-Index-Parsed-Block-Count`, `X-RAG-Index-Chunk-Count`, `X-RAG-Index-Vector-Count`,
 `X-RAG-Job-Id`만 사용한다.

--- a/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineController.java
+++ b/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineController.java
@@ -23,8 +23,6 @@ package studio.one.application.web.controller;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.time.Instant;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -51,8 +49,11 @@ import studio.one.application.web.dto.EmbeddingVectorDto;
 import studio.one.application.web.dto.SearchRequest;
 import studio.one.application.web.dto.SearchResponse;
 import studio.one.application.web.dto.SearchResult;
+import studio.one.application.web.service.AttachmentRagIndexCommand;
 import studio.one.application.web.service.AttachmentRagIndexDiagnostics;
-import studio.one.application.web.service.AttachmentStructuredRagIndexer;
+import studio.one.application.web.service.AttachmentRagIndexResult;
+import studio.one.application.web.service.AttachmentRagIndexService;
+import studio.one.application.web.service.AttachmentRagIndexUnavailableException;
 import studio.one.platform.ai.core.MetadataFilter;
 import studio.one.platform.ai.core.embedding.EmbeddingPort;
 import studio.one.platform.ai.core.embedding.EmbeddingRequest;
@@ -60,8 +61,6 @@ import studio.one.platform.ai.core.embedding.EmbeddingResponse;
 import studio.one.platform.ai.core.embedding.EmbeddingVector;
 import studio.one.platform.ai.core.rag.RagIndexJob;
 import studio.one.platform.ai.core.rag.RagIndexJobCreateRequest;
-import studio.one.platform.ai.core.rag.RagIndexJobLogCode;
-import studio.one.platform.ai.core.rag.RagIndexRequest;
 import studio.one.platform.ai.core.rag.RagSearchRequest;
 import studio.one.platform.ai.core.rag.RagSearchResult;
 import studio.one.platform.ai.core.vector.VectorDocument;
@@ -110,8 +109,8 @@ public class AttachmentEmbeddingPipelineController {
     private final ObjectProvider<EmbeddingPort> embeddingPortProvider;
     private final ObjectProvider<VectorStorePort> vectorStoreProvider;
     private final ObjectProvider<RagPipelineService> ragPipelineProvider;
-    private final ObjectProvider<AttachmentStructuredRagIndexer> structuredRagIndexerProvider;
     private final ObjectProvider<RagIndexJobService> ragIndexJobServiceProvider;
+    private final AttachmentRagIndexService attachmentRagIndexService;
     private final ObjectProvider<I18n> i18nProvider;
 
     @Value("${studio.ai.endpoints.rag.diagnostics.allow-client-debug:false}")
@@ -261,64 +260,30 @@ public class AttachmentEmbeddingPipelineController {
         if (attachmentId <= 0) {
             return ResponseEntity.badRequest().build();
         }
-        FileContentExtractionService extractor = textExtractionProvider.getIfAvailable();
-        if (extractor == null) {
+        if (!attachmentRagIndexService.hasTextExtractor()) {
             return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
         }
-        Attachment attachment = attachmentService.getAttachmentById(attachmentId);
-        String documentId = resolveDocumentId(request, attachmentId);
-        String objectType = resolveObjectType(request);
-        String objectId = resolveObjectId(request, attachmentId);
-        Map<String, Object> metadata = buildMetadata(request, attachment, objectType, objectId);
+        AttachmentRagIndexCommand command = attachmentRagIndexService.command(
+                attachmentId,
+                request == null ? null : request.documentId(),
+                request == null ? null : request.objectType(),
+                request == null ? null : request.objectId(),
+                request == null ? null : request.metadata(),
+                request == null ? null : request.keywords(),
+                request == null ? null : request.useLlmKeywordExtraction());
         RagIndexJobService jobService = ragIndexJobServiceProvider.getIfAvailable();
-        RagIndexJob job = createJob(jobService, objectType, objectId, documentId);
+        RagIndexJob job = createJob(jobService, command);
         RagIndexProgressListener progress = job == null
                 ? RagIndexProgressListener.noop()
                 : jobService.progressListener(job.jobId());
         progress.onStarted();
-        AttachmentStructuredRagIndexer structuredIndexer = structuredRagIndexerProvider.getIfAvailable();
-        AttachmentRagIndexDiagnostics structuredDiagnostics = structuredIndexer == null
-                ? AttachmentRagIndexDiagnostics.fallback("missing_structured_indexer")
-                : null;
         try {
-            if (structuredIndexer != null) {
-                try (InputStream in = attachmentService.getInputStream(attachment)) {
-                    if (structuredIndexer.index(
-                            attachment,
-                            documentId,
-                            objectType,
-                            objectId,
-                            metadata,
-                            extractor,
-                            in,
-                            progress)) {
-                        progress.onCompleted();
-                        return accepted(request, structuredIndexer.latestDiagnostics()
-                                .orElse(AttachmentRagIndexDiagnostics.structuredUnknown()), job);
-                    }
-                    structuredDiagnostics = structuredIndexer.latestDiagnostics()
-                            .orElse(AttachmentRagIndexDiagnostics.fallback("structured_not_handled"));
-                } finally {
-                    structuredIndexer.clearDiagnostics();
-                }
-            }
-            RagPipelineService ragPipeline = ragPipelineProvider.getIfAvailable();
-            if (ragPipeline == null) {
-                progress.onError(null, RagIndexJobLogCode.SOURCE_UNSUPPORTED,
-                        "RAG pipeline service is not configured", null);
-                return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
-            }
-            try (InputStream in = attachmentService.getInputStream(attachment)) {
-                String text = extractor.extractText(attachment.getContentType(), attachment.getName(), in);
-                List<String> keywords = request != null && request.keywords() != null ? request.keywords() : List.of();
-                boolean useLlmKeywords = request != null && Boolean.TRUE.equals(request.useLlmKeywordExtraction());
-                ragPipeline.index(new RagIndexRequest(documentId, text, metadata, keywords, useLlmKeywords), progress);
-            }
+            AttachmentRagIndexResult result = attachmentRagIndexService.index(attachmentId, command, progress);
             progress.onCompleted();
-            return accepted(request, AttachmentRagIndexDiagnostics.fallback(
-                    structuredDiagnostics == null ? "structured_not_attempted" : structuredDiagnostics.fallbackReason()), job);
+            return accepted(request, result.diagnostics(), job);
+        } catch (AttachmentRagIndexUnavailableException ex) {
+            return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
         } catch (IOException | RuntimeException ex) {
-            progress.onError(null, RagIndexJobLogCode.UNKNOWN_ERROR, "Attachment RAG index failed", ex.getMessage());
             throw ex;
         }
     }
@@ -344,19 +309,20 @@ public class AttachmentEmbeddingPipelineController {
 
     private RagIndexJob createJob(
             RagIndexJobService jobService,
-            String objectType,
-            String objectId,
-            String documentId) {
+            AttachmentRagIndexCommand command) {
         if (jobService == null) {
             return null;
         }
         return jobService.createJob(new RagIndexJobCreateRequest(
-                objectType,
-                objectId,
-                documentId,
+                command.objectType(),
+                command.objectId(),
+                command.documentId(),
                 "attachment",
                 false,
-                null));
+                null,
+                command.metadata(),
+                command.keywords(),
+                command.useLlmKeywordExtraction()));
     }
 
     private void putHeader(ResponseEntity.BodyBuilder builder, String name, String value) {
@@ -400,47 +366,6 @@ public class AttachmentEmbeddingPipelineController {
         return response.vectors().stream()
                 .map(vector -> new EmbeddingVectorDto(vector.referenceId(), List.copyOf(vector.values())))
                 .toList();
-    }
-
-    private String resolveDocumentId(AttachmentRagIndexRequestDto request, long attachmentId) {
-        if (request != null && request.documentId() != null && !request.documentId().isBlank()) {
-            return request.documentId().trim();
-        }
-        return String.valueOf(attachmentId);
-    }
-
-    private String resolveObjectType(AttachmentRagIndexRequestDto request) {
-        if (request != null && request.objectType() != null && !request.objectType().isBlank()) {
-            return request.objectType().trim();
-        }
-        return "attachment";
-    }
-
-    private String resolveObjectId(AttachmentRagIndexRequestDto request, long attachmentId) {
-        if (request != null && request.objectId() != null && !request.objectId().isBlank()) {
-            return request.objectId().trim();
-        }
-        return String.valueOf(attachmentId);
-    }
-
-    private Map<String, Object> buildMetadata(AttachmentRagIndexRequestDto request,
-            Attachment attachment,
-            String objectType,
-            String objectId) {
-        Map<String, Object> metadata = request != null && request.metadata() != null
-                ? new HashMap<>(request.metadata())
-                : new HashMap<>();
-        metadata.putIfAbsent("objectType", objectType);
-        metadata.putIfAbsent("objectId", objectId);
-        metadata.putIfAbsent("attachmentId", attachment.getAttachmentId());
-        metadata.putIfAbsent("name", attachment.getName());
-        metadata.putIfAbsent("filename", attachment.getName());
-        metadata.putIfAbsent("sourceType", "attachment");
-        metadata.putIfAbsent("indexedAt", Instant.now().toString());
-        metadata.putIfAbsent("contentType", attachment.getContentType());
-        metadata.putIfAbsent("size", attachment.getSize());
-        metadata.putIfAbsent("chunkOrder", 0);
-        return metadata;
     }
 
     private void upsertVectorDocument(VectorStorePort vectorStore, Attachment attachment, String text, EmbeddingVector vector) {

--- a/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineController.java
+++ b/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineController.java
@@ -61,6 +61,7 @@ import studio.one.platform.ai.core.embedding.EmbeddingResponse;
 import studio.one.platform.ai.core.embedding.EmbeddingVector;
 import studio.one.platform.ai.core.rag.RagIndexJob;
 import studio.one.platform.ai.core.rag.RagIndexJobCreateRequest;
+import studio.one.platform.ai.core.rag.RagIndexJobSourceRequest;
 import studio.one.platform.ai.core.rag.RagSearchRequest;
 import studio.one.platform.ai.core.rag.RagSearchResult;
 import studio.one.platform.ai.core.vector.VectorDocument;
@@ -319,10 +320,11 @@ public class AttachmentEmbeddingPipelineController {
                 command.documentId(),
                 "attachment",
                 false,
-                null,
-                command.metadata(),
-                command.keywords(),
-                command.useLlmKeywordExtraction()));
+                null),
+                new RagIndexJobSourceRequest(
+                        command.metadata(),
+                        command.keywords(),
+                        command.useLlmKeywordExtraction()));
     }
 
     private void putHeader(ResponseEntity.BodyBuilder builder, String name, String value) {

--- a/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/AttachmentRagIndexCommand.java
+++ b/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/AttachmentRagIndexCommand.java
@@ -1,0 +1,25 @@
+package studio.one.application.web.service;
+
+import java.util.List;
+import java.util.Map;
+
+public record AttachmentRagIndexCommand(
+        String documentId,
+        String objectType,
+        String objectId,
+        Map<String, Object> metadata,
+        List<String> keywords,
+        boolean useLlmKeywordExtraction) {
+
+    public AttachmentRagIndexCommand {
+        documentId = normalize(documentId);
+        objectType = normalize(objectType);
+        objectId = normalize(objectId);
+        metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+        keywords = keywords == null ? List.of() : List.copyOf(keywords);
+    }
+
+    private static String normalize(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+}

--- a/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/AttachmentRagIndexJobSourceExecutor.java
+++ b/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/AttachmentRagIndexJobSourceExecutor.java
@@ -1,0 +1,62 @@
+package studio.one.application.web.service;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import studio.one.platform.ai.core.rag.RagIndexJob;
+import studio.one.platform.ai.core.rag.RagIndexJobCreateRequest;
+import studio.one.platform.ai.service.pipeline.RagIndexJobSourceExecutor;
+import studio.one.platform.ai.service.pipeline.RagIndexProgressListener;
+
+@Component
+@RequiredArgsConstructor
+public class AttachmentRagIndexJobSourceExecutor implements RagIndexJobSourceExecutor {
+
+    private static final String ATTACHMENT = "attachment";
+
+    private final AttachmentRagIndexService ragIndexService;
+
+    @Override
+    public boolean supports(RagIndexJobCreateRequest request) {
+        if (request == null || request.indexRequest() != null) {
+            return false;
+        }
+        return ATTACHMENT.equalsIgnoreCase(request.sourceType())
+                || ATTACHMENT.equalsIgnoreCase(request.objectType());
+    }
+
+    @Override
+    public void execute(RagIndexJob job, RagIndexJobCreateRequest request, RagIndexProgressListener listener) {
+        long attachmentId = attachmentId(request);
+        AttachmentRagIndexCommand command = ragIndexService.command(
+                attachmentId,
+                request.documentId(),
+                request.objectType(),
+                request.objectId(),
+                request.metadata(),
+                request.keywords(),
+                request.useLlmKeywordExtraction());
+        try {
+            ragIndexService.index(attachmentId, command, listener);
+        } catch (Exception ex) {
+            throw new IllegalStateException("Attachment RAG index job failed", ex);
+        }
+    }
+
+    private long attachmentId(RagIndexJobCreateRequest request) {
+        Object metadataAttachmentId = request.metadata().get("attachmentId");
+        String value = metadataAttachmentId == null ? request.objectId() : metadataAttachmentId.toString();
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("attachmentId is required for attachment RAG index job");
+        }
+        try {
+            long attachmentId = Long.parseLong(value.trim());
+            if (attachmentId <= 0L) {
+                throw new IllegalArgumentException("attachmentId must be positive");
+            }
+            return attachmentId;
+        } catch (NumberFormatException ex) {
+            throw new IllegalArgumentException("attachmentId must be numeric", ex);
+        }
+    }
+}

--- a/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/AttachmentRagIndexJobSourceExecutor.java
+++ b/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/AttachmentRagIndexJobSourceExecutor.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import lombok.RequiredArgsConstructor;
 import studio.one.platform.ai.core.rag.RagIndexJob;
 import studio.one.platform.ai.core.rag.RagIndexJobCreateRequest;
+import studio.one.platform.ai.core.rag.RagIndexJobSourceRequest;
 import studio.one.platform.ai.service.pipeline.RagIndexJobSourceExecutor;
 import studio.one.platform.ai.service.pipeline.RagIndexProgressListener;
 
@@ -17,25 +18,31 @@ public class AttachmentRagIndexJobSourceExecutor implements RagIndexJobSourceExe
     private final AttachmentRagIndexService ragIndexService;
 
     @Override
-    public boolean supports(RagIndexJobCreateRequest request) {
+    public boolean supports(RagIndexJobCreateRequest request, RagIndexJobSourceRequest sourceRequest) {
         if (request == null || request.indexRequest() != null) {
             return false;
         }
-        return ATTACHMENT.equalsIgnoreCase(request.sourceType())
-                || ATTACHMENT.equalsIgnoreCase(request.objectType());
+        return ATTACHMENT.equalsIgnoreCase(request.sourceType());
     }
 
     @Override
-    public void execute(RagIndexJob job, RagIndexJobCreateRequest request, RagIndexProgressListener listener) {
-        long attachmentId = attachmentId(request);
+    public void execute(
+            RagIndexJob job,
+            RagIndexJobCreateRequest request,
+            RagIndexJobSourceRequest sourceRequest,
+            RagIndexProgressListener listener) {
+        RagIndexJobSourceRequest source = sourceRequest == null
+                ? RagIndexJobSourceRequest.empty()
+                : sourceRequest;
+        long attachmentId = attachmentId(request, source);
         AttachmentRagIndexCommand command = ragIndexService.command(
                 attachmentId,
                 request.documentId(),
                 request.objectType(),
                 request.objectId(),
-                request.metadata(),
-                request.keywords(),
-                request.useLlmKeywordExtraction());
+                source.metadata(),
+                source.keywords(),
+                source.useLlmKeywordExtraction());
         try {
             ragIndexService.index(attachmentId, command, listener);
         } catch (Exception ex) {
@@ -43,8 +50,8 @@ public class AttachmentRagIndexJobSourceExecutor implements RagIndexJobSourceExe
         }
     }
 
-    private long attachmentId(RagIndexJobCreateRequest request) {
-        Object metadataAttachmentId = request.metadata().get("attachmentId");
+    private long attachmentId(RagIndexJobCreateRequest request, RagIndexJobSourceRequest sourceRequest) {
+        Object metadataAttachmentId = sourceRequest.metadata().get("attachmentId");
         String value = metadataAttachmentId == null ? request.objectId() : metadataAttachmentId.toString();
         if (value == null || value.isBlank()) {
             throw new IllegalArgumentException("attachmentId is required for attachment RAG index job");

--- a/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/AttachmentRagIndexResult.java
+++ b/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/AttachmentRagIndexResult.java
@@ -1,0 +1,4 @@
+package studio.one.application.web.service;
+
+public record AttachmentRagIndexResult(AttachmentRagIndexDiagnostics diagnostics) {
+}

--- a/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/AttachmentRagIndexService.java
+++ b/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/AttachmentRagIndexService.java
@@ -57,14 +57,14 @@ public class AttachmentRagIndexService {
         if (extractor == null) {
             throw new AttachmentRagIndexUnavailableException("Text extraction is not configured");
         }
-        Attachment attachment = attachmentService.getAttachmentById(attachmentId);
         RagIndexProgressListener progress = listener == null ? RagIndexProgressListener.noop() : listener;
-        Map<String, Object> metadata = buildMetadata(command, attachment);
-        AttachmentStructuredRagIndexer structuredIndexer = structuredRagIndexerProvider.getIfAvailable();
-        AttachmentRagIndexDiagnostics structuredDiagnostics = structuredIndexer == null
-                ? AttachmentRagIndexDiagnostics.fallback("missing_structured_indexer")
-                : null;
         try {
+            Attachment attachment = attachmentService.getAttachmentById(attachmentId);
+            Map<String, Object> metadata = buildMetadata(command, attachment);
+            AttachmentStructuredRagIndexer structuredIndexer = structuredRagIndexerProvider.getIfAvailable();
+            AttachmentRagIndexDiagnostics structuredDiagnostics = structuredIndexer == null
+                    ? AttachmentRagIndexDiagnostics.fallback("missing_structured_indexer")
+                    : null;
             if (structuredIndexer != null) {
                 try (InputStream in = attachmentService.getInputStream(attachment)) {
                     if (structuredIndexer.index(
@@ -103,6 +103,9 @@ public class AttachmentRagIndexService {
             return new AttachmentRagIndexResult(AttachmentRagIndexDiagnostics.fallback(
                     structuredDiagnostics == null ? "structured_not_attempted" : structuredDiagnostics.fallbackReason()));
         } catch (AttachmentRagIndexUnavailableException ex) {
+            throw ex;
+        } catch (NotFoundException ex) {
+            progress.onError(null, RagIndexJobLogCode.SOURCE_UNSUPPORTED, "Attachment was not found", ex.getMessage());
             throw ex;
         } catch (IOException | RuntimeException ex) {
             progress.onError(null, RagIndexJobLogCode.UNKNOWN_ERROR, "Attachment RAG index failed", ex.getMessage());

--- a/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/AttachmentRagIndexService.java
+++ b/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/AttachmentRagIndexService.java
@@ -1,0 +1,131 @@
+package studio.one.application.web.service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import studio.one.application.attachment.domain.model.Attachment;
+import studio.one.application.attachment.service.AttachmentService;
+import studio.one.platform.ai.core.rag.RagIndexJobLogCode;
+import studio.one.platform.ai.core.rag.RagIndexRequest;
+import studio.one.platform.ai.service.pipeline.RagIndexProgressListener;
+import studio.one.platform.ai.service.pipeline.RagPipelineService;
+import studio.one.platform.exception.NotFoundException;
+import studio.one.platform.textract.service.FileContentExtractionService;
+
+@Service
+@RequiredArgsConstructor
+public class AttachmentRagIndexService {
+
+    private final AttachmentService attachmentService;
+    private final ObjectProvider<FileContentExtractionService> textExtractionProvider;
+    private final ObjectProvider<RagPipelineService> ragPipelineProvider;
+    private final ObjectProvider<AttachmentStructuredRagIndexer> structuredRagIndexerProvider;
+
+    public AttachmentRagIndexCommand command(long attachmentId,
+            String documentId,
+            String objectType,
+            String objectId,
+            Map<String, Object> metadata,
+            List<String> keywords,
+            Boolean useLlmKeywordExtraction) {
+        return new AttachmentRagIndexCommand(
+                hasText(documentId) ? documentId.trim() : String.valueOf(attachmentId),
+                hasText(objectType) ? objectType.trim() : "attachment",
+                hasText(objectId) ? objectId.trim() : String.valueOf(attachmentId),
+                metadata,
+                keywords,
+                Boolean.TRUE.equals(useLlmKeywordExtraction));
+    }
+
+    public boolean hasTextExtractor() {
+        return textExtractionProvider.getIfAvailable() != null;
+    }
+
+    public AttachmentRagIndexResult index(
+            long attachmentId,
+            AttachmentRagIndexCommand command,
+            RagIndexProgressListener listener) throws NotFoundException, IOException {
+        FileContentExtractionService extractor = textExtractionProvider.getIfAvailable();
+        if (extractor == null) {
+            throw new AttachmentRagIndexUnavailableException("Text extraction is not configured");
+        }
+        Attachment attachment = attachmentService.getAttachmentById(attachmentId);
+        RagIndexProgressListener progress = listener == null ? RagIndexProgressListener.noop() : listener;
+        Map<String, Object> metadata = buildMetadata(command, attachment);
+        AttachmentStructuredRagIndexer structuredIndexer = structuredRagIndexerProvider.getIfAvailable();
+        AttachmentRagIndexDiagnostics structuredDiagnostics = structuredIndexer == null
+                ? AttachmentRagIndexDiagnostics.fallback("missing_structured_indexer")
+                : null;
+        try {
+            if (structuredIndexer != null) {
+                try (InputStream in = attachmentService.getInputStream(attachment)) {
+                    if (structuredIndexer.index(
+                            attachment,
+                            command.documentId(),
+                            command.objectType(),
+                            command.objectId(),
+                            metadata,
+                            extractor,
+                            in,
+                            progress)) {
+                        return new AttachmentRagIndexResult(structuredIndexer.latestDiagnostics()
+                                .orElse(AttachmentRagIndexDiagnostics.structuredUnknown()));
+                    }
+                    structuredDiagnostics = structuredIndexer.latestDiagnostics()
+                            .orElse(AttachmentRagIndexDiagnostics.fallback("structured_not_handled"));
+                } finally {
+                    structuredIndexer.clearDiagnostics();
+                }
+            }
+            RagPipelineService ragPipeline = ragPipelineProvider.getIfAvailable();
+            if (ragPipeline == null) {
+                progress.onError(null, RagIndexJobLogCode.SOURCE_UNSUPPORTED,
+                        "RAG pipeline service is not configured", null);
+                throw new AttachmentRagIndexUnavailableException("RAG pipeline service is not configured");
+            }
+            try (InputStream in = attachmentService.getInputStream(attachment)) {
+                String text = extractor.extractText(attachment.getContentType(), attachment.getName(), in);
+                ragPipeline.index(new RagIndexRequest(
+                        command.documentId(),
+                        text,
+                        metadata,
+                        command.keywords(),
+                        command.useLlmKeywordExtraction()), progress);
+            }
+            return new AttachmentRagIndexResult(AttachmentRagIndexDiagnostics.fallback(
+                    structuredDiagnostics == null ? "structured_not_attempted" : structuredDiagnostics.fallbackReason()));
+        } catch (AttachmentRagIndexUnavailableException ex) {
+            throw ex;
+        } catch (IOException | RuntimeException ex) {
+            progress.onError(null, RagIndexJobLogCode.UNKNOWN_ERROR, "Attachment RAG index failed", ex.getMessage());
+            throw ex;
+        }
+    }
+
+    private Map<String, Object> buildMetadata(AttachmentRagIndexCommand command, Attachment attachment) {
+        Map<String, Object> metadata = new HashMap<>(command.metadata());
+        metadata.putIfAbsent("objectType", command.objectType());
+        metadata.putIfAbsent("objectId", command.objectId());
+        metadata.putIfAbsent("attachmentId", attachment.getAttachmentId());
+        metadata.putIfAbsent("name", attachment.getName());
+        metadata.putIfAbsent("filename", attachment.getName());
+        metadata.putIfAbsent("sourceType", "attachment");
+        metadata.putIfAbsent("indexedAt", Instant.now().toString());
+        metadata.putIfAbsent("contentType", attachment.getContentType());
+        metadata.putIfAbsent("size", attachment.getSize());
+        metadata.putIfAbsent("chunkOrder", 0);
+        return metadata;
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/AttachmentRagIndexUnavailableException.java
+++ b/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/AttachmentRagIndexUnavailableException.java
@@ -1,0 +1,8 @@
+package studio.one.application.web.service;
+
+public class AttachmentRagIndexUnavailableException extends RuntimeException {
+
+    public AttachmentRagIndexUnavailableException(String message) {
+        super(message);
+    }
+}

--- a/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineControllerTest.java
+++ b/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineControllerTest.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import studio.one.application.attachment.domain.model.Attachment;
 import studio.one.application.attachment.service.AttachmentService;
 import studio.one.application.web.service.AttachmentStructuredRagIndexer;
+import studio.one.application.web.service.AttachmentRagIndexService;
 import studio.one.application.web.service.DefaultAttachmentStructuredRagIndexer;
 import studio.one.platform.ai.core.embedding.EmbeddingPort;
 import studio.one.platform.ai.core.embedding.EmbeddingRequest;
@@ -95,14 +96,19 @@ class AttachmentEmbeddingPipelineControllerTest {
             AttachmentStructuredRagIndexer structuredRagIndexer,
             boolean allowClientDebug,
             RagIndexJobService ragIndexJobService) {
+        AttachmentRagIndexService attachmentRagIndexService = new AttachmentRagIndexService(
+                attachmentService,
+                provider(extractionService),
+                provider(ragPipelineService),
+                provider(structuredRagIndexer));
         AttachmentEmbeddingPipelineController controller = new AttachmentEmbeddingPipelineController(
                 attachmentService,
                 provider(extractionService),
                 provider(embeddingPort),
                 provider((VectorStorePort) null),
                 provider(ragPipelineService),
-                provider(structuredRagIndexer),
                 provider(ragIndexJobService),
+                attachmentRagIndexService,
                 provider((I18n) null));
         ReflectionTestUtils.setField(controller, "allowClientDebug", allowClientDebug);
 

--- a/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineControllerTest.java
+++ b/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineControllerTest.java
@@ -43,6 +43,7 @@ import studio.one.platform.ai.core.embedding.EmbeddingResponse;
 import studio.one.platform.ai.core.embedding.EmbeddingVector;
 import studio.one.platform.ai.core.rag.RagIndexJob;
 import studio.one.platform.ai.core.rag.RagIndexJobCreateRequest;
+import studio.one.platform.ai.core.rag.RagIndexJobSourceRequest;
 import studio.one.platform.ai.core.rag.RagIndexRequest;
 import studio.one.platform.ai.core.rag.RagSearchRequest;
 import studio.one.platform.ai.core.rag.RagSearchResult;
@@ -383,7 +384,7 @@ class AttachmentEmbeddingPipelineControllerTest {
     void ragIndexAddsJobHeaderWhenJobServiceIsConfigured() throws Exception {
         RagIndexJobService jobService = mock(RagIndexJobService.class);
         configureMockMvc(null, false, jobService);
-        when(jobService.createJob(any(RagIndexJobCreateRequest.class)))
+        when(jobService.createJob(any(RagIndexJobCreateRequest.class), any(RagIndexJobSourceRequest.class)))
                 .thenReturn(RagIndexJob.pending(
                         "job-1",
                         "attachment",

--- a/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/service/AttachmentRagIndexJobSourceExecutorTest.java
+++ b/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/service/AttachmentRagIndexJobSourceExecutorTest.java
@@ -1,0 +1,79 @@
+package studio.one.application.web.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.ai.core.rag.RagIndexJob;
+import studio.one.platform.ai.core.rag.RagIndexJobCreateRequest;
+import studio.one.platform.ai.service.pipeline.RagIndexProgressListener;
+
+class AttachmentRagIndexJobSourceExecutorTest {
+
+    @Test
+    void supportsAttachmentSourceWithoutRawIndexRequest() {
+        AttachmentRagIndexJobSourceExecutor executor = new AttachmentRagIndexJobSourceExecutor(
+                mock(AttachmentRagIndexService.class));
+
+        assertThat(executor.supports(new RagIndexJobCreateRequest(
+                "custom",
+                "42",
+                "doc-1",
+                "attachment",
+                false,
+                null))).isTrue();
+    }
+
+    @Test
+    void delegatesAttachmentJobToAttachmentRagIndexService() throws Exception {
+        AttachmentRagIndexService service = mock(AttachmentRagIndexService.class);
+        AttachmentRagIndexCommand command = new AttachmentRagIndexCommand(
+                "doc-1",
+                "attachment",
+                "42",
+                Map.of("attachmentId", "42"),
+                List.of("alpha"),
+                true);
+        when(service.command(
+                eq(42L),
+                eq("doc-1"),
+                eq("attachment"),
+                eq("42"),
+                eq(Map.of("attachmentId", "42")),
+                eq(List.of("alpha")),
+                eq(true))).thenReturn(command);
+        when(service.index(eq(42L), eq(command), any(RagIndexProgressListener.class)))
+                .thenReturn(new AttachmentRagIndexResult(AttachmentRagIndexDiagnostics.fallback("structured_not_attempted")));
+        AttachmentRagIndexJobSourceExecutor executor = new AttachmentRagIndexJobSourceExecutor(service);
+        RagIndexJob job = RagIndexJob.pending(
+                "job-1",
+                "attachment",
+                "42",
+                "doc-1",
+                "attachment",
+                Instant.parse("2026-04-26T00:00:00Z"));
+        RagIndexJobCreateRequest request = new RagIndexJobCreateRequest(
+                "attachment",
+                "42",
+                "doc-1",
+                "attachment",
+                false,
+                null,
+                Map.of("attachmentId", "42"),
+                List.of("alpha"),
+                true);
+
+        executor.execute(job, request, RagIndexProgressListener.noop());
+
+        verify(service).index(eq(42L), eq(command), any(RagIndexProgressListener.class));
+    }
+}

--- a/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/service/AttachmentRagIndexJobSourceExecutorTest.java
+++ b/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/service/AttachmentRagIndexJobSourceExecutorTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import studio.one.platform.ai.core.rag.RagIndexJob;
 import studio.one.platform.ai.core.rag.RagIndexJobCreateRequest;
+import studio.one.platform.ai.core.rag.RagIndexJobSourceRequest;
 import studio.one.platform.ai.service.pipeline.RagIndexProgressListener;
 
 class AttachmentRagIndexJobSourceExecutorTest {
@@ -30,7 +31,21 @@ class AttachmentRagIndexJobSourceExecutorTest {
                 "doc-1",
                 "attachment",
                 false,
-                null))).isTrue();
+                null), RagIndexJobSourceRequest.empty())).isTrue();
+    }
+
+    @Test
+    void doesNotSupportObjectTypeOnlyAttachmentRequests() {
+        AttachmentRagIndexJobSourceExecutor executor = new AttachmentRagIndexJobSourceExecutor(
+                mock(AttachmentRagIndexService.class));
+
+        assertThat(executor.supports(new RagIndexJobCreateRequest(
+                "attachment",
+                "42",
+                "doc-1",
+                "custom-source",
+                false,
+                null), RagIndexJobSourceRequest.empty())).isFalse();
     }
 
     @Test
@@ -67,12 +82,11 @@ class AttachmentRagIndexJobSourceExecutorTest {
                 "doc-1",
                 "attachment",
                 false,
-                null,
-                Map.of("attachmentId", "42"),
-                List.of("alpha"),
-                true);
+                null);
+        RagIndexJobSourceRequest sourceRequest =
+                new RagIndexJobSourceRequest(Map.of("attachmentId", "42"), List.of("alpha"), true);
 
-        executor.execute(job, request, RagIndexProgressListener.noop());
+        executor.execute(job, request, sourceRequest, RagIndexProgressListener.noop());
 
         verify(service).index(eq(42L), eq(command), any(RagIndexProgressListener.class));
     }

--- a/studio-platform-ai/README.md
+++ b/studio-platform-ai/README.md
@@ -41,6 +41,7 @@ RAG indexing용 chunking 계약과 구현은 `studio-platform-chunking`과 `stud
 | `RagIndexJob` / `RagIndexJobLog` | `core.rag` | RAG 색인 작업 상태와 단계별 로그 모델 |
 | `RagIndexJobRepository` / `RagIndexJobService` | `service.pipeline` | RAG 색인 작업 저장소와 실행 service 계약 |
 | `RagIndexProgressListener` | `service.pipeline` | 색인 실행 단계와 count를 job service에 전달하는 listener 계약 |
+| `RagIndexJobSourceExecutor` | `service.pipeline` | attachment 같은 source 기반 job 실행을 core 의존성 없이 연결하는 확장점 |
 | `TextCleaner` | `service.cleaning` | 색인 전 추출 텍스트 정제 계약 |
 | `KeywordExtractor` | `service.keyword` | 색인/검색 keyword 추출 계약 |
 | `PromptRenderer` | `service.prompt` | 프롬프트 렌더링 계약 |
@@ -221,6 +222,10 @@ default wrapper로 추가됐다. 구현체는 listener를 통해 `CHUNKING`, `EM
 `COMPLETED` 단계와 chunk/embedded/indexed count, warning/error log를 전달할 수 있다.
 상태(`PENDING`, `RUNNING`, `SUCCEEDED`, `WARNING`, `FAILED`, `CANCELLED`)와 단계는 별도 필드다.
 `WARNING`은 색인은 완료됐지만 경고 로그가 있는 상태로 사용한다.
+
+`RagIndexJobSourceExecutor`는 raw text가 아닌 source 기반 job을 연결하기 위한 포트다.
+예를 들어 attachment 모듈은 `sourceType=attachment` 요청을 받아 기존 attachment 색인 pipeline을 실행할 수 있다.
+ai core는 이 인터페이스만 제공하며 attachment, textract, chunking, provider, vector DB 구현에는 의존하지 않는다.
 
 ## 구현 분리 원칙
 이 모듈은 구현체를 포함하지 않는다. `ai.core`는 provider 구현과 DB 구현에 의존하지 않는 계약 계층으로 유지한다.

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/rag/RagIndexJobCreateRequest.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/rag/RagIndexJobCreateRequest.java
@@ -1,6 +1,5 @@
 package studio.one.platform.ai.core.rag;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -10,42 +9,20 @@ public record RagIndexJobCreateRequest(
         String documentId,
         String sourceType,
         boolean forceReindex,
-        RagIndexRequest indexRequest,
-        Map<String, Object> metadata,
-        List<String> keywords,
-        boolean useLlmKeywordExtraction) {
+        RagIndexRequest indexRequest) {
 
     public RagIndexJobCreateRequest {
         objectType = normalize(objectType);
         objectId = normalize(objectId);
         sourceType = normalize(sourceType);
-        metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
-        keywords = keywords == null ? List.of() : List.copyOf(keywords);
         if (indexRequest != null) {
             documentId = normalize(documentId);
             if (documentId == null) {
                 documentId = indexRequest.documentId();
             }
-            if (metadata.isEmpty()) {
-                metadata = indexRequest.metadata();
-            }
-            if (keywords.isEmpty()) {
-                keywords = indexRequest.keywords();
-            }
-            useLlmKeywordExtraction = useLlmKeywordExtraction || indexRequest.useLlmKeywordExtraction();
         } else {
             documentId = normalize(documentId);
         }
-    }
-
-    public RagIndexJobCreateRequest(
-            String objectType,
-            String objectId,
-            String documentId,
-            String sourceType,
-            boolean forceReindex,
-            RagIndexRequest indexRequest) {
-        this(objectType, objectId, documentId, sourceType, forceReindex, indexRequest, Map.of(), List.of(), false);
     }
 
     public String requiredDocumentId() {
@@ -61,10 +38,7 @@ public record RagIndexJobCreateRequest(
                 indexRequest.documentId(),
                 text(metadata.get("sourceType")),
                 false,
-                indexRequest,
-                metadata,
-                indexRequest.keywords(),
-                indexRequest.useLlmKeywordExtraction());
+                indexRequest);
     }
 
     private static String text(Object value) {

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/rag/RagIndexJobCreateRequest.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/rag/RagIndexJobCreateRequest.java
@@ -1,5 +1,6 @@
 package studio.one.platform.ai.core.rag;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -9,20 +10,42 @@ public record RagIndexJobCreateRequest(
         String documentId,
         String sourceType,
         boolean forceReindex,
-        RagIndexRequest indexRequest) {
+        RagIndexRequest indexRequest,
+        Map<String, Object> metadata,
+        List<String> keywords,
+        boolean useLlmKeywordExtraction) {
 
     public RagIndexJobCreateRequest {
         objectType = normalize(objectType);
         objectId = normalize(objectId);
         sourceType = normalize(sourceType);
+        metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+        keywords = keywords == null ? List.of() : List.copyOf(keywords);
         if (indexRequest != null) {
             documentId = normalize(documentId);
             if (documentId == null) {
                 documentId = indexRequest.documentId();
             }
+            if (metadata.isEmpty()) {
+                metadata = indexRequest.metadata();
+            }
+            if (keywords.isEmpty()) {
+                keywords = indexRequest.keywords();
+            }
+            useLlmKeywordExtraction = useLlmKeywordExtraction || indexRequest.useLlmKeywordExtraction();
         } else {
             documentId = normalize(documentId);
         }
+    }
+
+    public RagIndexJobCreateRequest(
+            String objectType,
+            String objectId,
+            String documentId,
+            String sourceType,
+            boolean forceReindex,
+            RagIndexRequest indexRequest) {
+        this(objectType, objectId, documentId, sourceType, forceReindex, indexRequest, Map.of(), List.of(), false);
     }
 
     public String requiredDocumentId() {
@@ -38,7 +61,10 @@ public record RagIndexJobCreateRequest(
                 indexRequest.documentId(),
                 text(metadata.get("sourceType")),
                 false,
-                indexRequest);
+                indexRequest,
+                metadata,
+                indexRequest.keywords(),
+                indexRequest.useLlmKeywordExtraction());
     }
 
     private static String text(Object value) {

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/rag/RagIndexJobSourceRequest.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/rag/RagIndexJobSourceRequest.java
@@ -1,0 +1,19 @@
+package studio.one.platform.ai.core.rag;
+
+import java.util.List;
+import java.util.Map;
+
+public record RagIndexJobSourceRequest(
+        Map<String, Object> metadata,
+        List<String> keywords,
+        boolean useLlmKeywordExtraction) {
+
+    public RagIndexJobSourceRequest {
+        metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+        keywords = keywords == null ? List.of() : List.copyOf(keywords);
+    }
+
+    public static RagIndexJobSourceRequest empty() {
+        return new RagIndexJobSourceRequest(Map.of(), List.of(), false);
+    }
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagIndexJobService.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagIndexJobService.java
@@ -14,6 +14,12 @@ public interface RagIndexJobService {
 
     RagIndexJob createJob(RagIndexJobCreateRequest request);
 
+    default RagIndexJob createJob(
+            RagIndexJobCreateRequest request,
+            studio.one.platform.ai.core.rag.RagIndexJobSourceRequest sourceRequest) {
+        return createJob(request);
+    }
+
     RagIndexJob startJob(String jobId);
 
     RagIndexJob retryJob(String jobId);

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagIndexJobSourceExecutor.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagIndexJobSourceExecutor.java
@@ -1,0 +1,14 @@
+package studio.one.platform.ai.service.pipeline;
+
+import studio.one.platform.ai.core.rag.RagIndexJob;
+import studio.one.platform.ai.core.rag.RagIndexJobCreateRequest;
+
+/**
+ * Executes non-text RAG index job sources without coupling ai core to source-specific modules.
+ */
+public interface RagIndexJobSourceExecutor {
+
+    boolean supports(RagIndexJobCreateRequest request);
+
+    void execute(RagIndexJob job, RagIndexJobCreateRequest request, RagIndexProgressListener listener);
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagIndexJobSourceExecutor.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagIndexJobSourceExecutor.java
@@ -2,13 +2,18 @@ package studio.one.platform.ai.service.pipeline;
 
 import studio.one.platform.ai.core.rag.RagIndexJob;
 import studio.one.platform.ai.core.rag.RagIndexJobCreateRequest;
+import studio.one.platform.ai.core.rag.RagIndexJobSourceRequest;
 
 /**
  * Executes non-text RAG index job sources without coupling ai core to source-specific modules.
  */
 public interface RagIndexJobSourceExecutor {
 
-    boolean supports(RagIndexJobCreateRequest request);
+    boolean supports(RagIndexJobCreateRequest request, RagIndexJobSourceRequest sourceRequest);
 
-    void execute(RagIndexJob job, RagIndexJobCreateRequest request, RagIndexProgressListener listener);
+    void execute(
+            RagIndexJob job,
+            RagIndexJobCreateRequest request,
+            RagIndexJobSourceRequest sourceRequest,
+            RagIndexProgressListener listener);
 }


### PR DESCRIPTION
## Why

- RAG management API에서 attachment 기반 색인 job을 생성, 추적, 재시도할 수 있어야 합니다.
- 기존 attachment `/rag/index` API의 구조화/fallback 색인 흐름을 중복 구현하지 않고 job executor에서 재사용해야 합니다.
- attachment 색인 권한 경계(`features:attachment write`)는 신규 `/api/mgmt/ai/rag/jobs` source 실행에서도 유지되어야 합니다.

## What

- `studio-platform-ai`에 `RagIndexJobSourceExecutor` 계약을 추가했습니다.
- `RagIndexJobCreateRequest`가 source 기반 실행에 필요한 `metadata`, `keywords`, `useLlmKeywordExtraction`을 보존하도록 확장하고 기존 6-arg 생성자는 유지했습니다.
- `DefaultRagIndexJobService`가 raw text job은 기존 `RagPipelineService`, source job은 등록된 executor로 실행하도록 연결했습니다.
- `content-embedding-pipeline`에 `AttachmentRagIndexService`와 `AttachmentRagIndexJobSourceExecutor`를 추가하고, 기존 attachment controller도 같은 service를 재사용하도록 정리했습니다.
- `/api/mgmt/ai/rag/jobs`에서 `sourceType=attachment` 요청을 text 없이 받을 수 있게 했고, 생성/재시도 시 `features:attachment write` 권한도 요구하도록 보강했습니다.
- README와 CHANGELOG에 attachment source job 흐름과 권한 조건을 문서화했습니다.

## Related Issues

- Closes #319

## Validation

- Command: `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test :studio-application-modules:content-embedding-pipeline:test`
- Result: PASS
- Command: `git diff --check`
- Result: PASS

## Risk / Rollback

- Risk: 신규 source executor 선택 경로가 잘못 구성되면 source 기반 job이 `FAILED`로 기록될 수 있습니다. attachment source job은 추가 권한 검사를 요구하므로 기존 raw text job보다 권한 요구가 강합니다.
- Rollback: 이 PR을 revert하면 `/rag/jobs`는 PR #318의 raw text 중심 실행으로 돌아가고, 기존 attachment `/rag/index` API는 독립 경로로 계속 사용할 수 있습니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: 대상 모듈 테스트와 `git diff --check`를 실행했고, 자체 리뷰에서 attachment source 권한 우회 가능성을 찾아 보완했습니다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
