### PR TITLE
fix(rag): attachment RAG service auto-config 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2026-04-26
 
 ### 변경됨
+- 이슈 #333 대응으로 `content-embedding-pipeline`이 `AttachmentRagIndexService`와 attachment source executor를 auto-configuration으로 등록해 attachment RAG controller 생성 시 service bean 누락이 발생하지 않도록 했다.
 - 이슈 #329/#330/#331 대응으로 RAG job JDBC repository opt-in, chunk page 조회 API, job HTTP 상태 smoke 테스트를 보강하고 job 생성/retry 권한을 write 기준으로 정리했다.
 - 이슈 #327 대응으로 AI client update guide의 RAG chat attachment-only 제약, job 조회 권한, in-memory job 404 처리, chunk 조회 limit 안내를 보완했다.
 - 이슈 #325 대응으로 AI client update guide의 RAG job 운영 화면 API 목록과 polling/retry/cancel 흐름을 최신화했다.

--- a/studio-application-modules/content-embedding-pipeline/README.md
+++ b/studio-application-modules/content-embedding-pipeline/README.md
@@ -71,8 +71,10 @@ RAG 색인은 `TextractNormalizedDocumentAdapter`, `ChunkingOrchestrator`, `Embe
 
 컨트롤러는 `studio.features.attachment.web.mgmt-base-path`(기본 `/api/mgmt/attachments`) 경로에 등록된다.
 따라서 attachment-service의 `web.enabled=true`와 `mgmt-base-path` 설정을 공유한다.
-`content-embedding-pipeline`은 application module이므로 컨트롤러와 구조화 색인 컴포넌트는 애플리케이션의
-component scan 범위에 포함되어야 등록된다.
+`content-embedding-pipeline`은 auto-configuration으로 `AttachmentRagIndexService`,
+`AttachmentRagIndexJobSourceExecutor`, 기본 구조화 색인 adapter를 등록한다.
+컨트롤러는 attachment web endpoint 설정과 같은 base path를 사용하며, 기존 attachment endpoint component scan
+또는 애플리케이션 component scan으로 등록된다.
 
 | 메서드 | 경로 | 설명 | 권한 |
 |--------|------|------|------|

--- a/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/autoconfigure/ContentEmbeddingPipelineAutoConfiguration.java
+++ b/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/autoconfigure/ContentEmbeddingPipelineAutoConfiguration.java
@@ -1,0 +1,68 @@
+package studio.one.application.web.autoconfigure;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+import studio.one.application.attachment.service.AttachmentService;
+import studio.one.application.web.service.AttachmentRagIndexJobSourceExecutor;
+import studio.one.application.web.service.AttachmentRagIndexService;
+import studio.one.application.web.service.AttachmentStructuredRagIndexer;
+import studio.one.application.web.service.DefaultAttachmentStructuredRagIndexer;
+import studio.one.platform.ai.core.embedding.EmbeddingPort;
+import studio.one.platform.ai.core.vector.VectorStorePort;
+import studio.one.platform.ai.service.pipeline.RagPipelineService;
+import studio.one.platform.chunking.core.ChunkingOrchestrator;
+import studio.one.platform.chunking.service.TextractNormalizedDocumentAdapter;
+import studio.one.platform.textract.service.FileContentExtractionService;
+
+@AutoConfiguration
+@AutoConfigureAfter(name = "studio.one.application.attachment.autoconfigure.AttachmentAutoConfiguration")
+@ConditionalOnClass({AttachmentService.class, RagPipelineService.class})
+@ConditionalOnBean(AttachmentService.class)
+public class ContentEmbeddingPipelineAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    AttachmentRagIndexService attachmentRagIndexService(
+            AttachmentService attachmentService,
+            ObjectProvider<FileContentExtractionService> textExtractionProvider,
+            ObjectProvider<RagPipelineService> ragPipelineProvider,
+            ObjectProvider<AttachmentStructuredRagIndexer> structuredRagIndexerProvider) {
+        return new AttachmentRagIndexService(
+                attachmentService,
+                textExtractionProvider,
+                ragPipelineProvider,
+                structuredRagIndexerProvider);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    AttachmentRagIndexJobSourceExecutor attachmentRagIndexJobSourceExecutor(
+            AttachmentRagIndexService ragIndexService) {
+        return new AttachmentRagIndexJobSourceExecutor(ragIndexService);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(AttachmentStructuredRagIndexer.class)
+    @ConditionalOnClass(name = {
+            "studio.one.platform.chunking.core.ChunkingOrchestrator",
+            "studio.one.platform.chunking.service.TextractNormalizedDocumentAdapter",
+            "studio.one.platform.textract.model.ParsedFile"
+    })
+    DefaultAttachmentStructuredRagIndexer defaultAttachmentStructuredRagIndexer(
+            ObjectProvider<TextractNormalizedDocumentAdapter> normalizedDocumentAdapterProvider,
+            ObjectProvider<ChunkingOrchestrator> chunkingOrchestratorProvider,
+            ObjectProvider<EmbeddingPort> embeddingPortProvider,
+            ObjectProvider<VectorStorePort> vectorStoreProvider) {
+        return new DefaultAttachmentStructuredRagIndexer(
+                normalizedDocumentAdapterProvider,
+                chunkingOrchestratorProvider,
+                embeddingPortProvider,
+                vectorStoreProvider);
+    }
+}

--- a/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/autoconfigure/ContentEmbeddingPipelineAutoConfiguration.java
+++ b/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/autoconfigure/ContentEmbeddingPipelineAutoConfiguration.java
@@ -7,23 +7,21 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 import studio.one.application.attachment.service.AttachmentService;
 import studio.one.application.web.service.AttachmentRagIndexJobSourceExecutor;
 import studio.one.application.web.service.AttachmentRagIndexService;
 import studio.one.application.web.service.AttachmentStructuredRagIndexer;
-import studio.one.application.web.service.DefaultAttachmentStructuredRagIndexer;
-import studio.one.platform.ai.core.embedding.EmbeddingPort;
-import studio.one.platform.ai.core.vector.VectorStorePort;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
-import studio.one.platform.chunking.core.ChunkingOrchestrator;
-import studio.one.platform.chunking.service.TextractNormalizedDocumentAdapter;
 import studio.one.platform.textract.service.FileContentExtractionService;
 
 @AutoConfiguration
 @AutoConfigureAfter(name = "studio.one.application.attachment.autoconfigure.AttachmentAutoConfiguration")
 @ConditionalOnClass({AttachmentService.class, RagPipelineService.class})
 @ConditionalOnBean(AttachmentService.class)
+@Import(ContentEmbeddingPipelineStructuredRagAutoConfiguration.class)
 public class ContentEmbeddingPipelineAutoConfiguration {
 
     @Bean
@@ -47,19 +45,25 @@ public class ContentEmbeddingPipelineAutoConfiguration {
         return new AttachmentRagIndexJobSourceExecutor(ragIndexService);
     }
 
+}
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(name = {
+        "studio.one.platform.chunking.core.ChunkingOrchestrator",
+        "studio.one.platform.chunking.service.TextractNormalizedDocumentAdapter",
+        "studio.one.platform.textract.model.ParsedFile"
+})
+class ContentEmbeddingPipelineStructuredRagAutoConfiguration {
+
     @Bean
     @ConditionalOnMissingBean(AttachmentStructuredRagIndexer.class)
-    @ConditionalOnClass(name = {
-            "studio.one.platform.chunking.core.ChunkingOrchestrator",
-            "studio.one.platform.chunking.service.TextractNormalizedDocumentAdapter",
-            "studio.one.platform.textract.model.ParsedFile"
-    })
-    DefaultAttachmentStructuredRagIndexer defaultAttachmentStructuredRagIndexer(
-            ObjectProvider<TextractNormalizedDocumentAdapter> normalizedDocumentAdapterProvider,
-            ObjectProvider<ChunkingOrchestrator> chunkingOrchestratorProvider,
-            ObjectProvider<EmbeddingPort> embeddingPortProvider,
-            ObjectProvider<VectorStorePort> vectorStoreProvider) {
-        return new DefaultAttachmentStructuredRagIndexer(
+    studio.one.application.web.service.DefaultAttachmentStructuredRagIndexer defaultAttachmentStructuredRagIndexer(
+            ObjectProvider<studio.one.platform.chunking.service.TextractNormalizedDocumentAdapter>
+                    normalizedDocumentAdapterProvider,
+            ObjectProvider<studio.one.platform.chunking.core.ChunkingOrchestrator> chunkingOrchestratorProvider,
+            ObjectProvider<studio.one.platform.ai.core.embedding.EmbeddingPort> embeddingPortProvider,
+            ObjectProvider<studio.one.platform.ai.core.vector.VectorStorePort> vectorStoreProvider) {
+        return new studio.one.application.web.service.DefaultAttachmentStructuredRagIndexer(
                 normalizedDocumentAdapterProvider,
                 chunkingOrchestratorProvider,
                 embeddingPortProvider,

--- a/studio-application-modules/content-embedding-pipeline/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/studio-application-modules/content-embedding-pipeline/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+studio.one.application.web.autoconfigure.ContentEmbeddingPipelineAutoConfiguration

--- a/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/autoconfigure/ContentEmbeddingPipelineAutoConfigurationTest.java
+++ b/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/autoconfigure/ContentEmbeddingPipelineAutoConfigurationTest.java
@@ -5,11 +5,14 @@ import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import studio.one.application.attachment.service.AttachmentService;
 import studio.one.application.web.service.AttachmentRagIndexJobSourceExecutor;
 import studio.one.application.web.service.AttachmentRagIndexService;
+import studio.one.application.web.service.AttachmentStructuredRagIndexer;
+import studio.one.application.web.service.DefaultAttachmentStructuredRagIndexer;
 
 class ContentEmbeddingPipelineAutoConfigurationTest {
 
@@ -24,6 +27,62 @@ class ContentEmbeddingPipelineAutoConfigurationTest {
                     assertThat(context).hasNotFailed();
                     assertThat(context).hasSingleBean(AttachmentRagIndexService.class);
                     assertThat(context).hasSingleBean(AttachmentRagIndexJobSourceExecutor.class);
+                });
+    }
+
+    @Test
+    void backsOffWhenUserDefinedAttachmentRagIndexServiceExists() {
+        AttachmentRagIndexService userService = mock(AttachmentRagIndexService.class);
+
+        contextRunner
+                .withBean(AttachmentService.class, () -> mock(AttachmentService.class))
+                .withBean(AttachmentRagIndexService.class, () -> userService)
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).hasSingleBean(AttachmentRagIndexService.class);
+                    assertThat(context.getBean(AttachmentRagIndexService.class)).isSameAs(userService);
+                });
+    }
+
+    @Test
+    void backsOffWhenUserDefinedAttachmentRagIndexJobSourceExecutorExists() {
+        AttachmentRagIndexJobSourceExecutor userExecutor = mock(AttachmentRagIndexJobSourceExecutor.class);
+
+        contextRunner
+                .withBean(AttachmentService.class, () -> mock(AttachmentService.class))
+                .withBean(AttachmentRagIndexJobSourceExecutor.class, () -> userExecutor)
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).hasSingleBean(AttachmentRagIndexJobSourceExecutor.class);
+                    assertThat(context.getBean(AttachmentRagIndexJobSourceExecutor.class)).isSameAs(userExecutor);
+                });
+    }
+
+    @Test
+    void backsOffWhenUserDefinedStructuredRagIndexerExists() {
+        AttachmentStructuredRagIndexer userIndexer = mock(AttachmentStructuredRagIndexer.class);
+
+        contextRunner
+                .withBean(AttachmentService.class, () -> mock(AttachmentService.class))
+                .withBean(AttachmentStructuredRagIndexer.class, () -> userIndexer)
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).hasSingleBean(AttachmentStructuredRagIndexer.class);
+                    assertThat(context.getBean(AttachmentStructuredRagIndexer.class)).isSameAs(userIndexer);
+                    assertThat(context).doesNotHaveBean(DefaultAttachmentStructuredRagIndexer.class);
+                });
+    }
+
+    @Test
+    void skipsStructuredRagIndexerWhenChunkingIsNotAvailable() {
+        contextRunner
+                .withClassLoader(new FilteredClassLoader("studio.one.platform.chunking"))
+                .withBean(AttachmentService.class, () -> mock(AttachmentService.class))
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).hasSingleBean(AttachmentRagIndexService.class);
+                    assertThat(context).doesNotHaveBean(AttachmentStructuredRagIndexer.class);
+                    assertThat(context).doesNotHaveBean(DefaultAttachmentStructuredRagIndexer.class);
                 });
     }
 

--- a/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/autoconfigure/ContentEmbeddingPipelineAutoConfigurationTest.java
+++ b/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/autoconfigure/ContentEmbeddingPipelineAutoConfigurationTest.java
@@ -1,0 +1,38 @@
+package studio.one.application.web.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import studio.one.application.attachment.service.AttachmentService;
+import studio.one.application.web.service.AttachmentRagIndexJobSourceExecutor;
+import studio.one.application.web.service.AttachmentRagIndexService;
+
+class ContentEmbeddingPipelineAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(ContentEmbeddingPipelineAutoConfiguration.class));
+
+    @Test
+    void registersAttachmentRagIndexServicesWhenAttachmentServiceExists() {
+        contextRunner
+                .withBean(AttachmentService.class, () -> mock(AttachmentService.class))
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).hasSingleBean(AttachmentRagIndexService.class);
+                    assertThat(context).hasSingleBean(AttachmentRagIndexJobSourceExecutor.class);
+                });
+    }
+
+    @Test
+    void backsOffWhenAttachmentServiceIsMissing() {
+        contextRunner.run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).doesNotHaveBean(AttachmentRagIndexService.class);
+            assertThat(context).doesNotHaveBean(AttachmentRagIndexJobSourceExecutor.class);
+        });
+    }
+}


### PR DESCRIPTION
## Why

`content-embedding-pipeline` 의존성 추가 시 attachment endpoint component scan이 `AttachmentEmbeddingPipelineController`를 등록하지만 sibling package인 `studio.one.application.web.service`는 스캔하지 않아 `AttachmentRagIndexService` bean 누락으로 애플리케이션 컨텍스트가 실패할 수 있다.

## What

- `ContentEmbeddingPipelineAutoConfiguration`을 추가해 `AttachmentService`가 있을 때 attachment RAG service, source executor, 기본 structured indexer를 조건부 등록한다.
- Spring Boot `AutoConfiguration.imports`에 등록했다.
- auto-configuration 회귀 테스트를 추가하고 README/CHANGELOG를 갱신했다.

## Related Issues

- Closes #333

## Validation

- Command: `./gradlew :studio-application-modules:content-embedding-pipeline:test`
- Result: PASS
- Command: `git diff --check`
- Result: PASS

## Risk / Rollback

- Risk: `AttachmentService`가 있는 애플리케이션에서 attachment RAG 관련 bean이 자동 등록된다. 기존 사용자 정의 bean은 `@ConditionalOnMissingBean`으로 우선된다.
- Rollback: 이 커밋을 revert하면 기존 component scan 기반 동작으로 돌아간다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: content-embedding-pipeline 모듈 테스트와 diff check를 실행했다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included