### PR TITLE
[ai-assisted] docs(rag): embedding profile 운영 가이드 추가

### DIFF
--- a/docs/dev/ai-client-update-guide.md
+++ b/docs/dev/ai-client-update-guide.md
@@ -22,6 +22,7 @@
 | 벡터 검색 응답 | grid key는 `id`를 우선 사용하고, 기존 `documentId`도 호환 처리 |
 | 오류 처리 | 현재 명시적으로 매핑된 provider quota/rate limit만 HTTP 429 `ProblemDetails`로 처리 |
 | RAG diagnostics | 서버와 요청이 모두 허용할 때만 `metadata.ragDiagnostics`, `metadata.ragContextDiagnostics` 표시 |
+| RAG embedding profile | 색인/검색/채팅 RAG 요청에서 `embeddingProfileId`를 같은 값으로 유지 |
 
 ## API 경로 변경
 
@@ -88,6 +89,11 @@ job 조회 권한은 별도이므로 job 화면 연결은 `services:ai_rag read`
   "useLlmKeywordExtraction": false
 }
 ```
+
+RAG embedding profile을 선택하는 운영 화면은 색인과 검색/채팅에 같은 `embeddingProfileId`를 보낸다.
+`chat.provider`와 `chat.model`은 답변 생성 모델 선택이고, `embeddingProfileId`, `embeddingProvider`,
+`embeddingModel`은 retrieval embedding 선택이다. 설정 책임과 provider별 예시는
+[`RAG embedding profile 운영 가이드`](rag-embedding-profile-ops.md)를 따른다.
 
 운영 화면은 아래 순서로 동작한다.
 

--- a/docs/dev/rag-embedding-profile-ops.md
+++ b/docs/dev/rag-embedding-profile-ops.md
@@ -1,0 +1,171 @@
+# RAG embedding profile 운영 가이드
+
+이 문서는 RAG 색인/검색에서 embedding provider, model, profile을 선택할 때의 운영 기준을 정리한다.
+서버 런타임 설정은 Spring AI가 소유하고, Studio 설정은 RAG orchestration과 선택 정책을 소유한다.
+
+## 설정 책임
+
+| 영역 | Canonical source | 설명 |
+|---|---|---|
+| API key / base-url | `spring.ai.*` | provider SDK 접속 설정이다. |
+| chat model | `spring.ai.<provider>.chat.options.model` | 실제 chat provider 호출 model이다. |
+| embedding model / dimension | `spring.ai.<provider>.embedding.*` | 실제 embedding provider 호출 model과 dimension이다. |
+| provider enable / default provider | `studio.ai.providers.*`, `studio.ai.default-provider` | Studio가 사용할 provider id와 기본 provider 선택이다. |
+| RAG embedding profile | `studio.ai.rag.embedding-profiles.*` | RAG 요청에서 선택할 profile id와 metadata/filter 기준이다. |
+
+`studio.ai.providers.<id>.chat.model`과 `studio.ai.providers.<id>.embedding.model`은 legacy/fallback 성격이다.
+Spring AI provider를 쓰는 운영 환경에서는 가능하면 `spring.ai.*`만 runtime model source로 사용한다.
+
+## 기본 예시
+
+Google Gemini embedding을 RAG 기본 profile로 사용하는 예시다.
+
+```yaml
+studio:
+  ai:
+    enabled: true
+    default-provider: gemini
+    providers:
+      gemini:
+        type: GOOGLE_AI_GEMINI
+        enabled: true
+        chat:
+          enabled: true
+        embedding:
+          enabled: true
+        google-embedding:
+          task-type: RETRIEVAL_DOCUMENT
+    rag:
+      default-embedding-profile: retrieval-ko
+      embedding-profiles:
+        retrieval-ko:
+          provider: gemini
+          model: gemini-embedding-001
+          dimension: 768
+          supported-input-types: [TEXT, TABLE_TEXT, IMAGE_CAPTION, OCR_TEXT]
+
+spring:
+  ai:
+    google:
+      genai:
+        chat:
+          api-key: ${GOOGLE_AI_API_KEY}
+          options:
+            model: gemini-2.5-flash
+        embedding:
+          api-key: ${GOOGLE_AI_API_KEY}
+          text:
+            options:
+              model: gemini-embedding-001
+              dimensions: 768
+```
+
+OpenAI embedding을 사용할 때는 `spring.ai.openai.embedding.options.model`을 실제 embedding model source로 둔다.
+
+```yaml
+studio:
+  ai:
+    default-provider: openai
+    providers:
+      openai:
+        type: OPENAI
+        enabled: true
+        chat:
+          enabled: true
+        embedding:
+          enabled: true
+    rag:
+      default-embedding-profile: openai-small
+      embedding-profiles:
+        openai-small:
+          provider: openai
+          model: text-embedding-3-small
+          dimension: 1536
+
+spring:
+  ai:
+    openai:
+      api-key: ${OPENAI_API_KEY}
+      chat:
+        options:
+          model: gpt-4o-mini
+      embedding:
+        options:
+          model: text-embedding-3-small
+```
+
+## 선택 우선순위
+
+RAG 색인/검색 요청의 embedding 선택은 다음 순서로 처리한다.
+
+1. 요청의 `embeddingProfileId`
+2. 요청의 `embeddingProvider` / `embeddingModel`
+3. `studio.ai.rag.default-embedding-profile`
+4. 기본 `EmbeddingPort`
+
+`embeddingProfileId`와 `embeddingProvider`/`embeddingModel`을 동시에 보내는 요청은 혼합 해석을 막기 위해 거부한다.
+요청에서 provider/model만 지정하면 default profile의 model/dimension을 섞어 쓰지 않는다.
+
+Spring AI adapter는 등록 시점의 `EmbeddingModel` 하나를 호출한다. 따라서 profile/request의 `embeddingModel`은
+실제 `spring.ai.*` embedding model 설정과 일치해야 한다. 다른 model을 요청하면 metadata만 다른 vector space로
+저장되는 것을 막기 위해 실패한다.
+
+## API 요청 필드
+
+다음 API는 기존 request body를 유지하면서 optional embedding 선택 필드를 받는다.
+
+| API | 필드 |
+|---|---|
+| `POST /api/mgmt/ai/rag/index` | `embeddingProfileId`, `embeddingProvider`, `embeddingModel` |
+| `POST /api/mgmt/ai/rag/search` | `embeddingProfileId`, `embeddingProvider`, `embeddingModel` |
+| `POST /api/mgmt/ai/rag/jobs` | `embeddingProfileId`, `embeddingProvider`, `embeddingModel` |
+| `POST /api/ai/chat/rag` | `embeddingProfileId`, `embeddingProvider`, `embeddingModel` |
+| `POST /api/mgmt/attachments/{attachmentId}/rag/index` | `embeddingProfileId`, `embeddingProvider`, `embeddingModel` |
+| `POST /api/mgmt/attachments/rag/search` | `embeddingProfileId`, `embeddingProvider`, `embeddingModel` |
+| `POST /api/mgmt/ai/vectors/search` | `embeddingProfileId`, `embeddingProvider`, `embeddingModel` |
+
+`/api/ai/chat/rag`에서 `chat.provider`와 `chat.model`은 답변 생성 model 선택이고,
+`embeddingProfileId`/`embeddingProvider`/`embeddingModel`은 retrieval embedding 선택이다.
+
+## Metadata와 검색 범위
+
+새로 색인되는 `VectorRecord`에는 가능한 범위에서 아래 metadata가 기록된다.
+
+- `embeddingProvider`
+- `embeddingModel`
+- `embeddingDimension`
+- `embeddingProfileId`
+- `embeddingInputType`
+
+검색 요청에 embedding 선택 필드가 명시되면 같은 metadata 기준이 `VectorSearchRequest.metadataFilter()`에 추가된다.
+반대로 minimal legacy 검색 요청에는 기존 chunk와의 호환성을 위해 default profile metadata filter를 강제로 붙이지 않는다.
+
+## 구조화 chunk input type
+
+textract/chunking 기반 structured RAG 색인은 chunk type을 embedding input type metadata로 보존한다.
+
+| chunk | embedding input type |
+|---|---|
+| 일반 텍스트 | `TEXT` |
+| table text | `TABLE_TEXT` |
+| image caption | `IMAGE_CAPTION` |
+| OCR text | `OCR_TEXT` |
+
+현재 범위는 image bytes/URI embedding이 아니라 caption, alt text, OCR text 같은 텍스트 embedding이다.
+provider-specific multimodal embedding은 별도 adapter/starter에서 다룬다.
+
+## 운영 화면 권장 흐름
+
+1. 설정 화면에서 `/api/ai/info/providers`로 활성 provider를 표시한다.
+2. RAG 색인 화면은 대상별 기본 `embeddingProfileId`를 선택하거나 서버 default profile을 사용한다.
+3. `POST /api/mgmt/ai/rag/jobs` 또는 attachment RAG index API에 profile field를 포함해 색인을 요청한다.
+4. `X-RAG-Job-Id` 또는 job create response로 job 상태를 polling한다.
+5. 색인 완료 후 object metadata/chunk API에서 `embeddingProfileId`, `embeddingModel`, `embeddingInputType`을 확인한다.
+6. RAG 검색/채팅 화면은 색인에 사용한 profile과 같은 `embeddingProfileId`를 보낸다.
+
+## 운영 주의사항
+
+- 같은 provider에서 여러 embedding model을 동시에 쓰려면 서로 다른 `EmbeddingPort`가 실제로 등록되어야 한다.
+- profile metadata가 없는 legacy chunk는 explicit profile 검색에서 제외될 수 있다.
+- legacy chunk까지 검색해야 하는 화면은 embedding 선택 필드를 비워 minimal legacy 검색으로 호출한다.
+- profile 기반 운영으로 전환할 때는 object scope 단위 재색인을 먼저 수행한다.

--- a/docs/dev/rag-embedding-profile-ops.md
+++ b/docs/dev/rag-embedding-profile-ops.md
@@ -1,20 +1,23 @@
 # RAG embedding profile 운영 가이드
 
 이 문서는 RAG 색인/검색에서 embedding provider, model, profile을 선택할 때의 운영 기준을 정리한다.
-서버 런타임 설정은 Spring AI가 소유하고, Studio 설정은 RAG orchestration과 선택 정책을 소유한다.
+서버 런타임 설정은 Spring AI와 provider별 Studio adapter 설정이 함께 담당하고, Studio RAG 설정은
+orchestration과 선택 정책을 소유한다.
 
 ## 설정 책임
 
 | 영역 | Canonical source | 설명 |
 |---|---|---|
-| API key / base-url | `spring.ai.*` | provider SDK 접속 설정이다. |
-| chat model | `spring.ai.<provider>.chat.options.model` | 실제 chat provider 호출 model이다. |
-| embedding model / dimension | `spring.ai.<provider>.embedding.*` | 실제 embedding provider 호출 model과 dimension이다. |
+| API key / base-url | `spring.ai.*`, provider별 `studio.ai.providers.<id>.*` fallback | provider SDK 접속 설정이다. Google Gemini chat은 `studio.ai.providers.<id>.api-key`와 `base-url` fallback도 사용한다. |
+| chat model | `spring.ai.<provider>.chat.options.model`, provider별 chat model fallback | 실제 chat provider 호출 model이다. Google Gemini chat은 `studio.ai.providers.<id>.chat.model` fallback을 지원한다. |
+| embedding runtime model | `spring.ai.<provider>.embedding.*` | 현재 embedding provider 호출 model source다. OpenAI, Google Gemini, Ollama embedding은 Spring AI embedding model 설정이 필요하다. |
+| RAG embedding dimension/filter | `studio.ai.rag.embedding-profiles.*.dimension` | explicit profile 검색과 Vector metadata filter에 쓰는 RAG 기준값이다. 실제 provider dimension 설정과 일치해야 한다. |
 | provider enable / default provider | `studio.ai.providers.*`, `studio.ai.default-provider` | Studio가 사용할 provider id와 기본 provider 선택이다. |
 | RAG embedding profile | `studio.ai.rag.embedding-profiles.*` | RAG 요청에서 선택할 profile id와 metadata/filter 기준이다. |
 
-`studio.ai.providers.<id>.chat.model`과 `studio.ai.providers.<id>.embedding.model`은 legacy/fallback 성격이다.
-Spring AI provider를 쓰는 운영 환경에서는 가능하면 `spring.ai.*`만 runtime model source로 사용한다.
+`studio.ai.providers.<id>.embedding.model`은 현재 runtime embedding model fallback으로 쓰지 않는다.
+Spring AI provider를 쓰는 embedding 운영 환경에서는 `spring.ai.*.embedding.*`과
+`studio.ai.rag.embedding-profiles.*`의 model/dimension 값을 같이 맞춘다.
 
 ## 기본 예시
 
@@ -156,7 +159,7 @@ provider-specific multimodal embedding은 별도 adapter/starter에서 다룬다
 
 ## 운영 화면 권장 흐름
 
-1. 설정 화면에서 `/api/ai/info/providers`로 활성 provider를 표시한다.
+1. 설정 화면에서 `/api/ai/info/providers`로 configured provider와 channel enabled 상태를 표시한다.
 2. RAG 색인 화면은 대상별 기본 `embeddingProfileId`를 선택하거나 서버 default profile을 사용한다.
 3. `POST /api/mgmt/ai/rag/jobs` 또는 attachment RAG index API에 profile field를 포함해 색인을 요청한다.
 4. `X-RAG-Job-Id` 또는 job create response로 job 상태를 polling한다.
@@ -166,6 +169,7 @@ provider-specific multimodal embedding은 별도 adapter/starter에서 다룬다
 ## 운영 주의사항
 
 - 같은 provider에서 여러 embedding model을 동시에 쓰려면 서로 다른 `EmbeddingPort`가 실제로 등록되어야 한다.
+  provider type별 제약이 있으며, 현재 `OPENAI` provider type은 enabled provider를 하나만 허용한다.
 - profile metadata가 없는 legacy chunk는 explicit profile 검색에서 제외될 수 있다.
 - legacy chunk까지 검색해야 하는 화면은 embedding 선택 필드를 비워 minimal legacy 검색으로 호출한다.
 - profile 기반 운영으로 전환할 때는 object scope 단위 재색인을 먼저 수행한다.

--- a/docs/dev/spring-ai-openai.md
+++ b/docs/dev/spring-ai-openai.md
@@ -48,11 +48,18 @@ spring:
   - `studio.ai.enabled`
   - `studio.ai.default-provider`
   - `studio.ai.endpoints.*`
+- RAG embedding profile:
+  - `studio.ai.rag.default-embedding-profile`
+  - `studio.ai.rag.embedding-profiles.*`
 - OpenAI runtime config:
   - `spring.ai.openai.api-key`
   - `spring.ai.openai.base-url`
   - `spring.ai.openai.chat.options.*`
   - `spring.ai.openai.embedding.options.*`
+
+`studio.ai.rag.embedding-profiles.*.model`은 RAG metadata/filter 계약에 쓰는 이름이며,
+실제 OpenAI embedding 호출 model은 `spring.ai.openai.embedding.options.model`과 일치해야 한다.
+전체 운영 기준은 [`RAG embedding profile 운영 가이드`](rag-embedding-profile-ops.md)를 참고한다.
 
 ## deprecated / removed
 

--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -164,6 +164,8 @@ Chunk 조회 API는 기존 list 응답 호환을 유지한다. `/chunks`는 `lim
 RAG 색인/검색 계열 요청은 기존 body를 유지하면서 `embeddingProfileId`, `embeddingProvider`,
 `embeddingModel` optional field를 받을 수 있다. 이 필드는 retrieval embedding 선택용이며,
 chat request의 `provider`/`model`은 답변 생성 모델 선택용이다.
+서버 설정과 운영 화면 적용 기준은
+[`RAG embedding profile 운영 가이드`](../../docs/dev/rag-embedding-profile-ops.md)를 따른다.
 
 ### 채팅 요청 예시
 

--- a/starter/studio-platform-starter-ai/README.md
+++ b/starter/studio-platform-starter-ai/README.md
@@ -86,6 +86,8 @@ Spring AI adapter는 등록 시점의 `EmbeddingModel`을 사용하므로, profi
 embedding model 설정과 일치해야 한다. 다른 model이 들어오면 metadata만 다른 vector space로 기록되는 것을 막기 위해
 요청을 거부한다. 여러 embedding model을 동시에 쓰려면 provider id/profile을 분리해 각각 다른 `EmbeddingPort`로
 등록하는 adapter 구성이 필요하다.
+운영 설정 기준과 API 요청 흐름은
+[`RAG embedding profile 운영 가이드`](../../docs/dev/rag-embedding-profile-ops.md)를 따른다.
 
 ```yaml
 studio:


### PR DESCRIPTION
## Why

- RAG embedding profile 도입 후 `spring.ai.*`와 `studio.ai.rag.*` 설정 책임이 함께 존재합니다.
- 운영 화면과 서버 설정에서 embedding profile, provider, model 선택 기준을 한 곳에서 확인할 수 있어야 합니다.

## What

- `docs/dev/rag-embedding-profile-ops.md` 운영 가이드를 추가했습니다.
- `starter-ai`, `starter-ai-web`, `docs/dev/spring-ai-openai.md`, `docs/dev/ai-client-update-guide.md`에서 새 가이드를 연결했습니다.
- 색인/검색/채팅 RAG의 `embeddingProfileId` 사용 흐름과 legacy 검색 호환 기준을 정리했습니다.

## Related Issues

- Closes #338

## Validation

- Command: `git diff --check`
- Result: PASS
- Command: 문서 diff review
- Result: PASS

## Risk / Rollback

- Risk: 문서 변경만 포함하므로 런타임 영향은 없습니다.
- Rollback: 이 PR을 revert하면 기존 문서 상태로 돌아갑니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope:
- Main author validation: 문서 diff와 `git diff --check` 확인

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
