### PR TITLE
feat(rag): Chunk Preview 관리 API 추가

### DIFF
--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -94,6 +94,8 @@ studio:
 | `GET` | `{mgmtBasePath}/rag/objects/{objectType}/{objectId}/chunks` | object scope 기준 chunk 조회 | `services:ai_rag read` |
 | `GET` | `{mgmtBasePath}/rag/objects/{objectType}/{objectId}/chunks/page` | object scope 기준 chunk 페이지 조회 | `services:ai_rag read` |
 | `GET` | `{mgmtBasePath}/rag/objects/{objectType}/{objectId}/metadata` | object scope 기준 RAG metadata 조회 | `services:ai_rag read` |
+| `POST` | `{mgmtBasePath}/rag/chunks/preview` | 색인 전 text chunk preview | `services:ai_rag read` |
+| `GET` | `{mgmtBasePath}/rag/chunks/config` | chunk/RAG 설정 조회 | `services:ai_rag read` |
 
 > `studio.ai.endpoints.enabled=false`이면 위 AI web endpoint 전체가 등록되지 않는다.
 
@@ -170,6 +172,58 @@ chat request의 `provider`/`model`은 답변 생성 모델 선택용이다.
 [`RAG embedding profile 운영 가이드`](../../docs/dev/rag-embedding-profile-ops.md)를 따른다.
 기존 chunk를 profile 기반 metadata로 재색인하는 운영 절차는
 [`Legacy RAG chunk metadata 재색인 가이드`](../../docs/dev/rag-legacy-chunk-migration.md)를 따른다.
+
+### Chunk Preview / Config
+
+운영 화면은 `POST {mgmtBasePath}/rag/chunks/preview`로 색인 전에 text chunk 결과를 확인할 수 있다.
+이 API는 embedding 생성, vector upsert, job 생성을 하지 않고 현재 등록된 `ChunkingOrchestrator`만 호출한다.
+`ChunkingOrchestrator`가 없으면 `503 Service Unavailable`을 반환한다.
+
+```http
+POST /api/mgmt/ai/rag/chunks/preview
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "text": "첫 번째 문단입니다.\n\n두 번째 문단입니다.",
+  "documentId": "preview-doc",
+  "objectType": "attachment",
+  "objectId": "101",
+  "strategy": "recursive",
+  "maxSize": 800,
+  "overlap": 100,
+  "metadata": {
+    "category": "manual"
+  }
+}
+```
+
+`strategy`, `maxSize`, `overlap`, `unit`을 생략하면 실제 신규 chunking 경로와 같은
+`studio.chunking.*` configured default를 사용한다. 지원 preview 전략은 `fixed-size`, `recursive`,
+`structure-based`이며, text-only `structure-based` 요청은 starter-chunking의 text fallback 동작을 따른다.
+`semantic`, `llm-based`는 AI-linked 전략 후보라 이 preview API에서 실행하지 않는다.
+
+preview 안전장치는 `studio.ai.endpoints.rag.chunk-preview.*`로 조정한다. 이 설정은 운영 화면 API limit만
+제어하며 실제 색인 chunk 크기와 overlap은 계속 `studio.chunking.*`로 조정한다.
+
+```yaml
+studio:
+  ai:
+    endpoints:
+      rag:
+        chunk-preview:
+          enabled: true
+          max-input-chars: 200000
+          max-preview-chunks: 500
+```
+
+`GET {mgmtBasePath}/rag/chunks/config`는 비밀 없는 운영 안전값만 반환한다. 응답에는
+chunking availability, `studio.chunking.*` 값, 등록된 chunker 이름, deprecated legacy fallback
+`studio.ai.pipeline.chunk-size/chunk-overlap`, RAG context/expansion 설정, preview limit이 포함된다.
+API key, raw environment 값, provider secret은 노출하지 않는다.
+
+Attachment 파일을 직접 읽어 `parseStructured` 결과를 preview하는 기능과 `NormalizedDocument` JSON preview는
+후속 PR 범위이다. 현재 attachment RAG 색인은 기존 attachment RAG index/job API를 사용한다.
 
 ### 채팅 요청 예시
 

--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -218,9 +218,13 @@ studio:
 ```
 
 `GET {mgmtBasePath}/rag/chunks/config`는 비밀 없는 운영 안전값만 반환한다. 응답에는
-chunking availability, `studio.chunking.*` 값, 등록된 chunker 이름, deprecated legacy fallback
+chunking availability, `studio.chunking.*` 값, preview에서 사용할 수 있는 기본 전략 여부(`previewStrategy`,
+`defaultStrategyPreviewSupported`), 등록된 chunker 이름, deprecated legacy fallback
 `studio.ai.pipeline.chunk-size/chunk-overlap`, RAG context/expansion 설정, preview limit이 포함된다.
 API key, raw environment 값, provider secret은 노출하지 않는다.
+`studio.chunking.strategy`가 `semantic` 또는 `llm-based`처럼 preview에서 실행하지 않는 전략이면
+config API는 원래 설정값을 `strategy`로 보여주되 `defaultStrategyPreviewSupported=false`를 반환하고,
+preview 요청에서 `strategy`를 생략하면 `400 Bad Request`가 반환된다.
 
 Attachment 파일을 직접 읽어 `parseStructured` 결과를 preview하는 기능과 `NormalizedDocument` JSON preview는
 후속 PR 범위이다. 현재 attachment RAG 색인은 기존 attachment RAG index/job API를 사용한다.

--- a/starter/studio-platform-starter-ai-web/build.gradle.kts
+++ b/starter/studio-platform-starter-ai-web/build.gradle.kts
@@ -32,5 +32,6 @@ dependencies {
     testImplementation("org.springframework.ai:spring-ai-starter-model-openai")
     testImplementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation("org.springframework.boot:spring-boot-starter-security")
+    testImplementation("org.springframework.boot:spring-boot-starter-validation")
     testImplementation(project(":studio-platform"))
 }

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
@@ -24,6 +24,7 @@ import studio.one.platform.ai.autoconfigure.config.RagPipelineProperties;
 import studio.one.platform.ai.core.chat.ChatMemoryStore;
 import studio.one.platform.ai.core.chat.ChatPort;
 import studio.one.platform.ai.core.chat.ConversationRepositoryPort;
+import studio.one.platform.ai.core.chunk.TextChunker;
 import studio.one.platform.ai.core.embedding.EmbeddingPort;
 import studio.one.platform.ai.core.registry.AiProviderRegistry;
 import studio.one.platform.ai.core.vector.VectorStorePort;
@@ -34,6 +35,7 @@ import studio.one.platform.ai.web.controller.AiInfoController;
 import studio.one.platform.ai.web.controller.ChatController;
 import studio.one.platform.ai.web.controller.EmbeddingController;
 import studio.one.platform.ai.web.controller.QueryRewriteController;
+import studio.one.platform.ai.web.controller.RagChunkPreviewController;
 import studio.one.platform.ai.web.controller.RagController;
 import studio.one.platform.ai.web.controller.RagContextBuilder;
 import studio.one.platform.ai.web.controller.RagIndexJobController;
@@ -45,7 +47,9 @@ import studio.one.platform.ai.web.service.InMemoryChatMemoryStore;
 import studio.one.platform.ai.service.pipeline.RagIndexJobService;
 import studio.one.platform.ai.service.pipeline.RagEmbeddingProfileResolver;
 import studio.one.platform.constant.PropertyKeys;
+import studio.one.platform.chunking.core.Chunker;
 import studio.one.platform.chunking.core.ChunkContextExpander;
+import studio.one.platform.chunking.core.ChunkingOrchestrator;
 
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(ChatPort.class)
@@ -143,6 +147,29 @@ public class AiWebAutoConfiguration {
                 vectorStorePort,
                 ragIndexJobExecutor,
                 ragPipelineProperties.getObjectScope().getMaxListLimit());
+    }
+
+    @Bean
+    @ConditionalOnProperty(
+            prefix = PropertyKeys.AI.Endpoints.PREFIX + ".rag.chunk-preview",
+            name = "enabled",
+            havingValue = "true",
+            matchIfMissing = true)
+    @SuppressWarnings("deprecation")
+    RagChunkPreviewController ragChunkPreviewController(
+            ObjectProvider<ChunkingOrchestrator> chunkingOrchestratorProvider,
+            ObjectProvider<Chunker> chunkers,
+            ObjectProvider<TextChunker> textChunkerProvider,
+            RagPipelineProperties ragPipelineProperties,
+            AiWebRagProperties ragProperties,
+            Environment environment) {
+        return new RagChunkPreviewController(
+                chunkingOrchestratorProvider.getIfAvailable(),
+                chunkers.stream().toList(),
+                textChunkerProvider.getIfAvailable(),
+                ragPipelineProperties,
+                ragProperties,
+                environment);
     }
 
     @Bean(name = "ragIndexJobEndpointSecurity")

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
@@ -52,7 +52,12 @@ import studio.one.platform.chunking.core.ChunkContextExpander;
 import studio.one.platform.chunking.core.ChunkingOrchestrator;
 
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnClass(ChatPort.class)
+@ConditionalOnClass(name = {
+        "studio.one.platform.ai.core.chat.ChatPort",
+        "jakarta.validation.Valid",
+        "org.springframework.security.access.prepost.PreAuthorize",
+        "org.springframework.web.bind.annotation.RestController"
+})
 @Conditional(AiWebEndpointCondition.class)
 @EnableConfigurationProperties({AiWebRagProperties.class, AiWebChatProperties.class, RagPipelineProperties.class})
 public class AiWebAutoConfiguration {
@@ -150,11 +155,6 @@ public class AiWebAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnProperty(
-            prefix = PropertyKeys.AI.Endpoints.PREFIX + ".rag.chunk-preview",
-            name = "enabled",
-            havingValue = "true",
-            matchIfMissing = true)
     @SuppressWarnings("deprecation")
     RagChunkPreviewController ragChunkPreviewController(
             ObjectProvider<ChunkingOrchestrator> chunkingOrchestratorProvider,

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebRagProperties.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebRagProperties.java
@@ -9,6 +9,7 @@ public class AiWebRagProperties {
 
     private final ContextProperties context = new ContextProperties();
     private final DiagnosticsProperties diagnostics = new DiagnosticsProperties();
+    private final ChunkPreviewProperties chunkPreview = new ChunkPreviewProperties();
 
     public ContextProperties getContext() {
         return context;
@@ -16,6 +17,10 @@ public class AiWebRagProperties {
 
     public DiagnosticsProperties getDiagnostics() {
         return diagnostics;
+    }
+
+    public ChunkPreviewProperties getChunkPreview() {
+        return chunkPreview;
     }
 
     public static class ContextProperties {
@@ -119,6 +124,36 @@ public class AiWebRagProperties {
 
         public void setAllowClientDebug(boolean allowClientDebug) {
             this.allowClientDebug = allowClientDebug;
+        }
+    }
+
+    public static class ChunkPreviewProperties {
+        private boolean enabled = true;
+        private int maxInputChars = 200_000;
+        private int maxPreviewChunks = 500;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public int getMaxInputChars() {
+            return maxInputChars;
+        }
+
+        public void setMaxInputChars(int maxInputChars) {
+            this.maxInputChars = Math.max(1, maxInputChars);
+        }
+
+        public int getMaxPreviewChunks() {
+            return maxPreviewChunks;
+        }
+
+        public void setMaxPreviewChunks(int maxPreviewChunks) {
+            this.maxPreviewChunks = Math.max(1, maxPreviewChunks);
         }
     }
 }

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/AiWebExceptionHandler.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/AiWebExceptionHandler.java
@@ -18,6 +18,7 @@ import studio.one.platform.web.dto.ProblemDetails;
         EmbeddingController.class,
         VectorController.class,
         RagController.class,
+        RagChunkPreviewController.class,
         RagIndexJobController.class,
         QueryRewriteController.class,
         AiInfoController.class

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagChunkPreviewController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagChunkPreviewController.java
@@ -76,6 +76,9 @@ public class RagChunkPreviewController {
     @PreAuthorize("@endpointAuthz.can('services:ai_rag','read')")
     public ResponseEntity<ApiResponse<RagChunkPreviewResponseDto>> preview(
             @Valid @RequestBody RagChunkPreviewRequestDto request) {
+        if (!ragProperties.getChunkPreview().isEnabled()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Chunk preview is disabled");
+        }
         if (chunkingOrchestrator == null) {
             throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "ChunkingOrchestrator is not configured");
         }
@@ -87,6 +90,7 @@ public class RagChunkPreviewController {
                     "text exceeds max chunk preview input length");
         }
         try {
+            Map<String, Object> requestMetadata = sanitizedMetadata(request.metadata());
             ChunkingContext context = toContext(request);
             List<Chunk> chunks = chunkingOrchestrator.chunk(context);
             int totalChars = chunks.stream().mapToInt(chunk -> chunk.content().length()).sum();
@@ -98,7 +102,7 @@ public class RagChunkPreviewController {
                 warnings.add("Chunk preview truncated to " + maxPreviewChunks + " chunks.");
             }
             return ResponseEntity.ok(ApiResponse.ok(new RagChunkPreviewResponseDto(
-                    returned.stream().map(this::toItem).toList(),
+                    returned.stream().map(chunk -> toItem(chunk, requestMetadata)).toList(),
                     chunks.size(),
                     totalChars,
                     effectiveStrategy(context).value(),
@@ -116,11 +120,15 @@ public class RagChunkPreviewController {
     public ResponseEntity<ApiResponse<RagChunkConfigResponseDto>> config() {
         AiWebRagProperties.ContextProperties context = ragProperties.getContext();
         AiWebRagProperties.ExpansionProperties expansion = context.getExpansion();
+        String configuredStrategy = environment.getProperty(CHUNKING_PREFIX + ".strategy", "recursive");
+        ChunkingStrategyType previewStrategy = previewStrategyOrNull(configuredStrategy);
         RagChunkConfigResponseDto response = new RagChunkConfigResponseDto(
                 new RagChunkConfigResponseDto.ChunkingConfigDto(
                         chunkingOrchestrator != null,
                         environment.getProperty(CHUNKING_PREFIX + ".enabled", Boolean.class, true),
-                        environment.getProperty(CHUNKING_PREFIX + ".strategy", "recursive"),
+                        configuredStrategy,
+                        previewStrategy == null ? null : previewStrategy.value(),
+                        previewStrategy != null,
                         environment.getProperty(CHUNKING_PREFIX + ".max-size", Integer.class,
                                 ChunkingContext.DEFAULT_MAX_SIZE),
                         environment.getProperty(CHUNKING_PREFIX + ".overlap", Integer.class,
@@ -151,15 +159,16 @@ public class RagChunkPreviewController {
     }
 
     private ChunkingContext toContext(RagChunkPreviewRequestDto request) {
+        Map<String, Object> metadata = sanitizedMetadata(request.metadata());
         ChunkingContext.Builder builder = ChunkingContext.builder(request.text())
                 .sourceDocumentId(text(request.documentId()))
                 .objectType(text(request.objectType()))
                 .objectId(text(request.objectId()))
                 .contentType(text(request.contentType()))
                 .filename(text(request.filename()))
-                .metadata(sanitizedMetadata(request.metadata()));
+                .metadata(metadata);
         if (!hasText(request.strategy())) {
-            builder.useConfiguredStrategy();
+            builder.strategy(configuredPreviewStrategy());
         } else {
             builder.strategy(supportedStrategy(request.strategy()));
         }
@@ -188,8 +197,33 @@ public class RagChunkPreviewController {
         return strategy;
     }
 
-    private RagChunkPreviewItemDto toItem(Chunk chunk) {
-        Map<String, Object> metadata = chunk.metadata().toMap();
+    private ChunkingStrategyType configuredPreviewStrategy() {
+        String configuredStrategy = environment.getProperty(CHUNKING_PREFIX + ".strategy", "recursive");
+        ChunkingStrategyType previewStrategy = previewStrategyOrNull(configuredStrategy);
+        if (previewStrategy == null) {
+            throw new IllegalArgumentException("Configured chunking strategy is not supported by chunk preview: "
+                    + configuredStrategy + ". Supported values are: fixed-size, recursive, structure-based.");
+        }
+        return previewStrategy;
+    }
+
+    private ChunkingStrategyType previewStrategyOrNull(String value) {
+        try {
+            ChunkingStrategyType strategy = ChunkingStrategyType.from(value);
+            if (strategy == ChunkingStrategyType.FIXED_SIZE
+                    || strategy == ChunkingStrategyType.RECURSIVE
+                    || strategy == ChunkingStrategyType.STRUCTURE_BASED) {
+                return strategy;
+            }
+            return null;
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+
+    private RagChunkPreviewItemDto toItem(Chunk chunk, Map<String, Object> requestMetadata) {
+        Map<String, Object> metadata = new LinkedHashMap<>(requestMetadata);
+        metadata.putAll(chunk.metadata().toMap());
         return new RagChunkPreviewItemDto(
                 chunk.id(),
                 chunk.content(),

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagChunkPreviewController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagChunkPreviewController.java
@@ -1,0 +1,290 @@
+package studio.one.platform.ai.web.controller;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import jakarta.validation.Valid;
+
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import studio.one.platform.ai.autoconfigure.AiWebRagProperties;
+import studio.one.platform.ai.autoconfigure.config.RagPipelineProperties;
+import studio.one.platform.ai.core.chunk.TextChunker;
+import studio.one.platform.ai.web.dto.RagChunkConfigResponseDto;
+import studio.one.platform.ai.web.dto.RagChunkPreviewItemDto;
+import studio.one.platform.ai.web.dto.RagChunkPreviewRequestDto;
+import studio.one.platform.ai.web.dto.RagChunkPreviewResponseDto;
+import studio.one.platform.chunking.core.Chunk;
+import studio.one.platform.chunking.core.ChunkMetadata;
+import studio.one.platform.chunking.core.ChunkUnit;
+import studio.one.platform.chunking.core.Chunker;
+import studio.one.platform.chunking.core.ChunkingContext;
+import studio.one.platform.chunking.core.ChunkingOrchestrator;
+import studio.one.platform.chunking.core.ChunkingStrategyType;
+import studio.one.platform.constant.PropertyKeys;
+import studio.one.platform.web.dto.ApiResponse;
+
+@RestController
+@RequestMapping("${" + PropertyKeys.AI.Endpoints.MGMT_BASE_PATH + ":/api/mgmt/ai}/rag/chunks")
+@Validated
+@SuppressWarnings("deprecation")
+public class RagChunkPreviewController {
+
+    private static final List<String> AVAILABLE_STRATEGIES = List.of("fixed-size", "recursive", "structure-based");
+    private static final String CHUNKING_PREFIX = "studio.chunking";
+
+    @Nullable
+    private final ChunkingOrchestrator chunkingOrchestrator;
+    private final List<Chunker> chunkers;
+    @Nullable
+    private final TextChunker textChunker;
+    private final RagPipelineProperties ragPipelineProperties;
+    private final AiWebRagProperties ragProperties;
+    private final Environment environment;
+
+    public RagChunkPreviewController(
+            @Nullable ChunkingOrchestrator chunkingOrchestrator,
+            List<Chunker> chunkers,
+            @Nullable TextChunker textChunker,
+            RagPipelineProperties ragPipelineProperties,
+            AiWebRagProperties ragProperties,
+            Environment environment) {
+        this.chunkingOrchestrator = chunkingOrchestrator;
+        this.chunkers = chunkers == null ? List.of() : List.copyOf(chunkers);
+        this.textChunker = textChunker;
+        this.ragPipelineProperties = Objects.requireNonNull(ragPipelineProperties, "ragPipelineProperties");
+        this.ragProperties = Objects.requireNonNull(ragProperties, "ragProperties");
+        this.environment = Objects.requireNonNull(environment, "environment");
+    }
+
+    @PostMapping("/preview")
+    @PreAuthorize("@endpointAuthz.can('services:ai_rag','read')")
+    public ResponseEntity<ApiResponse<RagChunkPreviewResponseDto>> preview(
+            @Valid @RequestBody RagChunkPreviewRequestDto request) {
+        if (chunkingOrchestrator == null) {
+            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "ChunkingOrchestrator is not configured");
+        }
+        if (!hasText(request.text())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "text must not be blank");
+        }
+        if (request.text().length() > ragProperties.getChunkPreview().getMaxInputChars()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "text exceeds max chunk preview input length");
+        }
+        try {
+            ChunkingContext context = toContext(request);
+            List<Chunk> chunks = chunkingOrchestrator.chunk(context);
+            int totalChars = chunks.stream().mapToInt(chunk -> chunk.content().length()).sum();
+            int maxPreviewChunks = ragProperties.getChunkPreview().getMaxPreviewChunks();
+            List<String> warnings = new ArrayList<>();
+            List<Chunk> returned = chunks;
+            if (chunks.size() > maxPreviewChunks) {
+                returned = chunks.subList(0, maxPreviewChunks);
+                warnings.add("Chunk preview truncated to " + maxPreviewChunks + " chunks.");
+            }
+            return ResponseEntity.ok(ApiResponse.ok(new RagChunkPreviewResponseDto(
+                    returned.stream().map(this::toItem).toList(),
+                    chunks.size(),
+                    totalChars,
+                    effectiveStrategy(context).value(),
+                    effectiveMaxSize(context),
+                    effectiveOverlap(context),
+                    context.unit().value(),
+                    warnings)));
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+        }
+    }
+
+    @GetMapping("/config")
+    @PreAuthorize("@endpointAuthz.can('services:ai_rag','read')")
+    public ResponseEntity<ApiResponse<RagChunkConfigResponseDto>> config() {
+        AiWebRagProperties.ContextProperties context = ragProperties.getContext();
+        AiWebRagProperties.ExpansionProperties expansion = context.getExpansion();
+        RagChunkConfigResponseDto response = new RagChunkConfigResponseDto(
+                new RagChunkConfigResponseDto.ChunkingConfigDto(
+                        chunkingOrchestrator != null,
+                        environment.getProperty(CHUNKING_PREFIX + ".enabled", Boolean.class, true),
+                        environment.getProperty(CHUNKING_PREFIX + ".strategy", "recursive"),
+                        environment.getProperty(CHUNKING_PREFIX + ".max-size", Integer.class,
+                                ChunkingContext.DEFAULT_MAX_SIZE),
+                        environment.getProperty(CHUNKING_PREFIX + ".overlap", Integer.class,
+                                ChunkingContext.DEFAULT_OVERLAP),
+                        AVAILABLE_STRATEGIES,
+                        registeredChunkers(),
+                        chunkingOrchestrator != null),
+                new RagChunkConfigResponseDto.LegacyFallbackConfigDto(
+                        ragPipelineProperties.getChunkSize(),
+                        ragPipelineProperties.getChunkOverlap(),
+                        textChunker != null),
+                new RagChunkConfigResponseDto.RagContextConfigDto(
+                        context.getMaxChunks(),
+                        context.getMaxChars(),
+                        context.isIncludeScores(),
+                        new RagChunkConfigResponseDto.RagContextExpansionConfigDto(
+                                expansion.isEnabled(),
+                                expansion.getCandidateMultiplier(),
+                                expansion.getMaxCandidates(),
+                                expansion.getPreviousWindow(),
+                                expansion.getNextWindow(),
+                                expansion.isIncludeParentContent())),
+                new RagChunkConfigResponseDto.ChunkPreviewLimitsDto(
+                        ragProperties.getChunkPreview().isEnabled(),
+                        ragProperties.getChunkPreview().getMaxInputChars(),
+                        ragProperties.getChunkPreview().getMaxPreviewChunks()));
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    private ChunkingContext toContext(RagChunkPreviewRequestDto request) {
+        ChunkingContext.Builder builder = ChunkingContext.builder(request.text())
+                .sourceDocumentId(text(request.documentId()))
+                .objectType(text(request.objectType()))
+                .objectId(text(request.objectId()))
+                .contentType(text(request.contentType()))
+                .filename(text(request.filename()))
+                .metadata(sanitizedMetadata(request.metadata()));
+        if (!hasText(request.strategy())) {
+            builder.useConfiguredStrategy();
+        } else {
+            builder.strategy(supportedStrategy(request.strategy()));
+        }
+        if (request.maxSize() == null) {
+            builder.useConfiguredMaxSize();
+        } else {
+            builder.maxSize(request.maxSize());
+        }
+        if (request.overlap() == null) {
+            builder.useConfiguredOverlap();
+        } else {
+            builder.overlap(request.overlap());
+        }
+        builder.unit(ChunkUnit.from(request.unit()));
+        return builder.build();
+    }
+
+    private ChunkingStrategyType supportedStrategy(String value) {
+        ChunkingStrategyType strategy = ChunkingStrategyType.from(value);
+        if (strategy != ChunkingStrategyType.FIXED_SIZE
+                && strategy != ChunkingStrategyType.RECURSIVE
+                && strategy != ChunkingStrategyType.STRUCTURE_BASED) {
+            throw new IllegalArgumentException("Unsupported chunk preview strategy: " + value
+                    + ". Supported values are: fixed-size, recursive, structure-based.");
+        }
+        return strategy;
+    }
+
+    private RagChunkPreviewItemDto toItem(Chunk chunk) {
+        Map<String, Object> metadata = chunk.metadata().toMap();
+        return new RagChunkPreviewItemDto(
+                chunk.id(),
+                chunk.content(),
+                chunk.content().length(),
+                integer(metadata.get(ChunkMetadata.KEY_CHUNK_ORDER)),
+                text(metadata.get(ChunkMetadata.KEY_CHUNK_TYPE)),
+                text(metadata.get(ChunkMetadata.KEY_PARENT_CHUNK_ID)),
+                text(metadata.get(ChunkMetadata.KEY_PREVIOUS_CHUNK_ID)),
+                text(metadata.get(ChunkMetadata.KEY_NEXT_CHUNK_ID)),
+                text(metadata.get(ChunkMetadata.KEY_HEADING_PATH)),
+                text(metadata.get(ChunkMetadata.KEY_SECTION)),
+                text(firstPresent(metadata, ChunkMetadata.KEY_SOURCE_REF, ChunkMetadata.KEY_SOURCE_REFS)),
+                integer(metadata.get(ChunkMetadata.KEY_PAGE)),
+                integer(metadata.get(ChunkMetadata.KEY_SLIDE)),
+                metadata);
+    }
+
+    private List<String> registeredChunkers() {
+        return chunkers.stream()
+                .map(chunker -> chunker.getClass().getSimpleName())
+                .sorted(Comparator.naturalOrder())
+                .toList();
+    }
+
+    private ChunkingStrategyType effectiveStrategy(ChunkingContext context) {
+        if (context.strategy() != null) {
+            return context.strategy();
+        }
+        return ChunkingStrategyType.from(environment.getProperty(CHUNKING_PREFIX + ".strategy", "recursive"));
+    }
+
+    private int effectiveMaxSize(ChunkingContext context) {
+        return context.maxSize() == ChunkingContext.USE_CONFIGURED_MAX_SIZE
+                ? environment.getProperty(CHUNKING_PREFIX + ".max-size", Integer.class,
+                        ChunkingContext.DEFAULT_MAX_SIZE)
+                : context.maxSize();
+    }
+
+    private int effectiveOverlap(ChunkingContext context) {
+        return context.overlap() == ChunkingContext.USE_CONFIGURED_OVERLAP
+                ? environment.getProperty(CHUNKING_PREFIX + ".overlap", Integer.class,
+                        ChunkingContext.DEFAULT_OVERLAP)
+                : context.overlap();
+    }
+
+    private Map<String, Object> sanitizedMetadata(Map<String, Object> metadata) {
+        if (metadata == null || metadata.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, Object> sanitized = new LinkedHashMap<>();
+        metadata.forEach((key, value) -> {
+            if (key == null || key.isBlank() || value == null) {
+                return;
+            }
+            if (value instanceof String text && text.isBlank()) {
+                return;
+            }
+            sanitized.put(key, value);
+        });
+        return sanitized;
+    }
+
+    private Object firstPresent(Map<String, Object> metadata, String... keys) {
+        for (String key : keys) {
+            Object value = metadata.get(key);
+            if (value != null && (!(value instanceof String text) || !text.isBlank())) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private String text(Object value) {
+        if (value == null) {
+            return null;
+        }
+        String text = Objects.toString(value, null);
+        return text == null || text.isBlank() ? null : text;
+    }
+
+    private Integer integer(Object value) {
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        if (value instanceof String text && !text.isBlank()) {
+            try {
+                return Integer.valueOf(text.trim());
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/RagChunkConfigResponseDto.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/RagChunkConfigResponseDto.java
@@ -1,0 +1,49 @@
+package studio.one.platform.ai.web.dto;
+
+import java.util.List;
+
+public record RagChunkConfigResponseDto(
+        ChunkingConfigDto chunking,
+        LegacyFallbackConfigDto legacyFallback,
+        RagContextConfigDto ragContext,
+        ChunkPreviewLimitsDto limits) {
+
+    public record ChunkingConfigDto(
+            boolean available,
+            boolean enabled,
+            String strategy,
+            int maxSize,
+            int overlap,
+            List<String> availableStrategies,
+            List<String> registeredChunkers,
+            boolean chunkingOrchestratorAvailable) {
+    }
+
+    public record LegacyFallbackConfigDto(
+            int chunkSize,
+            int chunkOverlap,
+            boolean textChunkerAvailable) {
+    }
+
+    public record RagContextConfigDto(
+            int maxChunks,
+            int maxChars,
+            boolean includeScores,
+            RagContextExpansionConfigDto expansion) {
+    }
+
+    public record RagContextExpansionConfigDto(
+            boolean enabled,
+            int candidateMultiplier,
+            int maxCandidates,
+            int previousWindow,
+            int nextWindow,
+            boolean includeParentContent) {
+    }
+
+    public record ChunkPreviewLimitsDto(
+            boolean enabled,
+            int maxInputChars,
+            int maxPreviewChunks) {
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/RagChunkConfigResponseDto.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/RagChunkConfigResponseDto.java
@@ -12,6 +12,8 @@ public record RagChunkConfigResponseDto(
             boolean available,
             boolean enabled,
             String strategy,
+            String previewStrategy,
+            boolean defaultStrategyPreviewSupported,
             int maxSize,
             int overlap,
             List<String> availableStrategies,

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/RagChunkPreviewItemDto.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/RagChunkPreviewItemDto.java
@@ -1,0 +1,20 @@
+package studio.one.platform.ai.web.dto;
+
+import java.util.Map;
+
+public record RagChunkPreviewItemDto(
+        String chunkId,
+        String content,
+        int contentLength,
+        Integer chunkOrder,
+        String chunkType,
+        String parentChunkId,
+        String previousChunkId,
+        String nextChunkId,
+        String headingPath,
+        String section,
+        String sourceRef,
+        Integer page,
+        Integer slide,
+        Map<String, Object> metadata) {
+}

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/RagChunkPreviewRequestDto.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/RagChunkPreviewRequestDto.java
@@ -1,0 +1,19 @@
+package studio.one.platform.ai.web.dto;
+
+import java.util.Map;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RagChunkPreviewRequestDto(
+        @NotBlank String text,
+        String documentId,
+        String objectType,
+        String objectId,
+        String contentType,
+        String filename,
+        String strategy,
+        Integer maxSize,
+        Integer overlap,
+        String unit,
+        Map<String, Object> metadata) {
+}

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/RagChunkPreviewResponseDto.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/RagChunkPreviewResponseDto.java
@@ -1,0 +1,14 @@
+package studio.one.platform.ai.web.dto;
+
+import java.util.List;
+
+public record RagChunkPreviewResponseDto(
+        List<RagChunkPreviewItemDto> chunks,
+        int totalChunks,
+        int totalChars,
+        String strategy,
+        int maxSize,
+        int overlap,
+        String unit,
+        List<String> warnings) {
+}

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/AiWebRagPropertiesTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/AiWebRagPropertiesTest.java
@@ -23,6 +23,9 @@ class AiWebRagPropertiesTest {
         assertThat(properties.getContext().getExpansion().getPreviousWindow()).isEqualTo(1);
         assertThat(properties.getContext().getExpansion().getNextWindow()).isEqualTo(1);
         assertThat(properties.getContext().getExpansion().isIncludeParentContent()).isTrue();
+        assertThat(properties.getChunkPreview().isEnabled()).isTrue();
+        assertThat(properties.getChunkPreview().getMaxInputChars()).isEqualTo(200_000);
+        assertThat(properties.getChunkPreview().getMaxPreviewChunks()).isEqualTo(500);
         assertThat(properties.getDiagnostics().isAllowClientDebug()).isFalse();
     }
 
@@ -36,6 +39,9 @@ class AiWebRagPropertiesTest {
                 Map.entry("studio.ai.endpoints.rag.context.expansion.previous-window", "2"),
                 Map.entry("studio.ai.endpoints.rag.context.expansion.next-window", "3"),
                 Map.entry("studio.ai.endpoints.rag.context.expansion.include-parent-content", "false"),
+                Map.entry("studio.ai.endpoints.rag.chunk-preview.enabled", "false"),
+                Map.entry("studio.ai.endpoints.rag.chunk-preview.max-input-chars", "1000"),
+                Map.entry("studio.ai.endpoints.rag.chunk-preview.max-preview-chunks", "25"),
                 Map.entry("studio.ai.endpoints.rag.diagnostics.allow-client-debug", "true"))));
 
         AiWebRagProperties properties = new Binder(ConfigurationPropertySources.get(environment))
@@ -48,6 +54,9 @@ class AiWebRagPropertiesTest {
         assertThat(properties.getContext().getExpansion().getPreviousWindow()).isEqualTo(2);
         assertThat(properties.getContext().getExpansion().getNextWindow()).isEqualTo(3);
         assertThat(properties.getContext().getExpansion().isIncludeParentContent()).isFalse();
+        assertThat(properties.getChunkPreview().isEnabled()).isFalse();
+        assertThat(properties.getChunkPreview().getMaxInputChars()).isEqualTo(1000);
+        assertThat(properties.getChunkPreview().getMaxPreviewChunks()).isEqualTo(25);
         assertThat(properties.getDiagnostics().isAllowClientDebug()).isTrue();
     }
 }

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
@@ -15,6 +15,7 @@ import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.embedding.Embedding;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -227,12 +228,48 @@ class OpenAiProviderAutoConfigurationTest {
     }
 
     @Test
-    void doesNotRegisterChunkPreviewControllerWhenDisabled() {
+    void keepsChunkPreviewControllerForConfigWhenPreviewIsDisabled() {
         contextRunner
                 .withPropertyValues("studio.ai.endpoints.rag.chunk-preview.enabled=false")
                 .run(context -> {
                     assertThat(context).hasNotFailed();
+                    assertThat(context).hasSingleBean(RagChunkPreviewController.class);
+                });
+    }
+
+    @Test
+    void backsOffWhenWebEndpointClassesAreMissing() {
+        contextRunner
+                .withClassLoader(new FilteredClassLoader("org.springframework.web.bind.annotation"))
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).doesNotHaveBean(ChatController.class);
                     assertThat(context).doesNotHaveBean(RagChunkPreviewController.class);
+                    assertThat(context).doesNotHaveBean(AiInfoController.class);
+                });
+    }
+
+    @Test
+    void backsOffWhenMethodSecurityClassesAreMissing() {
+        contextRunner
+                .withClassLoader(new FilteredClassLoader("org.springframework.security.access.prepost"))
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).doesNotHaveBean(ChatController.class);
+                    assertThat(context).doesNotHaveBean(RagChunkPreviewController.class);
+                    assertThat(context).doesNotHaveBean(AiInfoController.class);
+                });
+    }
+
+    @Test
+    void backsOffWhenValidationClassesAreMissing() {
+        contextRunner
+                .withClassLoader(new FilteredClassLoader("jakarta.validation"))
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).doesNotHaveBean(ChatController.class);
+                    assertThat(context).doesNotHaveBean(RagChunkPreviewController.class);
+                    assertThat(context).doesNotHaveBean(AiInfoController.class);
                 });
     }
 

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
@@ -35,6 +35,7 @@ import studio.one.platform.ai.web.controller.AiInfoController;
 import studio.one.platform.ai.web.controller.ChatController;
 import studio.one.platform.ai.web.controller.EmbeddingController;
 import studio.one.platform.ai.web.controller.QueryRewriteController;
+import studio.one.platform.ai.web.controller.RagChunkPreviewController;
 import studio.one.platform.ai.web.controller.RagController;
 import studio.one.platform.ai.web.controller.RagIndexJobController;
 import studio.one.platform.ai.web.controller.RagIndexJobEndpointSecurity;
@@ -45,6 +46,8 @@ import studio.one.platform.ai.web.dto.ChatResponseDto;
 import studio.one.platform.ai.web.dto.EmbeddingRequestDto;
 import studio.one.platform.ai.web.dto.EmbeddingResponseDto;
 import studio.one.platform.ai.web.service.ConversationChatService;
+import studio.one.platform.chunking.core.Chunker;
+import studio.one.platform.chunking.core.ChunkingOrchestrator;
 import studio.one.platform.service.I18n;
 import studio.one.platform.web.dto.ApiResponse;
 
@@ -86,6 +89,7 @@ class OpenAiProviderAutoConfigurationTest {
             assertThat(context).hasSingleBean(EmbeddingPort.class);
             assertThat(context).hasSingleBean(ChatController.class);
             assertThat(context).hasSingleBean(EmbeddingController.class);
+            assertThat(context).hasSingleBean(RagChunkPreviewController.class);
             assertThat(context).hasSingleBean(AiInfoController.class);
             assertThat(context).hasSingleBean(ConversationRepositoryPort.class);
             assertThat(context).hasSingleBean(ConversationChatService.class);
@@ -212,6 +216,27 @@ class OpenAiProviderAutoConfigurationTest {
     }
 
     @Test
+    void registersChunkPreviewControllerWhenChunkingOrchestratorExists() {
+        contextRunner
+                .withBean(ChunkingOrchestrator.class, () -> org.mockito.Mockito.mock(ChunkingOrchestrator.class))
+                .withBean(Chunker.class, () -> org.mockito.Mockito.mock(Chunker.class))
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).hasSingleBean(RagChunkPreviewController.class);
+                });
+    }
+
+    @Test
+    void doesNotRegisterChunkPreviewControllerWhenDisabled() {
+        contextRunner
+                .withPropertyValues("studio.ai.endpoints.rag.chunk-preview.enabled=false")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).doesNotHaveBean(RagChunkPreviewController.class);
+                });
+    }
+
+    @Test
     void exposesOpenAiFromInfoControllerInRuntimeContext() {
         contextRunner.run(context -> {
             assertThat(context).hasNotFailed();
@@ -268,8 +293,9 @@ class OpenAiProviderAutoConfigurationTest {
                     assertThat(context).doesNotHaveBean(EmbeddingController.class);
                     assertThat(context).doesNotHaveBean(AiInfoController.class);
                     assertThat(context).doesNotHaveBean(VectorController.class);
-                    assertThat(context).doesNotHaveBean(RagController.class);
-                    assertThat(context).doesNotHaveBean(QueryRewriteController.class);
+            assertThat(context).doesNotHaveBean(RagController.class);
+            assertThat(context).doesNotHaveBean(RagChunkPreviewController.class);
+            assertThat(context).doesNotHaveBean(QueryRewriteController.class);
                 });
     }
 

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagChunkPreviewControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagChunkPreviewControllerTest.java
@@ -1,0 +1,241 @@
+package studio.one.platform.ai.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
+
+import studio.one.platform.ai.autoconfigure.AiWebRagProperties;
+import studio.one.platform.ai.autoconfigure.config.RagPipelineProperties;
+import studio.one.platform.ai.web.dto.RagChunkConfigResponseDto;
+import studio.one.platform.ai.web.dto.RagChunkPreviewRequestDto;
+import studio.one.platform.ai.web.dto.RagChunkPreviewResponseDto;
+import studio.one.platform.chunking.core.Chunk;
+import studio.one.platform.chunking.core.ChunkMetadata;
+import studio.one.platform.chunking.core.ChunkType;
+import studio.one.platform.chunking.core.ChunkUnit;
+import studio.one.platform.chunking.core.Chunker;
+import studio.one.platform.chunking.core.ChunkingContext;
+import studio.one.platform.chunking.core.ChunkingOrchestrator;
+import studio.one.platform.chunking.core.ChunkingStrategyType;
+import studio.one.platform.web.dto.ApiResponse;
+
+class RagChunkPreviewControllerTest {
+
+    @Test
+    void previewsChunksWithExplicitOptionsAndMetadata() {
+        CapturingChunkingOrchestrator orchestrator = new CapturingChunkingOrchestrator();
+        RagChunkPreviewController controller = controller(orchestrator);
+
+        ResponseEntity<ApiResponse<RagChunkPreviewResponseDto>> response = controller.preview(
+                new RagChunkPreviewRequestDto(
+                        "alpha beta gamma",
+                        "doc-1",
+                        "attachment",
+                        "42",
+                        "text/plain",
+                        "sample.txt",
+                        "recursive",
+                        100,
+                        10,
+                        "token",
+                        Map.of("category", "manual")));
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(orchestrator.context.sourceDocumentId()).isEqualTo("doc-1");
+        assertThat(orchestrator.context.objectType()).isEqualTo("attachment");
+        assertThat(orchestrator.context.objectId()).isEqualTo("42");
+        assertThat(orchestrator.context.contentType()).isEqualTo("text/plain");
+        assertThat(orchestrator.context.filename()).isEqualTo("sample.txt");
+        assertThat(orchestrator.context.strategy()).isEqualTo(ChunkingStrategyType.RECURSIVE);
+        assertThat(orchestrator.context.maxSize()).isEqualTo(100);
+        assertThat(orchestrator.context.overlap()).isEqualTo(10);
+        assertThat(orchestrator.context.unit()).isEqualTo(ChunkUnit.TOKEN);
+        assertThat(orchestrator.context.metadata()).containsEntry("category", "manual");
+
+        RagChunkPreviewResponseDto body = response.getBody().getData();
+        assertThat(body.totalChunks()).isEqualTo(1);
+        assertThat(body.strategy()).isEqualTo("recursive");
+        assertThat(body.maxSize()).isEqualTo(100);
+        assertThat(body.overlap()).isEqualTo(10);
+        assertThat(body.unit()).isEqualTo("token");
+        assertThat(body.chunks()).hasSize(1);
+        assertThat(body.chunks().get(0).chunkId()).isEqualTo("doc-1-0");
+        assertThat(body.chunks().get(0).chunkOrder()).isZero();
+        assertThat(body.chunks().get(0).chunkType()).isEqualTo("child");
+    }
+
+    @Test
+    void usesConfiguredDefaultsWhenOptionsAreMissing() {
+        CapturingChunkingOrchestrator orchestrator = new CapturingChunkingOrchestrator();
+        RagChunkPreviewController controller = controller(orchestrator);
+
+        ResponseEntity<ApiResponse<RagChunkPreviewResponseDto>> response = controller.preview(
+                new RagChunkPreviewRequestDto(
+                        "alpha",
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null));
+
+        assertThat(orchestrator.context.strategy()).isNull();
+        assertThat(orchestrator.context.maxSize()).isEqualTo(ChunkingContext.USE_CONFIGURED_MAX_SIZE);
+        assertThat(orchestrator.context.overlap()).isEqualTo(ChunkingContext.USE_CONFIGURED_OVERLAP);
+        assertThat(response.getBody().getData().strategy()).isEqualTo("fixed-size");
+        assertThat(response.getBody().getData().maxSize()).isEqualTo(120);
+        assertThat(response.getBody().getData().overlap()).isEqualTo(12);
+    }
+
+    @Test
+    void rejectsInvalidPreviewRequests() {
+        RagChunkPreviewController controller = controller(new CapturingChunkingOrchestrator());
+
+        assertStatus(() -> controller.preview(new RagChunkPreviewRequestDto(
+                " ", null, null, null, null, null, null, null, null, null, null)), 400);
+        assertStatus(() -> controller.preview(new RagChunkPreviewRequestDto(
+                "alpha", null, null, null, null, null, "semantic", null, null, null, null)), 400);
+        assertStatus(() -> controller.preview(new RagChunkPreviewRequestDto(
+                "alpha", null, null, null, null, null, null, 10, 10, null, null)), 400);
+    }
+
+    @Test
+    void returnsServiceUnavailableWhenChunkingOrchestratorIsMissing() {
+        RagChunkPreviewController controller = controller(null);
+
+        assertStatus(() -> controller.preview(new RagChunkPreviewRequestDto(
+                "alpha", null, null, null, null, null, null, null, null, null, null)), 503);
+    }
+
+    @Test
+    void rejectsInputLongerThanPreviewLimit() {
+        AiWebRagProperties properties = new AiWebRagProperties();
+        properties.getChunkPreview().setMaxInputChars(3);
+        RagChunkPreviewController controller = controller(new CapturingChunkingOrchestrator(), properties);
+
+        assertStatus(() -> controller.preview(new RagChunkPreviewRequestDto(
+                "alpha", null, null, null, null, null, null, null, null, null, null)), 400);
+    }
+
+    @Test
+    void truncatesReturnedChunksAtPreviewLimit() {
+        AiWebRagProperties properties = new AiWebRagProperties();
+        properties.getChunkPreview().setMaxPreviewChunks(1);
+        RagChunkPreviewController controller = controller(context -> List.of(
+                chunk("doc-0", "first", 0),
+                chunk("doc-1", "second", 1)), properties);
+
+        ResponseEntity<ApiResponse<RagChunkPreviewResponseDto>> response = controller.preview(
+                new RagChunkPreviewRequestDto(
+                        "alpha beta", null, null, null, null, null, null, null, null, null, null));
+
+        assertThat(response.getBody().getData().totalChunks()).isEqualTo(2);
+        assertThat(response.getBody().getData().chunks()).hasSize(1);
+        assertThat(response.getBody().getData().warnings()).containsExactly("Chunk preview truncated to 1 chunks.");
+    }
+
+    @Test
+    void configExposesSafeChunkingAndRagSettings() {
+        RagChunkPreviewController controller = controller(new CapturingChunkingOrchestrator());
+
+        ResponseEntity<ApiResponse<RagChunkConfigResponseDto>> response = controller.config();
+
+        RagChunkConfigResponseDto data = response.getBody().getData();
+        assertThat(data.chunking().available()).isTrue();
+        assertThat(data.chunking().strategy()).isEqualTo("fixed-size");
+        assertThat(data.chunking().maxSize()).isEqualTo(120);
+        assertThat(data.chunking().overlap()).isEqualTo(12);
+        assertThat(data.chunking().registeredChunkers()).containsExactly("TestChunker");
+        assertThat(data.legacyFallback().chunkSize()).isEqualTo(500);
+        assertThat(data.legacyFallback().chunkOverlap()).isEqualTo(50);
+        assertThat(data.ragContext().expansion().maxCandidates()).isEqualTo(100);
+        assertThat(data.limits().maxInputChars()).isEqualTo(200_000);
+        assertThat(data.limits().maxPreviewChunks()).isEqualTo(500);
+    }
+
+    @Test
+    void configReportsUnavailableChunkingWhenOrchestratorIsMissing() {
+        RagChunkPreviewController controller = controller(null);
+
+        ResponseEntity<ApiResponse<RagChunkConfigResponseDto>> response = controller.config();
+
+        assertThat(response.getBody().getData().chunking().available()).isFalse();
+        assertThat(response.getBody().getData().chunking().chunkingOrchestratorAvailable()).isFalse();
+    }
+
+    private RagChunkPreviewController controller(ChunkingOrchestrator orchestrator) {
+        return controller(orchestrator, new AiWebRagProperties());
+    }
+
+    private RagChunkPreviewController controller(ChunkingOrchestrator orchestrator, AiWebRagProperties properties) {
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().addFirst(new MapPropertySource("test", Map.of(
+                "studio.chunking.strategy", "fixed-size",
+                "studio.chunking.max-size", "120",
+                "studio.chunking.overlap", "12")));
+        return new RagChunkPreviewController(
+                orchestrator,
+                List.of(new TestChunker()),
+                null,
+                new RagPipelineProperties(),
+                properties,
+                environment);
+    }
+
+    private Chunk chunk(String id, String content, int order) {
+        return Chunk.of(id, content, ChunkMetadata.builder(ChunkingStrategyType.RECURSIVE, order)
+                .chunkType(ChunkType.CHILD)
+                .build());
+    }
+
+    private void assertStatus(Runnable action, int expectedStatus) {
+        assertThatThrownBy(action::run)
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode().value())
+                        .isEqualTo(expectedStatus));
+    }
+
+    private static final class CapturingChunkingOrchestrator implements ChunkingOrchestrator {
+        private ChunkingContext context;
+
+        @Override
+        public List<Chunk> chunk(ChunkingContext context) {
+            this.context = context;
+            ChunkMetadata metadata = ChunkMetadata.builder(ChunkingStrategyType.RECURSIVE, 0)
+                    .sourceDocumentId(context.sourceDocumentId() == null ? "doc" : context.sourceDocumentId())
+                    .chunkType(ChunkType.CHILD)
+                    .objectType(context.objectType())
+                    .objectId(context.objectId())
+                    .attributes(context.metadata())
+                    .build();
+            return List.of(Chunk.of(
+                    (context.sourceDocumentId() == null ? "doc" : context.sourceDocumentId()) + "-0",
+                    context.text(),
+                    metadata));
+        }
+    }
+
+    private static final class TestChunker implements Chunker {
+        @Override
+        public ChunkingStrategyType strategy() {
+            return ChunkingStrategyType.RECURSIVE;
+        }
+
+        @Override
+        public List<Chunk> chunk(ChunkingContext context) {
+            return List.of();
+        }
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagChunkPreviewControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagChunkPreviewControllerTest.java
@@ -70,6 +70,7 @@ class RagChunkPreviewControllerTest {
         assertThat(body.chunks().get(0).chunkId()).isEqualTo("doc-1-0");
         assertThat(body.chunks().get(0).chunkOrder()).isZero();
         assertThat(body.chunks().get(0).chunkType()).isEqualTo("child");
+        assertThat(body.chunks().get(0).metadata()).containsEntry("category", "manual");
     }
 
     @Test
@@ -91,7 +92,7 @@ class RagChunkPreviewControllerTest {
                         null,
                         null));
 
-        assertThat(orchestrator.context.strategy()).isNull();
+        assertThat(orchestrator.context.strategy()).isEqualTo(ChunkingStrategyType.FIXED_SIZE);
         assertThat(orchestrator.context.maxSize()).isEqualTo(ChunkingContext.USE_CONFIGURED_MAX_SIZE);
         assertThat(orchestrator.context.overlap()).isEqualTo(ChunkingContext.USE_CONFIGURED_OVERLAP);
         assertThat(response.getBody().getData().strategy()).isEqualTo("fixed-size");
@@ -112,6 +113,22 @@ class RagChunkPreviewControllerTest {
     }
 
     @Test
+    void rejectsUnsupportedConfiguredDefaultStrategyWhenStrategyIsOmitted() {
+        RagChunkPreviewController controller = controller(
+                new CapturingChunkingOrchestrator(),
+                new AiWebRagProperties(),
+                "semantic");
+
+        assertStatus(() -> controller.preview(new RagChunkPreviewRequestDto(
+                "alpha", null, null, null, null, null, null, null, null, null, null)), 400);
+
+        ResponseEntity<ApiResponse<RagChunkConfigResponseDto>> config = controller.config();
+        assertThat(config.getBody().getData().chunking().strategy()).isEqualTo("semantic");
+        assertThat(config.getBody().getData().chunking().previewStrategy()).isNull();
+        assertThat(config.getBody().getData().chunking().defaultStrategyPreviewSupported()).isFalse();
+    }
+
+    @Test
     void returnsServiceUnavailableWhenChunkingOrchestratorIsMissing() {
         RagChunkPreviewController controller = controller(null);
 
@@ -127,6 +144,19 @@ class RagChunkPreviewControllerTest {
 
         assertStatus(() -> controller.preview(new RagChunkPreviewRequestDto(
                 "alpha", null, null, null, null, null, null, null, null, null, null)), 400);
+    }
+
+    @Test
+    void rejectsPreviewWhenPreviewIsDisabledButKeepsConfigAvailable() {
+        AiWebRagProperties properties = new AiWebRagProperties();
+        properties.getChunkPreview().setEnabled(false);
+        RagChunkPreviewController controller = controller(new CapturingChunkingOrchestrator(), properties);
+
+        assertStatus(() -> controller.preview(new RagChunkPreviewRequestDto(
+                "alpha", null, null, null, null, null, null, null, null, null, null)), 404);
+
+        ResponseEntity<ApiResponse<RagChunkConfigResponseDto>> response = controller.config();
+        assertThat(response.getBody().getData().limits().enabled()).isFalse();
     }
 
     @Test
@@ -155,6 +185,8 @@ class RagChunkPreviewControllerTest {
         RagChunkConfigResponseDto data = response.getBody().getData();
         assertThat(data.chunking().available()).isTrue();
         assertThat(data.chunking().strategy()).isEqualTo("fixed-size");
+        assertThat(data.chunking().previewStrategy()).isEqualTo("fixed-size");
+        assertThat(data.chunking().defaultStrategyPreviewSupported()).isTrue();
         assertThat(data.chunking().maxSize()).isEqualTo(120);
         assertThat(data.chunking().overlap()).isEqualTo(12);
         assertThat(data.chunking().registeredChunkers()).containsExactly("TestChunker");
@@ -180,9 +212,16 @@ class RagChunkPreviewControllerTest {
     }
 
     private RagChunkPreviewController controller(ChunkingOrchestrator orchestrator, AiWebRagProperties properties) {
+        return controller(orchestrator, properties, "fixed-size");
+    }
+
+    private RagChunkPreviewController controller(
+            ChunkingOrchestrator orchestrator,
+            AiWebRagProperties properties,
+            String configuredStrategy) {
         StandardEnvironment environment = new StandardEnvironment();
         environment.getPropertySources().addFirst(new MapPropertySource("test", Map.of(
-                "studio.chunking.strategy", "fixed-size",
+                "studio.chunking.strategy", configuredStrategy,
                 "studio.chunking.max-size", "120",
                 "studio.chunking.overlap", "12")));
         return new RagChunkPreviewController(

--- a/starter/studio-platform-starter-chunking/README.md
+++ b/starter/studio-platform-starter-chunking/README.md
@@ -101,6 +101,11 @@ heading 없이 시작하는 문서는 빈 `section` 값과 body-only `parentChun
 구조화 chunk metadata가 vector storage에서 어떻게 해석되는지는
 [`studio-platform-ai` RAG metadata key reference](../../studio-platform-ai/README.md#rag-metadata-key-reference)를 기준으로 합니다.
 
+`starter:studio-platform-starter-ai-web`의 RAG chunk preview API는 운영 화면에서 같은 `ChunkingOrchestrator`를 호출해
+색인 전 text chunk 결과를 확인합니다. preview API도 `studio.chunking.strategy`, `studio.chunking.max-size`,
+`studio.chunking.overlap` configured default를 사용하므로 실제 신규 RAG 색인 경로와 같은 chunking 설정을 기준으로 합니다.
+다만 preview API는 embedding 생성, vector upsert, attachment parsing을 실행하지 않습니다.
+
 ```java
 ParsedFile parsedFile = fileContentExtractionService.parseStructured(...);
 NormalizedDocument document = new TextractNormalizedDocumentAdapter()


### PR DESCRIPTION
## Why

RAG 운영 화면에서 실제 색인을 실행하기 전에 현재 chunking 설정이 어떤 chunk를 만드는지 확인할 수 있어야 합니다. 또한 운영 UI가 `studio.chunking.*`, RAG context, legacy fallback, preview limit을 비밀 노출 없이 조회할 수 있는 API가 필요합니다.

## What

- `POST /api/mgmt/ai/rag/chunks/preview` text 기반 chunk preview API를 추가했습니다.
- `GET /api/mgmt/ai/rag/chunks/config` 비밀 없는 chunk/RAG 설정 조회 API를 추가했습니다.
- `studio.ai.endpoints.rag.chunk-preview.*` preview 안전장치 설정을 추가했습니다.
- `ChunkingOrchestrator`가 없을 때 preview는 `503`, config는 `chunking.available=false`로 응답하도록 했습니다.
- starter-ai-web 및 starter-chunking README에 운영 화면 사용법과 범위 제한을 문서화했습니다.

## Related Issues

- Closes #346

## Validation

- Command: `./gradlew :starter:studio-platform-starter-ai-web:test :starter:studio-platform-starter-chunking:test`
- Result: PASS
- Command: `git diff --check`
- Result: PASS

## Risk / Rollback

- Risk: 신규 management endpoint가 등록되므로 권한/설정 조건이 예상과 다르면 운영 화면에서 preview 접근이 제한되거나 노출될 수 있습니다. 기존 RAG index/job/search API 응답은 변경하지 않았습니다.
- Rollback: 이 PR revert 또는 `studio.ai.endpoints.rag.chunk-preview.enabled=false`로 신규 preview/config controller 등록을 끌 수 있습니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: Yes
- Delegated scope: PR #347의 chunk preview/config API correctness, API compatibility, permission exposure, classpath/autoconfiguration risk, test gap 리뷰
- Main author validation: 서브에이전트 finding 3건을 보완하고 Gradle 테스트와 `git diff --check`를 재실행했습니다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included

