### PR TITLE
RAG 채팅 system 메시지 병합과 topK 제한 보강

### DIFF
--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
@@ -288,7 +288,7 @@ public class ChatController {
     private ResponseEntity<ApiResponse<ChatResponseDto>> chatInternal(ChatRequestDto request, Principal principal) {
         ChatMemoryContext memory = resolveMemory(request, principal);
         List<ChatMessage> domainMessages = toDomainMessages(request, memory.history());
-        ChatResponse response = chatPort(request.provider()).chat(toDomainChatRequest(request, domainMessages));
+        ChatResponse response = executeChat(chatPort(request.provider()), toDomainChatRequest(request, domainMessages));
         int memoryMessageCount = appendMemory(memory, request.messages(), response);
         appendConversation(principal, memory, request.messages().stream().map(this::toDomainMessage).toList(), response);
         return ResponseEntity.ok(ApiResponse.ok(toDto(response, null, false, memoryMetadata(memory, memoryMessageCount))));
@@ -303,12 +303,12 @@ public class ChatController {
         List<ChatMessage> domainMessages = toDomainMessages(request, memory.history());
         ChatPort port = chatPort(request.provider());
         ChatRequest domainRequest = toDomainChatRequest(request, domainMessages);
+        java.util.stream.Stream<ChatStreamEvent> events = openStream(port, domainRequest);
         String requestId = UUID.randomUUID().toString();
         StreamingResponseBody body = outputStream -> writeStreamEvents(
                 outputStream,
                 requestId,
-                port,
-                domainRequest,
+                events,
                 memory,
                 request.messages().stream().map(this::toDomainMessage).toList(),
                 principal);
@@ -372,6 +372,7 @@ public class ChatController {
                         request.embeddingModel()));
             }
         }
+        ragResults = limitRagResults(ragResults, ragTopK);
         RagRetrievalDiagnostics diagnostics = ragPipelineService.latestDiagnostics().orElse(null);
 
         List<RagSearchResult> expansionCandidates = contextExpansionCandidates(
@@ -384,10 +385,7 @@ public class ChatController {
         String context = contextResult.context();
 
         List<ChatMessageDto> augmentedMessages = new ArrayList<>();
-        augmentedMessages.add(new ChatMessageDto("system", context));
-        if (chat.systemPrompt() != null && !chat.systemPrompt().isBlank()) {
-            augmentedMessages.add(new ChatMessageDto("system", chat.systemPrompt()));
-        }
+        augmentedMessages.add(new ChatMessageDto("system", combineSystemPrompts(context, chat.systemPrompt())));
         ChatMemoryContext memory = resolveMemory(chat, principal);
         augmentedMessages.addAll(toDtoMessages(memory.history()));
         augmentedMessages.addAll(chat.messages());
@@ -404,7 +402,7 @@ public class ChatController {
                 chat.stopSequences(),
                 chat.memory());
 
-        ChatResponse response = chatPort(chat.provider()).chat(toDomainChatRequest(augmented));
+        ChatResponse response = executeChat(chatPort(chat.provider()), toDomainChatRequest(augmented));
         int memoryMessageCount = appendMemory(memory, chat.messages(), response);
         appendConversation(principal, memory, chat.messages().stream().map(this::toDomainMessage).toList(), response);
         boolean exposeDiagnostics = shouldExposeDiagnostics(request);
@@ -562,6 +560,22 @@ public class ChatController {
         }
     }
 
+    private ChatResponse executeChat(ChatPort port, ChatRequest request) {
+        try {
+            return port.chat(request);
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+        }
+    }
+
+    private java.util.stream.Stream<ChatStreamEvent> openStream(ChatPort port, ChatRequest request) {
+        try {
+            return port.stream(request);
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+        }
+    }
+
     private ObjectScope resolveObjectScope(String objectType, String objectId) {
         String normalizedObjectType = normalizeText(objectType);
         String normalizedObjectId = normalizeText(objectId);
@@ -581,6 +595,18 @@ public class ChatController {
         }
         String trimmed = value.trim();
         return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private String combineSystemPrompts(String primary, String secondary) {
+        String first = normalizeText(primary);
+        String second = normalizeText(secondary);
+        if (first == null) {
+            return second == null ? "" : second;
+        }
+        if (second == null) {
+            return first;
+        }
+        return first + "\n\n" + second;
     }
 
     private List<ChatMessage> toDomainMessages(ChatRequestDto request) {
@@ -632,6 +658,15 @@ public class ChatController {
 
     private boolean shouldExposeDiagnostics(ChatRagRequestDto request) {
         return allowClientDebug && Boolean.TRUE.equals(request.debug());
+    }
+
+    private List<RagSearchResult> limitRagResults(List<RagSearchResult> results, int topK) {
+        if (results == null || results.isEmpty()) {
+            return List.of();
+        }
+        return results.stream()
+                .limit(Math.max(topK, 0))
+                .toList();
     }
 
     private String resolveRagQuery(ChatRagRequestDto request) {
@@ -756,15 +791,14 @@ public class ChatController {
     private void writeStreamEvents(
             OutputStream outputStream,
             String requestId,
-            ChatPort port,
-            ChatRequest request,
+            java.util.stream.Stream<ChatStreamEvent> events,
             ChatMemoryContext memory,
             List<ChatMessage> requestMessages,
             Principal principal) throws IOException {
         StringBuilder assistant = new StringBuilder();
         ChatStreamEvent last = null;
         boolean streamFailed = false;
-        try (java.util.stream.Stream<ChatStreamEvent> events = port.stream(request)) {
+        try (events) {
             Iterator<ChatStreamEvent> iterator = events.iterator();
             while (iterator.hasNext()) {
                 ChatStreamEvent event = iterator.next();

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
@@ -169,6 +169,48 @@ class ChatControllerTest {
     }
 
     @Test
+    void chatMapsProviderPromptValidationFailureToBadRequest() {
+        when(googleChatPort.chat(any(ChatRequest.class)))
+                .thenThrow(new IllegalArgumentException("Google GenAI supports only leading system messages"));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> controller.chat(new ChatRequestDto(
+                        "google",
+                        null,
+                        List.of(new ChatMessageDto("user", "hello")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null)));
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(ex.getReason()).contains("leading system messages");
+    }
+
+    @Test
+    void streamMapsProviderPromptValidationFailureToBadRequest() {
+        when(googleChatPort.stream(any(ChatRequest.class)))
+                .thenThrow(new IllegalArgumentException("Google GenAI supports only leading system messages"));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> controller.stream(new ChatRequestDto(
+                        "google",
+                        null,
+                        List.of(new ChatMessageDto("user", "hello")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null), null));
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(ex.getReason()).contains("leading system messages");
+    }
+
+    @Test
     void chatPrependsSystemPrompt() {
         ArgumentCaptor<ChatRequest> captor = ArgumentCaptor.forClass(ChatRequest.class);
 
@@ -538,12 +580,11 @@ class ChatControllerTest {
         assertThat(ragCaptor.getValue().metadataFilter().objectType()).isEqualTo("attachment");
         assertThat(ragCaptor.getValue().metadataFilter().objectId()).isEqualTo("123");
         verify(googleChatPort).chat(chatCaptor.capture());
-        assertThat(chatCaptor.getValue().messages()).hasSize(3);
+        assertThat(chatCaptor.getValue().messages()).hasSize(2);
         assertThat(chatCaptor.getValue().messages().get(0).role().name()).isEqualTo("SYSTEM");
         assertThat(chatCaptor.getValue().messages().get(0).content()).contains("file text");
-        assertThat(chatCaptor.getValue().messages().get(1).role().name()).isEqualTo("SYSTEM");
-        assertThat(chatCaptor.getValue().messages().get(1).content()).isEqualTo("answer from file");
-        assertThat(chatCaptor.getValue().messages().get(2).role().name()).isEqualTo("USER");
+        assertThat(chatCaptor.getValue().messages().get(0).content()).contains("answer from file");
+        assertThat(chatCaptor.getValue().messages().get(1).role().name()).isEqualTo("USER");
     }
 
     @Test
@@ -987,6 +1028,37 @@ class ChatControllerTest {
                 "123"));
 
         verify(ragPipelineService).listByObject("attachment", "123", 3);
+    }
+
+    @Test
+    void ragChatLimitsObjectListResultsBeforeBuildingContext() {
+        ArgumentCaptor<ChatRequest> chatCaptor = ArgumentCaptor.forClass(ChatRequest.class);
+        when(ragPipelineService.listByObject("attachment", "123", 2))
+                .thenReturn(List.of(
+                        new RagSearchResult("doc-1", "file text 1", Map.of(), 1.0d),
+                        new RagSearchResult("doc-2", "file text 2", Map.of(), 1.0d),
+                        new RagSearchResult("doc-3", "file text 3", Map.of(), 1.0d)));
+
+        controller.chatWithRag(new ChatRagRequestDto(
+                new ChatRequestDto(
+                        null,
+                        null,
+                        List.of(new ChatMessageDto("user", "summarize")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null),
+                null,
+                2,
+                "attachment",
+                "123"));
+
+        verify(defaultChatPort).chat(chatCaptor.capture());
+        assertThat(chatCaptor.getValue().messages().get(0).content())
+                .contains("file text 1", "file text 2")
+                .doesNotContain("file text 3");
     }
 
     @Test

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/adapter/GoogleSpringAiChatAdapter.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/adapter/GoogleSpringAiChatAdapter.java
@@ -1,9 +1,14 @@
 package studio.one.platform.ai.autoconfigure.adapter;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
 
+import studio.one.platform.ai.core.chat.ChatMessage;
+import studio.one.platform.ai.core.chat.ChatMessageRole;
 import studio.one.platform.ai.core.chat.ChatRequest;
 
 public class GoogleSpringAiChatAdapter extends SpringAiChatAdapter {
@@ -14,6 +19,35 @@ public class GoogleSpringAiChatAdapter extends SpringAiChatAdapter {
 
     public GoogleSpringAiChatAdapter(ChatModel chatModel, String provider, String configuredModel) {
         super(chatModel, provider, configuredModel);
+    }
+
+    @Override
+    protected List<ChatMessage> prepareMessages(ChatRequest request) {
+        List<ChatMessage> messages = super.prepareMessages(request);
+        if (messages.isEmpty()) {
+            return messages;
+        }
+        List<String> leadingSystemContents = new ArrayList<>();
+        int index = 0;
+        while (index < messages.size() && messages.get(index).role() == ChatMessageRole.SYSTEM) {
+            String content = messages.get(index).content();
+            if (content != null && !content.isBlank()) {
+                leadingSystemContents.add(content);
+            }
+            index++;
+        }
+        for (int i = index; i < messages.size(); i++) {
+            if (messages.get(i).role() == ChatMessageRole.SYSTEM) {
+                throw new IllegalArgumentException("Google GenAI supports only leading system messages");
+            }
+        }
+        if (leadingSystemContents.size() <= 1) {
+            return messages;
+        }
+        List<ChatMessage> prepared = new ArrayList<>(messages.size() - leadingSystemContents.size() + 1);
+        prepared.add(ChatMessage.system(String.join("\n\n", leadingSystemContents)));
+        prepared.addAll(messages.subList(index, messages.size()));
+        return List.copyOf(prepared);
     }
 
     @Override

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/adapter/SpringAiChatAdapter.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/adapter/SpringAiChatAdapter.java
@@ -19,7 +19,6 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.Prompt;
 
 import studio.one.platform.ai.core.chat.ChatMessage;
-import studio.one.platform.ai.core.chat.ChatMessageRole;
 import studio.one.platform.ai.core.chat.ChatPort;
 import studio.one.platform.ai.core.chat.ChatRequest;
 import studio.one.platform.ai.core.chat.ChatResponse;
@@ -50,7 +49,7 @@ public class SpringAiChatAdapter implements ChatPort {
 
     @Override
     public ChatResponse chat(ChatRequest request) {
-        List<Message> messages = request.messages().stream()
+        List<Message> messages = prepareMessages(request).stream()
                 .map(this::toSpringAiMessage)
                 .toList();
 
@@ -81,7 +80,7 @@ public class SpringAiChatAdapter implements ChatPort {
 
     @Override
     public Stream<ChatStreamEvent> stream(ChatRequest request) {
-        List<Message> messages = request.messages().stream()
+        List<Message> messages = prepareMessages(request).stream()
                 .map(this::toSpringAiMessage)
                 .toList();
         org.springframework.ai.chat.prompt.ChatOptions options = createChatOptions(request);
@@ -104,6 +103,10 @@ public class SpringAiChatAdapter implements ChatPort {
             case USER -> new UserMessage(message.content());
             case ASSISTANT -> new AssistantMessage(message.content());
         };
+    }
+
+    protected List<ChatMessage> prepareMessages(ChatRequest request) {
+        return request.messages() == null ? List.of() : request.messages();
     }
 
     protected org.springframework.ai.chat.prompt.ChatOptions createChatOptions(ChatRequest request) {

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagPipelineService.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagPipelineService.java
@@ -439,7 +439,10 @@ public class DefaultRagPipelineService implements RagPipelineService {
     @Override
     public List<RagSearchResult> listByObject(String objectType, String objectId, Integer limit) {
         clearDiagnostics();
-        List<VectorSearchResult> results = vectorStorePort.listByObject(objectType, objectId, options.clampListLimit(limit));
+        int effectiveLimit = options.clampListLimit(limit);
+        List<VectorSearchResult> results = limitResults(
+                vectorStorePort.listByObject(objectType, objectId, effectiveLimit),
+                effectiveLimit);
         return results.stream()
                 .map(result -> new RagSearchResult(
                         result.document().id(),
@@ -623,7 +626,7 @@ public class DefaultRagPipelineService implements RagPipelineService {
             Supplier<List<VectorSearchResult>> semanticSearch,
             String objectType,
             String objectId) {
-        List<VectorSearchResult> results = hybridSearch.apply(query);
+        List<VectorSearchResult> results = limitResults(hybridSearch.apply(query), searchRequest.topK());
         if (hasRelevantResults(results)) {
             recordDiagnostics(RagRetrievalDiagnostics.Strategy.HYBRID,
                     results.size(), results.size(), searchRequest, objectType, objectId, results);
@@ -633,7 +636,7 @@ public class DefaultRagPipelineService implements RagPipelineService {
 
         String enrichedQuery = options.keywordFallbackEnabled() ? enrichQuery(query) : query;
         if (options.keywordFallbackEnabled() && !enrichedQuery.equals(query)) {
-            List<VectorSearchResult> enrichedResults = hybridSearch.apply(enrichedQuery);
+            List<VectorSearchResult> enrichedResults = limitResults(hybridSearch.apply(enrichedQuery), searchRequest.topK());
             if (hasRelevantResults(enrichedResults)) {
                 recordDiagnostics(RagRetrievalDiagnostics.Strategy.KEYWORD_ENRICHED_HYBRID,
                         initialResultCount, enrichedResults.size(), searchRequest, objectType, objectId, enrichedResults);
@@ -642,7 +645,7 @@ public class DefaultRagPipelineService implements RagPipelineService {
         }
 
         if (options.semanticFallbackEnabled()) {
-            List<VectorSearchResult> semanticResults = semanticSearch.get();
+            List<VectorSearchResult> semanticResults = limitResults(semanticSearch.get(), searchRequest.topK());
             if (hasRelevantResults(semanticResults)) {
                 recordDiagnostics(RagRetrievalDiagnostics.Strategy.SEMANTIC,
                         initialResultCount, semanticResults.size(), searchRequest, objectType, objectId, semanticResults);
@@ -652,6 +655,15 @@ public class DefaultRagPipelineService implements RagPipelineService {
         recordDiagnostics(RagRetrievalDiagnostics.Strategy.NONE,
                 initialResultCount, 0, searchRequest, objectType, objectId, List.of());
         return List.of();
+    }
+
+    private List<VectorSearchResult> limitResults(List<VectorSearchResult> results, int topK) {
+        if (results == null || results.isEmpty()) {
+            return List.of();
+        }
+        return results.stream()
+                .limit(Math.max(topK, 0))
+                .toList();
     }
 
     private String enrichQuery(String query) {

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/adapter/GoogleSpringAiChatAdapterTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/adapter/GoogleSpringAiChatAdapterTest.java
@@ -1,14 +1,18 @@
 package studio.one.platform.ai.autoconfigure.adapter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.DefaultUsage;
@@ -18,6 +22,7 @@ import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
 
+import reactor.core.publisher.Flux;
 import studio.one.platform.ai.core.chat.ChatMessage;
 import studio.one.platform.ai.core.chat.ChatRequest;
 
@@ -52,7 +57,7 @@ class GoogleSpringAiChatAdapterTest {
         assertThat(response.model()).isEqualTo("gemini-2.5-flash");
 
         org.mockito.ArgumentCaptor<Prompt> promptCaptor = org.mockito.ArgumentCaptor.forClass(Prompt.class);
-        org.mockito.Mockito.verify(model).call(promptCaptor.capture());
+        verify(model).call(promptCaptor.capture());
         Prompt prompt = promptCaptor.getValue();
         assertThat(prompt.getOptions()).isInstanceOf(GoogleGenAiChatOptions.class);
         GoogleGenAiChatOptions options = (GoogleGenAiChatOptions) prompt.getOptions();
@@ -62,5 +67,68 @@ class GoogleSpringAiChatAdapterTest {
         assertThat(options.getTopK()).isEqualTo(20);
         assertThat(options.getMaxOutputTokens()).isEqualTo(100);
         assertThat(options.getStopSequences()).containsExactly("STOP");
+    }
+
+    @Test
+    void coalescesLeadingSystemMessagesBeforeCallingGoogle() {
+        ChatModel model = mock(ChatModel.class);
+        when(model.call(any(Prompt.class)))
+                .thenReturn(new ChatResponse(
+                        List.of(new Generation(new AssistantMessage("hello"))),
+                        null));
+        GoogleSpringAiChatAdapter adapter = new GoogleSpringAiChatAdapter(model);
+
+        adapter.chat(ChatRequest.builder()
+                .messages(List.of(
+                        ChatMessage.system("rag context"),
+                        ChatMessage.system("client system prompt"),
+                        ChatMessage.user("question")))
+                .build());
+
+        org.mockito.ArgumentCaptor<Prompt> promptCaptor = org.mockito.ArgumentCaptor.forClass(Prompt.class);
+        verify(model).call(promptCaptor.capture());
+        Prompt prompt = promptCaptor.getValue();
+        assertThat(prompt.getInstructions()).hasSize(2);
+        assertThat(prompt.getInstructions().get(0)).isInstanceOf(SystemMessage.class);
+        assertThat(prompt.getInstructions().get(0).getText()).isEqualTo("rag context\n\nclient system prompt");
+        assertThat(prompt.getInstructions().get(1)).isInstanceOf(UserMessage.class);
+    }
+
+    @Test
+    void coalescesLeadingSystemMessagesBeforeStreamingToGoogle() {
+        ChatModel model = mock(ChatModel.class);
+        when(model.stream(any(Prompt.class)))
+                .thenReturn(Flux.just(new ChatResponse(List.of(new Generation(new AssistantMessage("hello"))))));
+        GoogleSpringAiChatAdapter adapter = new GoogleSpringAiChatAdapter(model);
+
+        adapter.stream(ChatRequest.builder()
+                .messages(List.of(
+                        ChatMessage.system("rag context"),
+                        ChatMessage.system("client system prompt"),
+                        ChatMessage.user("question")))
+                .build()).toList();
+
+        org.mockito.ArgumentCaptor<Prompt> promptCaptor = org.mockito.ArgumentCaptor.forClass(Prompt.class);
+        verify(model).stream(promptCaptor.capture());
+        Prompt prompt = promptCaptor.getValue();
+        assertThat(prompt.getInstructions()).hasSize(2);
+        assertThat(prompt.getInstructions().get(0)).isInstanceOf(SystemMessage.class);
+        assertThat(prompt.getInstructions().get(0).getText()).isEqualTo("rag context\n\nclient system prompt");
+        assertThat(prompt.getInstructions().get(1)).isInstanceOf(UserMessage.class);
+    }
+
+    @Test
+    void rejectsNonLeadingSystemMessagesForGoogle() {
+        ChatModel model = mock(ChatModel.class);
+        GoogleSpringAiChatAdapter adapter = new GoogleSpringAiChatAdapter(model);
+
+        assertThatThrownBy(() -> adapter.chat(ChatRequest.builder()
+                .messages(List.of(
+                        ChatMessage.system("first"),
+                        ChatMessage.user("question"),
+                        ChatMessage.system("later")))
+                .build()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("leading system messages");
     }
 }

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
@@ -606,6 +606,24 @@ class RagPipelineServiceTest {
     }
 
     @Test
+    void shouldLimitSearchResultsToRequestedTopK() {
+        RagSearchRequest request = new RagSearchRequest("hello", 2);
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("hello", List.of(0.5, 0.6)))));
+        when(vectorStorePort.hybridSearch(anyString(), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(
+                        new VectorSearchResult(new VectorDocument("doc-1", "chunk 1", Map.of(), List.of()), 0.9),
+                        new VectorSearchResult(new VectorDocument("doc-2", "chunk 2", Map.of(), List.of()), 0.8),
+                        new VectorSearchResult(new VectorDocument("doc-3", "chunk 3", Map.of(), List.of()), 0.7)));
+
+        List<RagSearchResult> results = ragPipelineService.search(request);
+
+        assertThat(results)
+                .extracting(RagSearchResult::documentId)
+                .containsExactly("doc-1", "doc-2");
+    }
+
+    @Test
     void shouldConstrainSearchToRequestedEmbeddingProfileMetadata() {
         RagEmbeddingProfileResolver resolver = selection -> new ResolvedRagEmbedding(
                 embeddingPort,
@@ -801,6 +819,28 @@ class RagPipelineServiceTest {
         assertThat(results.get(0).metadata()).containsEntry("source", "object-keyword-fallback");
         verify(vectorStorePort).hybridSearchByObject(eq("hello"), eq("attachment"), eq("42"), any(VectorSearchRequest.class), anyDouble(), anyDouble());
         verify(vectorStorePort).hybridSearchByObject(eq("hello greeting salutation"), eq("attachment"), eq("42"), any(VectorSearchRequest.class), anyDouble(), anyDouble());
+    }
+
+    @Test
+    void shouldLimitObjectScopedKeywordFallbackResultsToRequestedTopK() {
+        RagSearchRequest request = new RagSearchRequest("hello", 2);
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("hello", List.of(0.5, 0.6)))));
+        when(keywordExtractor.extract("hello")).thenReturn(List.of("greeting"));
+        when(vectorStorePort.hybridSearchByObject(eq("hello"), eq("attachment"), eq("42"), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("doc-low", "weak", Map.of(), List.of(0.5, 0.6)), 0.05)));
+        when(vectorStorePort.hybridSearchByObject(eq("hello greeting"), eq("attachment"), eq("42"), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(
+                        new VectorSearchResult(new VectorDocument("doc-1", "chunk 1", Map.of(), List.of()), 0.9),
+                        new VectorSearchResult(new VectorDocument("doc-2", "chunk 2", Map.of(), List.of()), 0.8),
+                        new VectorSearchResult(new VectorDocument("doc-3", "chunk 3", Map.of(), List.of()), 0.7)));
+
+        List<RagSearchResult> results = ragPipelineService.searchByObject(request, "attachment", "42");
+
+        assertThat(results)
+                .extracting(RagSearchResult::documentId)
+                .containsExactly("doc-1", "doc-2");
     }
 
     @Test
@@ -1036,6 +1076,21 @@ class RagPipelineServiceTest {
     }
 
     @Test
+    void shouldLimitObjectListResultsToEffectiveLimit() {
+        when(vectorStorePort.listByObject(eq("attachment"), eq("42"), eq(2)))
+                .thenReturn(List.of(
+                        new VectorSearchResult(new VectorDocument("doc-1", "chunk 1", Map.of(), List.of()), 1.0d),
+                        new VectorSearchResult(new VectorDocument("doc-2", "chunk 2", Map.of(), List.of()), 1.0d),
+                        new VectorSearchResult(new VectorDocument("doc-3", "chunk 3", Map.of(), List.of()), 1.0d)));
+
+        List<RagSearchResult> results = ragPipelineService.listByObject("attachment", "42", 2);
+
+        assertThat(results)
+                .extracting(RagSearchResult::documentId)
+                .containsExactly("doc-1", "doc-2");
+    }
+
+    @Test
     void shouldNotExposeDiagnosticsWhenDisabled() {
         RagSearchRequest request = new RagSearchRequest("hello", 2);
         when(embeddingPort.embed(any(EmbeddingRequest.class)))
@@ -1056,25 +1111,27 @@ class RagPipelineServiceTest {
                 null,
                 new RagPipelineOptions(0.2d, 0.8d, 0.4d, true, true, 20, 100),
                 new RagPipelineDiagnosticsOptions(true, false, 120));
-        RagSearchRequest request = new RagSearchRequest("hello", 7);
+        RagSearchRequest request = new RagSearchRequest("hello", 2);
         when(embeddingPort.embed(any(EmbeddingRequest.class)))
                 .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("hello", List.of(0.5, 0.6)))));
         when(vectorStorePort.hybridSearch(anyString(), any(VectorSearchRequest.class), eq(0.2d), eq(0.8d)))
-                .thenReturn(List.of(new VectorSearchResult(
-                        new VectorDocument("doc-1", "chunk", Map.of(), List.of(0.5, 0.6)), 0.9)));
+                .thenReturn(List.of(
+                        new VectorSearchResult(new VectorDocument("doc-1", "chunk 1", Map.of(), List.of()), 0.9),
+                        new VectorSearchResult(new VectorDocument("doc-2", "chunk 2", Map.of(), List.of()), 0.8),
+                        new VectorSearchResult(new VectorDocument("doc-3", "chunk 3", Map.of(), List.of()), 0.7)));
 
         ragPipelineService.search(request);
 
         assertThat(ragPipelineService.latestDiagnostics()).hasValueSatisfying(diagnostics -> {
             assertThat(diagnostics.strategy()).isEqualTo(RagRetrievalDiagnostics.Strategy.HYBRID);
-            assertThat(diagnostics.initialResultCount()).isEqualTo(1);
-            assertThat(diagnostics.finalResultCount()).isEqualTo(1);
+            assertThat(diagnostics.initialResultCount()).isEqualTo(2);
+            assertThat(diagnostics.finalResultCount()).isEqualTo(2);
             assertThat(diagnostics.minScore()).isEqualTo(0.4d);
             assertThat(diagnostics.vectorWeight()).isEqualTo(0.2d);
             assertThat(diagnostics.lexicalWeight()).isEqualTo(0.8d);
             assertThat(diagnostics.objectType()).isNull();
             assertThat(diagnostics.objectId()).isNull();
-            assertThat(diagnostics.topK()).isEqualTo(7);
+            assertThat(diagnostics.topK()).isEqualTo(2);
         });
     }
 


### PR DESCRIPTION
## Why

/api/ai/chat/rag 호출에서 RAG context와 클라이언트 systemPrompt가 각각 system 메시지로 전달되어 Google GenAI가 `Only one system message is allowed in the prompt` 오류를 반환한다.

또한 운영 pgvector 경로는 SQL `LIMIT :limit`로 topK를 적용하지만, VectorStorePort 구현체나 fallback/list 경로가 초과 결과를 반환할 경우 최종 RAG 검색 결과가 topK를 넘지 않도록 서버 방어 로직이 필요하다.

## What

- RAG chat context와 클라이언트 systemPrompt를 단일 system 메시지로 병합한다.
- GoogleSpringAiChatAdapter에서 선두 system 메시지만 병합하고, 중간 system 메시지는 의미 변경을 피하기 위해 명시적으로 거부한다.
- SpringAiChatAdapter의 공통 전역 system 재배치 로직은 제거하고, provider별 메시지 준비 hook만 둔다.
- Google prompt validation 실패를 chat/stream 웹 경계에서 `400 Bad Request`로 매핑한다.
- DefaultRagPipelineService에서 hybrid, keyword-enriched hybrid, semantic fallback, listByObject 결과를 topK로 제한한다.
- ChatController에서도 RAG 결과를 context 생성 전 topK로 최종 제한한다.
- ChatControllerTest, GoogleSpringAiChatAdapterTest, RagPipelineServiceTest를 갱신 및 추가한다.

## Related Issues

- Closes #352

## Validation

- Command: `./gradlew :starter:studio-platform-starter-ai:test --tests studio.one.platform.ai.autoconfigure.adapter.GoogleSpringAiChatAdapterTest --tests studio.one.platform.ai.autoconfigure.adapter.SpringAiChatAdapterTest --tests studio.one.platform.ai.service.pipeline.RagPipelineServiceTest`
- Result: SUCCESS
- Command: `./gradlew :starter:studio-platform-starter-ai-web:test --tests studio.one.platform.ai.web.controller.ChatControllerTest --tests studio.one.platform.ai.web.controller.AiWebExceptionHandlerTest`
- Result: SUCCESS
- Command: `git diff --check`
- Result: SUCCESS

## Risk / Rollback

- Risk: Google provider에서는 중간에 등장하는 system 메시지를 더 이상 조용히 재배치하지 않고 400으로 거부한다. 기존에 interleaved system transcript를 Google로 보내던 호출이 있다면 명시 오류가 발생할 수 있지만, system instruction의 적용 범위가 바뀌는 것보다 안전하다. RAG 검색/list 결과는 최종 topK 제한 때문에 초과 반환 구현체의 추가 결과가 더 이상 노출되지 않는다.
- Rollback: 이 커밋을 revert하면 기존 RAG prompt 조립 및 검색 결과 반환 동작으로 복구된다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: Yes
- Delegated scope: PR #353 변경 파일의 correctness review를 2회 수행했다. 1차 리뷰에서 전역 system 메시지 재배치 부작용, stream 테스트 누락, topK fallback 테스트 보강 필요성을 지적받아 반영했다. 2차 리뷰에서 Google prompt validation의 400 매핑과 no-query object list 경로의 topK 최종 제한 누락을 지적받아 반영했다.
- Main author validation: 관련 Gradle 테스트와 `git diff --check` 실행 결과를 확인했다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included
