### PR TITLE
[ai-assisted] fix(ai): distinguish embedding quota search errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2026-04-28
 
 ### 변경됨
+- 이슈 #357 대응으로 Vector/RAG query 검색 중 embedding provider quota/rate limit이 발생하면 chat 오류와 구분되는 HTTP 429 메시지를 반환하도록 했다.
+- `starter-ai-web` README에 query 기반 Vector/RAG 검색이 embedding provider를 호출한다는 점과 provider-free chunk inspection 대체 경로를 명시했다.
 - 이슈 #355 대응으로 `studio-platform-textract-starter`의 기능/런타임 설정을 `studio.features.textract.*`와 `studio.textract.*`로 정리하고, 텍스트 추출 크기 제한을 `studio.textract.max-extract-size`에서 `10M`, `50MB` 같은 단위로 설정할 수 있도록 했다.
 - 기존 `studio.features.text.*`와 `studio.text.*`는 fallback과 deprecation warning, configuration metadata를 유지한다.
 - 텍스트 추출 크기 초과 예외 메시지에 감지된 크기, 제한값, 조치 설정 키를 포함하도록 보강했다.

--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -523,6 +523,11 @@ Content-Type: application/json
 
 `objectType`/`objectId`는 core `MetadataFilter.objectScope(...)`로 변환되어 RAG pipeline에 전달된다.
 둘 다 생략하면 전체 RAG 인덱스 검색을 수행한다.
+`POST /api/mgmt/ai/rag/search`는 query 기반 semantic search API이므로 검색 전에 embedding provider를 호출해
+query embedding을 생성한다. OpenAI quota 부족처럼 provider quota/rate limit이 발생하면 chat 오류와 구분되는
+HTTP 429 `ProblemDetails.detail`로 `Embedding provider quota exceeded...` 메시지를 반환한다.
+저장된 chunk 원문을 provider 호출 없이 확인하려면 `GET /api/mgmt/ai/rag/jobs/{jobId}/chunks`,
+`GET /api/mgmt/ai/rag/objects/{objectType}/{objectId}/chunks` 또는 각 `/chunks/page` variant를 사용한다.
 
 ### 파일 기반 RAG 흐름
 
@@ -541,6 +546,14 @@ Content-Type: application/json
 `POST /api/mgmt/ai/vectors/search` 응답 항목은 기존 `documentId`와 클라이언트 grid 호환용 `id`를 함께 반환한다.
 내부 검색 결과는 core `VectorSearchResults`/`VectorSearchHit` aggregate 계약으로 정규화하지만,
 HTTP 응답 shape는 기존 `List<VectorSearchResultDto>`를 유지한다.
+요청에 `embedding`을 직접 전달하면 provider 호출 없이 해당 벡터로 검색한다. `embedding` 없이 `query`만 전달하면
+검색 전에 configured `EmbeddingPort`가 호출되어 query embedding을 생성하므로 Spring AI/OpenAI 등 embedding
+provider quota를 사용한다. `hybrid=true`도 lexical score와 vector score를 함께 쓰기 때문에 query embedding이
+필요하며, 이 스타터는 별도 lexical-only debug search를 제공하지 않는다.
+query embedding 생성 중 provider quota/rate limit이 발생하면 HTTP 429 `ProblemDetails.detail`에
+`Embedding provider quota exceeded...` 메시지를 반환한다. 원시 chunk 확인이 목적이면 RAG chunk inspection API
+(`GET /api/mgmt/ai/rag/jobs/{jobId}/chunks`, `GET /api/mgmt/ai/rag/objects/{objectType}/{objectId}/chunks`,
+또는 각 `/chunks/page` variant)를 사용하면 provider 호출이 발생하지 않는다.
 요청에 `includeText=false` 또는 `includeMetadata=false`를 전달하면 core `VectorSearchRequest`에 그대로 전달되어
 응답 항목의 `content`가 `null`이거나 `metadata`가 빈 객체일 수 있다.
 `documentId`, `chunkId`, `sourceRef`, `page`, `slide` 같은 provenance key는
@@ -574,9 +587,12 @@ HTTP 응답 shape는 기존 `List<VectorSearchResultDto>`를 유지한다.
 ## 5) 참고 사항
 
 - `VectorController`는 `VectorStorePort` 빈이 없어도 등록되지만, 벡터 관련 요청 시 HTTP 503을 반환한다.
-- 벡터 검색 시 `hybrid=true`를 설정하면 BM25 + 벡터 하이브리드 검색이 활성화된다(query 텍스트 필수).
+- 벡터/RAG 검색에서 `query`만 전달하는 semantic search는 embedding provider 호출을 수반한다.
+- 벡터 검색 시 `hybrid=true`를 설정하면 BM25 + 벡터 하이브리드 검색이 활성화된다. lexical score 계산에는
+  `query` 텍스트가 필요하고, vector score 계산에는 직접 전달한 `embedding` 또는 query로 생성한 embedding이 필요하다.
 - 채팅 API의 `provider`는 Studio provider id 선택만 담당한다. OpenAI 런타임 설정은 계속 `spring.ai.openai.*`가 소유한다.
 - Google GenAI 등 provider quota/rate limit 오류는 AI web exception handler가 HTTP 429 `ProblemDetails`로 변환한다.
+- Vector/RAG query embedding quota/rate limit 오류는 chat quota와 구분되는 embedding provider 메시지로 반환한다.
 - `query-rewrite` 엔드포인트는 Mustache 템플릿(`query-rewrite`)이 없으면 내장 폴백 프롬프트를 사용한다.
 - 모든 엔드포인트는 Spring Security의 메서드 레벨 권한 검사(`@PreAuthorize`)를 사용한다.
   `endpointAuthz` 빈이 컨텍스트에 등록되어 있어야 한다.

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagController.java
@@ -23,6 +23,7 @@ import studio.one.platform.ai.core.rag.RagIndexJobStatus;
 import studio.one.platform.ai.core.rag.RagIndexRequest;
 import studio.one.platform.ai.core.rag.RagSearchRequest;
 import studio.one.platform.ai.core.rag.RagSearchResult;
+import studio.one.platform.ai.service.pipeline.EmbeddingProviderQuotaExceededException;
 import studio.one.platform.ai.service.pipeline.RagIndexJobService;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
 import studio.one.platform.ai.web.dto.IndexRequest;
@@ -128,13 +129,23 @@ public class RagController {
     @PostMapping("/search")
     @PreAuthorize("@endpointAuthz.can('services:ai_rag','read')")
     public ResponseEntity<SearchResponse> search(@Valid @RequestBody SearchRequest request) {
-        List<RagSearchResult> results = ragPipelineService.search(new RagSearchRequest(
-                request.query(),
-                request.topK(),
-                MetadataFilter.objectScope(request.objectType(), request.objectId()),
-                request.embeddingProfileId(),
-                request.embeddingProvider(),
-                request.embeddingModel()));
+        List<RagSearchResult> results;
+        try {
+            results = ragPipelineService.search(new RagSearchRequest(
+                    request.query(),
+                    request.topK(),
+                    MetadataFilter.objectScope(request.objectType(), request.objectId()),
+                    request.embeddingProfileId(),
+                    request.embeddingProvider(),
+                    request.embeddingModel()));
+        } catch (EmbeddingProviderQuotaExceededException ex) {
+            throw new ResponseStatusException(
+                    HttpStatus.TOO_MANY_REQUESTS,
+                    "Embedding provider quota exceeded while executing RAG search. Query-based RAG search "
+                            + "generates an embedding before vector lookup; use RAG chunk inspection endpoints "
+                            + "for provider-free inspection.",
+                    ex);
+        }
         List<SearchResult> payload = results.stream()
                 .map(result -> new SearchResult(
                         result.documentId(),

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/VectorController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/VectorController.java
@@ -34,6 +34,7 @@ import studio.one.platform.ai.core.vector.VectorStorePort;
 import studio.one.platform.ai.service.pipeline.RagEmbeddingProfileResolver;
 import studio.one.platform.ai.service.pipeline.RagEmbeddingSelection;
 import studio.one.platform.ai.service.pipeline.ResolvedRagEmbedding;
+import studio.one.platform.ai.service.pipeline.AiProviderExceptionSupport;
 import studio.one.platform.ai.web.dto.VectorDocumentDto;
 import studio.one.platform.ai.web.dto.VectorSearchRequestDto;
 import studio.one.platform.ai.web.dto.VectorSearchResultDto;
@@ -205,10 +206,10 @@ public class VectorController {
         EmbeddingResponse response;
         ResolvedRagEmbedding resolved = null;
         if (embeddingProfileResolver == null || !hasEmbeddingSelection(request)) {
-            response = embeddingPort.embed(new EmbeddingRequest(List.of(request.query())));
+            response = embedForSearch(embeddingPort, new EmbeddingRequest(List.of(request.query())));
         } else {
             resolved = resolveSelection(request);
-            response = resolved.embeddingPort().embed(resolved.request(List.of(request.query())));
+            response = embedForSearch(resolved.embeddingPort(), resolved.request(List.of(request.query())));
         }
         log.debug("embedding {} -> {}", request.query(), response.vectors().size());
         List<Double> values = List.copyOf(response.vectors().get(0).values());
@@ -220,6 +221,23 @@ public class VectorController {
                 resolved == null
                         ? null
                         : resolved.dimension() == null ? values.size() : resolved.dimension());
+    }
+
+    private EmbeddingResponse embedForSearch(EmbeddingPort port, EmbeddingRequest request) {
+        try {
+            return port.embed(request);
+        } catch (RuntimeException ex) {
+            if (AiProviderExceptionSupport.isQuotaOrRateLimit(ex)) {
+                throw new ResponseStatusException(
+                        HttpStatus.TOO_MANY_REQUESTS,
+                        "Embedding provider quota exceeded while converting vector search query to an embedding. "
+                                + "Query-based vector search calls the configured EmbeddingPort; provide a "
+                                + "precomputed embedding or use RAG chunk inspection endpoints for provider-free "
+                                + "inspection.",
+                        ex);
+            }
+            throw ex;
+        }
     }
 
     private ResolvedRagEmbedding resolveSelection(VectorSearchRequestDto request) {

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagControllerTest.java
@@ -1,6 +1,7 @@
 package studio.one.platform.ai.web.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -12,12 +13,14 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
 
 import studio.one.platform.ai.core.rag.RagIndexJob;
 import studio.one.platform.ai.core.rag.RagIndexJobCreateRequest;
 import studio.one.platform.ai.core.rag.RagIndexRequest;
 import studio.one.platform.ai.core.rag.RagSearchRequest;
 import studio.one.platform.ai.core.rag.RagSearchResult;
+import studio.one.platform.ai.service.pipeline.EmbeddingProviderQuotaExceededException;
 import studio.one.platform.ai.service.pipeline.RagIndexJobService;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
 import studio.one.platform.ai.web.dto.IndexRequest;
@@ -77,5 +80,22 @@ class RagControllerTest {
         assertThat(captor.getValue().topK()).isEqualTo(3);
         assertThat(captor.getValue().metadataFilter().objectType()).isEqualTo("attachment");
         assertThat(captor.getValue().metadataFilter().objectId()).isEqualTo("42");
+    }
+
+    @Test
+    void searchEmbeddingQuotaErrorIsReturnedAsEmbeddingProviderError() {
+        RagPipelineService ragPipelineService = mock(RagPipelineService.class);
+        RagController controller = new RagController(ragPipelineService);
+        when(ragPipelineService.search(any(RagSearchRequest.class)))
+                .thenThrow(new EmbeddingProviderQuotaExceededException(
+                        "Embedding provider quota exceeded while generating RAG embedding.",
+                        new RuntimeException("HTTP 429 insufficient_quota")));
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+                () -> controller.search(new SearchRequest("hello", 3, "attachment", "42")));
+
+        assertThat(exception.getStatusCode().value()).isEqualTo(429);
+        assertThat(exception.getReason()).contains("Embedding provider quota exceeded");
+        assertThat(exception.getReason()).contains("Query-based RAG search");
     }
 }

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/VectorControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/VectorControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -116,6 +117,20 @@ class VectorControllerTest {
         assertThat(captor.getValue().queryText()).isEqualTo("hello");
         assertThat(captor.getValue().includeText()).isTrue();
         assertThat(captor.getValue().includeMetadata()).isTrue();
+    }
+
+    @Test
+    void queryEmbeddingQuotaErrorIsReturnedAsEmbeddingProviderError() {
+        when(embeddingPort.embed(any()))
+                .thenThrow(new RuntimeException("HTTP 429 insufficient_quota"));
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> controller.search(
+                new VectorSearchRequestDto("hello", null, 3, false, null, null, null)));
+
+        assertThat(exception.getStatusCode().value()).isEqualTo(429);
+        assertThat(exception.getReason()).contains("Embedding provider quota exceeded");
+        assertThat(exception.getReason()).contains("precomputed embedding");
+        verifyNoInteractions(vectorStorePort);
     }
 
     @Test

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/AiProviderExceptionSupport.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/AiProviderExceptionSupport.java
@@ -1,0 +1,35 @@
+package studio.one.platform.ai.service.pipeline;
+
+import java.util.Locale;
+
+public final class AiProviderExceptionSupport {
+
+    private AiProviderExceptionSupport() {
+    }
+
+    public static boolean isQuotaOrRateLimit(Throwable ex) {
+        Throwable current = ex;
+        while (current != null) {
+            if (containsQuotaSignal(current.getMessage())) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private static boolean containsQuotaSignal(String message) {
+        if (message == null || message.isBlank()) {
+            return false;
+        }
+        String lower = message.toLowerCase(Locale.ROOT);
+        return lower.contains("insufficient_quota")
+                || lower.contains("quota")
+                || lower.contains("rate limit")
+                || lower.contains("resource_exhausted")
+                || lower.contains("too_many_requests")
+                || lower.contains("too many requests")
+                || lower.contains("http 429")
+                || lower.contains("status 429");
+    }
+}

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagPipelineService.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagPipelineService.java
@@ -502,7 +502,16 @@ public class DefaultRagPipelineService implements RagPipelineService {
 
     private EmbeddingResponse executeEmbedding(List<String> texts, ResolvedRagEmbedding resolvedEmbedding) {
         Supplier<EmbeddingResponse> supplier = () -> resolvedEmbedding.embeddingPort().embed(resolvedEmbedding.request(texts));
-        return Retry.decorateSupplier(retry, supplier).get();
+        try {
+            return Retry.decorateSupplier(retry, supplier).get();
+        } catch (RuntimeException ex) {
+            if (AiProviderExceptionSupport.isQuotaOrRateLimit(ex)) {
+                throw new EmbeddingProviderQuotaExceededException(
+                        "Embedding provider quota exceeded while generating RAG embedding.",
+                        ex);
+            }
+            throw ex;
+        }
     }
 
     private ResolvedRagEmbedding resolveLegacyEmbedding() {

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/EmbeddingProviderQuotaExceededException.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/EmbeddingProviderQuotaExceededException.java
@@ -1,0 +1,8 @@
+package studio.one.platform.ai.service.pipeline;
+
+public class EmbeddingProviderQuotaExceededException extends RuntimeException {
+
+    public EmbeddingProviderQuotaExceededException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
@@ -606,6 +606,33 @@ class RagPipelineServiceTest {
     }
 
     @Test
+    void searchEmbeddingQuotaErrorIsMarkedAsEmbeddingProviderFailure() {
+        RagSearchRequest request = new RagSearchRequest("hello", 2);
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenThrow(new RuntimeException("HTTP 429 insufficient_quota"));
+
+        assertThatThrownBy(() -> ragPipelineService.search(request))
+                .isInstanceOf(EmbeddingProviderQuotaExceededException.class)
+                .hasMessageContaining("Embedding provider quota exceeded")
+                .hasRootCauseMessage("HTTP 429 insufficient_quota");
+
+        verify(vectorStorePort, never()).hybridSearch(anyString(), any(VectorSearchRequest.class), anyDouble(), anyDouble());
+    }
+
+    @Test
+    void searchVectorStoreQuotaErrorIsNotMarkedAsEmbeddingProviderFailure() {
+        RagSearchRequest request = new RagSearchRequest("hello", 2);
+        RuntimeException vectorStoreFailure = new RuntimeException("HTTP 429 too many requests");
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("hello", List.of(0.5, 0.6)))));
+        when(vectorStorePort.hybridSearch(anyString(), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenThrow(vectorStoreFailure);
+
+        assertThatThrownBy(() -> ragPipelineService.search(request))
+                .isSameAs(vectorStoreFailure);
+    }
+
+    @Test
     void shouldLimitSearchResultsToRequestedTopK() {
         RagSearchRequest request = new RagSearchRequest("hello", 2);
         when(embeddingPort.embed(any(EmbeddingRequest.class)))


### PR DESCRIPTION
## Why

- query 기반 Vector/RAG 검색은 chat 호출이 아니지만, query embedding 생성을 위해 embedding provider를 호출한다.
- OpenAI `HTTP 429 insufficient_quota` 같은 오류가 chat quota 오류처럼 보이지 않도록 embedding provider 오류로 구분해야 한다.

## What

- Vector query 검색에서 embedding 생성 중 quota/rate-limit 신호가 발생하면 HTTP 429 `Embedding provider quota exceeded...` 메시지로 반환한다.
- RAG 검색은 `DefaultRagPipelineService.executeEmbedding()`의 실제 embedding 실행 지점에서만 `EmbeddingProviderQuotaExceededException`으로 감싸고, `RagController`는 이 typed exception만 429로 매핑한다.
- vector store 단계의 429가 embedding provider quota로 오분류되지 않도록 회귀 테스트를 추가했다.
- README에 query 기반 Vector/RAG 검색의 provider 호출 여부, 직접 `embedding` 전달, provider-free RAG chunk inspection API를 문서화했다.
- `CHANGELOG.md`에 이슈 #357 변경 사항을 기록했다.

## Related Issues

- Closes #357

## Validation

- Command: `./gradlew :starter:studio-platform-starter-ai:test --tests 'studio.one.platform.ai.service.pipeline.RagPipelineServiceTest' :starter:studio-platform-starter-ai-web:test --tests 'studio.one.platform.ai.web.controller.VectorControllerTest' --tests 'studio.one.platform.ai.web.controller.RagControllerTest'`
- Result: `BUILD SUCCESSFUL`
- Command: `./gradlew :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test`
- Result: `BUILD SUCCESSFUL`
- Command: `git diff --check`
- Result: `PASS`
- Command: `./gradlew test`
- Result: `BUILD SUCCESSFUL`

## Risk / Rollback

- Risk: provider SDK별 quota/rate-limit 예외 payload가 다르면 메시지 기반 판별이 누락될 수 있다. 다만 적용 지점은 embedding 호출로 제한했다.
- Rollback: 이 PR의 commit을 revert하면 기존 예외 전파와 문서 상태로 돌아간다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: Yes
- Delegated scope: 이슈 #357 변경에 대한 코드 리뷰 2회. 1차 리뷰에서 RAG 검색 전체 catch의 오분류 리스크를 지적했고, main author가 service embedding 실행 지점의 typed exception 방식으로 반영했다. 2차 리뷰에서 blocking 없음 확인.
- Main author validation: 대상 테스트, starter-ai/starter-ai-web 테스트, 전체 `./gradlew test`, `git diff --check`를 실행했다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included