### PR TITLE
[ai-assisted] feat(ai): add rag job source name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2026-04-28
 
 ### 변경됨
+- 이슈 #360 대응으로 RAG job 응답 DTO에 `sourceName`을 추가하고, in-memory/JDBC job 저장소와 attachment RAG job 생성 경로에서 표시명을 유지하도록 했다.
 - 이슈 #357 대응으로 Vector/RAG query 검색 중 embedding provider quota/rate limit이 발생하면 chat 오류와 구분되는 HTTP 429 메시지를 반환하도록 했다.
 - `starter-ai-web` README에 query 기반 Vector/RAG 검색이 embedding provider를 호출한다는 점과 provider-free chunk inspection 대체 경로를 명시했다.
 - 이슈 #355 대응으로 `studio-platform-textract-starter`의 기능/런타임 설정을 `studio.features.textract.*`와 `studio.textract.*`로 정리하고, 텍스트 추출 크기 제한을 `studio.textract.max-extract-size`에서 `10M`, `50MB` 같은 단위로 설정할 수 있도록 했다.

--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -112,6 +112,10 @@ raw `text`가 있으면 같은 `RagPipelineService`를 in-memory job service로 
 `sourceType=attachment` job executor를 제공하며 기존 attachment RAG index 경로를 재사용한다.
 job 생성과 retry는 `services:ai_rag write`가 필요하다. attachment source job 생성과 retry는 기존
 attachment 색인 API와 동일하게 `features:attachment write` 권한도 필요하다.
+job 응답 DTO에는 grid 표시용 `sourceName`이 포함된다. attachment source job은 파일명을 저장하고,
+raw text job은 요청 `sourceName`, metadata의 `sourceName`/`title`/`filename`/`fileName`/`name`, `documentId`
+순서로 표시명을 결정한다. `sourceName`은 `GET /jobs`, `GET /jobs/{jobId}`, create/retry/cancel 응답에
+동일하게 포함되며 저장 경계에 맞춰 최대 300자까지 보존한다.
 
 attachment source job 예시:
 
@@ -125,6 +129,7 @@ Content-Type: application/json
   "objectId": "101",
   "documentId": "doc-101",
   "sourceType": "attachment",
+  "sourceName": "sample.pdf",
   "metadata": {
     "category": "manual"
   },

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagIndexJobController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagIndexJobController.java
@@ -305,11 +305,21 @@ public class RagIndexJobController {
                 documentId,
                 request.sourceType(),
                 Boolean.TRUE.equals(request.forceReindex()),
-                indexRequest), sourceRequest);
+                indexRequest,
+                sourceName(request, metadata, documentId)), sourceRequest);
     }
 
     private boolean isAttachmentSource(RagIndexJobCreateRequestDto request) {
         return "attachment".equalsIgnoreCase(request.sourceType());
+    }
+
+    private String sourceName(RagIndexJobCreateRequestDto request, Map<String, Object> metadata, String documentId) {
+        String sourceName = text(request.sourceName());
+        if (sourceName != null) {
+            return sourceName;
+        }
+        sourceName = text(firstPresent(metadata, "sourceName", "title", "filename", "fileName", "name"));
+        return sourceName == null ? documentId : sourceName;
     }
 
     private void dispatch(String jobId, Runnable task) {

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/RagIndexJobCreateRequestDto.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/RagIndexJobCreateRequestDto.java
@@ -17,7 +17,8 @@ public record RagIndexJobCreateRequestDto(
         Boolean useLlmKeywordExtraction,
         String embeddingProfileId,
         String embeddingProvider,
-        String embeddingModel) {
+        String embeddingModel,
+        String sourceName) {
     public RagIndexJobCreateRequestDto(
             String objectType,
             String objectId,
@@ -29,6 +30,6 @@ public record RagIndexJobCreateRequestDto(
             List<String> keywords,
             Boolean useLlmKeywordExtraction) {
         this(objectType, objectId, documentId, sourceType, forceReindex, text, metadata, keywords,
-                useLlmKeywordExtraction, null, null, null);
+                useLlmKeywordExtraction, null, null, null, null);
     }
 }

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/RagIndexJobDto.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/RagIndexJobDto.java
@@ -12,6 +12,7 @@ public record RagIndexJobDto(
         String objectId,
         String documentId,
         String sourceType,
+        String sourceName,
         RagIndexJobStatus status,
         RagIndexJobStep currentStep,
         int chunkCount,
@@ -31,6 +32,7 @@ public record RagIndexJobDto(
                 job.objectId(),
                 job.documentId(),
                 job.sourceType(),
+                sourceName(job),
                 job.status(),
                 job.currentStep(),
                 job.chunkCount(),
@@ -42,5 +44,9 @@ public record RagIndexJobDto(
                 job.startedAt(),
                 job.finishedAt(),
                 job.durationMs());
+    }
+
+    private static String sourceName(RagIndexJob job) {
+        return job.sourceName() == null ? job.documentId() : job.sourceName();
     }
 }

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagIndexJobControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagIndexJobControllerTest.java
@@ -86,6 +86,7 @@ class RagIndexJobControllerTest {
 
         assertThat(response.getStatusCode().value()).isEqualTo(202);
         assertThat(response.getBody().getData().jobId()).isEqualTo("job-1");
+        assertThat(response.getBody().getData().sourceName()).isEqualTo("sample.pdf");
         assertThat(jobService.createdRequest.indexRequest().metadata())
                 .containsEntry("objectType", "attachment")
                 .containsEntry("objectId", "42")
@@ -107,7 +108,7 @@ class RagIndexJobControllerTest {
                 "attachment",
                 false,
                 null,
-                Map.of("attachmentId", "42"),
+                Map.of("attachmentId", "42", "filename", "sample.pdf"),
                 List.of("alpha"),
                 false));
 
@@ -115,7 +116,81 @@ class RagIndexJobControllerTest {
         assertThat(jobService.createdRequest.indexRequest()).isNull();
         assertThat(jobService.createdRequest.sourceType()).isEqualTo("attachment");
         assertThat(jobService.createdRequest.documentId()).isEqualTo("doc-1");
+        assertThat(jobService.createdRequest.sourceName()).isEqualTo("sample.pdf");
         assertThat(jobService.createdSourceRequest.metadata()).containsEntry("attachmentId", "42");
+    }
+
+    @Test
+    void createJobSourceNamePriorityUsesRequestThenMetadataThenDocumentId() {
+        CapturingJobService explicitJobService = new CapturingJobService();
+        RagIndexJobController explicitController = new RagIndexJobController(
+                explicitJobService,
+                mock(RagPipelineService.class),
+                null);
+
+        explicitController.createJob(new RagIndexJobCreateRequestDto(
+                "attachment",
+                "42",
+                "doc-1",
+                "attachment",
+                false,
+                null,
+                Map.of("sourceName", "metadata-source.pdf", "title", "title.pdf", "filename", "filename.pdf",
+                        "fileName", "file-name.pdf", "name", "name.pdf"),
+                List.of(),
+                false,
+                null,
+                null,
+                null,
+                "request-source.pdf"));
+
+        assertThat(explicitJobService.createdRequest.sourceName()).isEqualTo("request-source.pdf");
+
+        CapturingJobService metadataJobService = new CapturingJobService();
+        RagIndexJobController metadataController = new RagIndexJobController(
+                metadataJobService,
+                mock(RagPipelineService.class),
+                null);
+
+        metadataController.createJob(new RagIndexJobCreateRequestDto(
+                "attachment",
+                "42",
+                "doc-1",
+                "attachment",
+                false,
+                null,
+                Map.of("title", "title.pdf", "filename", "filename.pdf",
+                        "fileName", "file-name.pdf", "name", "name.pdf"),
+                List.of(),
+                false));
+
+        assertThat(metadataJobService.createdRequest.sourceName()).isEqualTo("title.pdf");
+    }
+
+    @Test
+    void createJobClampsLongSourceNameBeforePersistence() {
+        CapturingJobService jobService = new CapturingJobService();
+        RagIndexJobController controller = new RagIndexJobController(
+                jobService,
+                mock(RagPipelineService.class),
+                null);
+
+        controller.createJob(new RagIndexJobCreateRequestDto(
+                "attachment",
+                "42",
+                "doc-1",
+                "attachment",
+                false,
+                null,
+                Map.of(),
+                List.of(),
+                false,
+                null,
+                null,
+                null,
+                "x".repeat(RagIndexJob.MAX_SOURCE_NAME_LENGTH + 20)));
+
+        assertThat(jobService.createdRequest.sourceName()).hasSize(RagIndexJob.MAX_SOURCE_NAME_LENGTH);
     }
 
     @Test
@@ -138,6 +213,7 @@ class RagIndexJobControllerTest {
                 false));
 
         assertThat(jobService.createdRequest.documentId()).isEqualTo("42");
+        assertThat(jobService.createdRequest.sourceName()).isEqualTo("42");
         assertThat(jobService.createdSourceRequest.metadata()).containsEntry("attachmentId", "42");
     }
 
@@ -177,13 +253,40 @@ class RagIndexJobControllerTest {
         ResponseEntity<ApiResponse<List<RagIndexJobLogDto>>> logsResponse = controller.getLogs("job-1");
 
         assertThat(listResponse.getBody().getData().items()).hasSize(1);
+        assertThat(listResponse.getBody().getData().items().get(0).sourceName()).isEqualTo("sample.pdf");
         assertThat(detailResponse.getBody().getData().jobId()).isEqualTo("job-1");
+        assertThat(detailResponse.getBody().getData().sourceName()).isEqualTo("sample.pdf");
         assertThat(retryResponse.getStatusCode().value()).isEqualTo(202);
+        assertThat(retryResponse.getBody().getData().sourceName()).isEqualTo("sample.pdf");
         assertThat(logsResponse.getBody().getData())
                 .extracting(RagIndexJobLogDto::code)
                 .containsExactly(RagIndexJobLogCode.JOB_STARTED);
         assertThat(jobService.sort.field()).isEqualTo(RagIndexJobSort.Field.CREATED_AT);
         assertThat(jobService.sort.direction()).isEqualTo(RagIndexJobSort.Direction.DESC);
+    }
+
+    @Test
+    void dtoFallsBackSourceNameToDocumentIdForLegacyRows() {
+        RagIndexJob legacyJob = new RagIndexJob(
+                "job-legacy",
+                "attachment",
+                "42",
+                "doc-legacy",
+                "attachment",
+                null,
+                RagIndexJobStatus.PENDING,
+                null,
+                0,
+                0,
+                0,
+                0,
+                null,
+                java.time.Instant.parse("2026-04-26T00:00:00Z"),
+                null,
+                null,
+                null);
+
+        assertThat(RagIndexJobDto.from(legacyJob).sourceName()).isEqualTo("doc-legacy");
     }
 
     @Test
@@ -209,7 +312,8 @@ class RagIndexJobControllerTest {
                         .param("sort", " document-id ")
                         .param("direction", "sideways"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.items[0].jobId").value("job-1"));
+                .andExpect(jsonPath("$.data.items[0].jobId").value("job-1"))
+                .andExpect(jsonPath("$.data.items[0].sourceName").value("sample.pdf"));
 
         assertThat(jobService.sort.field()).isEqualTo(RagIndexJobSort.Field.DOCUMENT_ID);
         assertThat(jobService.sort.direction()).isEqualTo(RagIndexJobSort.Direction.DESC);
@@ -263,6 +367,7 @@ class RagIndexJobControllerTest {
 
         assertThat(response.getStatusCode().value()).isEqualTo(202);
         assertThat(response.getBody().getData().status()).isEqualTo(RagIndexJobStatus.CANCELLED);
+        assertThat(response.getBody().getData().sourceName()).isEqualTo("sample.pdf");
     }
 
     @Test
@@ -588,6 +693,7 @@ class RagIndexJobControllerTest {
                     "42",
                     "doc-1",
                     "attachment",
+                    "sample.pdf",
                     java.time.Instant.parse("2026-04-26T00:00:00Z"))
                     .withStatus(status, RagIndexJobStep.COMPLETED, null,
                             java.time.Instant.parse("2026-04-26T00:00:01Z"));

--- a/starter/studio-platform-starter-ai/README.md
+++ b/starter/studio-platform-starter-ai/README.md
@@ -258,7 +258,8 @@ raw text가 없는 source 기반 job은 등록된 `RagIndexJobSourceExecutor`가
 bounded eviction으로 제한한다. 영구 이력, 다중 인스턴스 공유, 감사 로그가 필요하면 같은
 `RagIndexJobRepository` 계약으로 DB 기반 구현을 등록한다. JDBC 기반 기본 구현을 사용하려면
 `NamedParameterJdbcTemplate` bean과 AI schema migration(`schema/ai/{db}/V601__create_rag_index_job_tables.sql`)을
-적용한 뒤 아래 설정을 사용한다.
+적용한 뒤 아래 설정을 사용한다. 기존 V601 적용 환경은 `V602__add_rag_index_job_source_name.sql`로
+RAG job grid 표시명인 `source_name` 컬럼을 추가한다.
 
 ```yaml
 studio:

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagIndexJobService.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagIndexJobService.java
@@ -66,6 +66,7 @@ public class DefaultRagIndexJobService implements RagIndexJobService {
                 request.objectId(),
                 request.documentId(),
                 request.sourceType(),
+                request.sourceName(),
                 Instant.now());
         requests.put(jobId, new StoredRequest(request, sourceRequest));
         requestOrder.add(jobId);

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/JdbcRagIndexJobRepository.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/JdbcRagIndexJobRepository.java
@@ -32,6 +32,7 @@ public class JdbcRagIndexJobRepository implements RagIndexJobRepository {
             rs.getString("object_id"),
             rs.getString("document_id"),
             rs.getString("source_type"),
+            rs.getString("source_name"),
             enumValue(RagIndexJobStatus.class, rs.getString("status"), RagIndexJobStatus.PENDING),
             enumValue(RagIndexJobStep.class, rs.getString("current_step"), null),
             rs.getInt("chunk_count"),
@@ -69,6 +70,7 @@ public class JdbcRagIndexJobRepository implements RagIndexJobRepository {
                            object_id = :objectId,
                            document_id = :documentId,
                            source_type = :sourceType,
+                           source_name = :sourceName,
                            status = :status,
                            current_step = :currentStep,
                            chunk_count = :chunkCount,
@@ -86,11 +88,11 @@ public class JdbcRagIndexJobRepository implements RagIndexJobRepository {
         }
         template.update("""
                 INSERT INTO tb_ai_rag_index_job(
-                    job_id, object_type, object_id, document_id, source_type,
+                    job_id, object_type, object_id, document_id, source_type, source_name,
                     status, current_step, chunk_count, embedded_count, indexed_count,
                     warning_count, error_message, created_at, started_at, finished_at, duration_ms)
                 VALUES (
-                    :jobId, :objectType, :objectId, :documentId, :sourceType,
+                    :jobId, :objectType, :objectId, :documentId, :sourceType, :sourceName,
                     :status, :currentStep, :chunkCount, :embeddedCount, :indexedCount,
                     :warningCount, :errorMessage, :createdAt, :startedAt, :finishedAt, :durationMs)
                 """, jobParameters(job));
@@ -228,6 +230,7 @@ public class JdbcRagIndexJobRepository implements RagIndexJobRepository {
                 .addValue("objectId", job.objectId())
                 .addValue("documentId", job.documentId())
                 .addValue("sourceType", job.sourceType())
+                .addValue("sourceName", job.sourceName())
                 .addValue("status", job.status().name())
                 .addValue("currentStep", enumName(job.currentStep()))
                 .addValue("chunkCount", job.chunkCount())

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/JdbcRagIndexJobRepositoryTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/JdbcRagIndexJobRepositoryTest.java
@@ -66,6 +66,7 @@ class JdbcRagIndexJobRepositoryTest {
                 new RagIndexJobSort(RagIndexJobSort.Field.DOCUMENT_ID, RagIndexJobSort.Direction.DESC));
 
         assertThat(repository.findById("job-1")).contains(older);
+        assertThat(repository.findById("job-1").orElseThrow().sourceName()).isEqualTo("doc-1");
         assertThat(page.total()).isEqualTo(2);
         assertThat(page.jobs()).extracting(RagIndexJob::jobId).containsExactly("job-2", "job-1");
     }
@@ -120,6 +121,7 @@ class JdbcRagIndexJobRepositoryTest {
                 objectId,
                 documentId,
                 "attachment",
+                documentId,
                 Instant.parse("2026-04-26T00:00:00Z"));
     }
 
@@ -132,6 +134,7 @@ class JdbcRagIndexJobRepositoryTest {
                   object_id VARCHAR(150),
                   document_id VARCHAR(200),
                   source_type VARCHAR(100),
+                  source_name VARCHAR(300),
                   status VARCHAR(30) NOT NULL,
                   current_step VARCHAR(30),
                   chunk_count INT NOT NULL DEFAULT 0,

--- a/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineController.java
+++ b/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineController.java
@@ -276,7 +276,7 @@ public class AttachmentEmbeddingPipelineController {
                 request == null ? null : request.embeddingProvider(),
                 request == null ? null : request.embeddingModel());
         RagIndexJobService jobService = ragIndexJobServiceProvider.getIfAvailable();
-        RagIndexJob job = createJob(jobService, command);
+        RagIndexJob job = createJob(jobService, attachmentId, command);
         RagIndexProgressListener progress = job == null
                 ? RagIndexProgressListener.noop()
                 : jobService.progressListener(job.jobId());
@@ -313,6 +313,7 @@ public class AttachmentEmbeddingPipelineController {
 
     private RagIndexJob createJob(
             RagIndexJobService jobService,
+            long attachmentId,
             AttachmentRagIndexCommand command) {
         if (jobService == null) {
             return null;
@@ -323,7 +324,8 @@ public class AttachmentEmbeddingPipelineController {
                 command.documentId(),
                 "attachment",
                 false,
-                null),
+                null,
+                attachmentSourceName(attachmentId, command)),
                 new RagIndexJobSourceRequest(
                         command.metadata(),
                         command.keywords(),
@@ -331,6 +333,33 @@ public class AttachmentEmbeddingPipelineController {
                         command.embeddingProfileId(),
                         command.embeddingProvider(),
                         command.embeddingModel()));
+    }
+
+    private String attachmentSourceName(long attachmentId, AttachmentRagIndexCommand command) {
+        String sourceName = text(firstPresent(command.metadata(), "sourceName", "title", "filename", "fileName", "name"));
+        if (sourceName != null) {
+            return sourceName;
+        }
+        Attachment attachment = attachmentService.getAttachmentById(attachmentId);
+        return text(attachment.getName()) == null ? command.documentId() : attachment.getName().trim();
+    }
+
+    private Object firstPresent(Map<String, Object> metadata, String... keys) {
+        for (String key : keys) {
+            Object value = metadata.get(key);
+            if (value != null && (!(value instanceof String text) || !text.isBlank())) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private String text(Object value) {
+        if (value == null) {
+            return null;
+        }
+        String text = value.toString().trim();
+        return text.isBlank() ? null : text;
     }
 
     private void putHeader(ResponseEntity.BodyBuilder builder, String name, String value) {

--- a/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineControllerTest.java
+++ b/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/controller/AttachmentEmbeddingPipelineControllerTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
@@ -483,6 +484,10 @@ class AttachmentEmbeddingPipelineControllerTest {
                         .content("{}"))
                 .andExpect(status().isAccepted())
                 .andExpect(header().string("X-RAG-Job-Id", "job-1"));
+
+        ArgumentCaptor<RagIndexJobCreateRequest> captor = ArgumentCaptor.forClass(RagIndexJobCreateRequest.class);
+        verify(jobService).createJob(captor.capture(), any(RagIndexJobSourceRequest.class));
+        org.assertj.core.api.Assertions.assertThat(captor.getValue().sourceName()).isEqualTo("sample.txt");
     }
 
     @Test

--- a/studio-platform-ai/README.md
+++ b/studio-platform-ai/README.md
@@ -297,5 +297,6 @@ List<RagSearchResult> filtered = ragPipelineService.search(
 
 - `src/main/resources/schema/ai/{postgres,mysql,mariadb}/V600__create_vector_tables.sql`
 - `src/main/resources/schema/ai/{postgres,mysql,mariadb}/V601__create_rag_index_job_tables.sql`
+- `src/main/resources/schema/ai/{postgres,mysql,mariadb}/V602__add_rag_index_job_source_name.sql`
 
 Flyway 버전 범위는 `docs/flyway-versioning.md`의 ai 범위(V600-V699)를 따른다.

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/rag/RagIndexJob.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/rag/RagIndexJob.java
@@ -9,6 +9,7 @@ public record RagIndexJob(
         String objectId,
         String documentId,
         String sourceType,
+        String sourceName,
         RagIndexJobStatus status,
         RagIndexJobStep currentStep,
         int chunkCount,
@@ -21,12 +22,15 @@ public record RagIndexJob(
         Instant finishedAt,
         Long durationMs) {
 
+    public static final int MAX_SOURCE_NAME_LENGTH = 300;
+
     public RagIndexJob {
         jobId = requireText(jobId, "jobId");
         documentId = normalize(documentId);
         objectType = normalize(objectType);
         objectId = normalize(objectId);
         sourceType = normalize(sourceType);
+        sourceName = normalizeSourceName(sourceName);
         status = status == null ? RagIndexJobStatus.PENDING : status;
         chunkCount = Math.max(0, chunkCount);
         embeddedCount = Math.max(0, embeddedCount);
@@ -39,6 +43,28 @@ public record RagIndexJob(
         }
     }
 
+    public RagIndexJob(
+            String jobId,
+            String objectType,
+            String objectId,
+            String documentId,
+            String sourceType,
+            RagIndexJobStatus status,
+            RagIndexJobStep currentStep,
+            int chunkCount,
+            int embeddedCount,
+            int indexedCount,
+            int warningCount,
+            String errorMessage,
+            Instant createdAt,
+            Instant startedAt,
+            Instant finishedAt,
+            Long durationMs) {
+        this(jobId, objectType, objectId, documentId, sourceType, null, status, currentStep,
+                chunkCount, embeddedCount, indexedCount, warningCount, errorMessage,
+                createdAt, startedAt, finishedAt, durationMs);
+    }
+
     public static RagIndexJob pending(
             String jobId,
             String objectType,
@@ -46,12 +72,24 @@ public record RagIndexJob(
             String documentId,
             String sourceType,
             Instant createdAt) {
+        return pending(jobId, objectType, objectId, documentId, sourceType, null, createdAt);
+    }
+
+    public static RagIndexJob pending(
+            String jobId,
+            String objectType,
+            String objectId,
+            String documentId,
+            String sourceType,
+            String sourceName,
+            Instant createdAt) {
         return new RagIndexJob(
                 jobId,
                 objectType,
                 objectId,
                 documentId,
                 sourceType,
+                sourceName,
                 RagIndexJobStatus.PENDING,
                 null,
                 0,
@@ -87,6 +125,7 @@ public record RagIndexJob(
                 objectId,
                 documentId,
                 sourceType,
+                sourceName,
                 status,
                 step,
                 chunkCount,
@@ -107,6 +146,7 @@ public record RagIndexJob(
                 objectId,
                 documentId,
                 sourceType,
+                sourceName,
                 status,
                 currentStep,
                 chunkCount == null ? this.chunkCount : chunkCount,
@@ -127,6 +167,7 @@ public record RagIndexJob(
                 objectId,
                 documentId,
                 sourceType,
+                sourceName,
                 RagIndexJobStatus.PENDING,
                 null,
                 0,
@@ -154,5 +195,13 @@ public record RagIndexJob(
 
     private static String normalize(String value) {
         return value == null || value.isBlank() ? null : value.trim();
+    }
+
+    private static String normalizeSourceName(String value) {
+        String normalized = normalize(value);
+        if (normalized == null || normalized.length() <= MAX_SOURCE_NAME_LENGTH) {
+            return normalized;
+        }
+        return normalized.substring(0, MAX_SOURCE_NAME_LENGTH);
     }
 }

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/rag/RagIndexJobCreateRequest.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/rag/RagIndexJobCreateRequest.java
@@ -9,20 +9,38 @@ public record RagIndexJobCreateRequest(
         String documentId,
         String sourceType,
         boolean forceReindex,
-        RagIndexRequest indexRequest) {
+        RagIndexRequest indexRequest,
+        String sourceName) {
 
     public RagIndexJobCreateRequest {
         objectType = normalize(objectType);
         objectId = normalize(objectId);
         sourceType = normalize(sourceType);
+        sourceName = normalizeSourceName(sourceName);
         if (indexRequest != null) {
             documentId = normalize(documentId);
             if (documentId == null) {
                 documentId = indexRequest.documentId();
             }
+            if (sourceName == null) {
+                sourceName = displayName(indexRequest.metadata(), documentId);
+            }
         } else {
             documentId = normalize(documentId);
+            if (sourceName == null) {
+                sourceName = displayName(null, documentId);
+            }
         }
+    }
+
+    public RagIndexJobCreateRequest(
+            String objectType,
+            String objectId,
+            String documentId,
+            String sourceType,
+            boolean forceReindex,
+            RagIndexRequest indexRequest) {
+        this(objectType, objectId, documentId, sourceType, forceReindex, indexRequest, null);
     }
 
     public String requiredDocumentId() {
@@ -38,7 +56,25 @@ public record RagIndexJobCreateRequest(
                 indexRequest.documentId(),
                 text(metadata.get("sourceType")),
                 false,
-                indexRequest);
+                indexRequest,
+                displayName(metadata, indexRequest.documentId()));
+    }
+
+    private static String displayName(Map<String, Object> metadata, String documentId) {
+        String sourceName = metadata == null
+                ? null
+                : firstText(metadata, "sourceName", "title", "filename", "fileName", "name");
+        return sourceName == null ? normalize(documentId) : sourceName;
+    }
+
+    private static String firstText(Map<String, Object> metadata, String... keys) {
+        for (String key : keys) {
+            String value = text(metadata.get(key));
+            if (value != null) {
+                return value;
+            }
+        }
+        return null;
     }
 
     private static String text(Object value) {
@@ -47,5 +83,13 @@ public record RagIndexJobCreateRequest(
 
     private static String normalize(String value) {
         return value == null || value.isBlank() ? null : value.trim();
+    }
+
+    private static String normalizeSourceName(String value) {
+        String normalized = normalize(value);
+        if (normalized == null || normalized.length() <= RagIndexJob.MAX_SOURCE_NAME_LENGTH) {
+            return normalized;
+        }
+        return normalized.substring(0, RagIndexJob.MAX_SOURCE_NAME_LENGTH);
     }
 }

--- a/studio-platform-ai/src/main/resources/schema/ai/mariadb/V602__add_rag_index_job_source_name.sql
+++ b/studio-platform-ai/src/main/resources/schema/ai/mariadb/V602__add_rag_index_job_source_name.sql
@@ -1,0 +1,7 @@
+ALTER TABLE tb_ai_rag_index_job
+  ADD COLUMN source_name VARCHAR(300);
+
+UPDATE tb_ai_rag_index_job
+   SET source_name = document_id
+ WHERE source_name IS NULL
+   AND document_id IS NOT NULL;

--- a/studio-platform-ai/src/main/resources/schema/ai/mysql/V602__add_rag_index_job_source_name.sql
+++ b/studio-platform-ai/src/main/resources/schema/ai/mysql/V602__add_rag_index_job_source_name.sql
@@ -1,0 +1,7 @@
+ALTER TABLE tb_ai_rag_index_job
+  ADD COLUMN source_name VARCHAR(300);
+
+UPDATE tb_ai_rag_index_job
+   SET source_name = document_id
+ WHERE source_name IS NULL
+   AND document_id IS NOT NULL;

--- a/studio-platform-ai/src/main/resources/schema/ai/postgres/V602__add_rag_index_job_source_name.sql
+++ b/studio-platform-ai/src/main/resources/schema/ai/postgres/V602__add_rag_index_job_source_name.sql
@@ -1,0 +1,7 @@
+ALTER TABLE tb_ai_rag_index_job
+  ADD COLUMN source_name VARCHAR(300);
+
+UPDATE tb_ai_rag_index_job
+   SET source_name = document_id
+ WHERE source_name IS NULL
+   AND document_id IS NOT NULL;

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/core/rag/RagIndexJobContractTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/core/rag/RagIndexJobContractTest.java
@@ -23,11 +23,13 @@ class RagIndexJobContractTest {
                 " 42 ",
                 " doc-1 ",
                 " attachment ",
+                " sample.pdf ",
                 Instant.parse("2026-04-26T00:00:00Z"));
 
         assertThat(job.jobId()).isEqualTo("job-1");
         assertThat(job.objectType()).isEqualTo("attachment");
         assertThat(job.objectId()).isEqualTo("42");
+        assertThat(job.sourceName()).isEqualTo("sample.pdf");
         assertThat(job.status()).isEqualTo(RagIndexJobStatus.PENDING);
         assertThat(job.chunkCount()).isZero();
         assertThat(job.durationMs()).isNull();
@@ -56,14 +58,70 @@ class RagIndexJobContractTest {
         RagIndexRequest indexRequest = new RagIndexRequest(
                 "doc-1",
                 "content",
-                Map.of("objectType", "attachment", "objectId", "42", "sourceType", "attachment"));
+                Map.of("objectType", "attachment", "objectId", "42", "sourceType", "attachment",
+                        "filename", "sample.pdf"));
 
         RagIndexJobCreateRequest request = RagIndexJobCreateRequest.forIndexRequest(indexRequest);
 
         assertThat(request.objectType()).isEqualTo("attachment");
         assertThat(request.objectId()).isEqualTo("42");
         assertThat(request.documentId()).isEqualTo("doc-1");
+        assertThat(request.sourceName()).isEqualTo("sample.pdf");
         assertThat(request.indexRequest()).isSameAs(indexRequest);
+    }
+
+    @Test
+    void createRequestFallsBackSourceNameToDocumentId() {
+        RagIndexJobCreateRequest request = new RagIndexJobCreateRequest(
+                "attachment",
+                "42",
+                "doc-1",
+                "attachment",
+                false,
+                null);
+
+        assertThat(request.sourceName()).isEqualTo("doc-1");
+    }
+
+    @Test
+    void createRequestSourceNamePriorityIsStable() {
+        RagIndexRequest indexRequest = new RagIndexRequest(
+                "doc-1",
+                "content",
+                Map.of(
+                        "sourceName", "source-name.pdf",
+                        "title", "title.pdf",
+                        "filename", "filename.pdf",
+                        "fileName", "file-name.pdf",
+                        "name", "name.pdf"));
+
+        RagIndexJobCreateRequest request = RagIndexJobCreateRequest.forIndexRequest(indexRequest);
+
+        assertThat(request.sourceName()).isEqualTo("source-name.pdf");
+    }
+
+    @Test
+    void sourceNameIsClampedToDatabaseBoundary() {
+        String longName = "x".repeat(RagIndexJob.MAX_SOURCE_NAME_LENGTH + 20);
+        RagIndexJob job = RagIndexJob.pending(
+                "job-1",
+                "attachment",
+                "42",
+                "doc-1",
+                "attachment",
+                longName,
+                Instant.parse("2026-04-26T00:00:00Z"));
+        RagIndexJobCreateRequest request = new RagIndexJobCreateRequest(
+                "attachment",
+                "42",
+                "doc-1",
+                "attachment",
+                false,
+                null,
+                longName);
+
+        assertThat(job.sourceName()).hasSize(RagIndexJob.MAX_SOURCE_NAME_LENGTH);
+        assertThat(request.sourceName()).hasSize(RagIndexJob.MAX_SOURCE_NAME_LENGTH);
     }
 
     @Test


### PR DESCRIPTION
## Why

- RAG client job grid에서 문서/파일 표시명을 바로 보여줘야 한다.
- 목록 렌더링 때 chunk/vector metadata를 추가 조회하는 방식은 느려질 수 있으므로 job 생성 시점에 표시명을 저장한다.

## What

- `RagIndexJob`, `RagIndexJobCreateRequest`, `RagIndexJobDto`에 `sourceName`을 추가했다.
- `GET /api/mgmt/ai/rag/jobs`, `GET /api/mgmt/ai/rag/jobs/{jobId}`, `POST /api/mgmt/ai/rag/jobs`, `retry`, `cancel` 응답에 같은 DTO로 `sourceName`이 포함된다.
- 표시명 결정 순서는 요청 `sourceName`, metadata `sourceName/title/filename/fileName/name`, `documentId` fallback이다.
- attachment RAG job 생성 경로는 attachment 파일명을 `sourceName`으로 저장한다.
- JDBC repository에 `source_name` 저장/조회와 `V602__add_rag_index_job_source_name.sql` migration을 추가했다. 기존 row는 `document_id`로 backfill한다.
- README와 CHANGELOG를 갱신했다.

## Related Issues

- Closes #360

## Validation

- Command: `./gradlew :studio-platform-ai:test --tests 'studio.one.platform.ai.core.rag.RagIndexJobContractTest' :starter:studio-platform-starter-ai-web:test --tests 'studio.one.platform.ai.web.controller.RagIndexJobControllerTest' :starter:studio-platform-starter-ai:test --tests 'studio.one.platform.ai.service.pipeline.JdbcRagIndexJobRepositoryTest' :studio-application-modules:content-embedding-pipeline:test --tests 'studio.one.application.web.controller.AttachmentEmbeddingPipelineControllerTest'`
- Result: `BUILD SUCCESSFUL`
- Command: `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test :studio-application-modules:content-embedding-pipeline:test`
- Result: `BUILD SUCCESSFUL`
- Command: `git diff --check`
- Result: `PASS`
- Command: `./gradlew test`
- Result: `BUILD SUCCESSFUL`

## Risk / Rollback

- Risk: DB migration이 포함된다. `V601`은 수정하지 않고 additive `V602`만 추가했으며 기존 row는 `document_id`로 backfill한다.
- Rollback: PR commit을 revert하고, 이미 적용된 DB에는 필요 시 `source_name` 컬럼 제거 migration을 별도 운영 절차로 적용한다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: Yes
- Delegated scope: 이슈 #360 변경 리뷰 2회. 1차 리뷰에서 V601 수정 + V602 중복 migration blocking을 지적했고 main author가 V601 변경 제거와 V602-only migration으로 반영했다. 2차 리뷰의 기존 row fallback/문서/테스트 보강 의견도 반영했다.
- Main author validation: 대상 테스트, 관련 모듈 테스트, 전체 `./gradlew test`, `git diff --check`를 실행했다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included