### PR TITLE
[ai-assisted] fix(ai): resolve rag job source names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2026-04-28
 
 ### 변경됨
+- 이슈 #362 대응으로 RAG job source 표시명 resolver SPI를 추가하고, generic attachment source job 생성 시 `sourceName`이 attachment id 대신 파일명으로 보강되도록 했다.
 - 이슈 #360 대응으로 RAG job 응답 DTO에 `sourceName`을 추가하고, in-memory/JDBC job 저장소와 attachment RAG job 생성 경로에서 표시명을 유지하도록 했다.
 - 이슈 #357 대응으로 Vector/RAG query 검색 중 embedding provider quota/rate limit이 발생하면 chat 오류와 구분되는 HTTP 429 메시지를 반환하도록 했다.
 - `starter-ai-web` README에 query 기반 Vector/RAG 검색이 embedding provider를 호출한다는 점과 provider-free chunk inspection 대체 경로를 명시했다.

--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -109,13 +109,14 @@ job 추적이 활성화된 경우 `X-RAG-Job-Id` 헤더만 추가한다. 신규 
 raw `text`가 있으면 같은 `RagPipelineService`를 in-memory job service로 감싸 비동기 실행하고,
 응답 body에 생성된 job을 반환한다. `text`가 없고 `sourceType`이 있으면 등록된
 `RagIndexJobSourceExecutor`가 해당 source를 실행한다. `content-embedding-pipeline`은
-`sourceType=attachment` job executor를 제공하며 기존 attachment RAG index 경로를 재사용한다.
+`sourceType=attachment` job executor와 source 표시명 resolver를 제공하며 기존 attachment RAG index 경로를 재사용한다.
 job 생성과 retry는 `services:ai_rag write`가 필요하다. attachment source job 생성과 retry는 기존
 attachment 색인 API와 동일하게 `features:attachment write` 권한도 필요하다.
-job 응답 DTO에는 grid 표시용 `sourceName`이 포함된다. attachment source job은 파일명을 저장하고,
-raw text job은 요청 `sourceName`, metadata의 `sourceName`/`title`/`filename`/`fileName`/`name`, `documentId`
-순서로 표시명을 결정한다. `sourceName`은 `GET /jobs`, `GET /jobs/{jobId}`, create/retry/cancel 응답에
-동일하게 포함되며 저장 경계에 맞춰 최대 300자까지 보존한다.
+job 응답 DTO에는 grid 표시용 `sourceName`이 포함된다. 표시명은 요청 `sourceName`, metadata의
+`sourceName`/`title`/`filename`/`fileName`/`name`, 등록된 `RagIndexJobSourceNameResolver`, `documentId`
+순서로 결정한다. attachment source job은 resolver가 `AttachmentService`로 파일명을 조회해 저장하므로,
+generic job API가 attachment 모듈에 직접 의존하지 않는다. `sourceName`은 `GET /jobs`,
+`GET /jobs/{jobId}`, create/retry/cancel 응답에 동일하게 포함되며 저장 경계에 맞춰 최대 300자까지 보존한다.
 
 attachment source job 예시:
 
@@ -129,7 +130,6 @@ Content-Type: application/json
   "objectId": "101",
   "documentId": "doc-101",
   "sourceType": "attachment",
-  "sourceName": "sample.pdf",
   "metadata": {
     "category": "manual"
   },

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
@@ -45,6 +45,7 @@ import studio.one.platform.ai.web.service.ConversationChatService;
 import studio.one.platform.ai.web.service.InMemoryConversationRepository;
 import studio.one.platform.ai.web.service.InMemoryChatMemoryStore;
 import studio.one.platform.ai.service.pipeline.RagIndexJobService;
+import studio.one.platform.ai.service.pipeline.RagIndexJobSourceNameResolver;
 import studio.one.platform.ai.service.pipeline.RagEmbeddingProfileResolver;
 import studio.one.platform.constant.PropertyKeys;
 import studio.one.platform.chunking.core.Chunker;
@@ -145,13 +146,15 @@ public class AiWebAutoConfiguration {
             RagPipelineService ragPipelineService,
             @Nullable VectorStorePort vectorStorePort,
             RagPipelineProperties ragPipelineProperties,
-            @Qualifier("ragIndexJobExecutor") Executor ragIndexJobExecutor) {
+            @Qualifier("ragIndexJobExecutor") Executor ragIndexJobExecutor,
+            ObjectProvider<RagIndexJobSourceNameResolver> sourceNameResolvers) {
         return new RagIndexJobController(
                 ragIndexJobService,
                 ragPipelineService,
                 vectorStorePort,
                 ragIndexJobExecutor,
-                ragPipelineProperties.getObjectScope().getMaxListLimit());
+                ragPipelineProperties.getObjectScope().getMaxListLimit(),
+                sourceNameResolvers.orderedStream().toList());
     }
 
     @Bean

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagIndexJobController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagIndexJobController.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
@@ -40,6 +41,7 @@ import studio.one.platform.ai.core.rag.RagSearchResult;
 import studio.one.platform.ai.core.vector.VectorRecord;
 import studio.one.platform.ai.core.vector.VectorStorePort;
 import studio.one.platform.ai.service.pipeline.RagIndexJobService;
+import studio.one.platform.ai.service.pipeline.RagIndexJobSourceNameResolver;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
 import studio.one.platform.ai.web.dto.RagIndexChunkDto;
 import studio.one.platform.ai.web.dto.RagIndexChunkPageResponseDto;
@@ -62,6 +64,7 @@ public class RagIndexJobController {
     private final RagPipelineService ragPipelineService;
     private final Executor jobExecutor;
     private final int maxChunkPageLimit;
+    private final List<RagIndexJobSourceNameResolver> sourceNameResolvers;
     @Nullable
     private final VectorStorePort vectorStorePort;
 
@@ -86,11 +89,22 @@ public class RagIndexJobController {
             @Nullable VectorStorePort vectorStorePort,
             Executor jobExecutor,
             int maxChunkPageLimit) {
+        this(jobService, ragPipelineService, vectorStorePort, jobExecutor, maxChunkPageLimit, List.of());
+    }
+
+    public RagIndexJobController(
+            RagIndexJobService jobService,
+            RagPipelineService ragPipelineService,
+            @Nullable VectorStorePort vectorStorePort,
+            Executor jobExecutor,
+            int maxChunkPageLimit,
+            List<RagIndexJobSourceNameResolver> sourceNameResolvers) {
         this.jobService = Objects.requireNonNull(jobService, "jobService");
         this.ragPipelineService = Objects.requireNonNull(ragPipelineService, "ragPipelineService");
         this.vectorStorePort = vectorStorePort;
         this.jobExecutor = Objects.requireNonNull(jobExecutor, "jobExecutor");
         this.maxChunkPageLimit = maxChunkPageLimit <= 0 ? DEFAULT_CHUNK_LIMIT : maxChunkPageLimit;
+        this.sourceNameResolvers = sourceNameResolvers == null ? List.of() : List.copyOf(sourceNameResolvers);
     }
 
     @GetMapping("/jobs")
@@ -299,6 +313,14 @@ public class RagIndexJobController {
                         request.embeddingProvider(),
                         request.embeddingModel())
                 : null;
+        RagIndexJobCreateRequest createRequest = new RagIndexJobCreateRequest(
+                request.objectType(),
+                request.objectId(),
+                documentId,
+                request.sourceType(),
+                Boolean.TRUE.equals(request.forceReindex()),
+                indexRequest);
+        String sourceName = sourceName(request, metadata, createRequest, sourceRequest);
         return new CreateJobCommand(new RagIndexJobCreateRequest(
                 request.objectType(),
                 request.objectId(),
@@ -306,20 +328,51 @@ public class RagIndexJobController {
                 request.sourceType(),
                 Boolean.TRUE.equals(request.forceReindex()),
                 indexRequest,
-                sourceName(request, metadata, documentId)), sourceRequest);
+                sourceName), sourceRequest);
     }
 
     private boolean isAttachmentSource(RagIndexJobCreateRequestDto request) {
         return "attachment".equalsIgnoreCase(request.sourceType());
     }
 
-    private String sourceName(RagIndexJobCreateRequestDto request, Map<String, Object> metadata, String documentId) {
+    private String sourceName(
+            RagIndexJobCreateRequestDto request,
+            Map<String, Object> metadata,
+            RagIndexJobCreateRequest createRequest,
+            @Nullable RagIndexJobSourceRequest sourceRequest) {
         String sourceName = text(request.sourceName());
         if (sourceName != null) {
             return sourceName;
         }
         sourceName = text(firstPresent(metadata, "sourceName", "title", "filename", "fileName", "name"));
-        return sourceName == null ? documentId : sourceName;
+        if (sourceName != null) {
+            return sourceName;
+        }
+        return resolveSourceName(createRequest, sourceRequest).orElse(createRequest.documentId());
+    }
+
+    private Optional<String> resolveSourceName(
+            RagIndexJobCreateRequest createRequest,
+            @Nullable RagIndexJobSourceRequest sourceRequest) {
+        if (sourceRequest == null) {
+            return Optional.empty();
+        }
+        for (RagIndexJobSourceNameResolver resolver : sourceNameResolvers) {
+            try {
+                if (!resolver.supports(createRequest, sourceRequest)) {
+                    continue;
+                }
+                Optional<String> resolved = resolver.resolveSourceName(createRequest, sourceRequest)
+                        .map(this::text)
+                        .filter(Objects::nonNull);
+                if (resolved.isPresent()) {
+                    return resolved;
+                }
+            } catch (RuntimeException ex) {
+                log.debug("RAG index job sourceName resolver failed: {}", ex.getMessage(), ex);
+            }
+        }
+        return Optional.empty();
     }
 
     private void dispatch(String jobId, Runnable task) {

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
@@ -33,6 +33,7 @@ import studio.one.platform.ai.core.embedding.EmbeddingPort;
 import studio.one.platform.ai.core.registry.AiProviderRegistry;
 import studio.one.platform.ai.service.prompt.PromptRenderer;
 import studio.one.platform.ai.service.pipeline.RagIndexJobService;
+import studio.one.platform.ai.service.pipeline.RagIndexJobSourceNameResolver;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
 import studio.one.platform.ai.web.controller.AiInfoController;
 import studio.one.platform.ai.web.controller.ChatController;
@@ -216,6 +217,26 @@ class OpenAiProviderAutoConfigurationTest {
                     RagIndexJobController controller = context.getBean(RagIndexJobController.class);
                     assertThat(ReflectionTestUtils.getField(controller, "jobExecutor"))
                             .isSameAs(context.getBean("ragIndexJobExecutor"));
+                });
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void registersRagIndexJobControllerWithSourceNameResolvers() {
+        RagIndexJobSourceNameResolver resolver = org.mockito.Mockito.mock(RagIndexJobSourceNameResolver.class);
+
+        contextRunner
+                .withBean(RagIndexJobService.class, () -> org.mockito.Mockito.mock(RagIndexJobService.class))
+                .withBean(RagIndexJobSourceNameResolver.class, () -> resolver)
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).hasSingleBean(RagIndexJobController.class);
+
+                    RagIndexJobController controller = context.getBean(RagIndexJobController.class);
+                    assertThat((List<RagIndexJobSourceNameResolver>) ReflectionTestUtils.getField(
+                            controller,
+                            "sourceNameResolvers"))
+                            .containsExactly(resolver);
                 });
     }
 

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagIndexJobControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagIndexJobControllerTest.java
@@ -41,6 +41,7 @@ import studio.one.platform.ai.core.rag.RagSearchResult;
 import studio.one.platform.ai.core.vector.VectorRecord;
 import studio.one.platform.ai.core.vector.VectorStorePort;
 import studio.one.platform.ai.service.pipeline.RagIndexJobService;
+import studio.one.platform.ai.service.pipeline.RagIndexJobSourceNameResolver;
 import studio.one.platform.ai.service.pipeline.RagIndexProgressListener;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
 import studio.one.platform.ai.web.dto.RagIndexChunkDto;
@@ -126,7 +127,10 @@ class RagIndexJobControllerTest {
         RagIndexJobController explicitController = new RagIndexJobController(
                 explicitJobService,
                 mock(RagPipelineService.class),
-                null);
+                null,
+                Runnable::run,
+                200,
+                List.of(new FixedSourceNameResolver("resolver-source.pdf")));
 
         explicitController.createJob(new RagIndexJobCreateRequestDto(
                 "attachment",
@@ -150,7 +154,10 @@ class RagIndexJobControllerTest {
         RagIndexJobController metadataController = new RagIndexJobController(
                 metadataJobService,
                 mock(RagPipelineService.class),
-                null);
+                null,
+                Runnable::run,
+                200,
+                List.of(new FixedSourceNameResolver("resolver-source.pdf")));
 
         metadataController.createJob(new RagIndexJobCreateRequestDto(
                 "attachment",
@@ -165,6 +172,109 @@ class RagIndexJobControllerTest {
                 false));
 
         assertThat(metadataJobService.createdRequest.sourceName()).isEqualTo("title.pdf");
+    }
+
+    @Test
+    void createJobUsesSourceNameResolverBeforeDocumentIdFallback() {
+        CapturingJobService jobService = new CapturingJobService();
+        RagIndexJobController controller = new RagIndexJobController(
+                jobService,
+                mock(RagPipelineService.class),
+                null,
+                Runnable::run,
+                200,
+                List.of(new FixedSourceNameResolver("attachment-name.pdf")));
+
+        controller.createJob(new RagIndexJobCreateRequestDto(
+                "attachment",
+                "42",
+                null,
+                "attachment",
+                false,
+                null,
+                Map.of(),
+                List.of(),
+                false));
+
+        assertThat(jobService.createdRequest.documentId()).isEqualTo("42");
+        assertThat(jobService.createdRequest.sourceName()).isEqualTo("attachment-name.pdf");
+        assertThat(jobService.createdSourceRequest.metadata()).containsEntry("attachmentId", "42");
+    }
+
+    @Test
+    void createTextJobDoesNotUseSourceNameResolver() {
+        CapturingJobService jobService = new CapturingJobService();
+        RagIndexJobController controller = new RagIndexJobController(
+                jobService,
+                mock(RagPipelineService.class),
+                null,
+                Runnable::run,
+                200,
+                List.of(new FixedSourceNameResolver("attachment-name.pdf")));
+
+        controller.createJob(new RagIndexJobCreateRequestDto(
+                "attachment",
+                "42",
+                "doc-1",
+                "attachment",
+                false,
+                "raw text",
+                Map.of(),
+                List.of(),
+                false));
+
+        assertThat(jobService.createdRequest.indexRequest()).isNotNull();
+        assertThat(jobService.createdRequest.sourceName()).isEqualTo("doc-1");
+    }
+
+    @Test
+    void createJobFallsBackToDocumentIdWhenSourceNameResolverReturnsEmpty() {
+        CapturingJobService jobService = new CapturingJobService();
+        RagIndexJobController controller = new RagIndexJobController(
+                jobService,
+                mock(RagPipelineService.class),
+                null,
+                Runnable::run,
+                200,
+                List.of(new EmptySourceNameResolver()));
+
+        controller.createJob(new RagIndexJobCreateRequestDto(
+                "attachment",
+                "42",
+                null,
+                "attachment",
+                false,
+                null,
+                Map.of(),
+                List.of(),
+                false));
+
+        assertThat(jobService.createdRequest.sourceName()).isEqualTo("42");
+    }
+
+    @Test
+    void createJobFallsBackToDocumentIdWhenSourceNameResolverThrows() {
+        CapturingJobService jobService = new CapturingJobService();
+        RagIndexJobController controller = new RagIndexJobController(
+                jobService,
+                mock(RagPipelineService.class),
+                null,
+                Runnable::run,
+                200,
+                List.of(new ThrowingSourceNameResolver()));
+
+        controller.createJob(new RagIndexJobCreateRequestDto(
+                "attachment",
+                "42",
+                null,
+                "attachment",
+                false,
+                null,
+                Map.of(),
+                List.of(),
+                false));
+
+        assertThat(jobService.createdRequest.sourceName()).isEqualTo("42");
     }
 
     @Test
@@ -593,6 +703,51 @@ class RagIndexJobControllerTest {
                                 .build()))
                 .setControllerAdvice(new AiWebExceptionHandler())
                 .build();
+    }
+
+    private record FixedSourceNameResolver(String sourceName) implements RagIndexJobSourceNameResolver {
+
+        @Override
+        public boolean supports(RagIndexJobCreateRequest request, RagIndexJobSourceRequest sourceRequest) {
+            return true;
+        }
+
+        @Override
+        public Optional<String> resolveSourceName(
+                RagIndexJobCreateRequest request,
+                RagIndexJobSourceRequest sourceRequest) {
+            return Optional.of(sourceName);
+        }
+    }
+
+    private static class EmptySourceNameResolver implements RagIndexJobSourceNameResolver {
+
+        @Override
+        public boolean supports(RagIndexJobCreateRequest request, RagIndexJobSourceRequest sourceRequest) {
+            return true;
+        }
+
+        @Override
+        public Optional<String> resolveSourceName(
+                RagIndexJobCreateRequest request,
+                RagIndexJobSourceRequest sourceRequest) {
+            return Optional.empty();
+        }
+    }
+
+    private static class ThrowingSourceNameResolver implements RagIndexJobSourceNameResolver {
+
+        @Override
+        public boolean supports(RagIndexJobCreateRequest request, RagIndexJobSourceRequest sourceRequest) {
+            throw new IllegalStateException("resolver unavailable");
+        }
+
+        @Override
+        public Optional<String> resolveSourceName(
+                RagIndexJobCreateRequest request,
+                RagIndexJobSourceRequest sourceRequest) {
+            throw new IllegalStateException("resolver unavailable");
+        }
     }
 
     private static String preAuthorizeValue(Method method) {

--- a/starter/studio-platform-starter-ai/README.md
+++ b/starter/studio-platform-starter-ai/README.md
@@ -227,6 +227,7 @@ studio:
 | `RagIndexJobRepository` | RAG 색인 작업 상태/로그 저장소. 기본 구현은 단일 인스턴스용 in-memory repository |
 | `RagIndexJobService` | RAG 색인 작업 생성/조회/취소/재시도와 progress listener 연결 |
 | `RagIndexJobSourceExecutor` | source 기반 RAG job 실행 확장점. 등록된 Bean은 job service가 ordered stream으로 조회 |
+| `RagIndexJobSourceNameResolver` | source 기반 RAG job 표시명 확장점. ai-web은 등록된 Bean으로 `sourceName`을 보강 |
 | `ChunkingOrchestrator` | `starter-chunking`이 있을 때 RAG indexing chunk 생성에 사용 |
 | `PromptManager` | Mustache 템플릿 기반 프롬프트 렌더러 |
 | `TextCleaner` | `studio.ai.rag.cleaner.enabled=true`일 때 색인 전 텍스트 정제 |

--- a/studio-application-modules/content-embedding-pipeline/README.md
+++ b/studio-application-modules/content-embedding-pipeline/README.md
@@ -76,7 +76,8 @@ table, image caption, OCR chunk는 각각 `TABLE_TEXT`, `IMAGE_CAPTION`, `OCR_TE
 컨트롤러는 `studio.features.attachment.web.mgmt-base-path`(기본 `/api/mgmt/attachments`) 경로에 등록된다.
 따라서 attachment-service의 `web.enabled=true`와 `mgmt-base-path` 설정을 공유한다.
 `content-embedding-pipeline`은 auto-configuration으로 `AttachmentRagIndexService`,
-`AttachmentRagIndexJobSourceExecutor`, 기본 구조화 색인 adapter를 등록한다.
+`AttachmentRagIndexJobSourceExecutor`, `AttachmentRagIndexJobSourceNameResolver`,
+기본 구조화 색인 adapter를 등록한다.
 컨트롤러는 attachment web endpoint 설정과 같은 base path를 사용하며, 기존 attachment endpoint component scan
 또는 애플리케이션 component scan으로 등록된다.
 

--- a/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/autoconfigure/ContentEmbeddingPipelineAutoConfiguration.java
+++ b/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/autoconfigure/ContentEmbeddingPipelineAutoConfiguration.java
@@ -12,6 +12,7 @@ import org.springframework.context.annotation.Import;
 
 import studio.one.application.attachment.service.AttachmentService;
 import studio.one.application.web.service.AttachmentRagIndexJobSourceExecutor;
+import studio.one.application.web.service.AttachmentRagIndexJobSourceNameResolver;
 import studio.one.application.web.service.AttachmentRagIndexService;
 import studio.one.application.web.service.AttachmentStructuredRagIndexer;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
@@ -43,6 +44,13 @@ public class ContentEmbeddingPipelineAutoConfiguration {
     AttachmentRagIndexJobSourceExecutor attachmentRagIndexJobSourceExecutor(
             AttachmentRagIndexService ragIndexService) {
         return new AttachmentRagIndexJobSourceExecutor(ragIndexService);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    AttachmentRagIndexJobSourceNameResolver attachmentRagIndexJobSourceNameResolver(
+            AttachmentService attachmentService) {
+        return new AttachmentRagIndexJobSourceNameResolver(attachmentService);
     }
 
 }

--- a/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/AttachmentRagIndexJobSourceNameResolver.java
+++ b/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/service/AttachmentRagIndexJobSourceNameResolver.java
@@ -1,0 +1,61 @@
+package studio.one.application.web.service;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import studio.one.application.attachment.domain.model.Attachment;
+import studio.one.application.attachment.service.AttachmentService;
+import studio.one.platform.ai.core.rag.RagIndexJobCreateRequest;
+import studio.one.platform.ai.core.rag.RagIndexJobSourceRequest;
+import studio.one.platform.ai.service.pipeline.RagIndexJobSourceNameResolver;
+
+@Component
+@RequiredArgsConstructor
+public class AttachmentRagIndexJobSourceNameResolver implements RagIndexJobSourceNameResolver {
+
+    private static final String ATTACHMENT = "attachment";
+
+    private final AttachmentService attachmentService;
+
+    @Override
+    public boolean supports(RagIndexJobCreateRequest request, RagIndexJobSourceRequest sourceRequest) {
+        return request != null && request.indexRequest() == null && ATTACHMENT.equalsIgnoreCase(request.sourceType());
+    }
+
+    @Override
+    public Optional<String> resolveSourceName(
+            RagIndexJobCreateRequest request,
+            RagIndexJobSourceRequest sourceRequest) {
+        return attachmentId(request, sourceRequest)
+                .flatMap(this::attachmentName);
+    }
+
+    private Optional<Long> attachmentId(RagIndexJobCreateRequest request, RagIndexJobSourceRequest sourceRequest) {
+        Object metadataAttachmentId = sourceRequest == null ? null : sourceRequest.metadata().get("attachmentId");
+        String value = metadataAttachmentId == null ? request.objectId() : metadataAttachmentId.toString();
+        if (value == null || value.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            long attachmentId = Long.parseLong(value.trim());
+            return attachmentId <= 0L ? Optional.empty() : Optional.of(attachmentId);
+        } catch (NumberFormatException ex) {
+            return Optional.empty();
+        }
+    }
+
+    private Optional<String> attachmentName(long attachmentId) {
+        try {
+            Attachment attachment = attachmentService.getAttachmentById(attachmentId);
+            return text(attachment == null ? null : attachment.getName());
+        } catch (RuntimeException ex) {
+            return Optional.empty();
+        }
+    }
+
+    private Optional<String> text(String value) {
+        return value == null || value.isBlank() ? Optional.empty() : Optional.of(value.trim());
+    }
+}

--- a/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/autoconfigure/ContentEmbeddingPipelineAutoConfigurationTest.java
+++ b/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/autoconfigure/ContentEmbeddingPipelineAutoConfigurationTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import studio.one.application.attachment.service.AttachmentService;
 import studio.one.application.web.service.AttachmentRagIndexJobSourceExecutor;
+import studio.one.application.web.service.AttachmentRagIndexJobSourceNameResolver;
 import studio.one.application.web.service.AttachmentRagIndexService;
 import studio.one.application.web.service.AttachmentStructuredRagIndexer;
 import studio.one.application.web.service.DefaultAttachmentStructuredRagIndexer;
@@ -27,6 +28,7 @@ class ContentEmbeddingPipelineAutoConfigurationTest {
                     assertThat(context).hasNotFailed();
                     assertThat(context).hasSingleBean(AttachmentRagIndexService.class);
                     assertThat(context).hasSingleBean(AttachmentRagIndexJobSourceExecutor.class);
+                    assertThat(context).hasSingleBean(AttachmentRagIndexJobSourceNameResolver.class);
                 });
     }
 
@@ -55,6 +57,20 @@ class ContentEmbeddingPipelineAutoConfigurationTest {
                     assertThat(context).hasNotFailed();
                     assertThat(context).hasSingleBean(AttachmentRagIndexJobSourceExecutor.class);
                     assertThat(context.getBean(AttachmentRagIndexJobSourceExecutor.class)).isSameAs(userExecutor);
+                });
+    }
+
+    @Test
+    void backsOffWhenUserDefinedAttachmentRagIndexJobSourceNameResolverExists() {
+        AttachmentRagIndexJobSourceNameResolver userResolver = mock(AttachmentRagIndexJobSourceNameResolver.class);
+
+        contextRunner
+                .withBean(AttachmentService.class, () -> mock(AttachmentService.class))
+                .withBean(AttachmentRagIndexJobSourceNameResolver.class, () -> userResolver)
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).hasSingleBean(AttachmentRagIndexJobSourceNameResolver.class);
+                    assertThat(context.getBean(AttachmentRagIndexJobSourceNameResolver.class)).isSameAs(userResolver);
                 });
     }
 
@@ -92,6 +108,7 @@ class ContentEmbeddingPipelineAutoConfigurationTest {
             assertThat(context).hasNotFailed();
             assertThat(context).doesNotHaveBean(AttachmentRagIndexService.class);
             assertThat(context).doesNotHaveBean(AttachmentRagIndexJobSourceExecutor.class);
+            assertThat(context).doesNotHaveBean(AttachmentRagIndexJobSourceNameResolver.class);
         });
     }
 }

--- a/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/service/AttachmentRagIndexJobSourceNameResolverTest.java
+++ b/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/service/AttachmentRagIndexJobSourceNameResolverTest.java
@@ -1,0 +1,118 @@
+package studio.one.application.web.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import studio.one.application.attachment.domain.model.Attachment;
+import studio.one.application.attachment.service.AttachmentService;
+import studio.one.platform.ai.core.rag.RagIndexJobCreateRequest;
+import studio.one.platform.ai.core.rag.RagIndexJobSourceRequest;
+
+class AttachmentRagIndexJobSourceNameResolverTest {
+
+    @Test
+    void supportsAttachmentSource() {
+        AttachmentRagIndexJobSourceNameResolver resolver = new AttachmentRagIndexJobSourceNameResolver(
+                mock(AttachmentService.class));
+
+        assertThat(resolver.supports(new RagIndexJobCreateRequest(
+                "attachment",
+                "42",
+                "42",
+                "attachment",
+                false,
+                null), RagIndexJobSourceRequest.empty())).isTrue();
+    }
+
+    @Test
+    void doesNotSupportRawTextIndexRequests() {
+        AttachmentRagIndexJobSourceNameResolver resolver = new AttachmentRagIndexJobSourceNameResolver(
+                mock(AttachmentService.class));
+
+        assertThat(resolver.supports(new RagIndexJobCreateRequest(
+                "attachment",
+                "42",
+                "42",
+                "attachment",
+                false,
+                new studio.one.platform.ai.core.rag.RagIndexRequest(
+                        "42",
+                        "raw text",
+                        Map.of(),
+                        java.util.List.of(),
+                        false)), RagIndexJobSourceRequest.empty())).isFalse();
+    }
+
+    @Test
+    void resolvesAttachmentNameFromMetadataAttachmentId() throws Exception {
+        AttachmentService attachmentService = mock(AttachmentService.class);
+        Attachment attachment = mock(Attachment.class);
+        when(attachment.getName()).thenReturn("sample.pdf");
+        when(attachmentService.getAttachmentById(99L)).thenReturn(attachment);
+        AttachmentRagIndexJobSourceNameResolver resolver = new AttachmentRagIndexJobSourceNameResolver(attachmentService);
+
+        assertThat(resolver.resolveSourceName(
+                new RagIndexJobCreateRequest(
+                        "attachment",
+                        "42",
+                        "42",
+                        "attachment",
+                        false,
+                        null),
+                new RagIndexJobSourceRequest(Map.of("attachmentId", "99"), java.util.List.of(), false)))
+                .contains("sample.pdf");
+        verify(attachmentService).getAttachmentById(99L);
+    }
+
+    @Test
+    void resolvesAttachmentNameFromObjectIdWhenMetadataAttachmentIdIsMissing() throws Exception {
+        AttachmentService attachmentService = mock(AttachmentService.class);
+        Attachment attachment = mock(Attachment.class);
+        when(attachment.getName()).thenReturn(" object.pdf ");
+        when(attachmentService.getAttachmentById(42L)).thenReturn(attachment);
+        AttachmentRagIndexJobSourceNameResolver resolver = new AttachmentRagIndexJobSourceNameResolver(attachmentService);
+
+        assertThat(resolver.resolveSourceName(
+                new RagIndexJobCreateRequest(
+                        "attachment",
+                        "42",
+                        "42",
+                        "attachment",
+                        false,
+                        null),
+                RagIndexJobSourceRequest.empty()))
+                .contains("object.pdf");
+    }
+
+    @Test
+    void returnsEmptyWhenAttachmentIdIsInvalidOrLookupFails() throws Exception {
+        AttachmentService attachmentService = mock(AttachmentService.class);
+        when(attachmentService.getAttachmentById(42L)).thenThrow(new RuntimeException("missing attachment"));
+        AttachmentRagIndexJobSourceNameResolver resolver = new AttachmentRagIndexJobSourceNameResolver(attachmentService);
+
+        assertThat(resolver.resolveSourceName(
+                new RagIndexJobCreateRequest(
+                        "attachment",
+                        "not-numeric",
+                        "not-numeric",
+                        "attachment",
+                        false,
+                        null),
+                RagIndexJobSourceRequest.empty())).isEmpty();
+        assertThat(resolver.resolveSourceName(
+                new RagIndexJobCreateRequest(
+                        "attachment",
+                        "42",
+                        "42",
+                        "attachment",
+                        false,
+                        null),
+                RagIndexJobSourceRequest.empty())).isEmpty();
+    }
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagIndexJobSourceNameResolver.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagIndexJobSourceNameResolver.java
@@ -1,0 +1,16 @@
+package studio.one.platform.ai.service.pipeline;
+
+import java.util.Optional;
+
+import studio.one.platform.ai.core.rag.RagIndexJobCreateRequest;
+import studio.one.platform.ai.core.rag.RagIndexJobSourceRequest;
+
+/**
+ * Resolves display names for source-based RAG index jobs without coupling ai-web to source modules.
+ */
+public interface RagIndexJobSourceNameResolver {
+
+    boolean supports(RagIndexJobCreateRequest request, RagIndexJobSourceRequest sourceRequest);
+
+    Optional<String> resolveSourceName(RagIndexJobCreateRequest request, RagIndexJobSourceRequest sourceRequest);
+}


### PR DESCRIPTION
## Why

- generic RAG job API에서 attachment source job을 생성할 때 표시명 정보가 없으면 `sourceName`이 attachment id로 fallback되어 운영 grid에 파일명이 아닌 id가 표시될 수 있었다.
- `starter-ai-web`은 attachment 모듈에 직접 의존하지 않아야 하므로 source별 표시명 조회를 확장점으로 분리한다.

## What

- `RagIndexJobSourceNameResolver` SPI를 추가했다.
- `RagIndexJobController`가 source job 생성 시 요청/metadata 표시명 다음으로 resolver를 사용하고, 실패하면 기존 `documentId` fallback을 유지하도록 했다.
- `content-embedding-pipeline`에 attachment resolver를 추가해 `AttachmentService`에서 파일명을 조회한다.
- raw text job에는 resolver가 개입하지 않도록 source job으로 범위를 제한했다.
- controller, auto-configuration, attachment resolver 테스트와 README/CHANGELOG를 갱신했다.

## Related Issues

- Closes #362

## Validation

- Command: `./gradlew :studio-platform-ai:test --tests 'studio.one.platform.ai.core.rag.RagIndexJobContractTest'`
- Result: passed
- Command: `./gradlew :starter:studio-platform-starter-ai-web:test --tests 'studio.one.platform.ai.web.controller.RagIndexJobControllerTest' --tests 'studio.one.platform.ai.autoconfigure.config.OpenAiProviderAutoConfigurationTest'`
- Result: passed
- Command: `./gradlew :studio-application-modules:content-embedding-pipeline:test --tests 'studio.one.application.web.service.AttachmentRagIndexJobSourceNameResolverTest' --tests 'studio.one.application.web.autoconfigure.ContentEmbeddingPipelineAutoConfigurationTest'`
- Result: passed
- Command: `./gradlew :starter:studio-platform-starter-ai-web:test :studio-application-modules:content-embedding-pipeline:test`
- Result: passed
- Command: `./gradlew test`
- Result: passed
- Command: `git diff --check`
- Result: passed

## Risk / Rollback

- Risk: source별 resolver가 잘못 구현되면 표시명 보강이 실패할 수 있다. controller는 resolver 예외를 debug log 후 기존 fallback으로 처리해 job 생성 실패로 전파하지 않는다.
- Rollback: 이 PR을 revert하면 generic attachment job은 기존처럼 명시 `sourceName`/metadata가 없을 때 `documentId`로 표시된다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: Yes
- Delegated scope: 구현 후 code-reviewer가 module boundary, backward compatibility, auto-configuration, test adequacy를 검토했다.
- Main author validation: subagent가 지적한 raw text job 회귀 위험과 auto-config resolver 주입 테스트 누락을 반영한 뒤 대상 테스트, 관련 모듈 테스트, 전체 테스트, `git diff --check`를 실행했다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included