### PR TITLE
fix(ai): RAG context 확장 fallback 보강

### DIFF
--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagContextBuilder.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagContextBuilder.java
@@ -106,11 +106,28 @@ public class RagContextBuilder {
         int fallbackHitCount = 0;
         String strategy = null;
         String fallbackReason = expansionSupported ? null : "disabled";
+        boolean contextLimitHit = false;
         for (int i = 0; i < count; i++) {
-            ExpansionAttempt attempt = expandResultWithDiagnostics(results.get(i), expansionCandidates);
+            RagSearchResult original = results.get(i);
+            ExpansionAttempt attempt = expandResultWithDiagnostics(original, expansionCandidates);
             String chunk = formatChunk(i + 1, attempt.result());
             if (!appendWithinLimit(sb, chunk)) {
-                break;
+                contextLimitHit = true;
+                if (!attempt.expanded()) {
+                    fallbackReason = "context_limit";
+                    break;
+                }
+                String fallbackChunk = formatChunk(i + 1, original);
+                if (!appendWithinLimit(sb, fallbackChunk)) {
+                    fallbackReason = "context_limit";
+                    break;
+                }
+                fallbackHitCount++;
+                fallbackReason = "context_limit";
+                if (strategy == null) {
+                    strategy = attempt.strategy();
+                }
+                continue;
             }
             if (attempt.expanded()) {
                 expandedHitCount++;
@@ -127,7 +144,8 @@ public class RagContextBuilder {
         String context = sb.toString().trim();
         if (HEADER.trim().equals(context)) {
             return new BuildResult(NO_CONTEXT_MESSAGE, new Diagnostics(
-                    expansionSupported, false, null, 0, 0, candidateCount, resultCount, "no_context"));
+                    expansionSupported, false, strategy, 0, fallbackHitCount, candidateCount, resultCount,
+                    contextLimitHit ? "context_limit" : "no_context"));
         }
         return new BuildResult(context, new Diagnostics(
                 expansionSupported,
@@ -156,10 +174,6 @@ public class RagContextBuilder {
         }
         sb.append("\n").append(result.content()).append("\n\n");
         return sb.toString();
-    }
-
-    private RagSearchResult expandResult(RagSearchResult result, List<RagSearchResult> expansionCandidates) {
-        return expandResultWithDiagnostics(result, expansionCandidates).result();
     }
 
     private ExpansionAttempt expandResultWithDiagnostics(RagSearchResult result, List<RagSearchResult> expansionCandidates) {

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
@@ -1116,6 +1116,55 @@ class ChatControllerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    void ragChatFallsBackToSearchChunkWhenExpandedContextExceedsLimit() {
+        controller = new ChatController(providerRegistry, ragPipelineService,
+                new RagContextBuilder(8, 80, true, TestWindowChunkContextExpander.asList()), true);
+        ArgumentCaptor<ChatRequest> chatCaptor = ArgumentCaptor.forClass(ChatRequest.class);
+        when(ragPipelineService.search(any(RagSearchRequest.class)))
+                .thenReturn(List.of(new RagSearchResult("chunk-2", "seed body",
+                        chunkMetadata("chunk-2"), 0.9d)));
+        when(ragPipelineService.listByObject("attachment", "123", 12))
+                .thenReturn(List.of(
+                        new RagSearchResult("chunk-1", "previous text that makes the expanded content too long",
+                                chunkMetadata("chunk-1", null, "chunk-2", 0), 1.0d),
+                        new RagSearchResult("chunk-2", "seed body",
+                                chunkMetadata("chunk-2", "chunk-1", "chunk-3", 1), 1.0d),
+                        new RagSearchResult("chunk-3", "next text that makes the expanded content too long",
+                                chunkMetadata("chunk-3", "chunk-2", null, 2), 1.0d)));
+
+        ChatResponseDto response = controller.chatWithRag(new ChatRagRequestDto(
+                new ChatRequestDto(
+                        null,
+                        null,
+                        List.of(new ChatMessageDto("user", "summarize")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null),
+                "summary",
+                3,
+                "attachment",
+                "123",
+                true)).getBody().getData();
+
+        verify(defaultChatPort).chat(chatCaptor.capture());
+        assertThat(chatCaptor.getValue().messages().get(0).content())
+                .contains("seed body")
+                .doesNotContain("참고할 문서가 없습니다")
+                .doesNotContain("previous text that makes the expanded content too long")
+                .doesNotContain("next text that makes the expanded content too long");
+        Map<String, Object> contextDiagnostics = (Map<String, Object>) response.metadata()
+                .get("ragContextDiagnostics");
+        assertThat(contextDiagnostics)
+                .containsEntry("applied", false)
+                .containsEntry("fallbackReason", "context_limit")
+                .containsEntry("fallbackHitCount", 1);
+    }
+
+    @Test
     void ragChatListsByObjectWhenQueryMissingAndObjectFilterPresent() {
         when(ragPipelineService.listByObject("attachment", "123", 3))
                 .thenReturn(List.of(new RagSearchResult("doc-1", "file text", Map.of(), 1.0d)));

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagContextBuilderTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagContextBuilderTest.java
@@ -112,10 +112,10 @@ class RagContextBuilderTest {
     }
 
     @Test
-    void keepsCharacterBudgetAfterExpansion() {
+    void fallsBackToOriginalChunkWhenExpandedContextExceedsCharacterBudget() {
         RagContextBuilder builder = new RagContextBuilder(8, 80, true, TestWindowChunkContextExpander.asList());
 
-        String context = builder.build(
+        RagContextBuilder.BuildResult result = builder.buildWithDiagnostics(
                 List.of(result("chunk-2", "seed", metadata("chunk-2"))),
                 List.of(
                         result("chunk-1", "previous text that makes the expanded content too long",
@@ -124,7 +124,35 @@ class RagContextBuilderTest {
                         result("chunk-3", "next text that makes the expanded content too long",
                                 metadata("chunk-3", "chunk-2", null, 2))));
 
-        assertThat(context).isEqualTo("참고할 문서가 없습니다. 일반적으로 답변하세요.");
+        assertThat(result.context())
+                .contains("docId=chunk-2")
+                .contains("seed")
+                .doesNotContain("previous text that makes the expanded content too long")
+                .doesNotContain("next text that makes the expanded content too long");
+        assertThat(result.diagnostics().toMetadata())
+                .containsEntry("applied", false)
+                .containsEntry("expandedHitCount", 0)
+                .containsEntry("fallbackHitCount", 1)
+                .containsEntry("fallbackReason", "context_limit");
+    }
+
+    @Test
+    void reportsContextLimitWhenOriginalChunkAlsoExceedsCharacterBudget() {
+        RagContextBuilder builder = new RagContextBuilder(8, 50, true, TestWindowChunkContextExpander.asList());
+
+        RagContextBuilder.BuildResult result = builder.buildWithDiagnostics(
+                List.of(result("chunk-2", "seed text that is too long for the remaining context budget",
+                        metadata("chunk-2"))),
+                List.of(
+                        result("chunk-1", "previous", metadata("chunk-1", null, "chunk-2", 0)),
+                        result("chunk-2", "seed text that is too long for the remaining context budget",
+                                metadata("chunk-2", "chunk-1", "chunk-3", 1)),
+                        result("chunk-3", "next", metadata("chunk-3", "chunk-2", null, 2))));
+
+        assertThat(result.context()).isEqualTo("참고할 문서가 없습니다. 일반적으로 답변하세요.");
+        assertThat(result.diagnostics().toMetadata())
+                .containsEntry("resultCount", 1)
+                .containsEntry("fallbackReason", "context_limit");
     }
 
     private RagSearchResult result(String chunkId, String content, Map<String, Object> metadata) {


### PR DESCRIPTION
## Why

`/api/ai/chat/rag`에서 RAG 검색 결과가 있어도 parent/window 확장 context가 `maxChars`를 초과하면 전체 답변 문맥이 `NO_CONTEXT_MESSAGE`로 대체될 수 있었습니다.
검색 chunk는 존재하므로, 확장 context가 제한을 초과하더라도 원본 검색 chunk는 system context에 남아야 합니다.

## What

- `RagContextBuilder`에서 확장 context append 실패 시 원본 `RagSearchResult` chunk로 fallback하도록 변경했습니다.
- 확장 context 또는 원본 chunk가 character budget을 초과하는 경우 diagnostics에 `fallbackReason=context_limit`을 남기도록 했습니다.
- builder 단위 테스트에 확장 초과 fallback과 원본 초과 diagnostics 케이스를 추가했습니다.
- `/api/ai/chat/rag` controller 조립 경로에서 원본 chunk fallback과 `ragContextDiagnostics` 노출을 검증했습니다.

## Related Issues

- Closes #370

## Validation

- Command: `./gradlew :starter:studio-platform-starter-ai-web:test --tests 'studio.one.platform.ai.web.controller.RagContextBuilderTest' --tests 'studio.one.platform.ai.web.controller.ChatControllerTest'`
- Result: 성공
- Command: `git diff --check`
- Result: 성공
- Command: `./gradlew test`
- Result: 성공
- Review: code-reviewer subagent review approve, blocking findings 없음

## Risk / Rollback

- Risk: 매우 작은 RAG context budget에서 fallback 원본 chunk도 들어가지 못하면 기존처럼 `NO_CONTEXT_MESSAGE`가 유지됩니다. 다만 diagnostics는 `context_limit`으로 남습니다.
- Rollback: 이 PR 커밋을 revert하면 기존 확장 context limit 동작으로 돌아갑니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: Yes
- Delegated scope: 변경 diff에 대한 code-reviewer 검토
- Main author validation: targeted test, full `./gradlew test`, `git diff --check`를 실행하고 리뷰 결과를 확인했습니다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
