### PR TITLE
[ai-assisted] feat(user): 관리자 사용자 삭제 API 추가

### DIFF
--- a/starter/studio-platform-starter-user/README.md
+++ b/starter/studio-platform-starter-user/README.md
@@ -140,6 +140,9 @@ studio:
 - `/api/mgmt/roles`
 - `/api/self`
 
+기본 사용자 관리 API에는 `DELETE /api/mgmt/users/{id}`가 포함된다. 이 엔드포인트는
+`features:user` admin 권한을 요구하며, 성공 시 `204 No Content`를 반환한다.
+
 기본 컨트롤러는 `ApplicationUserMapper`/`ApplicationUserService` 빈이 있을 때만 등록된다.
 커스텀 컨트롤러를 제공할 때는 `UserMgmtApi`/`UserPublicApi`/`UserAuthPublicApi`/`UserMeApi`
 인터페이스를 구현하면 기본 컨트롤러가 자동으로 비활성화된다.

--- a/studio-platform-user-default/src/main/java/studio/one/base/user/service/impl/ApplicationUserServiceImpl.java
+++ b/studio-platform-user-default/src/main/java/studio/one/base/user/service/impl/ApplicationUserServiceImpl.java
@@ -175,6 +175,10 @@ public class ApplicationUserServiceImpl implements ApplicationUserService<Applic
     }
 
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(cacheNames = CacheNames.User.BY_USER_ID, key = "#userId"),
+            @CacheEvict(cacheNames = CacheNames.User.BY_USERNAME, allEntries = true)
+    })
     public void delete(Long userId) {
         ApplicationUser u = get(userId);
         userRepo.delete(u);

--- a/studio-platform-user-default/src/main/java/studio/one/base/user/web/controller/UserMgmtController.java
+++ b/studio-platform-user-default/src/main/java/studio/one/base/user/web/controller/UserMgmtController.java
@@ -176,6 +176,14 @@ public class UserMgmtController extends AbstractPasswordPolicyControllerSupport 
                 return ResponseEntity.ok(ApiResponse.ok(userMapper.toDto(updated)));
         }
 
+        @DeleteMapping("/{id}")
+        @PreAuthorize("@endpointAuthz.can('features:user','admin')")
+        @Override
+        public ResponseEntity<Void> delete(@PathVariable Long id) {
+                userService.delete(id);
+                return ResponseEntity.noContent().build();
+        }
+
         @GetMapping("/password-policy")
         @PreAuthorize("@endpointAuthz.can('features:user','admin')")
         @Override

--- a/studio-platform-user-default/src/test/java/studio/one/base/user/web/controller/UserMgmtControllerAuthorizationTest.java
+++ b/studio-platform-user-default/src/test/java/studio/one/base/user/web/controller/UserMgmtControllerAuthorizationTest.java
@@ -87,6 +87,16 @@ class UserMgmtControllerAuthorizationTest {
     }
 
     @Test
+    void deleteDelegatesToUserService() {
+        UserMgmtController controller = controller();
+
+        var response = controller.delete(10L);
+
+        assertEquals(204, response.getStatusCode().value());
+        verify(userService).delete(10L);
+    }
+
+    @Test
     void updateUserRolesDelegatesDistinctRoleIds() {
         UserMgmtController controller = controller();
         UserDetails actor = User.withUsername("admin").password("n/a").authorities("ROLE_ADMIN").build();

--- a/studio-platform-user/README.md
+++ b/studio-platform-user/README.md
@@ -24,6 +24,7 @@ Response: `ApiResponse<MeProfileDto>`
 Password policy is defined by configuration and enforced on:
 - **Self password change**: `PUT /api/self/password`
 - **Admin reset**: `POST /api/mgmt/users/{id}/password`
+- **Admin delete**: `DELETE /api/mgmt/users/{id}` removes the user through the configured `ApplicationUserService` implementation.
 
 ### Policy Config (YAML)
 ```yaml
@@ -116,6 +117,13 @@ Response: `ApiResponse<Void>` (OK only)
 Returns current password policy configuration for admin UI.
 
 Response: `ApiResponse<PasswordPolicyDto>`
+
+### DELETE /api/mgmt/users/{id}
+Deletes a user from the admin API.
+
+Auth: `features:user` admin permission
+
+Response: `204 No Content`
 
 ## Example Requests
 

--- a/studio-platform-user/src/main/java/studio/one/base/user/web/controller/UserMgmtApi.java
+++ b/studio-platform-user/src/main/java/studio/one/base/user/web/controller/UserMgmtApi.java
@@ -50,6 +50,10 @@ public interface UserMgmtApi {
 
     ResponseEntity<ApiResponse<UserDto>> update(Long id, @RequestBody UpdateUserRequest req);
 
+    default ResponseEntity<Void> delete(Long id) {
+        throw new UnsupportedOperationException("User delete endpoint is not implemented");
+    }
+
     ResponseEntity<ApiResponse<PasswordPolicyDto>> passwordPolicy();
 
     ResponseEntity<Void> passwordReset(Long id, @Valid @RequestBody ChangePasswordRequest req,


### PR DESCRIPTION
## Why

- Admin 회원 목록에는 사용자 삭제 액션이 있지만 서버 기본 사용자 관리 API에 `DELETE /api/mgmt/users/{id}`가 없어 클라이언트에서 삭제 기능을 연결할 수 없었습니다.
- `ApplicationUserService.delete(Long userId)`는 이미 존재하므로 기본 관리 컨트롤러에 엔드포인트를 노출합니다.

## What

- `UserMgmtController`에 `DELETE /{id}` 엔드포인트를 추가했습니다.
- 기존 사용자 관리 권한 체계에 맞춰 `features:user` admin 권한을 적용했습니다.
- 성공 응답은 삭제 API 관례에 맞춰 `204 No Content`로 반환합니다.
- `UserMgmtApi`에는 default 메서드로 delete 계약을 추가해 커스텀 컨트롤러 구현체의 컴파일 호환성을 유지했습니다.
- `ApplicationUserServiceImpl.delete` 성공 시 user id cache와 username cache를 정리하도록 보강했습니다.
- user/starter README에 삭제 API를 문서화했습니다.

## Related Issues

- Fixes donghyuck/studio-api#376

## Validation

- Command: `./gradlew :studio-platform-user:compileJava :studio-platform-user-default:test :starter:studio-platform-starter-user:test`
- Result: 성공
- Command: `./gradlew test`
- Result: 성공
- Command: `git diff --check`
- Result: 성공

## Risk / Rollback

- Risk: 기본 구현은 기존 `ApplicationUserService.delete`의 물리 삭제 정책을 그대로 사용합니다. user property, role, group membership은 스키마상 cascade 삭제 대상입니다. 별도 soft-delete 정책이 필요한 경우 후속 정책 이슈로 분리해야 합니다.
- Rollback: 해당 커밋을 revert하면 기본 사용자 관리 API에서 DELETE 엔드포인트가 제거됩니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: 없음
- Main author validation: 이슈 #376 요구사항 확인, 기존 role/group delete API와 권한 체계 비교, targeted test와 전체 test 수행

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
