### PR TITLE
feat(rag): RAG Chat 근거 metadata 추가

### DIFF
--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -448,6 +448,40 @@ RAG context는 이슈 #202부터 설정된 chunk 수와 문자 수를 넘지 않
 retrieval hit content만 사용한다. 확장 후에도 아래 `max-chunks`, `max-chars`, `include-scores`
 설정은 그대로 적용된다.
 
+RAG Chat 응답은 실제 답변 생성 프롬프트에 포함된 근거를 `metadata.ragReferences` 배열로 반환한다.
+순서는 system context의 `[1]`, `[2]` 순서와 같으며, context expansion 또는 fallback이 적용된 경우에도
+최종 프롬프트에 들어간 content를 기준으로 한다. 클라이언트는 별도 management search를 다시 호출하지 않고
+이 값으로 출처 UI를 구성할 수 있다.
+
+```json
+{
+  "metadata": {
+    "ragReferences": [
+      {
+        "index": 1,
+        "documentId": "3",
+        "sourceName": "sample.pdf",
+        "chunkId": "chunk-1",
+        "chunkOrder": 0,
+        "score": 0.91,
+        "content": "프롬프트에 포함된 근거 본문",
+        "page": 3,
+        "pageNumber": 3,
+        "sourceRef": "page[3]",
+        "metadata": {
+          "objectType": "attachment",
+          "objectId": "3"
+        }
+      }
+    ]
+  }
+}
+```
+
+`sourceName`은 `sourceName`, `title`, `filename`, `fileName`, `name` metadata 순서로 선택한다.
+위치 정보는 metadata에 있으면 `page`/`pageNumber`, `slide`/`slideNumber`, `sourceRef`,
+`section`, `heading`으로 함께 내려간다.
+
 ```yaml
 studio:
   ai:

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
@@ -24,6 +24,7 @@ package studio.one.platform.ai.web.controller;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -71,6 +72,7 @@ import studio.one.platform.ai.core.registry.AiProviderRegistry;
 import studio.one.platform.ai.core.rag.RagRetrievalDiagnostics;
 import studio.one.platform.ai.core.rag.RagSearchRequest;
 import studio.one.platform.ai.core.rag.RagSearchResult;
+import studio.one.platform.ai.core.vector.VectorRecord;
 import studio.one.platform.ai.autoconfigure.AiWebRagProperties;
 import studio.one.platform.ai.service.pipeline.RagPipelineOptions;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
@@ -441,6 +443,7 @@ public class ChatController {
         appendConversation(principal, memory, chat.messages().stream().map(this::toDomainMessage).toList(), response);
         boolean exposeDiagnostics = shouldExposeDiagnostics(request);
         Map<String, Object> extraMetadata = memoryMetadata(memory, memoryMessageCount);
+        extraMetadata.put("ragReferences", ragReferences(contextResult.usedResults()));
         if (exposeDiagnostics && contextResult.diagnostics() != null) {
             extraMetadata.put("ragContextDiagnostics", contextResult.diagnostics().toMetadata());
         }
@@ -688,6 +691,101 @@ public class ChatController {
             metadata.put("ragDiagnostics", diagnostics.toMetadata());
         }
         return new ChatResponseDto(messages, response.model(), metadata);
+    }
+
+    private List<Map<String, Object>> ragReferences(List<RagSearchResult> results) {
+        if (results == null || results.isEmpty()) {
+            return List.of();
+        }
+        List<Map<String, Object>> references = new ArrayList<>(results.size());
+        for (int i = 0; i < results.size(); i++) {
+            references.add(ragReference(i + 1, results.get(i)));
+        }
+        return List.copyOf(references);
+    }
+
+    private Map<String, Object> ragReference(int index, RagSearchResult result) {
+        Map<String, Object> metadata = result.metadata() == null ? Map.of() : result.metadata();
+        Map<String, Object> reference = new LinkedHashMap<>();
+        reference.put("index", index);
+        String documentId = firstText(metadata,
+                VectorRecord.KEY_DOCUMENT_ID,
+                "documentId",
+                "sourceDocumentId");
+        if (documentId == null) {
+            documentId = result.documentId();
+        }
+        put(reference, "documentId", documentId);
+        String sourceName = firstText(metadata, "sourceName", "title", "filename", "fileName", "name");
+        put(reference, "sourceName", sourceName == null ? documentId : sourceName);
+        String chunkId = firstText(metadata, VectorRecord.KEY_CHUNK_ID, "chunkId");
+        put(reference, "chunkId", chunkId == null ? documentId : chunkId);
+        put(reference, "chunkOrder", firstInteger(metadata, "chunkOrder", VectorRecord.KEY_CHUNK_INDEX));
+        put(reference, "score", result.score());
+        put(reference, "content", result.content());
+        Integer page = firstInteger(metadata, VectorRecord.KEY_PAGE, "page", "pageNumber");
+        if (page != null) {
+            reference.put("page", page);
+            reference.put("pageNumber", page);
+        }
+        Integer slide = firstInteger(metadata, VectorRecord.KEY_SLIDE, "slide", "slideNumber");
+        if (slide != null) {
+            reference.put("slide", slide);
+            reference.put("slideNumber", slide);
+        }
+        put(reference, "sourceRef", firstText(metadata, VectorRecord.KEY_SOURCE_REF, "sourceRef", "sourceRefs"));
+        put(reference, "section", firstText(metadata, "section", VectorRecord.KEY_HEADING_PATH, "headingPath"));
+        put(reference, "heading", firstText(metadata, "heading", VectorRecord.KEY_HEADING_PATH, "headingPath"));
+        if (!metadata.isEmpty()) {
+            reference.put("metadata", metadata);
+        }
+        return Map.copyOf(reference);
+    }
+
+    private void put(Map<String, Object> target, String key, Object value) {
+        if (value != null) {
+            target.put(key, value);
+        }
+    }
+
+    private String firstText(Map<String, Object> metadata, String... keys) {
+        for (String key : keys) {
+            Object value = metadata.get(key);
+            if (value instanceof String text && !text.isBlank()) {
+                return text.trim();
+            }
+            if (value != null && !(value instanceof String)) {
+                String text = value.toString();
+                if (!text.isBlank()) {
+                    return text.trim();
+                }
+            }
+        }
+        return null;
+    }
+
+    private Integer firstInteger(Map<String, Object> metadata, String... keys) {
+        for (String key : keys) {
+            Integer value = integer(metadata.get(key));
+            if (value != null) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private Integer integer(Object value) {
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        if (value instanceof String text && !text.isBlank()) {
+            try {
+                return Integer.parseInt(text.trim());
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
     }
 
     private boolean shouldExposeDiagnostics(ChatRagRequestDto request) {

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagContextBuilder.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagContextBuilder.java
@@ -1,5 +1,6 @@
 package studio.one.platform.ai.web.controller;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -107,6 +108,7 @@ public class RagContextBuilder {
         String strategy = null;
         String fallbackReason = expansionSupported ? null : "disabled";
         boolean contextLimitHit = false;
+        List<RagSearchResult> usedResults = new ArrayList<>();
         for (int i = 0; i < count; i++) {
             RagSearchResult original = results.get(i);
             ExpansionAttempt attempt = expandResultWithDiagnostics(original, expansionCandidates);
@@ -122,6 +124,7 @@ public class RagContextBuilder {
                     fallbackReason = "context_limit";
                     break;
                 }
+                usedResults.add(original);
                 fallbackHitCount++;
                 fallbackReason = "context_limit";
                 if (strategy == null) {
@@ -129,6 +132,7 @@ public class RagContextBuilder {
                 }
                 continue;
             }
+            usedResults.add(attempt.result());
             if (attempt.expanded()) {
                 expandedHitCount++;
                 if (strategy == null) {
@@ -155,7 +159,8 @@ public class RagContextBuilder {
                 fallbackHitCount,
                 candidateCount,
                 resultCount,
-                fallbackReason));
+                fallbackReason),
+                usedResults);
     }
 
     private boolean appendWithinLimit(StringBuilder sb, String chunk) {
@@ -339,7 +344,15 @@ public class RagContextBuilder {
         return value != null && !value.isBlank();
     }
 
-    public record BuildResult(String context, Diagnostics diagnostics) {
+    public record BuildResult(String context, Diagnostics diagnostics, List<RagSearchResult> usedResults) {
+
+        public BuildResult(String context, Diagnostics diagnostics) {
+            this(context, diagnostics, List.of());
+        }
+
+        public BuildResult {
+            usedResults = usedResults == null ? List.of() : List.copyOf(usedResults);
+        }
     }
 
     public record Diagnostics(

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
@@ -603,6 +603,54 @@ class ChatControllerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    void ragChatReturnsReferencesForPromptContext() {
+        when(ragPipelineService.search(any(RagSearchRequest.class)))
+                .thenReturn(List.of(new RagSearchResult(
+                        "doc-1",
+                        "file text",
+                        Map.of(
+                                "sourceName", "sample.pdf",
+                                RagContextBuilder.KEY_CHUNK_ID, "chunk-1",
+                                ChunkMetadata.KEY_CHUNK_ORDER, 7,
+                                "page", 3,
+                                "sourceRef", "page[3]"),
+                        0.9d)));
+
+        ChatResponseDto response = controller.chatWithRag(new ChatRagRequestDto(
+                new ChatRequestDto(
+                        null,
+                        null,
+                        List.of(new ChatMessageDto("user", "summarize")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null),
+                "summary",
+                3,
+                "attachment",
+                "123")).getBody().getData();
+
+        List<Map<String, Object>> references = (List<Map<String, Object>>) response.metadata().get("ragReferences");
+        assertThat(references).hasSize(1);
+        assertThat(references.get(0))
+                .containsEntry("index", 1)
+                .containsEntry("documentId", "doc-1")
+                .containsEntry("sourceName", "sample.pdf")
+                .containsEntry("chunkId", "chunk-1")
+                .containsEntry("chunkOrder", 7)
+                .containsEntry("score", 0.9d)
+                .containsEntry("content", "file text")
+                .containsEntry("page", 3)
+                .containsEntry("pageNumber", 3)
+                .containsEntry("sourceRef", "page[3]");
+        assertThat((Map<String, Object>) references.get(0).get("metadata"))
+                .containsEntry("sourceName", "sample.pdf");
+    }
+
+    @Test
     void ragChatAllowsNonAttachmentObjectScope() {
         ArgumentCaptor<RagSearchRequest> ragCaptor = ArgumentCaptor.forClass(RagSearchRequest.class);
         when(ragPipelineService.search(any(RagSearchRequest.class)))
@@ -1162,6 +1210,11 @@ class ChatControllerTest {
                 .containsEntry("applied", false)
                 .containsEntry("fallbackReason", "context_limit")
                 .containsEntry("fallbackHitCount", 1);
+        List<Map<String, Object>> references = (List<Map<String, Object>>) response.metadata().get("ragReferences");
+        assertThat(references).hasSize(1);
+        assertThat(references.get(0))
+                .containsEntry("content", "seed body")
+                .containsEntry("chunkId", "chunk-2");
     }
 
     @Test

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagContextBuilderTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagContextBuilderTest.java
@@ -134,6 +134,31 @@ class RagContextBuilderTest {
                 .containsEntry("expandedHitCount", 0)
                 .containsEntry("fallbackHitCount", 1)
                 .containsEntry("fallbackReason", "context_limit");
+        assertThat(result.usedResults())
+                .extracting(RagSearchResult::content)
+                .containsExactly("seed");
+    }
+
+    @Test
+    void reportsExpandedResultsInPromptOrder() {
+        RagContextBuilder builder = new RagContextBuilder(8, 12_000, true, TestWindowChunkContextExpander.asList());
+
+        RagContextBuilder.BuildResult result = builder.buildWithDiagnostics(
+                List.of(
+                        result("chunk-2", "seed", metadata("chunk-2")),
+                        result("chunk-4", "tail", metadata("chunk-4", "chunk-3", null, 3))),
+                List.of(
+                        result("chunk-1", "previous", metadata("chunk-1", null, "chunk-2", 0)),
+                        result("chunk-2", "seed", metadata("chunk-2", "chunk-1", "chunk-3", 1)),
+                        result("chunk-3", "next", metadata("chunk-3", "chunk-2", "chunk-4", 2)),
+                        result("chunk-4", "tail", metadata("chunk-4", "chunk-3", null, 3))));
+
+        assertThat(result.context())
+                .contains("[1] docId=chunk-2")
+                .contains("[2] docId=chunk-4");
+        assertThat(result.usedResults())
+                .extracting(RagSearchResult::content)
+                .containsExactly("previous\nseed\nnext\ntail", "previous\nseed\nnext\ntail");
     }
 
     @Test


### PR DESCRIPTION
## Why

- RAG Chat 화면이 출처를 표시하기 위해 별도 management search를 재호출하면 서버의 실제 context expansion/fallback 결과와 표시 근거가 달라질 수 있습니다.
- 답변 생성 프롬프트에 실제 포함된 근거를 응답 metadata로 내려 클라이언트 출처 UI와 서버 생성 근거를 일치시킵니다.

## What

- `RagContextBuilder.BuildResult`에 실제 프롬프트에 포함된 `usedResults`를 추가했습니다.
- `/api/ai/chat/rag` 응답 `metadata.ragReferences`에 `index`, `documentId`, `sourceName`, `chunkId`, `chunkOrder`, `score`, `content`, page/slide/sourceRef 등 표시용 metadata를 포함했습니다.
- context expansion fallback 시에도 실제 사용된 원본 chunk가 `ragReferences`에 남도록 테스트를 추가했습니다.
- AI web README에 응답 계약과 출처 표시 필드를 문서화했습니다.

## Related Issues

- Closes #373

## Validation

- Command: `./gradlew :starter:studio-platform-starter-ai-web:test`
- Result: PASS
- Command: `./gradlew test`
- Result: PASS
- Command: `git diff --check`
- Result: PASS

## Risk / Rollback

- Risk: `ragReferences.content`는 요구사항에 따라 실제 prompt context 본문을 포함하므로, 기존 diagnostics보다 응답 metadata가 커질 수 있습니다. 기존 RAG Chat 권한 경계 안에서만 반환됩니다.
- Rollback: PR 커밋을 revert하면 기존 RAG Chat 응답 metadata 구조로 돌아갑니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: 새 subagent 생성은 스레드 에이전트 한도 때문에 실패하여 main agent가 리뷰까지 수행했습니다.
- Main author validation: 타깃 테스트, 전체 테스트, diff whitespace 검사를 수행했습니다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included