### PR TITLE
[ai-assisted] fix(vector): projection 조회 SQL 오류 수정

### DIFF
--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -114,7 +114,10 @@ studio:
 projection job 상태와 미리 계산된 좌표만 저장한다. 화면 요청 시마다 고차원 벡터를 다시 projection하지 않는다.
 
 기본 알고리즘은 `PCA`다. v1 구현은 Java 내장 연산으로 PCA 좌표를 계산하고, 후속 UMAP/t-SNE는
-`VectorProjectionGenerator` 구현을 추가해 확장한다. `targetTypes`가 비어 있으면 전체 vector item을 대상으로 한다.
+`VectorProjectionGenerator` 구현을 추가해 확장한다. `targetTypes`는 UI 문서 분류가 아니라
+`tb_ai_document_chunk.object_type`에 저장된 RAG index objectType 기준이다. 예를 들어 `attachment`,
+`forums-post-attachment`, 정책 object type 값처럼 색인 job이 사용한 objectType을 지정한다.
+`targetTypes`가 비어 있으면 전체 vector item을 대상으로 한다.
 `filters`는 v1에서 metadata equality 조건만 사용하며 null 값은 무시한다. 한 projection job은 최대
 1,000개 vector item, 2,048 embedding dimension까지 처리한다. 더 큰 범위는 `targetTypes`나 metadata filter로 나눠 생성한다.
 projection 생성과 point/item/search visualization 조회는 object별 ACL을 행마다 평가하지 않는 corpus-level 관리 API이므로
@@ -139,7 +142,9 @@ Content-Type: application/json
 
 응답은 즉시 `REQUESTED`를 반환한다. 서버는 비동기 job에서 `PROCESSING`으로 전환한 뒤 기존
 `tb_ai_document_chunk`의 embedding을 읽어 좌표를 만들고, 기존 point를 삭제 후 재생성한다.
-완료 시 `COMPLETED`, 실패 시 `FAILED`와 `errorMessage`를 저장한다.
+완료 시 `COMPLETED`, 실패 시 `FAILED`와 `errorMessage`를 저장한다. 완료된 projection의 목록/상세 응답
+`targetTypes`는 실제 좌표에 포함된 `tb_ai_document_chunk.object_type` 목록을 반환하므로 클라이언트는 이 값을
+필터와 범례 구성에 사용할 수 있다.
 
 ```json
 {
@@ -184,7 +189,7 @@ Content-Type: application/json
 projection point를 매칭하고, query 위치는 매칭된 Top-K point 좌표의 평균으로 계산한다.
 매칭 point가 없으면 `query.x`, `query.y`는 `null`, `results`는 빈 배열로 200 응답한다.
 검색은 선택된 projection의 `targetTypes`와 `filters` 범위를 기준으로 제한하고, 요청 `targetTypes`가 있으면
-projection 범위와 교집합인 type만 대상으로 한다. `query`는 provider 비용과 지연을 제한하기 위해 최대
+projection 범위와 교집합인 RAG index objectType만 대상으로 한다. `query`는 provider 비용과 지연을 제한하기 위해 최대
 2,000자까지 허용한다.
 
 ### RAG Index Job Management

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/VectorVisualizationMgmtController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/VectorVisualizationMgmtController.java
@@ -155,6 +155,7 @@ public class VectorVisualizationMgmtController {
                 projection.name(),
                 projection.algorithm().name(),
                 projection.status().name(),
+                projection.targetTypes(),
                 projection.itemCount(),
                 projection.createdAt(),
                 projection.completedAt());

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/visualization/ProjectionSummaryResponse.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/visualization/ProjectionSummaryResponse.java
@@ -1,12 +1,14 @@
 package studio.one.platform.ai.web.dto.visualization;
 
 import java.time.Instant;
+import java.util.List;
 
 public record ProjectionSummaryResponse(
         String projectionId,
         String name,
         String algorithm,
         String status,
+        List<String> targetTypes,
         int itemCount,
         Instant createdAt,
         Instant completedAt) {

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/VectorVisualizationMgmtControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/VectorVisualizationMgmtControllerTest.java
@@ -78,6 +78,20 @@ class VectorVisualizationMgmtControllerTest {
     }
 
     @Test
+    void listProjectionIncludesActualTargetTypes() {
+        VectorProjectionService projectionService = mock(VectorProjectionService.class);
+        when(projectionService.list(50, 0)).thenReturn(List.of(projection(ProjectionStatus.COMPLETED)));
+        VectorVisualizationMgmtController controller = new VectorVisualizationMgmtController(
+                projectionService,
+                mock(VectorSearchVisualizationService.class));
+
+        var response = controller.listProjections(50, 0);
+
+        assertThat(response.getBody().getData().items()).singleElement()
+                .satisfies(item -> assertThat(item.targetTypes()).containsExactly("COURSE_CHUNK"));
+    }
+
+    @Test
     void itemDetailDoesNotReturnEmbeddingMetadata() {
         VectorProjectionService projectionService = mock(VectorProjectionService.class);
         when(projectionService.item("chunk-1")).thenReturn(new VectorItem(

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/visualization/DefaultVectorProjectionJobService.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/visualization/DefaultVectorProjectionJobService.java
@@ -55,7 +55,7 @@ public class DefaultVectorProjectionJobService implements VectorProjectionJobSer
             }
             pointRepository.deleteByProjectionId(projectionId);
             pointRepository.saveAll(points);
-            projectionRepository.markCompleted(projectionId, points.size(), Instant.now());
+            projectionRepository.markCompleted(projectionId, points.size(), actualTargetTypes(items), Instant.now());
         } catch (Exception ex) {
             log.warn("Vector projection job failed. projectionId={}", projectionId, ex);
             projectionRepository.updateStatus(
@@ -71,5 +71,13 @@ public class DefaultVectorProjectionJobService implements VectorProjectionJobSer
                 .filter(generator -> generator.algorithm() == projection.algorithm())
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("UNSUPPORTED_PROJECTION_ALGORITHM"));
+    }
+
+    private List<String> actualTargetTypes(List<VectorItem> items) {
+        return items.stream()
+                .map(VectorItem::targetType)
+                .filter(value -> value != null && !value.isBlank())
+                .distinct()
+                .toList();
     }
 }

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/visualization/JdbcVectorProjectionRepository.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/visualization/JdbcVectorProjectionRepository.java
@@ -89,10 +89,11 @@ public class JdbcVectorProjectionRepository implements VectorProjectionRepositor
     }
 
     @Override
-    public void markCompleted(String projectionId, int itemCount, Instant completedAt) {
+    public void markCompleted(String projectionId, int itemCount, List<String> targetTypes, Instant completedAt) {
         jdbcTemplate.update("""
                 UPDATE tb_ai_vector_projection
                    SET status = 'COMPLETED',
+                       target_types = :targetTypes,
                        item_count = :itemCount,
                        error_message = NULL,
                        completed_at = :completedAt
@@ -100,6 +101,7 @@ public class JdbcVectorProjectionRepository implements VectorProjectionRepositor
                 """, new MapSqlParameterSource()
                 .addValue("projectionId", projectionId)
                 .addValue("itemCount", itemCount)
+                .addValue("targetTypes", String.join(",", targetTypes == null ? List.of() : targetTypes))
                 .addValue("completedAt", timestamp(completedAt)));
     }
 

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/visualization/JdbcVectorProjectionSql.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/visualization/JdbcVectorProjectionSql.java
@@ -24,7 +24,10 @@ final class JdbcVectorProjectionSql {
     static String jsonText(String alias, String keyExpression, boolean postgres) {
         String column = alias == null || alias.isBlank() ? "metadata" : alias + ".metadata";
         if (postgres) {
-            return column + " ->> " + keyExpression;
+            if (keyExpression.startsWith(":")) {
+                return column + " ->> " + keyExpression;
+            }
+            return column + " ->> '" + keyExpression.replace("'", "''") + "'";
         }
         String path = keyExpression.startsWith(":")
                 ? "CONCAT('$.', " + keyExpression + ")"

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/visualization/DefaultVectorProjectionServiceTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/visualization/DefaultVectorProjectionServiceTest.java
@@ -69,6 +69,7 @@ class DefaultVectorProjectionServiceTest {
         VectorProjection saved = projections.findById(projection.projectionId()).orElseThrow();
         assertThat(saved.status()).isEqualTo(ProjectionStatus.COMPLETED);
         assertThat(saved.itemCount()).isEqualTo(1);
+        assertThat(saved.targetTypes()).containsExactly("COURSE_CHUNK");
         assertThat(points.points).hasSize(1);
     }
 
@@ -183,14 +184,14 @@ class DefaultVectorProjectionServiceTest {
         }
 
         @Override
-        public void markCompleted(String projectionId, int itemCount, Instant completedAt) {
+        public void markCompleted(String projectionId, int itemCount, List<String> targetTypes, Instant completedAt) {
             VectorProjection current = projections.get(projectionId);
             projections.put(projectionId, new VectorProjection(
                     current.projectionId(),
                     current.name(),
                     current.algorithm(),
                     ProjectionStatus.COMPLETED,
-                    current.targetTypes(),
+                    targetTypes,
                     current.filters(),
                     itemCount,
                     null,

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/visualization/JdbcVectorProjectionSqlTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/visualization/JdbcVectorProjectionSqlTest.java
@@ -1,0 +1,32 @@
+package studio.one.platform.ai.service.visualization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class JdbcVectorProjectionSqlTest {
+
+    @Test
+    void postgresJsonTextQuotesLiteralKey() {
+        assertThat(JdbcVectorProjectionSql.jsonText("c", "chunkId", true))
+                .isEqualTo("c.metadata ->> 'chunkId'");
+    }
+
+    @Test
+    void postgresJsonTextKeepsNamedParameterKey() {
+        assertThat(JdbcVectorProjectionSql.jsonText(null, ":filterKey0", true))
+                .isEqualTo("metadata ->> :filterKey0");
+    }
+
+    @Test
+    void mysqlJsonTextUsesJsonExtractPath() {
+        assertThat(JdbcVectorProjectionSql.jsonText("c", "chunkId", false))
+                .isEqualTo("JSON_UNQUOTE(JSON_EXTRACT(c.metadata, '$.chunkId'))");
+    }
+
+    @Test
+    void mysqlJsonTextUsesParameterizedPath() {
+        assertThat(JdbcVectorProjectionSql.jsonText(null, ":filterKey0", false))
+                .isEqualTo("JSON_UNQUOTE(JSON_EXTRACT(metadata, CONCAT('$.', :filterKey0)))");
+    }
+}

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/visualization/VectorProjectionRepository.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/visualization/VectorProjectionRepository.java
@@ -14,5 +14,5 @@ public interface VectorProjectionRepository {
 
     void updateStatus(String projectionId, ProjectionStatus status, String errorMessage, Instant completedAt);
 
-    void markCompleted(String projectionId, int itemCount, Instant completedAt);
+    void markCompleted(String projectionId, int itemCount, List<String> targetTypes, Instant completedAt);
 }


### PR DESCRIPTION
## Why

- `GET /api/mgmt/ai/vectors/projections/{projectionId}/points`와 `POST /api/mgmt/ai/vectors/search-visualization` 호출 시 PostgreSQL JSON key literal이 따옴표 없이 생성되어 런타임 SQL 오류와 500 응답이 발생할 수 있습니다.
- 완료된 Projection의 point 저장 건수와 `tb_ai_document_chunk` join 결과가 일치해야 관리자 산점도 화면이 렌더링됩니다.
- Vector Map 클라이언트가 필터와 범례를 정확히 구성하려면 `targetTypes`가 UI 문서 분류가 아니라 RAG index objectType 기준임이 API 계약으로 명확해야 합니다.

## What

- PostgreSQL JSON literal key를 `metadata ->> 'key'` 형태로 생성하도록 `JdbcVectorProjectionSql`을 수정했습니다.
- named parameter 기반 metadata filter는 기존처럼 `metadata ->> :param` 형태를 유지했습니다.
- projection 완료 시 실제 좌표에 포함된 `VectorItem.targetType`, 즉 `tb_ai_document_chunk.object_type` 목록을 저장합니다.
- projection 목록 응답에도 `targetTypes`를 포함해 클라이언트가 목록 단계에서 필터/범례 후보를 구성할 수 있게 했습니다.
- README에 `targetTypes` / `targetType` / search-visualization `targetTypes`가 모두 RAG index objectType 기준이라는 계약을 문서화했습니다.
- PostgreSQL/MySQL JSON path SQL 생성과 targetTypes 응답 회귀 테스트를 추가했습니다.

## Related Issues

- Closes #382

## Validation

- Command: `./gradlew :starter:studio-platform-starter-ai:test --tests '*JdbcVectorProjectionSqlTest' --tests '*DefaultVectorSearchVisualizationServiceTest' --tests '*DefaultVectorProjectionServiceTest'`
- Result: PASS
- Command: `./gradlew :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test && git diff --check`
- Result: PASS
- Command: `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test && git diff --check`
- Result: PASS
- Command: 로컬 PostgreSQL smoke query
- Result: 최신 `COMPLETED` projection `proj-20260430044829-105b3fa0`의 point join `122`건 확인

## Risk / Rollback

- Risk: projection 완료 시 `target_types`가 요청값이 아니라 실제 포함된 objectType 목록으로 갱신됩니다. 클라이언트 계약에는 더 적합하지만, 기존에 요청값 자체를 감사 용도로 사용했다면 의미가 달라질 수 있습니다.
- Rollback: 문제가 있으면 이 커밋을 revert하면 기존 SQL 생성 및 targetTypes 저장 방식으로 돌아갑니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: 관련 단위 테스트, AI web 테스트, `git diff --check`, 로컬 PostgreSQL join smoke를 수행했습니다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
