### PR TITLE
[ai-assisted] fix(vector): points 조회 ORDER BY SQL 조립 수정

### DIFF
--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/visualization/JdbcVectorProjectionPointRepository.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/visualization/JdbcVectorProjectionPointRepository.java
@@ -93,7 +93,7 @@ public class JdbcVectorProjectionPointRepository implements VectorProjectionPoin
                     ON p.vector_item_id = """ + pointJoinExpression() + """
                  WHERE p.projection_id = :projectionId
                 """ + where + """
-                 ORDER BY """ + JdbcVectorProjectionSql.orderByDisplayOrder(postgres) + """
+                """ + JdbcVectorProjectionSql.orderByDisplayOrderClause(postgres) + """
                  LIMIT :limit OFFSET :offset
                 """, params, rowMapper);
         return new ProjectionPointPage(total == null ? 0L : total, items);

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/visualization/JdbcVectorProjectionSql.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/visualization/JdbcVectorProjectionSql.java
@@ -48,4 +48,8 @@ final class JdbcVectorProjectionSql {
         }
         return "p.display_order IS NULL, p.display_order, p.vector_item_id";
     }
+
+    static String orderByDisplayOrderClause(boolean postgres) {
+        return " ORDER BY " + orderByDisplayOrder(postgres);
+    }
 }

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/visualization/JdbcVectorProjectionSqlTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/visualization/JdbcVectorProjectionSqlTest.java
@@ -29,4 +29,12 @@ class JdbcVectorProjectionSqlTest {
         assertThat(JdbcVectorProjectionSql.jsonText(null, ":filterKey0", false))
                 .isEqualTo("JSON_UNQUOTE(JSON_EXTRACT(metadata, CONCAT('$.', :filterKey0)))");
     }
+
+    @Test
+    void orderByDisplayOrderClauseKeepsSpaceAfterOrderBy() {
+        assertThat(JdbcVectorProjectionSql.orderByDisplayOrderClause(true))
+                .isEqualTo(" ORDER BY p.display_order NULLS LAST, p.vector_item_id");
+        assertThat("WHERE p.projection_id = :projectionId" + JdbcVectorProjectionSql.orderByDisplayOrderClause(true))
+                .contains(" ORDER BY p.display_order");
+    }
 }


### PR DESCRIPTION
## Why

- Vector Projection points 조회 SQL에서 Java text block의 줄 끝 공백 제거 때문에 `ORDER BYp.display_order` 형태의 PostgreSQL 문법 오류가 발생했습니다.
- 이 오류로 `GET /api/mgmt/ai/vectors/projections/{projectionId}/points`가 500을 반환하고 Vector Map 산점도 렌더링이 진행되지 않았습니다.

## What

- `JdbcVectorProjectionSql.orderByDisplayOrderClause(...)`를 추가해 `ORDER BY`와 정렬 표현식 사이 공백을 일반 문자열에서 보장했습니다.
- `JdbcVectorProjectionPointRepository.findPage()`가 새 ORDER BY clause helper를 사용하도록 수정했습니다.
- ORDER BY clause 조립 회귀 테스트를 추가했습니다.

## Related Issues

- Closes #384

## Validation

- Command: `./gradlew :starter:studio-platform-starter-ai:test --tests '*JdbcVectorProjectionSqlTest'`
- Result: PASS
- Command: `./gradlew :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test && git diff --check`
- Result: PASS
- Command: 로컬 PostgreSQL smoke query
- Result: `proj-20260430044829-105b3fa0` points query가 `ORDER BY` 포함 상태로 5건 조회됨
- Command: `scripts/run-dev.sh` via detached `screen` session
- Result: 서버 재시작 완료, `Tomcat started on port 8080` 확인
- Command: `curl -i 'http://localhost:8080/api/mgmt/ai/vectors/projections/proj-20260430044829-105b3fa0/points?limit=5&offset=0'`
- Result: 인증 없는 요청은 `401 Unauthorized`로 라우팅 확인

## Risk / Rollback

- Risk: points 조회 SQL의 ORDER BY 조립 방식만 변경되므로 영향 범위는 projection points 목록 정렬에 한정됩니다.
- Rollback: 문제가 있으면 이 커밋을 revert하면 기존 SQL 조립 방식으로 돌아갑니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: 관련 단위 테스트, AI web 테스트, `git diff --check`, 로컬 PostgreSQL smoke query, 서버 재시작 및 라우팅 확인을 수행했습니다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
