### PR TITLE
[ai-assisted] fix(vector): item 상세 조회 SQL 조립 수정

### DIFF
--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/visualization/JdbcExistingVectorItemRepository.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/visualization/JdbcExistingVectorItemRepository.java
@@ -81,12 +81,7 @@ public class JdbcExistingVectorItemRepository implements ExistingVectorItemRepos
         return jdbcTemplate.query("""
                 SELECT id, object_type, object_id, chunk_index, text, embedding, metadata, created_at
                  FROM tb_ai_document_chunk
-                 WHERE """ + jsonText(null, "chunkId") + """
-                    IN (:ids)
-                    OR """ + rowVectorItemId("id") + """
-                    IN (:ids)
-                    OR """ + jsonText(null, "documentId") + """
-                    IN (:ids)
+                """ + JdbcVectorProjectionSql.vectorItemIdMatchClause(postgres) + """
                  ORDER BY object_type, object_id, chunk_index, id
                 """, new MapSqlParameterSource("ids", ids), rowMapper);
     }

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/visualization/JdbcVectorProjectionSql.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/visualization/JdbcVectorProjectionSql.java
@@ -52,4 +52,10 @@ final class JdbcVectorProjectionSql {
     static String orderByDisplayOrderClause(boolean postgres) {
         return " ORDER BY " + orderByDisplayOrder(postgres);
     }
+
+    static String vectorItemIdMatchClause(boolean postgres) {
+        return " WHERE " + jsonText(null, "chunkId", postgres) + " IN (:ids)"
+                + " OR " + rowVectorItemId("id", postgres) + " IN (:ids)"
+                + " OR " + jsonText(null, "documentId", postgres) + " IN (:ids)";
+    }
 }

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/visualization/JdbcVectorProjectionSqlTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/visualization/JdbcVectorProjectionSqlTest.java
@@ -37,4 +37,12 @@ class JdbcVectorProjectionSqlTest {
         assertThat("WHERE p.projection_id = :projectionId" + JdbcVectorProjectionSql.orderByDisplayOrderClause(true))
                 .contains(" ORDER BY p.display_order");
     }
+
+    @Test
+    void vectorItemIdMatchClauseKeepsSpacesAroundWhereInAndOr() {
+        assertThat(JdbcVectorProjectionSql.vectorItemIdMatchClause(true))
+                .isEqualTo(" WHERE metadata ->> 'chunkId' IN (:ids)"
+                        + " OR 'row-' || id IN (:ids)"
+                        + " OR metadata ->> 'documentId' IN (:ids)");
+    }
 }


### PR DESCRIPTION
## Why

- Vector Map에서 Top-K 결과나 산점도 점 선택 시 `GET /api/mgmt/ai/vectors/items/{vectorItemId}`가 500을 반환했습니다.
- 원인은 `JdbcExistingVectorItemRepository.findByVectorItemIds()`에서 Java text block과 문자열 concat 경계의 공백이 제거되어 `WHEREmetadata`, `chunkId'IN`, `OR'row-'` 형태의 잘못된 SQL이 만들어지는 문제입니다.

## What

- `JdbcVectorProjectionSql.vectorItemIdMatchClause(...)`를 추가해 `WHERE`, `IN`, `OR` 주변 공백을 일반 문자열에서 보장했습니다.
- `JdbcExistingVectorItemRepository.findByVectorItemIds()`가 새 helper를 사용하도록 수정했습니다.
- `chunkId`, `row-{id}`, `documentId` 매칭 clause 조립 회귀 테스트를 추가했습니다.

## Related Issues

- Closes #386

## Validation

- Command: `./gradlew :starter:studio-platform-starter-ai:test --tests '*JdbcVectorProjectionSqlTest'`
- Result: PASS
- Command: `./gradlew :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test && git diff --check`
- Result: PASS
- Command: 로컬 PostgreSQL smoke query
- Result: `vectorItemId=6-18` 상세 조회 조건이 1건 조회됨
- Command: `scripts/run-dev.sh` via detached `screen` session
- Result: 서버 재시작 완료, `Tomcat started on port 8080` 확인
- Command: `curl -i 'http://localhost:8080/api/mgmt/ai/vectors/items/6-18'`
- Result: 인증 없는 요청은 `401 Unauthorized`로 라우팅 확인

## Risk / Rollback

- Risk: item 상세 조회의 vector item id 매칭 SQL 조립 방식만 변경되므로 영향 범위는 `GET /api/mgmt/ai/vectors/items/{vectorItemId}`와 동일 repository를 쓰는 상세 조회 경로에 한정됩니다.
- Rollback: 문제가 있으면 이 커밋을 revert하면 기존 SQL 조립 방식으로 돌아갑니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: 관련 단위 테스트, AI web 테스트, `git diff --check`, 로컬 PostgreSQL smoke query, 서버 재시작 및 라우팅 확인을 수행했습니다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
