### PR TITLE
[ai-assisted] fix(ai): prevent vector projection search null scope failure

### DIFF
--- a/starter/studio-platform-starter-ai/build.gradle.kts
+++ b/starter/studio-platform-starter-ai/build.gradle.kts
@@ -44,7 +44,10 @@ dependencies {
     testImplementation("org.mockito:mockito-core")
     testImplementation("org.assertj:assertj-core")
     testImplementation("org.springframework:spring-jdbc")
+    testImplementation("org.testcontainers:junit-jupiter")
+    testImplementation("org.testcontainers:postgresql")
     testImplementation("com.h2database:h2")
     testImplementation(project(":studio-platform"))
     testImplementation(project(":starter:studio-platform-starter-chunking"))
+    testRuntimeOnly("org.postgresql:postgresql")
 } 

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/adapters/vector/PgVectorStoreAdapterV2PostgresTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/adapters/vector/PgVectorStoreAdapterV2PostgresTest.java
@@ -1,0 +1,127 @@
+package studio.one.platform.ai.adapters.vector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import org.w3c.dom.Element;
+
+import studio.one.platform.ai.core.vector.VectorDocument;
+import studio.one.platform.ai.core.vector.VectorSearchRequest;
+import studio.one.platform.ai.core.vector.VectorSearchResult;
+
+@Testcontainers
+class PgVectorStoreAdapterV2PostgresTest {
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>(
+            DockerImageName.parse("pgvector/pgvector:pg16").asCompatibleSubstituteFor("postgres"));
+
+    private PgVectorStoreAdapterV2 adapter;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        JdbcTemplate jdbcTemplate = new JdbcTemplate(new DriverManagerDataSource(
+                POSTGRES.getJdbcUrl(),
+                POSTGRES.getUsername(),
+                POSTGRES.getPassword()));
+        jdbcTemplate.execute("CREATE EXTENSION IF NOT EXISTS vector");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS tb_ai_document_chunk");
+        jdbcTemplate.execute("""
+                CREATE TABLE tb_ai_document_chunk (
+                    id BIGSERIAL PRIMARY KEY,
+                    object_type VARCHAR(100) NOT NULL,
+                    object_id VARCHAR(100) NOT NULL,
+                    chunk_index INTEGER NOT NULL,
+                    text TEXT NOT NULL,
+                    metadata JSONB NOT NULL,
+                    embedding vector(2) NOT NULL,
+                    CONSTRAINT uq_test_chunk UNIQUE (object_type, object_id, chunk_index)
+                )
+                """);
+        adapter = new PgVectorStoreAdapterV2(jdbcTemplate);
+        setField("upsertSql", sql("upsertChunk"));
+        setField("searchByObjectSql", sql("searchByObject"));
+        setField("hybridSearchByObjectSql", sql("hybridSearchByObject"));
+        adapter.upsert(List.of(
+                document("chunk-1", "attachment", "6", 0, "java backend", List.of(0.1, 0.2)),
+                document("chunk-2", "forums-post-attachment", "7", 0, "spring api", List.of(0.2, 0.3))));
+    }
+
+    @Test
+    void searchByObjectAllowsObjectTypeOnlyScopeWithNullObjectId() {
+        List<VectorSearchResult> results = adapter.searchByObject(
+                "attachment",
+                null,
+                new VectorSearchRequest(List.of(0.1, 0.2), 10));
+
+        assertThat(results).singleElement()
+                .extracting(result -> result.document().id())
+                .isEqualTo("chunk-1");
+    }
+
+    @Test
+    void hybridSearchByObjectAllowsObjectTypeOnlyScopeWithNullObjectId() {
+        List<VectorSearchResult> results = adapter.hybridSearchByObject(
+                "java",
+                "attachment",
+                null,
+                new VectorSearchRequest(List.of(0.1, 0.2), 10),
+                0.7,
+                0.3);
+
+        assertThat(results).singleElement()
+                .extracting(result -> result.document().id())
+                .isEqualTo("chunk-1");
+    }
+
+    private static VectorDocument document(
+            String id,
+            String objectType,
+            String objectId,
+            int chunkIndex,
+            String text,
+            List<Double> embedding) {
+        return new VectorDocument(id, text, Map.of(
+                "objectType", objectType,
+                "objectId", objectId,
+                "chunkIndex", chunkIndex,
+                "chunkId", id), embedding);
+    }
+
+    private void setField(String fieldName, Object value) throws Exception {
+        Field field = PgVectorStoreAdapterV2.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(adapter, value);
+    }
+
+    private static String sql(String id) throws Exception {
+        try (var input = PgVectorStoreAdapterV2PostgresTest.class.getClassLoader()
+                .getResourceAsStream("sql/ai-sqlset.xml")) {
+            var document = DocumentBuilderFactory.newInstance()
+                    .newDocumentBuilder()
+                    .parse(new java.io.ByteArrayInputStream(Objects.requireNonNull(input).readAllBytes()));
+            var nodes = document.getElementsByTagName("sql-query");
+            for (int i = 0; i < nodes.getLength(); i++) {
+                Element element = (Element) nodes.item(i);
+                if (id.equals(element.getAttribute("id"))) {
+                    return element.getTextContent().trim();
+                }
+            }
+        }
+        throw new IllegalArgumentException("SQL not found: " + id);
+    }
+}

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/visualization/DefaultVectorSearchVisualizationServiceTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/visualization/DefaultVectorSearchVisualizationServiceTest.java
@@ -2,7 +2,9 @@ package studio.one.platform.ai.service.visualization;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
@@ -16,8 +18,10 @@ import org.junit.jupiter.api.Test;
 import studio.one.platform.ai.core.embedding.EmbeddingPort;
 import studio.one.platform.ai.core.embedding.EmbeddingResponse;
 import studio.one.platform.ai.core.embedding.EmbeddingVector;
+import studio.one.platform.ai.core.vector.VectorDocument;
 import studio.one.platform.ai.core.vector.VectorSearchHit;
 import studio.one.platform.ai.core.vector.VectorSearchRequest;
+import studio.one.platform.ai.core.vector.VectorSearchResult;
 import studio.one.platform.ai.core.vector.VectorSearchResults;
 import studio.one.platform.ai.core.vector.VectorStorePort;
 import studio.one.platform.ai.core.vector.visualization.ProjectionAlgorithm;
@@ -123,6 +127,39 @@ class DefaultVectorSearchVisualizationServiceTest {
         assertThat(result.results()).singleElement()
                 .extracting(VectorSearchVisualizationResult.ResultPoint::vectorItemId)
                 .isEqualTo("row-7");
+    }
+
+    @Test
+    void searchWithTargetTypesUsesObjectTypeOnlyVectorScope() {
+        EmbeddingPort embeddingPort = mock(EmbeddingPort.class);
+        VectorStorePort vectorStorePort = mock(VectorStorePort.class);
+        VectorProjectionRepository projections = mock(VectorProjectionRepository.class);
+        VectorProjectionPointRepository points = new FakePointRepository(List.of(
+                new ProjectionPointView("chunk-1", "attachment", "6", "Document", 0.2, 0.4, null, Map.of())));
+        when(projections.findById("proj-1")).thenReturn(Optional.of(projection()));
+        when(embeddingPort.embed(any())).thenReturn(new EmbeddingResponse(List.of(
+                new EmbeddingVector("query", List.of(0.1, 0.2)))));
+        when(vectorStorePort.searchByObject(eq("attachment"), eq(null), any(VectorSearchRequest.class)))
+                .thenReturn(List.of(new VectorSearchResult(
+                        new VectorDocument("chunk-1", "stored chunk", Map.of("chunkId", "chunk-1"), List.of()),
+                        0.9)));
+        DefaultVectorSearchVisualizationService service = new DefaultVectorSearchVisualizationService(
+                embeddingPort,
+                vectorStorePort,
+                projections,
+                points);
+
+        VectorSearchVisualizationResult result = service.search(new VectorSearchVisualizationCommand(
+                "proj-1",
+                "java",
+                List.of("attachment"),
+                10,
+                null));
+
+        assertThat(result.results()).singleElement()
+                .extracting(VectorSearchVisualizationResult.ResultPoint::vectorItemId)
+                .isEqualTo("chunk-1");
+        verify(vectorStorePort).searchByObject(eq("attachment"), eq(null), any(VectorSearchRequest.class));
     }
 
     private VectorProjection projection() {

--- a/studio-platform-ai/src/main/resources/sql/ai-sqlset.xml
+++ b/studio-platform-ai/src/main/resources/sql/ai-sqlset.xml
@@ -30,8 +30,8 @@
         <![CDATA[
         SELECT id, object_id, text, metadata, (embedding <-> :vector) AS distance
           FROM tb_ai_document_chunk
-         WHERE (:objectType IS NULL OR object_type = :objectType)
-           AND (:objectId IS NULL OR object_id = :objectId)
+         WHERE (CAST(:objectType AS varchar) IS NULL OR object_type = CAST(:objectType AS varchar))
+           AND (CAST(:objectId AS varchar) IS NULL OR object_id = CAST(:objectId AS varchar))
          ORDER BY embedding <-> :vector ASC
          LIMIT :limit
         ]]>
@@ -56,8 +56,8 @@
                ts_rank_cd(to_tsvector('simple', text || ' ' || COALESCE(metadata->>'keywordsText','')), plainto_tsquery(:query)) AS bm25,
                ((embedding <-> :vector) * :vectorWeight) - (COALESCE(ts_rank_cd(to_tsvector('simple', text || ' ' || COALESCE(metadata->>'keywordsText','')), plainto_tsquery(:query)),0) * :lexicalWeight) AS hybrid
           FROM tb_ai_document_chunk
-         WHERE (:objectType IS NULL OR object_type = :objectType)
-           AND (:objectId IS NULL OR object_id = :objectId)
+         WHERE (CAST(:objectType AS varchar) IS NULL OR object_type = CAST(:objectType AS varchar))
+           AND (CAST(:objectId AS varchar) IS NULL OR object_id = CAST(:objectId AS varchar))
          ORDER BY hybrid ASC
          LIMIT :limit
         ]]>

--- a/studio-platform-ai/src/test/java/studio/one/platform/ai/core/vector/VectorSqlSetContractTest.java
+++ b/studio-platform-ai/src/test/java/studio/one/platform/ai/core/vector/VectorSqlSetContractTest.java
@@ -1,0 +1,28 @@
+package studio.one.platform.ai.core.vector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+import org.junit.jupiter.api.Test;
+
+class VectorSqlSetContractTest {
+
+    @Test
+    void objectScopedSearchCastsNullableScopeParametersForPostgres() throws IOException {
+        String sqlset = new String(
+                Objects.requireNonNull(getClass().getClassLoader().getResourceAsStream("sql/ai-sqlset.xml"))
+                        .readAllBytes(),
+                StandardCharsets.UTF_8);
+
+        assertThat(sqlset)
+                .contains("sql-query id=\"searchByObject\"")
+                .contains("sql-query id=\"hybridSearchByObject\"");
+        assertThat(sqlset.split("CAST\\(:objectType AS varchar\\) IS NULL OR object_type = CAST\\(:objectType AS varchar\\)", -1))
+                .hasSize(3);
+        assertThat(sqlset.split("CAST\\(:objectId AS varchar\\) IS NULL OR object_id = CAST\\(:objectId AS varchar\\)", -1))
+                .hasSize(3);
+    }
+}


### PR DESCRIPTION
## Why

- Vector Projection 검색 시각화 API가 `targetTypes`를 지정하면 `objectId=null`인 object type 단독 검색을 수행합니다.
- 기존 PostgreSQL SQL은 `:objectId IS NULL` 형태의 nullable named parameter 타입을 추론하지 못해 `PROJECTION_SEARCH_FAILED`가 발생했습니다.

## What

- `searchByObject`, `hybridSearchByObject` SQL의 nullable `objectType`/`objectId` predicate에 `CAST(... AS varchar)`를 적용했습니다.
- 실제 PostgreSQL + pgvector Testcontainers 회귀 테스트를 추가해 `objectId == null` 검색 경로를 검증했습니다.
- 검색 시각화 서비스가 `targetTypes`를 objectType-only scope로 호출하는 계약을 테스트로 고정했습니다.
- SQL 리소스에서 두 object-scoped 검색 쿼리가 캐스팅된 nullable scope predicate를 유지하는지 정적 계약 테스트를 추가했습니다.

## Related Issues

- Closes #388

## Validation

- Command: `./gradlew :starter:studio-platform-starter-ai:test --tests 'studio.one.platform.ai.adapters.vector.PgVectorStoreAdapterV2PostgresTest' :studio-platform-ai:test --tests 'studio.one.platform.ai.core.vector.VectorSqlSetContractTest'`
- Result: PASS
- Command: `./gradlew :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test :studio-platform-ai:test`
- Result: PASS
- Command: `./gradlew test`
- Result: PASS
- Command: `git diff --check`
- Result: PASS

## Risk / Rollback

- Risk: Testcontainers 기반 회귀 테스트는 CI 환경에서 Docker 사용 가능 여부에 의존합니다. 런타임 SQL 변경 자체는 nullable scope 파라미터 타입 명시로 범위가 작습니다.
- Rollback: 이 PR의 커밋을 revert하면 기존 SQL로 복구됩니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: Yes
- Delegated scope: #388 수정안에 대한 코드 리뷰 및 PostgreSQL 회귀 테스트 보완 후 재리뷰
- Main author validation: 지적 사항을 반영해 PostgreSQL/Testcontainers 테스트를 추가하고 대상/전체 테스트를 실행했습니다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
