### PR TITLE
[ai-assisted] feat(textract): Excel 구조화 추출기 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### 변경됨
+- 이슈 #398 대응으로 `studio-platform-textract`에 Apache POI 기반 Excel 구조화 추출기를 추가해 `.xlsx`/`.xls`의 visible sheet used range를 `ParsedFile`, `ParsedBlock`, `ExtractedTable`로 반환하도록 했다.
 - 이슈 #395 대응으로 `DELETE /api/mgmt/ai/rag/objects/{objectType}/{objectId}`를 추가해 object scope의 RAG chunk/vector/metadata와 종료된 색인 이력을 삭제할 수 있게 했다. 진행 중인 `PENDING`/`RUNNING` job이 있으면 `409 Conflict`로 거부하고, 삭제 후 metadata 응답은 `indexed=false`를 반환한다.
 - 이슈 #392 대응으로 `studio-platform-textract` PDF 추출을 `PdfExtractionEngine` 전략 구조로 분리하고, 기존 PDFBox 구현은 기본/fallback 엔진으로 유지했다.
 - PyMuPDF4LLM 기반 Python worker 선택 연동을 위해 Java client/mapper/engine 구조와 `studio.textract.pdf.*` 설정 metadata를 추가했다.

--- a/starter/studio-platform-textract-starter/build.gradle.kts
+++ b/starter/studio-platform-textract-starter/build.gradle.kts
@@ -30,5 +30,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     testImplementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation("org.apache.pdfbox:pdfbox:${property("apachePdfBoxVersion")}")
+    testImplementation("org.apache.poi:poi-ooxml:${property("apachePoiVersion")}")
     testImplementation("org.apache.poi:poi:${property("apachePoiVersion")}")
 }

--- a/starter/studio-platform-textract-starter/src/main/java/studio/one/platform/textract/autoconfigure/TextractAutoConfiguration.java
+++ b/starter/studio-platform-textract-starter/src/main/java/studio/one/platform/textract/autoconfigure/TextractAutoConfiguration.java
@@ -26,6 +26,7 @@ import studio.one.platform.service.I18n;
 import studio.one.platform.textract.extractor.FileParser;
 import studio.one.platform.textract.extractor.FileParserFactory;
 import studio.one.platform.textract.extractor.impl.DocxFileParser;
+import studio.one.platform.textract.extractor.impl.ExcelFileParser;
 import studio.one.platform.textract.extractor.impl.HtmlFileParser;
 import studio.one.platform.textract.extractor.impl.HwpHwpxFileParser;
 import studio.one.platform.textract.extractor.impl.ImageFileParser;
@@ -106,6 +107,16 @@ public class TextractAutoConfiguration {
         logCreated(ImageFileParser.class);
         TextractProperties.Tesseract tesseract = resolveTesseractProperties();
         return new ImageFileParser(tesseract.getDatapath(), tesseract.getLanguage());
+    }
+
+    @Bean
+    @ConditionalOnClass(name = {
+            "org.apache.poi.ss.usermodel.WorkbookFactory",
+            "org.apache.poi.xssf.usermodel.XSSFWorkbook"
+    })
+    public FileParser excelFileParser() {
+        logCreated(ExcelFileParser.class);
+        return new ExcelFileParser();
     }
 
     @Bean

--- a/starter/studio-platform-textract-starter/src/test/java/studio/one/platform/textract/autoconfigure/TextractAutoConfigurationTest.java
+++ b/starter/studio-platform-textract-starter/src/test/java/studio/one/platform/textract/autoconfigure/TextractAutoConfigurationTest.java
@@ -233,6 +233,7 @@ class TextractAutoConfigurationTest {
                             .isEqualTo(10 * 1024 * 1024);
                     assertThat(context).hasBean("textFileParser");
                     assertThat(context).hasBean("pdfFileParser");
+                    assertThat(context).hasBean("excelFileParser");
                     assertThat(context).doesNotHaveBean(PyMuPdf4LlmClient.class);
                     assertThat(context).hasBean("hwpHwpxFileParser");
                 });
@@ -276,6 +277,26 @@ class TextractAutoConfigurationTest {
                 .run(context -> {
                     assertThat(context).hasNotFailed();
                     assertThat(context).doesNotHaveBean("hwpHwpxFileParser");
+                });
+    }
+
+    @Test
+    void skipsExcelParserWhenPoiWorkbookFactoryIsNotAvailable() {
+        contextRunner
+                .withClassLoader(new FilteredClassLoader("org.apache.poi.ss.usermodel.WorkbookFactory"))
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).doesNotHaveBean("excelFileParser");
+                });
+    }
+
+    @Test
+    void skipsExcelParserWhenPoiXlsxRuntimeIsNotAvailable() {
+        contextRunner
+                .withClassLoader(new FilteredClassLoader("org.apache.poi.xssf.usermodel"))
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).doesNotHaveBean("excelFileParser");
                 });
     }
 }

--- a/studio-platform-textract/README.md
+++ b/studio-platform-textract/README.md
@@ -7,7 +7,7 @@
 - `FileParser` 계약과 `FileParserFactory` dispatcher를 제공한다.
 - `FileContentExtractionService`로 파일 또는 `InputStream`에서 텍스트를 추출한다.
 - `ParsedFile`로 `plainText`, block 목록, 메타데이터, warning, 표/이미지/OCR 정보를 구조화해 반환한다.
-- PDF, DOCX, PPTX, HTML, TXT, 이미지 OCR, HWP/HWPX 파서를 단일 모듈 안에 패키지 수준으로 둔다.
+- PDF, Excel, DOCX, PPTX, HTML, TXT, 이미지 OCR, HWP/HWPX 파서를 단일 모듈 안에 패키지 수준으로 둔다.
 - HWP/HWPX 파서는 `rhwp`의 컨테이너/섹션/문단/컨트롤 흐름을 참고해 HWPX 문단·표·이미지와 HWP 본문·BinData 이미지를 추출한다.
 
 ## 패키지
@@ -48,6 +48,7 @@ List<ParsedBlock> blocks = parsed.blocks();
 | TXT/CSV/LOG | 전체 텍스트 | JDK |
 | HTML | Jsoup 기반 semantic block, 표, 이미지 src/alt | `org.jsoup:jsoup` |
 | PDF | PDFBox 기반 page/paragraph, 표 후보, 실제 content stream 이미지 | `org.apache.pdfbox:pdfbox` |
+| Excel | visible sheet의 used range, 표, 수식 표시값/formula metadata | `org.apache.poi:poi`, `org.apache.poi:poi-ooxml` |
 | DOCX | 문단, 표, header/footer/footnote/list, 내장 이미지/caption | `org.apache.poi:poi-ooxml` |
 | PPTX | slide title/body/footer, picture shape, caption 후보 | `org.apache.poi:poi-ooxml` |
 | Image | Tesseract OCR line/word, confidence, bbox, warning metadata | `net.sourceforge.tess4j:tess4j` |
@@ -117,6 +118,11 @@ RAG 색인은 기존 흐름을 유지한다.
 - `tables`: 표 markdown, cell 목록, `vectorText`, `headerRowCount`, sourceRef/format metadata
 - `images`: 이미지 sourceRef, sourceRefs, binDataRef, packageId, caption, src/altText, OCR metadata
 - `warnings`: `canonicalCode`, `severity`, `sourceRef`, `blockRef`, `partialParse` 기반 warning/error
+
+Excel parser는 `.xlsx`와 `.xls`를 지원한다.
+CSV는 기존처럼 텍스트 파일로 처리한다.
+숨김/very hidden sheet는 추출하지 않고, visible sheet의 non-empty used range를 sheet별 table로 만든다.
+수식 셀은 `DataFormatter`와 `FormulaEvaluator` 기반 표시값을 table text로 사용하고, 원본 formula는 cell metadata에 보존한다.
 
 ### 표 vector text
 

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/DocumentFormat.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/DocumentFormat.java
@@ -7,6 +7,7 @@ public enum DocumentFormat {
     TEXT,
     HTML,
     PDF,
+    EXCEL,
     DOCX,
     PPTX,
     IMAGE,

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/DocumentFormatDetector.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/DocumentFormatDetector.java
@@ -16,11 +16,20 @@ public final class DocumentFormatDetector {
         if (type.startsWith("text/html") || name.endsWith(".html") || name.endsWith(".htm")) {
             return DocumentFormat.HTML;
         }
+        if (name.endsWith(".csv")) {
+            return DocumentFormat.TEXT;
+        }
         if (type.startsWith("text/") || name.endsWith(".txt") || name.endsWith(".log") || name.endsWith(".csv")) {
             return DocumentFormat.TEXT;
         }
         if (type.startsWith("application/pdf") || name.endsWith(".pdf")) {
             return DocumentFormat.PDF;
+        }
+        if (type.startsWith("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+                || type.startsWith("application/vnd.ms-excel")
+                || name.endsWith(".xlsx")
+                || name.endsWith(".xls")) {
+            return DocumentFormat.EXCEL;
         }
         if (type.startsWith("application/vnd.openxmlformats-officedocument.wordprocessingml.document")
                 || name.endsWith(".docx")) {

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/AbstractFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/AbstractFileParser.java
@@ -8,15 +8,17 @@ import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import studio.one.platform.textract.extractor.FileParser;
 import studio.one.platform.textract.model.ExtractedImage;
 import studio.one.platform.textract.model.ExtractedTable;
 import studio.one.platform.textract.model.ExtractedTableCell;
 import studio.one.platform.textract.model.ParsedBlock;
 
-@Slf4j
 public abstract class AbstractFileParser implements FileParser {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractFileParser.class);
 
     private static final Pattern CONTROL_CHARS = Pattern.compile("[\\p{Cntrl}&&[^\r\n\t]]");
     private static final Pattern MULTI_BLANK_LINES = Pattern.compile("\\n{3,}");

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/ExcelFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/ExcelFileParser.java
@@ -1,0 +1,322 @@
+package studio.one.platform.textract.extractor.impl;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.DataFormatter;
+import org.apache.poi.ss.usermodel.FormulaEvaluator;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.apache.poi.ss.util.CellAddress;
+
+import studio.one.platform.textract.extractor.DocumentFormat;
+import studio.one.platform.textract.extractor.FileParseException;
+import studio.one.platform.textract.extractor.StructuredFileParser;
+import studio.one.platform.textract.model.BlockType;
+import studio.one.platform.textract.model.ExtractedTable;
+import studio.one.platform.textract.model.ExtractedTableCell;
+import studio.one.platform.textract.model.ParseWarning;
+import studio.one.platform.textract.model.ParsedBlock;
+import studio.one.platform.textract.model.ParsedFile;
+
+public class ExcelFileParser extends AbstractFileParser implements StructuredFileParser {
+
+    public static final String KEY_SHEET_NAME = "sheetName";
+    public static final String KEY_SHEET_INDEX = "sheetIndex";
+    public static final String KEY_ROW_INDEX = "rowIndex";
+    public static final String KEY_COLUMN_INDEX = "columnIndex";
+    public static final String KEY_CELL_ADDRESS = "cellAddress";
+    public static final String KEY_CELL_TYPE = "cellType";
+    public static final String KEY_FORMULA = "formula";
+
+    @Override
+    public boolean supports(String contentType, String filename) {
+        if (hasExtension(filename, ".csv")) {
+            return false;
+        }
+        if (isContentType(
+                contentType,
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                "application/vnd.ms-excel")) {
+            return true;
+        }
+        return hasExtension(filename, ".xlsx", ".xls");
+    }
+
+    @Override
+    public ParsedFile parseStructured(byte[] bytes, String contentType, String filename) throws FileParseException {
+        try (ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+                Workbook workbook = WorkbookFactory.create(in)) {
+            DataFormatter formatter = new DataFormatter();
+            FormulaEvaluator evaluator = workbook.getCreationHelper().createFormulaEvaluator();
+            List<ParsedBlock> blocks = new ArrayList<>();
+            List<ParsedBlock> pages = new ArrayList<>();
+            List<ExtractedTable> tables = new ArrayList<>();
+            List<ParseWarning> warnings = new ArrayList<>();
+            StringBuilder plainText = new StringBuilder();
+            int order = 0;
+
+            for (int sheetIndex = 0; sheetIndex < workbook.getNumberOfSheets(); sheetIndex++) {
+                if (workbook.isSheetHidden(sheetIndex) || workbook.isSheetVeryHidden(sheetIndex)) {
+                    continue;
+                }
+                Sheet sheet = workbook.getSheetAt(sheetIndex);
+                SheetExtraction sheetExtraction = extractSheet(sheet, sheetIndex, formatter, evaluator, warnings);
+                if (sheetExtraction.isEmpty()) {
+                    continue;
+                }
+
+                String sheetPath = sheetPath(sheetIndex);
+                Map<String, Object> metadata = sheetMetadata(sheetPath, sheet.getSheetName(), sheetIndex);
+                pages.add(ParsedBlock.text(
+                        sheetPath,
+                        BlockType.PAGE,
+                        sheetExtraction.plainText(),
+                        null,
+                        pages.size(),
+                        metadata));
+                blocks.add(ParsedBlock.text(
+                        sheetPath,
+                        BlockType.TABLE,
+                        sheetExtraction.markdown(),
+                        null,
+                        order,
+                        new LinkedHashMap<>(metadata)));
+                tables.add(new ExtractedTable(
+                        sheetPath,
+                        sheetExtraction.markdown(),
+                        sheetExtraction.cells(),
+                        excelTableMetadata(
+                                sheetPath,
+                                sheet.getSheetName(),
+                                sheetIndex,
+                                sheetExtraction.cells(),
+                                sheetExtraction.headerRowCount())));
+                plainText.append(sheet.getSheetName()).append("\n")
+                        .append(sheetExtraction.plainText())
+                        .append("\n\n");
+                order++;
+            }
+
+            return new ParsedFile(
+                    DocumentFormat.EXCEL,
+                    cleanText(plainText.toString()),
+                    blocks,
+                    fileMetadata(contentType, filename),
+                    warnings,
+                    pages,
+                    tables,
+                    List.of(),
+                    false);
+        } catch (IOException | RuntimeException e) {
+            throw new FileParseException("Failed to parse Excel file: " + safeFilename(filename), e);
+        }
+    }
+
+    @Override
+    public String parse(byte[] bytes, String contentType, String filename) throws FileParseException {
+        return parseStructured(bytes, contentType, filename).plainText();
+    }
+
+    private SheetExtraction extractSheet(
+            Sheet sheet,
+            int sheetIndex,
+            DataFormatter formatter,
+            FormulaEvaluator evaluator,
+            List<ParseWarning> warnings) {
+        Map<Integer, Map<Integer, CellExtraction>> rows = collectCells(sheet, sheetIndex, formatter, evaluator, warnings);
+        if (rows.isEmpty()) {
+            return SheetExtraction.empty();
+        }
+
+        int minColumn = rows.values().stream()
+                .flatMap(row -> row.keySet().stream())
+                .mapToInt(Integer::intValue)
+                .min()
+                .orElse(0);
+        int maxColumn = rows.values().stream()
+                .flatMap(row -> row.keySet().stream())
+                .mapToInt(Integer::intValue)
+                .max()
+                .orElse(0);
+
+        List<ExtractedTableCell> cells = new ArrayList<>();
+        List<String> markdownRows = new ArrayList<>();
+        StringBuilder sheetText = new StringBuilder();
+        int relativeRow = 0;
+        for (Map.Entry<Integer, Map<Integer, CellExtraction>> rowEntry : rows.entrySet()) {
+            List<String> markdownCells = new ArrayList<>();
+            List<String> plainCells = new ArrayList<>();
+            Map<Integer, CellExtraction> rowCells = rowEntry.getValue();
+            for (int columnIndex = minColumn; columnIndex <= maxColumn; columnIndex++) {
+                CellExtraction cell = rowCells.get(columnIndex);
+                String text = cell == null ? "" : cell.text();
+                markdownCells.add(markdownText(text));
+                if (cell != null) {
+                    int relativeColumn = columnIndex - minColumn;
+                    cells.add(extractedCell(
+                            relativeRow,
+                            relativeColumn,
+                            rowEntry.getKey(),
+                            columnIndex,
+                            cell,
+                            cells.size(),
+                            relativeRow == 0));
+                    plainCells.add(markdownText(text));
+                }
+            }
+            markdownRows.add("| " + String.join(" | ", markdownCells) + " |");
+            sheetText.append(String.join(" | ", plainCells)).append("\n");
+            relativeRow++;
+        }
+
+        return new SheetExtraction(cleanText(sheetText.toString()), String.join("\n", markdownRows), cells, 1);
+    }
+
+    private Map<Integer, Map<Integer, CellExtraction>> collectCells(
+            Sheet sheet,
+            int sheetIndex,
+            DataFormatter formatter,
+            FormulaEvaluator evaluator,
+            List<ParseWarning> warnings) {
+        Map<Integer, Map<Integer, CellExtraction>> rows = new TreeMap<>();
+        for (Row row : sheet) {
+            Map<Integer, CellExtraction> rowCells = new TreeMap<>();
+            for (Cell cell : row) {
+                CellExtraction extraction = extractCell(sheet, sheetIndex, cell, formatter, evaluator, warnings);
+                if (!extraction.text().isBlank()) {
+                    rowCells.put(cell.getColumnIndex(), extraction);
+                }
+            }
+            if (!rowCells.isEmpty()) {
+                rows.put(row.getRowNum(), rowCells);
+            }
+        }
+        return rows;
+    }
+
+    private CellExtraction extractCell(
+            Sheet sheet,
+            int sheetIndex,
+            Cell cell,
+            DataFormatter formatter,
+            FormulaEvaluator evaluator,
+            List<ParseWarning> warnings) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        CellType cellType = cell.getCellType();
+        metadata.put(KEY_SHEET_NAME, sheet.getSheetName());
+        metadata.put(KEY_SHEET_INDEX, sheetIndex);
+        metadata.put(KEY_ROW_INDEX, cell.getRowIndex());
+        metadata.put(KEY_COLUMN_INDEX, cell.getColumnIndex());
+        metadata.put(KEY_CELL_ADDRESS, new CellAddress(cell).formatAsString());
+        metadata.put(KEY_CELL_TYPE, cellType.name());
+        if (cellType == CellType.FORMULA) {
+            metadata.put(KEY_FORMULA, cell.getCellFormula());
+        }
+
+        String text;
+        try {
+            text = formatter.formatCellValue(cell, evaluator);
+        } catch (RuntimeException ex) {
+            if (cellType != CellType.FORMULA) {
+                throw ex;
+            }
+            text = formatter.formatCellValue(cell);
+            String sourceRef = cellPath(sheetIndex, cell.getRowIndex(), cell.getColumnIndex());
+            warnings.add(ParseWarning.partial(
+                    "EXCEL_FORMULA_EVALUATION_PARTIAL",
+                    "Excel formula evaluation failed; cached or raw cell display text was used.",
+                    sourceRef,
+                    Map.of(KEY_FORMULA, metadata.getOrDefault(KEY_FORMULA, ""))));
+        }
+        return new CellExtraction(cleanText(text), metadata);
+    }
+
+    private ExtractedTableCell extractedCell(
+            int row,
+            int col,
+            int rowIndex,
+            int columnIndex,
+            CellExtraction cell,
+            int order,
+            boolean header) {
+        Map<String, Object> metadata = new LinkedHashMap<>(cell.metadata());
+        String sourceRef = cellPath(
+                (Integer) metadata.get(KEY_SHEET_INDEX),
+                rowIndex,
+                columnIndex);
+        metadata.put(ExtractedTableCell.KEY_SOURCE_REF, sourceRef);
+        metadata.put(ExtractedTableCell.KEY_ORDER, order);
+        if (header) {
+            metadata.put(ExtractedTableCell.KEY_HEADER, true);
+        }
+        return new ExtractedTableCell(row, col, 1, 1, cell.text(), metadata);
+    }
+
+    private Map<String, Object> excelTableMetadata(
+            String sourceRef,
+            String sheetName,
+            int sheetIndex,
+            List<ExtractedTableCell> cells,
+            int headerRowCount) {
+        Map<String, Object> metadata = new LinkedHashMap<>(tableMetadata(sourceRef, "excel", cells, headerRowCount));
+        metadata.put(KEY_SHEET_NAME, sheetName);
+        metadata.put(KEY_SHEET_INDEX, sheetIndex);
+        return metadata;
+    }
+
+    private Map<String, Object> sheetMetadata(String sourceRef, String sheetName, int sheetIndex) {
+        Map<String, Object> metadata = new LinkedHashMap<>(blockMetadata(sourceRef));
+        metadata.put(KEY_SHEET_NAME, sheetName);
+        metadata.put(KEY_SHEET_INDEX, sheetIndex);
+        return metadata;
+    }
+
+    private String sheetPath(int sheetIndex) {
+        return "sheet[" + sheetIndex + "]";
+    }
+
+    private String cellPath(int sheetIndex, int rowIndex, int columnIndex) {
+        return sheetPath(sheetIndex) + "/row[" + rowIndex + "]/cell[" + columnIndex + "]";
+    }
+
+    private String markdownText(String text) {
+        return text == null ? "" : text.replace('\n', ' ').trim();
+    }
+
+    private record CellExtraction(String text, Map<String, Object> metadata) {
+        CellExtraction {
+            text = text == null ? "" : text;
+            metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+        }
+    }
+
+    private record SheetExtraction(
+            String plainText,
+            String markdown,
+            List<ExtractedTableCell> cells,
+            int headerRowCount) {
+        static SheetExtraction empty() {
+            return new SheetExtraction("", "", List.of(), 0);
+        }
+
+        SheetExtraction {
+            plainText = plainText == null ? "" : plainText;
+            markdown = markdown == null ? "" : markdown;
+            cells = cells == null ? List.of() : List.copyOf(cells);
+        }
+
+        boolean isEmpty() {
+            return cells.isEmpty();
+        }
+    }
+}

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PdfFileParser.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/impl/PdfFileParser.java
@@ -6,9 +6,10 @@ import java.util.Objects;
 
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 
-import lombok.extern.slf4j.Slf4j;
 import studio.one.platform.textract.extractor.FileParseException;
 import studio.one.platform.textract.extractor.StructuredFileParser;
 import studio.one.platform.textract.extractor.pdf.PdfExtractionEngineSelector;
@@ -18,8 +19,9 @@ import studio.one.platform.textract.extractor.pdf.PdfExtractionRequest;
 import studio.one.platform.textract.extractor.pdf.pdfbox.PdfBoxExtractionEngine;
 import studio.one.platform.textract.model.ParsedFile;
 
-@Slf4j
 public class PdfFileParser extends AbstractFileParser implements StructuredFileParser {
+
+    private static final Logger log = LoggerFactory.getLogger(PdfFileParser.class);
 
     private final PdfExtractionEngineSelector selector;
     private final PdfExtractionOptions options;

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/pdf/pdfbox/PdfBoxExtractionEngine.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/extractor/pdf/pdfbox/PdfBoxExtractionEngine.java
@@ -15,9 +15,10 @@ import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.graphics.image.PDImage;
 import org.apache.pdfbox.text.PDFTextStripper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 
-import lombok.extern.slf4j.Slf4j;
 import studio.one.platform.textract.extractor.DocumentFormat;
 import studio.one.platform.textract.extractor.FileParseException;
 import studio.one.platform.textract.extractor.impl.AbstractFileParser;
@@ -34,8 +35,9 @@ import studio.one.platform.textract.model.ParseWarning;
 import studio.one.platform.textract.model.ParsedBlock;
 import studio.one.platform.textract.model.ParsedFile;
 
-@Slf4j
 public class PdfBoxExtractionEngine extends AbstractFileParser implements PdfExtractionEngine {
+
+    private static final Logger log = LoggerFactory.getLogger(PdfBoxExtractionEngine.class);
 
     private static final double REPEATED_BOUNDARY_RATIO = 0.50d;
 

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/ExcelFileParserTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/ExcelFileParserTest.java
@@ -1,0 +1,206 @@
+package studio.one.platform.textract.extractor.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.time.LocalDateTime;
+
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.CreationHelper;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.SheetVisibility;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.textract.extractor.DocumentFormat;
+import studio.one.platform.textract.extractor.DocumentFormatDetector;
+import studio.one.platform.textract.model.BlockType;
+import studio.one.platform.textract.model.ExtractedTable;
+import studio.one.platform.textract.model.ExtractedTableCell;
+import studio.one.platform.textract.model.ParsedFile;
+
+class ExcelFileParserTest {
+
+    @Test
+    void supportsXlsxAndXlsButLeavesCsvAsText() {
+        ExcelFileParser parser = new ExcelFileParser();
+
+        assertTrue(parser.supports(
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                "sample.xlsx"));
+        assertTrue(parser.supports("application/vnd.ms-excel", "sample.xls"));
+        assertFalse(parser.supports("text/csv", "sample.csv"));
+        assertFalse(parser.supports("application/vnd.ms-excel", "sample.csv"));
+        assertEquals(DocumentFormat.EXCEL, DocumentFormatDetector.detect(null, "sample.xlsx"));
+        assertEquals(DocumentFormat.EXCEL, DocumentFormatDetector.detect(null, "sample.xls"));
+        assertEquals(DocumentFormat.TEXT, DocumentFormatDetector.detect("text/csv", "sample.csv"));
+        assertEquals(DocumentFormat.TEXT, DocumentFormatDetector.detect("application/vnd.ms-excel", "sample.csv"));
+    }
+
+    @Test
+    void parseStructuredExtractsVisibleXlsxSheetWithFormulaDisplayValueAndMetadata() throws Exception {
+        ParsedFile result = new ExcelFileParser().parseStructured(
+                xlsxWithTypedCellsAndFormula(),
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                "sample.xlsx");
+
+        assertEquals(DocumentFormat.EXCEL, result.format());
+        assertEquals(1, result.pages().size());
+        assertEquals(BlockType.PAGE, result.pages().get(0).blockType());
+        assertEquals(1, result.blocks().size());
+        assertEquals(BlockType.TABLE, result.blocks().get(0).blockType());
+        assertTrue(result.plainText().contains("Budget"));
+        assertTrue(result.plainText().contains("alpha | 10 | TRUE | 2026-01-02 | 20"));
+
+        ExtractedTable table = result.tables().get(0);
+        assertEquals("excel", table.format());
+        assertEquals("sheet[0]", table.sourceRef());
+        assertEquals("Budget", table.metadata().get(ExcelFileParser.KEY_SHEET_NAME));
+        assertEquals(0, table.metadata().get(ExcelFileParser.KEY_SHEET_INDEX));
+        assertEquals(2, table.rowCount());
+        assertEquals(10, table.cellCount());
+        assertEquals(1, table.headerRowCount());
+        assertEquals("""
+                Name | Amount | Active | Date | Total
+                Name: alpha | Amount: 10 | Active: TRUE | Date: 2026-01-02 | Total: 20""".strip(), table.vectorText());
+
+        ExtractedTableCell formulaCell = table.cells().stream()
+                .filter(cell -> "20".equals(cell.text()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals("sheet[0]/row[1]/cell[4]", formulaCell.sourceRef());
+        assertEquals("E2", formulaCell.metadata().get(ExcelFileParser.KEY_CELL_ADDRESS));
+        assertEquals("B2*2", formulaCell.metadata().get(ExcelFileParser.KEY_FORMULA));
+        assertEquals("FORMULA", formulaCell.metadata().get(ExcelFileParser.KEY_CELL_TYPE));
+    }
+
+    @Test
+    void parseStructuredExtractsLegacyXlsWorkbook() throws Exception {
+        ParsedFile result = new ExcelFileParser().parseStructured(
+                xlsWithSimpleTable(),
+                "application/vnd.ms-excel",
+                "legacy.xls");
+
+        assertEquals(DocumentFormat.EXCEL, result.format());
+        assertEquals(1, result.tables().size());
+        assertEquals("legacy", result.pages().get(0).metadata().get(ExcelFileParser.KEY_SHEET_NAME));
+        assertTrue(result.plainText().contains("A | B"));
+        assertTrue(result.plainText().contains("1 | 2"));
+    }
+
+    @Test
+    void parseStructuredSkipsHiddenSheets() throws Exception {
+        ParsedFile result = new ExcelFileParser().parseStructured(
+                xlsxWithHiddenSheets(),
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                "hidden.xlsx");
+
+        assertEquals(1, result.pages().size());
+        assertEquals(1, result.tables().size());
+        assertTrue(result.plainText().contains("visible value"));
+        assertFalse(result.plainText().contains("hidden value"));
+        assertFalse(result.plainText().contains("very hidden value"));
+    }
+
+    @Test
+    void parseStructuredCompactsBlankRowsAndSkipsBlankCellsInsideUsedRange() throws Exception {
+        ParsedFile result = new ExcelFileParser().parseStructured(
+                xlsxWithBlankRowsAndCells(),
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                "blank.xlsx");
+
+        ExtractedTable table = result.tables().get(0);
+        assertEquals(2, table.rowCount());
+        assertEquals(4, table.cellCount());
+        assertEquals("| A |  | C |\n| 1 |  | 3 |", table.markdown());
+        assertEquals("A | C\nA: 1 | C: 3", table.vectorText());
+        assertEquals(2, table.cells().get(1).col());
+        assertEquals("sheet[0]/row[0]/cell[2]", table.cells().get(1).sourceRef());
+        assertEquals("sheet[0]/row[2]/cell[2]", table.cells().get(3).sourceRef());
+    }
+
+    private byte[] xlsxWithTypedCellsAndFormula() throws Exception {
+        try (Workbook workbook = new XSSFWorkbook()) {
+            Sheet sheet = workbook.createSheet("Budget");
+            Row header = sheet.createRow(0);
+            header.createCell(0).setCellValue("Name");
+            header.createCell(1).setCellValue("Amount");
+            header.createCell(2).setCellValue("Active");
+            header.createCell(3).setCellValue("Date");
+            header.createCell(4).setCellValue("Total");
+
+            Row row = sheet.createRow(1);
+            row.createCell(0).setCellValue("alpha");
+            row.createCell(1).setCellValue(10);
+            row.createCell(2).setCellValue(true);
+            Cell date = row.createCell(3);
+            date.setCellValue(LocalDateTime.of(2026, 1, 2, 0, 0));
+            date.setCellStyle(dateStyle(workbook));
+            row.createCell(4).setCellFormula("B2*2");
+            return write(workbook);
+        }
+    }
+
+    private byte[] xlsWithSimpleTable() throws Exception {
+        try (Workbook workbook = new HSSFWorkbook()) {
+            Sheet sheet = workbook.createSheet("legacy");
+            Row header = sheet.createRow(0);
+            header.createCell(0).setCellValue("A");
+            header.createCell(1).setCellValue("B");
+            Row row = sheet.createRow(1);
+            row.createCell(0).setCellValue(1);
+            row.createCell(1).setCellValue(2);
+            return write(workbook);
+        }
+    }
+
+    private byte[] xlsxWithHiddenSheets() throws Exception {
+        try (Workbook workbook = new XSSFWorkbook()) {
+            addSingleCellSheet(workbook, "visible", "visible value");
+            addSingleCellSheet(workbook, "hidden", "hidden value");
+            addSingleCellSheet(workbook, "very-hidden", "very hidden value");
+            workbook.setSheetHidden(1, true);
+            workbook.setSheetVisibility(2, SheetVisibility.VERY_HIDDEN);
+            return write(workbook);
+        }
+    }
+
+    private byte[] xlsxWithBlankRowsAndCells() throws Exception {
+        try (Workbook workbook = new XSSFWorkbook()) {
+            Sheet sheet = workbook.createSheet("blank");
+            Row header = sheet.createRow(0);
+            header.createCell(0).setCellValue("A");
+            header.createCell(2).setCellValue("C");
+            sheet.createRow(1);
+            Row row = sheet.createRow(2);
+            row.createCell(0).setCellValue(1);
+            row.createCell(2).setCellValue(3);
+            return write(workbook);
+        }
+    }
+
+    private void addSingleCellSheet(Workbook workbook, String sheetName, String value) {
+        Sheet sheet = workbook.createSheet(sheetName);
+        sheet.createRow(0).createCell(0).setCellValue(value);
+    }
+
+    private CellStyle dateStyle(Workbook workbook) {
+        CreationHelper helper = workbook.getCreationHelper();
+        CellStyle style = workbook.createCellStyle();
+        style.setDataFormat(helper.createDataFormat().getFormat("yyyy-mm-dd"));
+        return style;
+    }
+
+    private byte[] write(Workbook workbook) throws Exception {
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            workbook.write(out);
+            return out.toByteArray();
+        }
+    }
+}

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/FormatGoldenTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/extractor/impl/FormatGoldenTest.java
@@ -20,6 +20,9 @@ import org.apache.pdfbox.pdmodel.font.PDType1Font;
 import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
 import org.apache.poi.poifs.filesystem.DirectoryEntry;
 import org.apache.poi.poifs.filesystem.POIFSFileSystem;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.wp.usermodel.HeaderFooterType;
 import org.apache.poi.xslf.usermodel.XMLSlideShow;
 import org.apache.poi.xslf.usermodel.XSLFSlide;
@@ -30,6 +33,7 @@ import org.apache.poi.xwpf.usermodel.XWPFFootnote;
 import org.apache.poi.xwpf.usermodel.XWPFHeader;
 import org.apache.poi.xwpf.usermodel.XWPFParagraph;
 import org.apache.poi.xwpf.usermodel.XWPFTable;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.Test;
 
 import studio.one.platform.textract.extractor.DocumentFormat;
@@ -107,6 +111,22 @@ class FormatGoldenTest {
         assertEquals(List.of("html|table[3]|2x2|4|A | B↵A: 1 | B: 2"), snapshot.tables());
         assertEquals(List.of("|img[4]|hero.png"), snapshot.images());
         assertTrue(!snapshot.plainText().contains("메뉴 링크"));
+    }
+
+    @Test
+    void excelGoldenCapturesSheetAndTableProvenance() throws Exception {
+        ParsedFile result = new ExcelFileParser().parseStructured(
+                excelBytes(),
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                "golden.xlsx");
+
+        GoldenSnapshot snapshot = snapshot(result);
+
+        assertEquals(DocumentFormat.EXCEL.name(), snapshot.format());
+        assertEquals(List.of("PAGE||sheet[0]|0"), snapshot.pages());
+        assertEquals(List.of("TABLE||sheet[0]|0|| A | B |↵| 1 | 2 |"), snapshot.blocks());
+        assertEquals(List.of("excel|sheet[0]|2x2|4|A | B↵A: 1 | B: 2"), snapshot.tables());
+        assertTrue(snapshot.plainText().contains("Sheet1"));
     }
 
     @Test
@@ -302,6 +322,21 @@ class FormatGoldenTest {
                   </body>
                 </html>
                 """.getBytes(UTF_8);
+    }
+
+    private byte[] excelBytes() throws Exception {
+        try (Workbook workbook = new XSSFWorkbook();
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            Sheet sheet = workbook.createSheet("Sheet1");
+            Row header = sheet.createRow(0);
+            header.createCell(0).setCellValue("A");
+            header.createCell(1).setCellValue("B");
+            Row row = sheet.createRow(1);
+            row.createCell(0).setCellValue(1);
+            row.createCell(1).setCellValue(2);
+            workbook.write(out);
+            return out.toByteArray();
+        }
     }
 
     private byte[] hwpxBytes() throws Exception {


### PR DESCRIPTION
## Why

RAG 색인과 파일 텍스트 미리보기에서 XLSX/XLS 문서를 표 단위 구조로 추출할 수 있어야 한다. 기존 textract 구조는 `ParsedFile`, `ParsedBlock`, `ExtractedTable` 계약과 POI 기반 문서 parser 패턴을 이미 제공하므로 Excel도 같은 Java-only 구조화 추출 경로로 확장한다.

## What

- `DocumentFormat.EXCEL`과 XLSX/XLS content type 및 확장자 감지를 추가했다.
- Apache POI `WorkbookFactory` 기반 `ExcelFileParser`를 추가해 visible sheet의 non-empty used range를 `PAGE` block, `TABLE` block, `ExtractedTable`로 변환한다.
- 수식 셀은 표시값을 추출하고 formula, cell address, sheet/row/column provenance metadata를 보존한다.
- starter auto-configuration에 Excel parser bean을 추가하고, XLSX 런타임 classpath가 있을 때만 등록되도록 했다.
- README, CHANGELOG, 단위/golden/auto-config 테스트를 갱신했다.

## Related Issues

- Closes #398

## Validation

- Command: `./gradlew :studio-platform-textract:test :starter:studio-platform-textract-starter:test`
- Result: pass
- Command: `git diff --check`
- Result: pass

## Risk / Rollback

- Risk: Excel 파일이 새 parser로 처리되면서 기존 unsupported 처리와 달리 표 추출 결과가 RAG 색인 입력으로 들어간다. 숨김 시트는 제외하고 CSV는 기존 TEXT 경로를 유지해 범위를 제한했다.
- Rollback: 이 PR 커밋을 revert하면 Excel format 감지와 parser auto-registration이 제거되어 이전처럼 Excel 파일은 지원되지 않는다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: Gradle 단위 테스트와 staged diff whitespace check를 실행했다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
