### PR TITLE
[ai-assisted] feat(attachment): 발급 감사 응답에 다운로드 횟수 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### 변경됨
+- 이슈 #408 대응으로 `GET /api/mgmt/audit/attachment-download-url-issues` 응답에 실제 signed-download 접근 이력 수인 `downloadCount`를 추가했다. 집계는 현재 페이지의 발급 로그를 `issueLogId`/`tokenHash` 기준으로 bulk 조회하며, 접근 이력이 없으면 `0`을 반환한다.
 - 이슈 #406 대응으로 `GET /api/attachments/signed-download` 실제 접근 이력을 `TB_APPLICATION_ATTACHMENT_DOWNLOAD_LOG`에 저장하고, `GET /api/mgmt/audit/attachment-downloads` 조회 API를 추가했다. 응답은 `tokenHash`만 노출하고 raw token/signed URL은 포함하지 않으며, `features:attachment_download_audit/read` 권한과 pagination/filter/default `requestedAt desc` 정렬을 적용한다.
 - 이슈 #404 대응으로 attachment download-url 기능을 object storage presigned URL에서 application-level HMAC-SHA256 signed link로 전환하고, `GET /api/attachments/signed-download` token-only 스트리밍 endpoint와 `linkType`/`tokenHash` 감사 로그 필드를 추가했다.
 - 이슈 #402 대응으로 object storage signed download URL 발급 감사 로그를 조회하는 `GET /api/mgmt/audit/attachment-download-url-issues` API를 추가했다. 조회 응답은 `objectKeyHash`만 노출하고 signed URL/raw object key는 포함하지 않으며, `features:attachment_download_url_issue_audit/read` 권한과 pagination/filter/default `issuedAt desc` 정렬을 적용한다.

--- a/starter/studio-application-starter-attachment/README.md
+++ b/starter/studio-application-starter-attachment/README.md
@@ -133,7 +133,7 @@ studio:
 | `GET` | `/attachment-download-url-issues` | signed download URL 발급 감사 로그 페이지 조회. `attachmentId`, `objectType`, `objectId`, `endpointKind`, `issuedByPrincipalName`, `from`, `to` 필터와 `page`/`size`/`sort` 지원 | `features:attachment_download_url_issue_audit/read` |
 | `GET` | `/attachment-downloads` | signed download URL 실제 접근 감사 로그 페이지 조회. `attachmentId`, `objectType`, `objectId`, `tokenHash`, `result`, `from`, `to`, `clientIp` 필터와 `page`/`size`/`sort` 지원 | `features:attachment_download_audit/read` |
 
-응답은 `logId`, `attachmentId`, `objectType`, `objectId`, `endpointKind`, `issuedByUserId`, `issuedByPrincipalName`, `issuedAt`, `expiresAt`, `ttlSeconds`, `linkType`, `tokenHash`, `storageProviderId`, `bucket`, `objectKeyHash`, `clientIp`, `userAgent`를 포함한다. signed URL, raw token, raw object key는 응답에 포함하지 않는다. 기본 정렬은 `issuedAt desc`, `logId desc`이다.
+발급 감사 응답은 `logId`, `attachmentId`, `objectType`, `objectId`, `endpointKind`, `issuedByUserId`, `issuedByPrincipalName`, `issuedAt`, `expiresAt`, `ttlSeconds`, `linkType`, `tokenHash`, `downloadCount`, `storageProviderId`, `bucket`, `objectKeyHash`, `clientIp`, `userAgent`를 포함한다. `downloadCount`는 해당 발급 로그의 실제 signed-download 접근 감사 로그 수이며, 접근 이력이 없으면 `0`이다. signed URL, raw token, raw object key는 응답에 포함하지 않는다. 기본 정렬은 `issuedAt desc`, `logId desc`이다.
 다운로드 접근 감사 응답은 `downloadLogId`, `issueLogId`, `tokenHash`, `attachmentId`, `objectType`, `objectId`, `linkType`, `requestedAt`, `result`, `httpStatus`, `downloadedBytes`, `clientIp`, `userAgent`, `errorCode`를 포함한다. raw token과 signed URL은 저장/응답하지 않으며 기본 정렬은 `requestedAt desc`, `downloadLogId desc`이다.
 
 ### 서비스 API (`/api/attachments`)

--- a/starter/studio-application-starter-attachment/src/test/java/studio/one/application/attachment/autoconfigure/AttachmentAutoConfigurationTest.java
+++ b/starter/studio-application-starter-attachment/src/test/java/studio/one/application/attachment/autoconfigure/AttachmentAutoConfigurationTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import studio.one.application.attachment.domain.entity.AttachmentDownloadAuditLog;
 import studio.one.application.attachment.domain.entity.AttachmentDownloadUrlIssueAuditLog;
 import studio.one.application.attachment.domain.model.Attachment;
+import studio.one.application.attachment.persistence.AttachmentDownloadAuditLogCount;
 import studio.one.application.attachment.persistence.AttachmentDownloadAuditLogRepository;
 import studio.one.application.attachment.persistence.AttachmentDownloadUrlIssueAuditLogRepository;
 import studio.one.application.attachment.persistence.AttachmentRepository;
@@ -359,6 +360,13 @@ class AttachmentAutoConfigurationTest {
                     AttachmentDownloadAuditLogQuery query,
                     org.springframework.data.domain.Pageable pageable) {
                 return Page.empty(pageable);
+            }
+
+            @Override
+            public List<AttachmentDownloadAuditLogCount> countByIssueLogIdsOrTokenHashes(
+                    java.util.Collection<Long> issueLogIds,
+                    java.util.Collection<String> tokenHashes) {
+                return List.of();
             }
         };
     }

--- a/studio-application-modules/attachment-service/README.md
+++ b/studio-application-modules/attachment-service/README.md
@@ -89,8 +89,9 @@ studio:
 ### 감사 API (기본 base-path: `/api/mgmt/audit`)
 - `GET /attachment-download-url-issues`: signed download URL 발급 감사 로그를 페이지로 조회한다. 권한 `features:attachment_download_url_issue_audit/read`.
 - 필터: `attachmentId`, `objectType`, `objectId`, `endpointKind`(`MGMT`/`SERVICE`), `issuedByPrincipalName`(부분 검색), `from`, `to`. `from`은 포함, `to`는 제외 기준으로 `issuedAt`에 적용한다.
-- 응답 필드: `logId`, `attachmentId`, `objectType`, `objectId`, `endpointKind`, `issuedByUserId`, `issuedByPrincipalName`, `issuedAt`, `expiresAt`, `ttlSeconds`, `linkType`, `tokenHash`, `storageProviderId`, `bucket`, `objectKeyHash`, `clientIp`, `userAgent`.
+- 응답 필드: `logId`, `attachmentId`, `objectType`, `objectId`, `endpointKind`, `issuedByUserId`, `issuedByPrincipalName`, `issuedAt`, `expiresAt`, `ttlSeconds`, `linkType`, `tokenHash`, `downloadCount`, `storageProviderId`, `bucket`, `objectKeyHash`, `clientIp`, `userAgent`.
 - signed URL, raw token, raw object key는 응답하지 않는다. 신규 application link는 `tokenHash`만 저장하고, `storageProviderId`/`bucket`/`objectKeyHash`는 legacy objectstorage presigned 로그 호환 필드다. 기본 정렬은 `issuedAt desc`, `logId desc`이다.
+- `downloadCount`는 해당 발급 로그의 실제 signed-download 접근 감사 로그 수다. `issueLogId`와 `tokenHash`를 기준으로 페이지 단위 bulk 집계하며, 접근 이력이 없으면 `0`을 반환한다.
 - `GET /attachment-downloads`: signed download URL 실제 접근 감사 로그를 페이지로 조회한다. 권한 `features:attachment_download_audit/read`.
 - 필터: `attachmentId`, `objectType`, `objectId`, `tokenHash`, `result`(`SUCCEEDED`/`FAILED`/`EXPIRED`/`INVALID_TOKEN`), `from`, `to`, `clientIp`. `from`은 포함, `to`는 제외 기준으로 `requestedAt`에 적용한다.
 - 응답 필드: `downloadLogId`, `issueLogId`, `tokenHash`, `attachmentId`, `objectType`, `objectId`, `linkType`, `requestedAt`, `result`, `httpStatus`, `downloadedBytes`, `clientIp`, `userAgent`, `errorCode`.
@@ -193,6 +194,7 @@ objecttypes:
 - **TB_APPLICATION_ATTACHMENT_PROPERTY**: 첨부 속성 맵(`PROPERTY_NAME`/`PROPERTY_VALUE`)을 저장.
 - **TB_APPLICATION_ATTACHMENT_DATA**: 바이너리 BLOB 저장(DB 스토리지 선택 시 사용).
 - **TB_APPLICATION_ATTACHMENT_URL_ISSUE_LOG**: signed download URL 발급 이력. raw URL/object key 대신 storage metadata와 `OBJECT_KEY_HASH`를 저장한다.
+- **TB_APPLICATION_ATTACHMENT_DOWNLOAD_LOG**: signed download 실제 접근 이력. raw token 대신 `TOKEN_HASH`를 저장하며, 발급 이력 응답의 `downloadCount` 집계 원본이다.
 
 ## 개발 시 참고사항
 - 업로드 시 `SecurityHelper.getUser()`가 존재하면 `createdBy`를 세팅한다.

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/persistence/AttachmentDownloadAuditLogCount.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/persistence/AttachmentDownloadAuditLogCount.java
@@ -1,0 +1,7 @@
+package studio.one.application.attachment.persistence;
+
+public record AttachmentDownloadAuditLogCount(
+        Long issueLogId,
+        String tokenHash,
+        long count) {
+}

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/persistence/AttachmentDownloadAuditLogRepository.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/persistence/AttachmentDownloadAuditLogRepository.java
@@ -1,5 +1,8 @@
 package studio.one.application.attachment.persistence;
 
+import java.util.Collection;
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -11,4 +14,8 @@ public interface AttachmentDownloadAuditLogRepository {
     AttachmentDownloadAuditLog save(AttachmentDownloadAuditLog log);
 
     Page<AttachmentDownloadAuditLog> search(AttachmentDownloadAuditLogQuery query, Pageable pageable);
+
+    List<AttachmentDownloadAuditLogCount> countByIssueLogIdsOrTokenHashes(
+            Collection<Long> issueLogIds,
+            Collection<String> tokenHashes);
 }

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/persistence/jdbc/JdbcAttachmentDownloadAuditLogRepository.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/persistence/jdbc/JdbcAttachmentDownloadAuditLogRepository.java
@@ -3,6 +3,7 @@ package studio.one.application.attachment.persistence.jdbc;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -20,6 +21,7 @@ import org.springframework.util.StringUtils;
 
 import lombok.RequiredArgsConstructor;
 import studio.one.application.attachment.domain.entity.AttachmentDownloadAuditLog;
+import studio.one.application.attachment.persistence.AttachmentDownloadAuditLogCount;
 import studio.one.application.attachment.persistence.AttachmentDownloadAuditLogRepository;
 import studio.one.application.attachment.service.AttachmentDownloadAuditLogQuery;
 
@@ -91,6 +93,38 @@ public class JdbcAttachmentDownloadAuditLogRepository implements AttachmentDownl
         }
         List<AttachmentDownloadAuditLog> content = template.query(dataSql, params, ROW_MAPPER);
         return new PageImpl<>(content, pageable == null ? Pageable.unpaged() : pageable, totalCount);
+    }
+
+    @Override
+    public List<AttachmentDownloadAuditLogCount> countByIssueLogIdsOrTokenHashes(
+            Collection<Long> issueLogIds,
+            Collection<String> tokenHashes) {
+        if ((issueLogIds == null || issueLogIds.isEmpty()) && (tokenHashes == null || tokenHashes.isEmpty())) {
+            return List.of();
+        }
+        Map<String, Object> params = new HashMap<>();
+        StringBuilder where = new StringBuilder();
+        if (issueLogIds != null && !issueLogIds.isEmpty()) {
+            where.append("ISSUE_LOG_ID in (:issueLogIds)");
+            params.put("issueLogIds", issueLogIds);
+        }
+        if (tokenHashes != null && !tokenHashes.isEmpty()) {
+            if (!where.isEmpty()) {
+                where.append(" or ");
+            }
+            where.append("TOKEN_HASH in (:tokenHashes)");
+            params.put("tokenHashes", tokenHashes);
+        }
+        String sql = """
+                select ISSUE_LOG_ID, TOKEN_HASH, count(*) as DOWNLOAD_COUNT
+                from %s
+                where %s
+                group by ISSUE_LOG_ID, TOKEN_HASH
+                """.formatted(TABLE, where);
+        return template.query(sql, params, (rs, rowNum) -> new AttachmentDownloadAuditLogCount(
+                nullableLong(rs, "ISSUE_LOG_ID"),
+                rs.getString("TOKEN_HASH"),
+                rs.getLong("DOWNLOAD_COUNT")));
     }
 
     private Map<String, Object> params(AttachmentDownloadAuditLog log) {

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/persistence/jpa/AttachmentDownloadAuditLogJpaRepository.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/persistence/jpa/AttachmentDownloadAuditLogJpaRepository.java
@@ -1,5 +1,6 @@
 package studio.one.application.attachment.persistence.jpa;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
@@ -9,8 +10,11 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import studio.one.application.attachment.domain.entity.AttachmentDownloadAuditLog;
+import studio.one.application.attachment.persistence.AttachmentDownloadAuditLogCount;
 import studio.one.application.attachment.persistence.AttachmentDownloadAuditLogRepository;
 import studio.one.application.attachment.service.AttachmentDownloadAuditLogQuery;
 
@@ -20,6 +24,22 @@ public interface AttachmentDownloadAuditLogJpaRepository
         AttachmentDownloadAuditLogRepository {
 
     Sort DEFAULT_SORT = Sort.by(Sort.Order.desc("requestedAt"), Sort.Order.desc("downloadLogId"));
+
+    @Override
+    @Query("""
+            select new studio.one.application.attachment.persistence.AttachmentDownloadAuditLogCount(
+                log.issueLogId,
+                log.tokenHash,
+                count(log)
+            )
+            from AttachmentDownloadAuditLog log
+            where log.issueLogId in :issueLogIds
+               or log.tokenHash in :tokenHashes
+            group by log.issueLogId, log.tokenHash
+            """)
+    List<AttachmentDownloadAuditLogCount> countByIssueLogIdsOrTokenHashes(
+            @Param("issueLogIds") Collection<Long> issueLogIds,
+            @Param("tokenHashes") Collection<String> tokenHashes);
 
     @Override
     default Page<AttachmentDownloadAuditLog> search(AttachmentDownloadAuditLogQuery query, Pageable pageable) {

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/service/AttachmentDownloadAuditLogService.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/service/AttachmentDownloadAuditLogService.java
@@ -1,13 +1,19 @@
 package studio.one.application.attachment.service;
 
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import studio.one.application.attachment.domain.entity.AttachmentDownloadAuditLog;
+import studio.one.application.attachment.domain.entity.AttachmentDownloadUrlIssueAuditLog;
 
 public interface AttachmentDownloadAuditLogService {
 
     AttachmentDownloadAuditLog record(AttachmentDownloadAuditLogCommand command);
 
     Page<AttachmentDownloadAuditLog> find(AttachmentDownloadAuditLogQuery query, Pageable pageable);
+
+    Map<Long, Long> countByIssueLogs(List<AttachmentDownloadUrlIssueAuditLog> issueLogs);
 }

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/service/AttachmentDownloadAuditLogServiceImpl.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/service/AttachmentDownloadAuditLogServiceImpl.java
@@ -2,8 +2,12 @@ package studio.one.application.attachment.service;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -15,6 +19,7 @@ import org.springframework.util.StringUtils;
 import lombok.RequiredArgsConstructor;
 import studio.one.application.attachment.domain.entity.AttachmentDownloadAuditLog;
 import studio.one.application.attachment.domain.entity.AttachmentDownloadUrlIssueAuditLog;
+import studio.one.application.attachment.persistence.AttachmentDownloadAuditLogCount;
 import studio.one.application.attachment.persistence.AttachmentDownloadAuditLogRepository;
 import studio.one.application.attachment.persistence.AttachmentDownloadUrlIssueAuditLogRepository;
 
@@ -22,6 +27,8 @@ import studio.one.application.attachment.persistence.AttachmentDownloadUrlIssueA
 public class AttachmentDownloadAuditLogServiceImpl implements AttachmentDownloadAuditLogService {
 
     private static final String LINK_TYPE_APPLICATION_SIGNED = "APPLICATION_SIGNED";
+    private static final Long NO_ISSUE_LOG_ID = Long.MIN_VALUE;
+    private static final String NO_TOKEN_HASH = "__no_attachment_download_token_hash__";
     private static final Sort DEFAULT_SORT = Sort.by(
             Sort.Order.desc("requestedAt"),
             Sort.Order.desc("downloadLogId"));
@@ -79,11 +86,57 @@ public class AttachmentDownloadAuditLogServiceImpl implements AttachmentDownload
         return downloadLogRepository.search(query, normalize(pageable));
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public Map<Long, Long> countByIssueLogs(List<AttachmentDownloadUrlIssueAuditLog> issueLogs) {
+        if (issueLogs == null || issueLogs.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, Long> issueLogIdByTokenHash = new HashMap<>();
+        Set<Long> issueLogIds = issueLogs.stream()
+                .map(AttachmentDownloadUrlIssueAuditLog::getLogId)
+                .filter(id -> id != null)
+                .collect(Collectors.toSet());
+        for (AttachmentDownloadUrlIssueAuditLog issueLog : issueLogs) {
+            if (issueLog.getLogId() != null && StringUtils.hasText(issueLog.getTokenHash())) {
+                issueLogIdByTokenHash.putIfAbsent(issueLog.getTokenHash(), issueLog.getLogId());
+            }
+        }
+        if (issueLogIds.isEmpty() && issueLogIdByTokenHash.isEmpty()) {
+            return Map.of();
+        }
+        Set<String> tokenHashes = issueLogIdByTokenHash.keySet();
+        List<AttachmentDownloadAuditLogCount> counts = downloadLogRepository.countByIssueLogIdsOrTokenHashes(
+                issueLogIds.isEmpty() ? Set.of(NO_ISSUE_LOG_ID) : issueLogIds,
+                tokenHashes.isEmpty() ? Set.of(NO_TOKEN_HASH) : tokenHashes);
+        Map<Long, Long> result = new LinkedHashMap<>();
+        for (AttachmentDownloadAuditLogCount count : counts) {
+            Long targetLogId = resolveIssueLogId(count, issueLogIds, issueLogIdByTokenHash);
+            if (targetLogId != null) {
+                result.merge(targetLogId, count.count(), Long::sum);
+            }
+        }
+        return result;
+    }
+
     private AttachmentDownloadUrlIssueAuditLog findIssueLog(String tokenHash) {
         if (!StringUtils.hasText(tokenHash)) {
             return null;
         }
         return issueLogRepository.findByTokenHash(tokenHash).orElse(null);
+    }
+
+    private Long resolveIssueLogId(
+            AttachmentDownloadAuditLogCount count,
+            Set<Long> issueLogIds,
+            Map<String, Long> issueLogIdByTokenHash) {
+        if (count.issueLogId() != null && issueLogIds.contains(count.issueLogId())) {
+            return count.issueLogId();
+        }
+        if (StringUtils.hasText(count.tokenHash())) {
+            return issueLogIdByTokenHash.get(count.tokenHash());
+        }
+        return null;
     }
 
     private Pageable normalize(Pageable pageable) {

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/AttachmentAuditMgmtController.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/controller/AttachmentAuditMgmtController.java
@@ -3,6 +3,7 @@ package studio.one.application.web.controller;
 import static org.springframework.http.ResponseEntity.ok;
 
 import java.time.OffsetDateTime;
+import java.util.Map;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -56,8 +57,11 @@ public class AttachmentAuditMgmtController {
                 issuedByPrincipalName,
                 from == null ? null : from.toInstant(),
                 to == null ? null : to.toInstant());
-        return ok(ApiResponse.ok(auditLogQueryService.find(query, pageable)
-                .map(AttachmentDownloadUrlIssueAuditLogDto::from)));
+        var page = auditLogQueryService.find(query, pageable);
+        Map<Long, Long> downloadCounts = downloadAuditLogService.countByIssueLogs(page.getContent());
+        return ok(ApiResponse.ok(page.map(log -> AttachmentDownloadUrlIssueAuditLogDto.from(
+                log,
+                log.getLogId() == null ? 0L : downloadCounts.getOrDefault(log.getLogId(), 0L)))));
     }
 
     @GetMapping("/attachment-downloads")

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/dto/AttachmentDownloadUrlIssueAuditLogDto.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/web/dto/AttachmentDownloadUrlIssueAuditLogDto.java
@@ -17,6 +17,7 @@ public record AttachmentDownloadUrlIssueAuditLogDto(
         Long ttlSeconds,
         String linkType,
         String tokenHash,
+        Long downloadCount,
         String storageProviderId,
         String bucket,
         String objectKeyHash,
@@ -24,6 +25,12 @@ public record AttachmentDownloadUrlIssueAuditLogDto(
         String userAgent) {
 
     public static AttachmentDownloadUrlIssueAuditLogDto from(AttachmentDownloadUrlIssueAuditLog log) {
+        return from(log, 0L);
+    }
+
+    public static AttachmentDownloadUrlIssueAuditLogDto from(
+            AttachmentDownloadUrlIssueAuditLog log,
+            long downloadCount) {
         return new AttachmentDownloadUrlIssueAuditLogDto(
                 log.getLogId(),
                 log.getAttachmentId(),
@@ -37,6 +44,7 @@ public record AttachmentDownloadUrlIssueAuditLogDto(
                 log.getTtlSeconds(),
                 log.getLinkType(),
                 log.getTokenHash(),
+                downloadCount,
                 log.getStorageProviderId(),
                 log.getBucket(),
                 log.getObjectKeyHash(),

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/persistence/jdbc/JdbcAttachmentDownloadAuditLogRepositoryTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/persistence/jdbc/JdbcAttachmentDownloadAuditLogRepositoryTest.java
@@ -21,6 +21,7 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 import studio.one.application.attachment.domain.entity.AttachmentDownloadAuditLog;
+import studio.one.application.attachment.persistence.AttachmentDownloadAuditLogCount;
 import studio.one.application.attachment.service.AttachmentDownloadAuditLogQuery;
 import studio.one.application.attachment.service.AttachmentDownloadAuditResult;
 
@@ -97,11 +98,35 @@ class JdbcAttachmentDownloadAuditLogRepositoryTest {
                 .doesNotContain("rawToken");
     }
 
+    @Test
+    void countByIssueLogIdsOrTokenHashesUsesBulkGroupQuery() {
+        JdbcAttachmentDownloadAuditLogRepository repository =
+                new JdbcAttachmentDownloadAuditLogRepository(template);
+        when(template.query(anyString(), anyParams(), anyCountRowMapper())).thenReturn(List.of());
+
+        repository.countByIssueLogIdsOrTokenHashes(List.of(1L, 2L), List.of("token-a"));
+
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(template).query(sqlCaptor.capture(), paramsCaptor.capture(), anyCountRowMapper());
+        assertThat(sqlCaptor.getValue())
+                .contains("ISSUE_LOG_ID in (:issueLogIds)")
+                .contains("TOKEN_HASH in (:tokenHashes)")
+                .contains("group by ISSUE_LOG_ID, TOKEN_HASH");
+        assertThat(paramsCaptor.getValue())
+                .containsEntry("issueLogIds", List.of(1L, 2L))
+                .containsEntry("tokenHashes", List.of("token-a"));
+    }
+
     private Map<String, ?> anyParams() {
         return org.mockito.ArgumentMatchers.any();
     }
 
     private RowMapper<AttachmentDownloadAuditLog> anyRowMapper() {
+        return org.mockito.ArgumentMatchers.any();
+    }
+
+    private RowMapper<AttachmentDownloadAuditLogCount> anyCountRowMapper() {
         return org.mockito.ArgumentMatchers.any();
     }
 }

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/service/AttachmentDownloadAuditLogServiceImplTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/service/AttachmentDownloadAuditLogServiceImplTest.java
@@ -8,7 +8,10 @@ import static org.mockito.Mockito.when;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -19,6 +22,7 @@ import org.springframework.data.domain.Sort;
 
 import studio.one.application.attachment.domain.entity.AttachmentDownloadAuditLog;
 import studio.one.application.attachment.domain.entity.AttachmentDownloadUrlIssueAuditLog;
+import studio.one.application.attachment.persistence.AttachmentDownloadAuditLogCount;
 import studio.one.application.attachment.persistence.AttachmentDownloadAuditLogRepository;
 import studio.one.application.attachment.persistence.AttachmentDownloadUrlIssueAuditLogRepository;
 
@@ -90,6 +94,52 @@ class AttachmentDownloadAuditLogServiceImplTest {
         assertThat(captor.getValue().getSort().toString()).contains("requestedAt: DESC", "downloadLogId: DESC");
     }
 
+    @Test
+    void countByIssueLogsAggregatesByIssueLogIdAndTokenHashFallback() {
+        AttachmentDownloadAuditLogRepository downloadRepository =
+                Mockito.mock(AttachmentDownloadAuditLogRepository.class);
+        AttachmentDownloadUrlIssueAuditLogRepository issueRepository =
+                Mockito.mock(AttachmentDownloadUrlIssueAuditLogRepository.class);
+        when(downloadRepository.countByIssueLogIdsOrTokenHashes(any(), any())).thenReturn(List.of(
+                new AttachmentDownloadAuditLogCount(1L, "token-a", 2L),
+                new AttachmentDownloadAuditLogCount(null, "token-b", 3L)));
+        AttachmentDownloadAuditLogServiceImpl service = new AttachmentDownloadAuditLogServiceImpl(
+                downloadRepository,
+                issueRepository,
+                Clock.fixed(NOW, ZoneOffset.UTC));
+
+        Map<Long, Long> counts = service.countByIssueLogs(List.of(
+                issueLog(1L, "token-a"),
+                issueLog(2L, "token-b")));
+
+        assertThat(counts).containsEntry(1L, 2L).containsEntry(2L, 3L);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Set<Long>> issueIdsCaptor = ArgumentCaptor.forClass(Set.class);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Set<String>> tokenHashesCaptor = ArgumentCaptor.forClass(Set.class);
+        verify(downloadRepository).countByIssueLogIdsOrTokenHashes(
+                issueIdsCaptor.capture(),
+                tokenHashesCaptor.capture());
+        assertThat(issueIdsCaptor.getValue()).containsExactlyInAnyOrder(1L, 2L);
+        assertThat(tokenHashesCaptor.getValue()).containsExactlyInAnyOrder("token-a", "token-b");
+    }
+
+    @Test
+    void countByIssueLogsReturnsEmptyForEmptyPage() {
+        AttachmentDownloadAuditLogRepository downloadRepository =
+                Mockito.mock(AttachmentDownloadAuditLogRepository.class);
+        AttachmentDownloadUrlIssueAuditLogRepository issueRepository =
+                Mockito.mock(AttachmentDownloadUrlIssueAuditLogRepository.class);
+        AttachmentDownloadAuditLogServiceImpl service = new AttachmentDownloadAuditLogServiceImpl(
+                downloadRepository,
+                issueRepository,
+                Clock.fixed(NOW, ZoneOffset.UTC));
+
+        assertThat(service.countByIssueLogs(List.of())).isEmpty();
+
+        Mockito.verifyNoInteractions(downloadRepository);
+    }
+
     private AttachmentDownloadUrlIssueAuditLog issueLog() {
         AttachmentDownloadUrlIssueAuditLog log = new AttachmentDownloadUrlIssueAuditLog();
         log.setLogId(1L);
@@ -97,6 +147,14 @@ class AttachmentDownloadAuditLogServiceImplTest {
         log.setObjectType(20);
         log.setObjectId(30L);
         log.setLinkType("APPLICATION_SIGNED");
+        log.setTokenHash("token-hash");
+        return log;
+    }
+
+    private AttachmentDownloadUrlIssueAuditLog issueLog(long logId, String tokenHash) {
+        AttachmentDownloadUrlIssueAuditLog log = issueLog();
+        log.setLogId(logId);
+        log.setTokenHash(tokenHash);
         return log;
     }
 }

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/web/controller/AttachmentAuditMgmtControllerTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/web/controller/AttachmentAuditMgmtControllerTest.java
@@ -11,6 +11,7 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -48,6 +49,7 @@ class AttachmentAuditMgmtControllerTest {
         var pageable = PageRequest.of(0, 20);
         AttachmentDownloadUrlIssueAuditLog log = auditLog();
         when(auditLogQueryService.find(any(), eq(pageable))).thenReturn(new PageImpl<>(List.of(log), pageable, 1));
+        when(downloadAuditLogService.countByIssueLogs(List.of(log))).thenReturn(Map.of(1L, 3L));
 
         var response = controller.listDownloadUrlIssueLogs(
                 10L,
@@ -75,7 +77,31 @@ class AttachmentAuditMgmtControllerTest {
         assertThat(dto.logId()).isEqualTo(1L);
         assertThat(dto.linkType()).isEqualTo("APPLICATION_SIGNED");
         assertThat(dto.tokenHash()).isEqualTo("token-hash");
+        assertThat(dto.downloadCount()).isEqualTo(3L);
         assertThat(dto.objectKeyHash()).isEqualTo("hash");
+    }
+
+    @Test
+    void listDownloadUrlIssueLogsDefaultsMissingDownloadCountToZero() {
+        AttachmentAuditMgmtController controller =
+                new AttachmentAuditMgmtController(auditLogQueryService, downloadAuditLogService);
+        var pageable = PageRequest.of(0, 20);
+        AttachmentDownloadUrlIssueAuditLog log = auditLog();
+        when(auditLogQueryService.find(any(), eq(pageable))).thenReturn(new PageImpl<>(List.of(log), pageable, 1));
+        when(downloadAuditLogService.countByIssueLogs(List.of(log))).thenReturn(Map.of());
+
+        var response = controller.listDownloadUrlIssueLogs(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                pageable);
+
+        AttachmentDownloadUrlIssueAuditLogDto dto = response.getBody().getData().getContent().get(0);
+        assertThat(dto.downloadCount()).isZero();
     }
 
     @Test
@@ -162,7 +188,7 @@ class AttachmentAuditMgmtControllerTest {
                 .toList();
 
         assertThat(fieldNames).doesNotContain("url", "signedUrl", "downloadUrl", "objectKey", "token", "rawToken");
-        assertThat(fieldNames).contains("objectKeyHash", "tokenHash", "linkType");
+        assertThat(fieldNames).contains("objectKeyHash", "tokenHash", "linkType", "downloadCount");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- 이슈 #408 대응으로 download URL 발급 감사 응답에 downloadCount를 추가했습니다.
- 현재 페이지의 발급 로그를 issueLogId/tokenHash 기준으로 bulk 집계해 N+1 없이 실제 signed-download 접근 횟수를 반환합니다.
- 접근 이력이 없는 발급 로그는 downloadCount=0으로 응답합니다.

## Changes
- AttachmentDownloadUrlIssueAuditLogDto에 downloadCount 필드를 추가했습니다.
- AttachmentDownloadAuditLogRepository에 bulk count 계약과 JDBC/JPA 구현을 추가했습니다.
- AttachmentAuditMgmtController가 페이지 content 기준으로 다운로드 횟수를 보강하도록 변경했습니다.
- controller/service/repository/starter 테스트와 README/CHANGELOG를 갱신했습니다.

## Validation
- ./gradlew :studio-application-modules:attachment-service:test :starter:studio-application-starter-attachment:test
- git diff --check

## AI-Assisted
- Yes
- Usage type: 구현, 테스트, 문서화, 리뷰 준비
- Subagent used: No

Closes #408