### PR TITLE
[ai-assisted] feat(workspace): 관리 목록 API 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### 변경됨
+- 이슈 #412 대응으로 Workspace 관리 화면 진입용 `GET /api/mgmt/workspaces` 목록 조회 API를 추가했다. `q`, `parentId`, `rootOnly`, `archived`, pagination, sort를 지원하고 기존 관리용 권한 정책을 적용한다.
 - 이슈 #410 대응으로 `studio-platform-workspace`, `studio-platform-workspace-default`, `starter:studio-platform-starter-workspace`를 추가해 workspace tree 생성/조회, member role, effective permission, 사용자용/관리용 API와 JPA 자동구성을 제공한다.
 - `workspace` Flyway range `1300-1399`와 `V1300__create_workspace_tables.sql`을 postgres/mysql/mariadb에 추가하고, 사용자용 `public-base-path`와 관리용 `mgmt-base-path`를 분리했다.
 - 이슈 #408 대응으로 `GET /api/mgmt/audit/attachment-download-url-issues` 응답에 실제 signed-download 접근 이력 수인 `downloadCount`를 추가했다. 집계는 현재 페이지의 발급 로그를 `issueLogId`/`tokenHash` 기준으로 bulk 조회하며, 접근 이력이 없으면 `0`을 반환한다.

--- a/starter/studio-platform-starter-workspace/README.md
+++ b/starter/studio-platform-starter-workspace/README.md
@@ -45,6 +45,8 @@ studio:
 
 관리용 API는 `features:workspace/manage` 또는 platform `ADMIN` role을 요구합니다. 사용자용 API는 endpoint auth 통과 후 service layer에서 workspace role/visibility permission을 다시 검사합니다.
 
+관리 화면에서 전체 workspace 목록을 시작점으로 조회할 때는 `GET /api/mgmt/workspaces`를 사용합니다. `q`, `parentId`, `rootOnly`, `archived`, `page`, `size`, `sort` query parameter를 지원하며 기본 정렬은 `path ASC`입니다.
+
 ## 자동구성
 - `WorkspaceAutoConfiguration`: JPA entity/repository scan, `WorkspaceTreeService`, `WorkspaceMemberService`, `WorkspacePermissionService`
 - `WorkspaceWebAutoConfiguration`: `WorkspaceController`, `WorkspaceMgmtController`

--- a/studio-platform-workspace-default/README.md
+++ b/studio-platform-workspace-default/README.md
@@ -41,6 +41,12 @@ root 생성 시 self closure와 creator `OWNER` member가 자동 생성됩니다
 
 관리용 기본 경로는 `/api/mgmt/workspaces`이며 같은 endpoint shape를 제공합니다. 관리용 API는 `features:workspace/manage` 또는 platform `ADMIN` role을 요구합니다.
 
+관리 화면의 첫 진입용 목록 API는 관리용 경로에만 제공됩니다.
+
+- `GET /api/mgmt/workspaces`
+
+지원 query parameter는 `q`, `parentId`, `rootOnly`, `archived`, `page`, `size`, `sort`입니다. `q`는 `name`, `slug`, `path`를 부분 검색하고, `rootOnly=true`는 root workspace만 반환합니다. 응답 item은 `id`, `parentId`, `rootId`, `name`, `slug`, `path`, `depth`, `visibility`, `archived`를 포함합니다.
+
 ## Schema
 Flyway range는 `workspace` `1300-1399`입니다.
 

--- a/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/persistence/jpa/WorkspaceJpaRepository.java
+++ b/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/persistence/jpa/WorkspaceJpaRepository.java
@@ -5,8 +5,9 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface WorkspaceJpaRepository extends JpaRepository<WorkspaceEntity, Long> {
+public interface WorkspaceJpaRepository extends JpaRepository<WorkspaceEntity, Long>, JpaSpecificationExecutor<WorkspaceEntity> {
 
     Optional<WorkspaceEntity> findByPath(String path);
 

--- a/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/service/impl/DefaultWorkspaceTreeService.java
+++ b/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/service/impl/DefaultWorkspaceTreeService.java
@@ -12,6 +12,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import jakarta.persistence.criteria.Predicate;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
@@ -31,6 +39,7 @@ import studio.one.platform.workspace.persistence.jpa.WorkspaceJpaRepository;
 import studio.one.platform.workspace.persistence.jpa.WorkspaceMemberEntity;
 import studio.one.platform.workspace.persistence.jpa.WorkspaceMemberJpaRepository;
 import studio.one.platform.workspace.service.CreateWorkspaceCommand;
+import studio.one.platform.workspace.service.WorkspaceListQuery;
 import studio.one.platform.workspace.service.UpdateWorkspaceCommand;
 import studio.one.platform.workspace.service.WorkspaceAccessContext;
 import studio.one.platform.workspace.service.WorkspacePermissionService;
@@ -40,6 +49,18 @@ import studio.one.platform.workspace.service.WorkspaceTreeService;
 public class DefaultWorkspaceTreeService implements WorkspaceTreeService {
 
     private static final Pattern SLUG = Pattern.compile("^[a-z0-9][a-z0-9-]*$");
+    private static final Sort DEFAULT_LIST_SORT = Sort.by("path").ascending();
+    private static final Map<String, String> LIST_SORT_PROPERTIES = Map.ofEntries(
+            Map.entry("id", "workspaceId"),
+            Map.entry("workspaceId", "workspaceId"),
+            Map.entry("parentId", "parentId"),
+            Map.entry("rootId", "rootId"),
+            Map.entry("name", "name"),
+            Map.entry("slug", "slug"),
+            Map.entry("path", "path"),
+            Map.entry("depth", "depth"),
+            Map.entry("visibility", "visibility"),
+            Map.entry("archived", "archived"));
 
     private final WorkspaceJpaRepository workspaceRepository;
     private final WorkspaceClosureJpaRepository closureRepository;
@@ -144,6 +165,17 @@ public class DefaultWorkspaceTreeService implements WorkspaceTreeService {
         WorkspaceEntity entity = workspaceByPath(path);
         permissionService.assertGranted(entity.getWorkspaceId(), actor, WorkspacePermissionActions.READ);
         return entity.toRef();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<WorkspaceRef> list(WorkspaceListQuery query, Pageable pageable, WorkspaceAccessContext actor) {
+        WorkspaceAccessContext resolved = requireActor(actor);
+        if (!resolved.platformAdmin()) {
+            throw new AccessDeniedException("Workspace management permission required");
+        }
+        return workspaceRepository.findAll(listSpecification(query), safeListPageable(pageable))
+                .map(WorkspaceEntity::toRef);
     }
 
     @Override
@@ -295,6 +327,63 @@ public class DefaultWorkspaceTreeService implements WorkspaceTreeService {
         }
         return workspaceRepository.findByPath(path.trim())
                 .orElseThrow(() -> new WorkspaceNotFoundException("Workspace not found by path: " + path));
+    }
+
+    private Specification<WorkspaceEntity> listSpecification(WorkspaceListQuery query) {
+        return (root, criteria, builder) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            if (query != null) {
+                if (StringUtils.hasText(query.q())) {
+                    String pattern = "%" + escapeLike(query.q().trim().toLowerCase(Locale.ROOT)) + "%";
+                    predicates.add(builder.or(
+                            builder.like(builder.lower(root.get("name")), pattern, '\\'),
+                            builder.like(builder.lower(root.get("slug")), pattern, '\\'),
+                            builder.like(builder.lower(root.get("path")), pattern, '\\')));
+                }
+                if (query.rootOnlyEnabled()) {
+                    predicates.add(builder.isNull(root.get("parentId")));
+                } else if (query.parentId() != null) {
+                    predicates.add(builder.equal(root.get("parentId"), query.parentId()));
+                }
+                if (query.archived() != null) {
+                    predicates.add(builder.equal(root.get("archived"), query.archived()));
+                }
+            }
+            return builder.and(predicates.toArray(Predicate[]::new));
+        };
+    }
+
+    private Pageable safeListPageable(Pageable pageable) {
+        if (pageable == null || pageable.isUnpaged()) {
+            return PageRequest.of(0, 20, DEFAULT_LIST_SORT);
+        }
+        int page = Math.max(pageable.getPageNumber(), 0);
+        int size = Math.min(Math.max(pageable.getPageSize(), 1), 200);
+        return PageRequest.of(page, size, safeListSort(pageable.getSort()));
+    }
+
+    private Sort safeListSort(Sort requested) {
+        if (requested == null || requested.isUnsorted()) {
+            return DEFAULT_LIST_SORT;
+        }
+        List<Sort.Order> orders = requested.stream()
+                .map(order -> {
+                    String property = LIST_SORT_PROPERTIES.get(order.getProperty());
+                    if (property == null) {
+                        return null;
+                    }
+                    return new Sort.Order(order.getDirection(), property);
+                })
+                .filter(order -> order != null)
+                .toList();
+        return orders.isEmpty() ? DEFAULT_LIST_SORT : Sort.by(orders);
+    }
+
+    private String escapeLike(String value) {
+        return value
+                .replace("\\", "\\\\")
+                .replace("%", "\\%")
+                .replace("_", "\\_");
     }
 
     private Map<Long, WorkspaceEntity> byId(List<Long> ids) {

--- a/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/web/controller/WorkspaceControllerSupport.java
+++ b/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/web/controller/WorkspaceControllerSupport.java
@@ -3,6 +3,8 @@ package studio.one.platform.workspace.web.controller;
 import java.util.List;
 
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 
 import studio.one.platform.identity.ApplicationPrincipal;
@@ -15,6 +17,7 @@ import studio.one.platform.workspace.permission.WorkspacePermissionDefinition;
 import studio.one.platform.workspace.service.CreateWorkspaceCommand;
 import studio.one.platform.workspace.service.UpdateWorkspaceCommand;
 import studio.one.platform.workspace.service.WorkspaceAccessContext;
+import studio.one.platform.workspace.service.WorkspaceListQuery;
 import studio.one.platform.workspace.service.WorkspaceMemberCommand;
 import studio.one.platform.workspace.service.WorkspaceMemberService;
 import studio.one.platform.workspace.service.WorkspacePermissionService;
@@ -71,6 +74,10 @@ abstract class WorkspaceControllerSupport {
 
     WorkspaceRef getByPath(String path, boolean platformAdmin) {
         return treeService.getByPath(path, context(platformAdmin));
+    }
+
+    Page<WorkspaceRef> list(WorkspaceListQuery query, Pageable pageable, boolean platformAdmin) {
+        return treeService.list(query, pageable, context(platformAdmin));
     }
 
     List<WorkspaceRef> children(Long workspaceId, boolean platformAdmin) {

--- a/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/web/controller/WorkspaceMgmtController.java
+++ b/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/web/controller/WorkspaceMgmtController.java
@@ -5,6 +5,10 @@ import java.util.List;
 import jakarta.validation.Valid;
 
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
@@ -25,6 +29,7 @@ import studio.one.platform.workspace.model.WorkspaceMemberRef;
 import studio.one.platform.workspace.model.WorkspaceRef;
 import studio.one.platform.workspace.model.WorkspaceTreeNode;
 import studio.one.platform.workspace.permission.WorkspacePermissionDefinition;
+import studio.one.platform.workspace.service.WorkspaceListQuery;
 import studio.one.platform.workspace.service.WorkspaceMemberService;
 import studio.one.platform.workspace.service.WorkspacePermissionService;
 import studio.one.platform.workspace.service.WorkspaceTreeService;
@@ -57,6 +62,19 @@ public class WorkspaceMgmtController extends WorkspaceControllerSupport {
             @PathVariable Long workspaceId,
             @Valid @RequestBody WorkspaceCreateRequest request) {
         return ResponseEntity.ok(ApiResponse.ok(createChild(workspaceId, request, true)));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<WorkspaceRef>>> list(
+            @RequestParam(value = "q", required = false) String q,
+            @RequestParam(value = "parentId", required = false) Long parentId,
+            @RequestParam(value = "rootOnly", required = false) Boolean rootOnly,
+            @RequestParam(value = "archived", required = false) Boolean archived,
+            @PageableDefault(size = 20, sort = "path", direction = Sort.Direction.ASC) Pageable pageable) {
+        return ResponseEntity.ok(ApiResponse.ok(list(
+                new WorkspaceListQuery(q, parentId, rootOnly, archived),
+                pageable,
+                true)));
     }
 
     @GetMapping("/{workspaceId:[\\p{Digit}]+}")

--- a/studio-platform-workspace-default/src/test/java/studio/one/platform/workspace/service/impl/DefaultWorkspaceServiceTest.java
+++ b/studio-platform-workspace-default/src/test/java/studio/one/platform/workspace/service/impl/DefaultWorkspaceServiceTest.java
@@ -10,6 +10,8 @@ import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.security.access.AccessDeniedException;
@@ -25,6 +27,7 @@ import studio.one.platform.workspace.persistence.jpa.WorkspaceMemberJpaRepositor
 import studio.one.platform.workspace.service.CreateWorkspaceCommand;
 import studio.one.platform.workspace.service.UpdateWorkspaceCommand;
 import studio.one.platform.workspace.service.WorkspaceAccessContext;
+import studio.one.platform.workspace.service.WorkspaceListQuery;
 import studio.one.platform.workspace.service.WorkspaceMemberCommand;
 import studio.one.platform.workspace.service.WorkspaceMemberService;
 import studio.one.platform.workspace.service.WorkspacePermissionService;
@@ -159,6 +162,49 @@ class DefaultWorkspaceServiceTest {
         assertThat(treeService.getDescendants(root.id(), authenticated)).isEmpty();
         assertThat(treeService.getTree(root.id(), authenticated).children()).isEmpty();
         assertThatThrownBy(() -> treeService.getById(privateChild.id(), authenticated))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void managementListFiltersAndPagesWorkspaces() {
+        var acme = createRoot("Acme", "acme", OWNER);
+        var engineering = treeService.createChild(acme.id(), createCommand("Engineering", "engineering", OWNER));
+        var design = treeService.createChild(acme.id(), createCommand("Design", "design", OWNER));
+        var beta = createRoot("Beta", "beta", OWNER);
+        treeService.archive(design.id(), OWNER);
+
+        var sortedByPath = PageRequest.of(0, 10, Sort.by("path").ascending());
+
+        assertThat(treeService.list(new WorkspaceListQuery(null, null, true, null), sortedByPath, PLATFORM_ADMIN)
+                .getContent())
+                .extracting(studio.one.platform.workspace.model.WorkspaceRef::id)
+                .containsExactly(acme.id(), beta.id());
+        assertThat(treeService.list(new WorkspaceListQuery(null, acme.id(), false, false), sortedByPath, PLATFORM_ADMIN)
+                .getContent())
+                .extracting(studio.one.platform.workspace.model.WorkspaceRef::id)
+                .containsExactly(engineering.id());
+        assertThat(treeService.list(new WorkspaceListQuery("ACME/ENG", null, null, null), sortedByPath, PLATFORM_ADMIN)
+                .getContent())
+                .extracting(studio.one.platform.workspace.model.WorkspaceRef::id)
+                .containsExactly(engineering.id());
+        assertThat(treeService.list(new WorkspaceListQuery(null, null, null, true), sortedByPath, PLATFORM_ADMIN)
+                .getContent())
+                .extracting(studio.one.platform.workspace.model.WorkspaceRef::id)
+                .containsExactly(design.id());
+        assertThat(treeService.list(new WorkspaceListQuery(null, null, null, null), PageRequest.of(0, 2, Sort.by("id").descending()), PLATFORM_ADMIN)
+                .getContent())
+                .extracting(studio.one.platform.workspace.model.WorkspaceRef::id)
+                .containsExactly(beta.id(), design.id());
+    }
+
+    @Test
+    void managementListRequiresPlatformAdminContext() {
+        createRoot("Acme", "acme", OWNER);
+
+        assertThatThrownBy(() -> treeService.list(
+                new WorkspaceListQuery(null, null, null, null),
+                PageRequest.of(0, 10),
+                OWNER))
                 .isInstanceOf(AccessDeniedException.class);
     }
 

--- a/studio-platform-workspace-default/src/test/java/studio/one/platform/workspace/web/controller/WorkspaceControllerTest.java
+++ b/studio-platform-workspace-default/src/test/java/studio/one/platform/workspace/web/controller/WorkspaceControllerTest.java
@@ -12,6 +12,8 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import studio.one.platform.identity.ApplicationPrincipal;
@@ -22,6 +24,7 @@ import studio.one.platform.workspace.model.WorkspaceVisibility;
 import studio.one.platform.workspace.permission.WorkspacePermissionActions;
 import studio.one.platform.workspace.service.CreateWorkspaceCommand;
 import studio.one.platform.workspace.service.WorkspaceAccessContext;
+import studio.one.platform.workspace.service.WorkspaceListQuery;
 import studio.one.platform.workspace.service.WorkspaceMemberService;
 import studio.one.platform.workspace.service.WorkspacePermissionService;
 import studio.one.platform.workspace.service.WorkspaceTreeService;
@@ -94,6 +97,29 @@ class WorkspaceControllerTest {
         ArgumentCaptor<CreateWorkspaceCommand> captor = ArgumentCaptor.forClass(CreateWorkspaceCommand.class);
         verify(treeService).createRoot(captor.capture());
         assertThat(captor.getValue().actor().platformAdmin()).isTrue();
+    }
+
+    @Test
+    void mgmtControllerListUsesFiltersAndPlatformAdminAccessContext() {
+        WorkspaceTreeService treeService = org.mockito.Mockito.mock(WorkspaceTreeService.class);
+        WorkspaceMemberService memberService = org.mockito.Mockito.mock(WorkspaceMemberService.class);
+        WorkspacePermissionService permissionService = org.mockito.Mockito.mock(WorkspacePermissionService.class);
+        var pageable = PageRequest.of(1, 5);
+        when(treeService.list(any(), eq(pageable), any()))
+                .thenReturn(new PageImpl<>(List.of(workspace()), pageable, 1));
+        WorkspaceMgmtController controller = new WorkspaceMgmtController(
+                treeService,
+                memberService,
+                permissionService,
+                principalProvider("admin", false));
+
+        controller.list("acme", 3L, false, true, pageable);
+
+        ArgumentCaptor<WorkspaceListQuery> queryCaptor = ArgumentCaptor.forClass(WorkspaceListQuery.class);
+        ArgumentCaptor<WorkspaceAccessContext> contextCaptor = ArgumentCaptor.forClass(WorkspaceAccessContext.class);
+        verify(treeService).list(queryCaptor.capture(), eq(pageable), contextCaptor.capture());
+        assertThat(queryCaptor.getValue()).isEqualTo(new WorkspaceListQuery("acme", 3L, false, true));
+        assertThat(contextCaptor.getValue().platformAdmin()).isTrue();
     }
 
     @Test

--- a/studio-platform-workspace/build.gradle.kts
+++ b/studio-platform-workspace/build.gradle.kts
@@ -19,5 +19,6 @@ tasks.named<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {
 dependencies {
     api(project(":studio-platform"))
     compileOnly("org.springframework:spring-web")
+    compileOnly("org.springframework.data:spring-data-commons")
     testImplementation("org.junit.jupiter:junit-jupiter")
 }

--- a/studio-platform-workspace/src/main/java/studio/one/platform/workspace/service/WorkspaceListQuery.java
+++ b/studio-platform-workspace/src/main/java/studio/one/platform/workspace/service/WorkspaceListQuery.java
@@ -1,0 +1,12 @@
+package studio.one.platform.workspace.service;
+
+public record WorkspaceListQuery(
+        String q,
+        Long parentId,
+        Boolean rootOnly,
+        Boolean archived) {
+
+    public boolean rootOnlyEnabled() {
+        return Boolean.TRUE.equals(rootOnly);
+    }
+}

--- a/studio-platform-workspace/src/main/java/studio/one/platform/workspace/service/WorkspaceTreeService.java
+++ b/studio-platform-workspace/src/main/java/studio/one/platform/workspace/service/WorkspaceTreeService.java
@@ -2,6 +2,9 @@ package studio.one.platform.workspace.service;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import studio.one.platform.workspace.model.WorkspaceRef;
 import studio.one.platform.workspace.model.WorkspaceTreeNode;
 
@@ -16,6 +19,8 @@ public interface WorkspaceTreeService {
     WorkspaceRef getById(Long workspaceId, WorkspaceAccessContext actor);
 
     WorkspaceRef getByPath(String path, WorkspaceAccessContext actor);
+
+    Page<WorkspaceRef> list(WorkspaceListQuery query, Pageable pageable, WorkspaceAccessContext actor);
 
     List<WorkspaceRef> getChildren(Long workspaceId, WorkspaceAccessContext actor);
 


### PR DESCRIPTION
## Why

Workspace 관리 화면이 첫 진입 시 root 또는 전체 workspace 목록에서 시작할 수 있도록 page 목록 API가 필요합니다. 기존 API는 id/path를 알고 있는 상태의 tree/member/permission 조회 중심이라 관리 화면의 진입점으로 쓰기 어렵습니다.

## What

- `GET /api/mgmt/workspaces` 관리 목록 API를 추가했습니다.
- `q`, `parentId`, `rootOnly`, `archived`, `page`, `size`, `sort` query parameter를 지원합니다.
- `q`는 `name`, `slug`, `path` 부분 검색으로 처리합니다.
- JPA `Specification` 기반 목록 조회와 sort whitelist/default `path ASC` 처리를 추가했습니다.
- 기존 관리용 권한 정책과 동일하게 `features:workspace/manage` 또는 platform `ADMIN` role 경로에서 동작합니다.
- README와 `CHANGELOG.md`를 갱신하고 service/controller 테스트를 추가했습니다.

## Related Issues

- Closes #412

## Validation

- Command: `./gradlew :studio-platform-workspace:build :studio-platform-workspace-default:build :starter:studio-platform-starter-workspace:build`
- Result: PASS
- Command: `./gradlew :studio-platform-workspace-default:test`
- Result: PASS
- Command: `git diff --check`
- Result: PASS

## Risk / Rollback

- Risk: 새 목록 API의 query/sort 처리 오류가 관리 화면 목록 조회에 영향을 줄 수 있습니다. 기존 id/path/tree/member endpoint 동작은 변경하지 않았습니다.
- Rollback: 이 PR 커밋을 revert하면 신규 목록 API와 관련 service/repository/test/doc 변경이 제거됩니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope:
- Main author validation: Gradle 대상 모듈 build/test와 `git diff --check`를 실행했습니다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included