### PR TITLE
[codex] Workspace Parent 변경 API 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### 변경됨
+- 이슈 #417 대응으로 Workspace parent 변경 API `PATCH /api/workspaces/{workspaceId}/parent`, `PATCH /api/mgmt/workspaces/{workspaceId}/parent`를 추가했다. `newParentId=null`은 root 이동으로 처리하고, subtree의 `rootId`/`path`/`depth`와 closure table을 재계산하며 자기 자신 또는 descendant 아래 이동은 거부한다.
 - 이슈 #415 대응으로 `studio-application-modules:wiki-service`와 `starter:studio-application-starter-wiki`를 추가해 workspace 단위 Wiki page/revision MVP, 사용자용/관리용 API, markdown render/sanitize, 기존 page write의 `baseRevisionId` 충돌 검증, JPA schema `V1400`을 제공한다.
 - 이슈 #412 대응으로 Workspace 관리 화면 진입용 `GET /api/mgmt/workspaces` 목록 조회 API를 추가했다. `q`, `parentId`, `rootOnly`, `archived`, pagination, sort를 지원하고 기존 관리용 권한 정책을 적용한다.
 - 이슈 #410 대응으로 `studio-platform-workspace`, `studio-platform-workspace-default`, `starter:studio-platform-starter-workspace`를 추가해 workspace tree 생성/조회, member role, effective permission, 사용자용/관리용 API와 JPA 자동구성을 제공한다.

--- a/starter/studio-platform-starter-workspace/README.md
+++ b/starter/studio-platform-starter-workspace/README.md
@@ -47,6 +47,16 @@ studio:
 
 관리 화면에서 전체 workspace 목록을 시작점으로 조회할 때는 `GET /api/mgmt/workspaces`를 사용합니다. `q`, `parentId`, `rootOnly`, `archived`, `page`, `size`, `sort` query parameter를 지원하며 기본 정렬은 `path ASC`입니다.
 
+Workspace parent 변경은 사용자용/관리용 경로 모두에서 `PATCH {base-path}/{workspaceId}/parent`로 제공합니다. 요청 body의 `newParentId`가 `null`이면 root로 이동합니다.
+
+```json
+{
+  "newParentId": 10
+}
+```
+
+서버는 이동 시 subtree의 `rootId`, `path`, `depth`와 closure table을 재계산합니다. 자기 자신 또는 descendant 아래로 이동하는 순환 구조는 `409 Conflict`로 거부하고, archived workspace 이동은 기존 mutation 정책에 따라 거부합니다.
+
 ## 자동구성
 - `WorkspaceAutoConfiguration`: JPA entity/repository scan, `WorkspaceTreeService`, `WorkspaceMemberService`, `WorkspacePermissionService`
 - `WorkspaceWebAutoConfiguration`: `WorkspaceController`, `WorkspaceMgmtController`

--- a/studio-platform-workspace-default/README.md
+++ b/studio-platform-workspace-default/README.md
@@ -1,6 +1,6 @@
 # Studio Platform Workspace Default
 
-`studio-platform-workspace` 계약의 JPA-only 기본 구현입니다. v1은 workspace tree와 member role 기반 effective permission만 다루며 Wiki, page-level ACL, custom role, deny override, hard delete, subtree move는 포함하지 않습니다.
+`studio-platform-workspace` 계약의 JPA-only 기본 구현입니다. v1은 workspace tree와 member role 기반 effective permission, parent 변경 기반 subtree move를 다루며 Wiki, page-level ACL, custom role, deny override, hard delete는 포함하지 않습니다.
 
 ## 저장 모델
 - `TB_PLATFORM_WORKSPACE`: workspace 본문, `parentId`, immutable `slug`, materialized `path`, archive 상태
@@ -8,6 +8,8 @@
 - `TB_PLATFORM_WORKSPACE_MEMBER`: workspace별 direct member role
 
 root 생성 시 self closure와 creator `OWNER` member가 자동 생성됩니다. child 생성 시 parent ancestor closure를 복사하고 self closure를 추가합니다.
+
+parent 변경 시 대상 subtree의 `parentId`, `rootId`, `path`, `depth`와 closure row를 서버에서 재계산합니다. `newParentId=null`은 root 이동으로 처리하며, 자기 자신 또는 descendant 아래로 이동하는 순환 구조는 거부합니다.
 
 ## 권한 규칙
 - effective role은 ancestor direct role 중 가장 높은 role입니다.
@@ -30,6 +32,7 @@ root 생성 시 self closure와 creator `OWNER` member가 자동 생성됩니다
 - `GET /api/workspaces/{workspaceId}/descendants`
 - `GET /api/workspaces/{workspaceId}/tree`
 - `PATCH /api/workspaces/{workspaceId}`
+- `PATCH /api/workspaces/{workspaceId}/parent`
 - `POST /api/workspaces/{workspaceId}/archive`
 - `GET /api/workspaces/{workspaceId}/members`
 - `GET /api/workspaces/{workspaceId}/members/effective`
@@ -40,6 +43,16 @@ root 생성 시 self closure와 creator `OWNER` member가 자동 생성됩니다
 - `GET /api/workspaces/{workspaceId}/permissions/actions`
 
 관리용 기본 경로는 `/api/mgmt/workspaces`이며 같은 endpoint shape를 제공합니다. 관리용 API는 `features:workspace/manage` 또는 platform `ADMIN` role을 요구합니다.
+
+parent 변경 request body:
+
+```json
+{
+  "newParentId": 10
+}
+```
+
+`newParentId`를 `null`로 보내면 root workspace로 이동합니다. 사용자용 API는 이동 대상 workspace에 `workspace.update`, 새 parent가 있으면 parent에 `workspace.create` 권한을 요구합니다. 관리용 API는 기존 platform admin 우회 정책을 사용합니다. archived workspace는 이동할 수 없고 archived parent 아래로도 이동할 수 없습니다.
 
 관리 화면의 첫 진입용 목록 API는 관리용 경로에만 제공됩니다.
 

--- a/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/persistence/jpa/WorkspaceClosureJpaRepository.java
+++ b/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/persistence/jpa/WorkspaceClosureJpaRepository.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -35,4 +36,12 @@ public interface WorkspaceClosureJpaRepository extends JpaRepository<WorkspaceCl
             where c.id.descendantId in :workspaceIds
             """)
     List<WorkspaceClosureEntity> findByDescendantIds(@Param("workspaceIds") Collection<Long> workspaceIds);
+
+    @Modifying
+    @Query("""
+            delete from WorkspaceClosureEntity c
+            where c.id.descendantId in :descendantIds
+              and c.id.ancestorId not in :descendantIds
+            """)
+    void deleteExternalAncestorsForDescendants(@Param("descendantIds") Collection<Long> descendantIds);
 }

--- a/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/service/impl/DefaultWorkspaceTreeService.java
+++ b/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/service/impl/DefaultWorkspaceTreeService.java
@@ -38,10 +38,11 @@ import studio.one.platform.workspace.persistence.jpa.WorkspaceEntity;
 import studio.one.platform.workspace.persistence.jpa.WorkspaceJpaRepository;
 import studio.one.platform.workspace.persistence.jpa.WorkspaceMemberEntity;
 import studio.one.platform.workspace.persistence.jpa.WorkspaceMemberJpaRepository;
+import studio.one.platform.workspace.service.ChangeWorkspaceParentCommand;
 import studio.one.platform.workspace.service.CreateWorkspaceCommand;
-import studio.one.platform.workspace.service.WorkspaceListQuery;
 import studio.one.platform.workspace.service.UpdateWorkspaceCommand;
 import studio.one.platform.workspace.service.WorkspaceAccessContext;
+import studio.one.platform.workspace.service.WorkspaceListQuery;
 import studio.one.platform.workspace.service.WorkspacePermissionService;
 import studio.one.platform.workspace.service.WorkspaceTreeService;
 
@@ -150,6 +151,91 @@ public class DefaultWorkspaceTreeService implements WorkspaceTreeService {
         }
         entity.setUpdatedBy(actor.requireUserId());
         return workspaceRepository.save(entity).toRef();
+    }
+
+    @Override
+    @Transactional
+    public WorkspaceRef changeParent(Long workspaceId, ChangeWorkspaceParentCommand command) {
+        WorkspaceAccessContext actor = requireActor(command.actor());
+        permissionService.assertGranted(workspaceId, actor, WorkspacePermissionActions.UPDATE);
+        WorkspaceEntity entity = workspace(workspaceId);
+        rejectArchivedMutation(entity);
+
+        Long newParentId = command.newParentId();
+        if (sameParent(entity.getParentId(), newParentId)) {
+            return entity.toRef();
+        }
+
+        List<WorkspaceClosureEntity> subtreeClosures = closureRepository.findByIdAncestorIdOrderByDepthAsc(workspaceId);
+        Set<Long> subtreeIds = new HashSet<>();
+        Map<Long, Integer> relativeDepths = new HashMap<>();
+        for (WorkspaceClosureEntity closure : subtreeClosures) {
+            subtreeIds.add(closure.descendantId());
+            relativeDepths.put(closure.descendantId(), closure.getDepth());
+        }
+        if (newParentId != null && subtreeIds.contains(newParentId)) {
+            throw new WorkspaceConflictException("Workspace cannot be moved under itself or its descendant");
+        }
+
+        WorkspaceEntity newParent = null;
+        if (newParentId != null) {
+            newParent = workspace(newParentId);
+            permissionService.assertGranted(newParentId, actor, WorkspacePermissionActions.CREATE);
+            rejectArchivedMutation(newParent);
+            if (workspaceRepository.countByParentId(newParentId) >= settings.maxChildrenPerNode()) {
+                throw new WorkspaceValidationException("Workspace max children per node exceeded");
+            }
+            if (workspaceRepository.existsByParentIdAndSlug(newParentId, entity.getSlug())) {
+                throw new WorkspaceConflictException("Duplicate child workspace slug: " + entity.getSlug());
+            }
+        } else if (workspaceRepository.existsByParentIdIsNullAndSlug(entity.getSlug())) {
+            throw new WorkspaceConflictException("Duplicate root workspace slug: " + entity.getSlug());
+        }
+
+        int newDepth = newParent == null ? 0 : newParent.getDepth() + 1;
+        int maxRelativeDepth = relativeDepths.values().stream().max(Integer::compareTo).orElse(0);
+        if (newDepth + maxRelativeDepth > settings.maxDepth()) {
+            throw new WorkspaceValidationException("Workspace max depth exceeded");
+        }
+
+        String oldBasePath = entity.getPath();
+        String newBasePath = newParent == null ? entity.getSlug() : newParent.getPath() + "/" + entity.getSlug();
+        Long newRootId = newParent == null ? entity.getWorkspaceId() : newParent.getRootId();
+        int newPosition = newParent == null ? 0 : (int) workspaceRepository.countByParentId(newParentId);
+
+        List<WorkspaceEntity> subtree = workspaceRepository.findByWorkspaceIdIn(subtreeIds).stream()
+                .sorted(Comparator.comparing(WorkspaceEntity::getDepth))
+                .toList();
+        Long updatedBy = actor.requireUserId();
+        for (WorkspaceEntity descendant : subtree) {
+            String suffix = descendant.getPath().substring(oldBasePath.length());
+            descendant.setRootId(newRootId);
+            descendant.setPath(newBasePath + suffix);
+            descendant.setDepth(newDepth + relativeDepths.get(descendant.getWorkspaceId()));
+            descendant.setUpdatedBy(updatedBy);
+            if (descendant.getWorkspaceId().equals(workspaceId)) {
+                descendant.setParentId(newParentId);
+                descendant.setPosition(newPosition);
+            }
+        }
+        workspaceRepository.saveAll(subtree);
+
+        closureRepository.deleteExternalAncestorsForDescendants(subtreeIds);
+        if (newParent != null) {
+            List<WorkspaceClosureEntity> newParentAncestors =
+                    closureRepository.findByIdDescendantIdOrderByDepthDesc(newParentId);
+            List<WorkspaceClosureEntity> newClosures = new ArrayList<>();
+            for (WorkspaceClosureEntity parentAncestor : newParentAncestors) {
+                for (WorkspaceClosureEntity subtreeClosure : subtreeClosures) {
+                    newClosures.add(new WorkspaceClosureEntity(
+                            parentAncestor.ancestorId(),
+                            subtreeClosure.descendantId(),
+                            parentAncestor.getDepth() + subtreeClosure.getDepth() + 1));
+                }
+            }
+            closureRepository.saveAll(newClosures);
+        }
+        return entity.toRef();
     }
 
     @Override
@@ -308,6 +394,10 @@ public class DefaultWorkspaceTreeService implements WorkspaceTreeService {
 
     private WorkspaceVisibility defaultVisibility(WorkspaceVisibility visibility) {
         return visibility == null ? WorkspaceVisibility.PRIVATE : visibility;
+    }
+
+    private boolean sameParent(Long currentParentId, Long newParentId) {
+        return currentParentId == null ? newParentId == null : currentParentId.equals(newParentId);
     }
 
     private void rejectArchivedMutation(WorkspaceEntity entity) {

--- a/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/web/controller/WorkspaceController.java
+++ b/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/web/controller/WorkspaceController.java
@@ -30,6 +30,7 @@ import studio.one.platform.workspace.service.WorkspacePermissionService;
 import studio.one.platform.workspace.service.WorkspaceTreeService;
 import studio.one.platform.workspace.web.dto.WorkspaceCreateRequest;
 import studio.one.platform.workspace.web.dto.WorkspaceMemberRequest;
+import studio.one.platform.workspace.web.dto.WorkspaceParentChangeRequest;
 import studio.one.platform.workspace.web.dto.WorkspacePermissionSummaryDto;
 import studio.one.platform.workspace.web.dto.WorkspaceUpdateRequest;
 
@@ -102,6 +103,14 @@ public class WorkspaceController extends WorkspaceControllerSupport {
             @PathVariable Long workspaceId,
             @Valid @RequestBody WorkspaceUpdateRequest request) {
         return ResponseEntity.ok(ApiResponse.ok(update(workspaceId, request, false)));
+    }
+
+    @PatchMapping("/{workspaceId:[\\p{Digit}]+}/parent")
+    @PreAuthorize("@endpointAuthz.can('features:workspace','write')")
+    public ResponseEntity<ApiResponse<WorkspaceRef>> changeParent(
+            @PathVariable Long workspaceId,
+            @Valid @RequestBody WorkspaceParentChangeRequest request) {
+        return ResponseEntity.ok(ApiResponse.ok(changeParent(workspaceId, request, false)));
     }
 
     @PostMapping("/{workspaceId:[\\p{Digit}]+}/archive")

--- a/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/web/controller/WorkspaceControllerSupport.java
+++ b/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/web/controller/WorkspaceControllerSupport.java
@@ -14,6 +14,7 @@ import studio.one.platform.workspace.model.WorkspaceRef;
 import studio.one.platform.workspace.model.WorkspaceTreeNode;
 import studio.one.platform.workspace.permission.WorkspacePermissionActions;
 import studio.one.platform.workspace.permission.WorkspacePermissionDefinition;
+import studio.one.platform.workspace.service.ChangeWorkspaceParentCommand;
 import studio.one.platform.workspace.service.CreateWorkspaceCommand;
 import studio.one.platform.workspace.service.UpdateWorkspaceCommand;
 import studio.one.platform.workspace.service.WorkspaceAccessContext;
@@ -24,6 +25,7 @@ import studio.one.platform.workspace.service.WorkspacePermissionService;
 import studio.one.platform.workspace.service.WorkspaceTreeService;
 import studio.one.platform.workspace.web.dto.WorkspaceCreateRequest;
 import studio.one.platform.workspace.web.dto.WorkspaceMemberRequest;
+import studio.one.platform.workspace.web.dto.WorkspaceParentChangeRequest;
 import studio.one.platform.workspace.web.dto.WorkspacePermissionSummaryDto;
 import studio.one.platform.workspace.web.dto.WorkspaceUpdateRequest;
 
@@ -65,6 +67,12 @@ abstract class WorkspaceControllerSupport {
         return treeService.update(workspaceId, new UpdateWorkspaceCommand(
                 request.name(),
                 request.visibility(),
+                context(platformAdmin)));
+    }
+
+    WorkspaceRef changeParent(Long workspaceId, WorkspaceParentChangeRequest request, boolean platformAdmin) {
+        return treeService.changeParent(workspaceId, new ChangeWorkspaceParentCommand(
+                request.newParentId(),
                 context(platformAdmin)));
     }
 

--- a/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/web/controller/WorkspaceMgmtController.java
+++ b/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/web/controller/WorkspaceMgmtController.java
@@ -35,6 +35,7 @@ import studio.one.platform.workspace.service.WorkspacePermissionService;
 import studio.one.platform.workspace.service.WorkspaceTreeService;
 import studio.one.platform.workspace.web.dto.WorkspaceCreateRequest;
 import studio.one.platform.workspace.web.dto.WorkspaceMemberRequest;
+import studio.one.platform.workspace.web.dto.WorkspaceParentChangeRequest;
 import studio.one.platform.workspace.web.dto.WorkspacePermissionSummaryDto;
 import studio.one.platform.workspace.web.dto.WorkspaceUpdateRequest;
 
@@ -112,6 +113,13 @@ public class WorkspaceMgmtController extends WorkspaceControllerSupport {
             @PathVariable Long workspaceId,
             @Valid @RequestBody WorkspaceUpdateRequest request) {
         return ResponseEntity.ok(ApiResponse.ok(update(workspaceId, request, true)));
+    }
+
+    @PatchMapping("/{workspaceId:[\\p{Digit}]+}/parent")
+    public ResponseEntity<ApiResponse<WorkspaceRef>> changeParent(
+            @PathVariable Long workspaceId,
+            @Valid @RequestBody WorkspaceParentChangeRequest request) {
+        return ResponseEntity.ok(ApiResponse.ok(changeParent(workspaceId, request, true)));
     }
 
     @PostMapping("/{workspaceId:[\\p{Digit}]+}/archive")

--- a/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/web/dto/WorkspaceParentChangeRequest.java
+++ b/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/web/dto/WorkspaceParentChangeRequest.java
@@ -1,0 +1,7 @@
+package studio.one.platform.workspace.web.dto;
+
+import jakarta.validation.constraints.Positive;
+
+public record WorkspaceParentChangeRequest(
+        @Positive Long newParentId) {
+}

--- a/studio-platform-workspace-default/src/test/java/studio/one/platform/workspace/service/impl/DefaultWorkspaceServiceTest.java
+++ b/studio-platform-workspace-default/src/test/java/studio/one/platform/workspace/service/impl/DefaultWorkspaceServiceTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.security.access.AccessDeniedException;
 
 import studio.one.platform.workspace.exception.WorkspaceConflictException;
+import studio.one.platform.workspace.exception.WorkspaceNotFoundException;
 import studio.one.platform.workspace.model.WorkspaceRole;
 import studio.one.platform.workspace.model.WorkspaceVisibility;
 import studio.one.platform.workspace.permission.WorkspacePermissionContributor;
@@ -26,6 +27,7 @@ import studio.one.platform.workspace.persistence.jpa.WorkspaceClosureEntity;
 import studio.one.platform.workspace.persistence.jpa.WorkspaceClosureJpaRepository;
 import studio.one.platform.workspace.persistence.jpa.WorkspaceJpaRepository;
 import studio.one.platform.workspace.persistence.jpa.WorkspaceMemberJpaRepository;
+import studio.one.platform.workspace.service.ChangeWorkspaceParentCommand;
 import studio.one.platform.workspace.service.CreateWorkspaceCommand;
 import studio.one.platform.workspace.service.UpdateWorkspaceCommand;
 import studio.one.platform.workspace.service.WorkspaceAccessContext;
@@ -55,6 +57,9 @@ class DefaultWorkspaceServiceTest {
 
     @jakarta.annotation.Resource
     private WorkspaceClosureJpaRepository closureRepository;
+
+    @jakarta.annotation.Resource
+    private WorkspaceJpaRepository workspaceRepository;
 
     @Test
     void createsRootAndChildWithPathClosureAndOwner() {
@@ -143,6 +148,102 @@ class DefaultWorkspaceServiceTest {
         var updated = treeService.getById(root.id(), OWNER);
         assertThat(updated.name()).isEqualTo("Renamed");
         assertThat(updated.visibility()).isEqualTo(WorkspaceVisibility.INTERNAL);
+    }
+
+    @Test
+    void changeParentMovesSubtreeAndRebuildsClosure() {
+        var acme = createRoot("Acme", "acme", OWNER);
+        var engineering = treeService.createChild(acme.id(), createCommand("Engineering", "engineering", OWNER));
+        var backend = treeService.createChild(engineering.id(), createCommand("Backend", "backend", OWNER));
+        var beta = createRoot("Beta", "beta", OWNER);
+
+        var moved = treeService.changeParent(
+                engineering.id(),
+                new ChangeWorkspaceParentCommand(beta.id(), OWNER));
+
+        assertThat(moved.parentId()).isEqualTo(beta.id());
+        assertThat(moved.rootId()).isEqualTo(beta.id());
+        assertThat(moved.path()).isEqualTo("beta/engineering");
+        assertThat(moved.depth()).isEqualTo(1);
+
+        var movedBackend = treeService.getById(backend.id(), OWNER);
+        assertThat(movedBackend.parentId()).isEqualTo(engineering.id());
+        assertThat(movedBackend.rootId()).isEqualTo(beta.id());
+        assertThat(movedBackend.path()).isEqualTo("beta/engineering/backend");
+        assertThat(movedBackend.depth()).isEqualTo(2);
+        assertThat(closureRepository.findAncestorIds(backend.id()))
+                .containsExactly(beta.id(), engineering.id(), backend.id());
+    }
+
+    @Test
+    void changeParentAllowsMovingWorkspaceToRoot() {
+        var acme = createRoot("Acme", "acme", OWNER);
+        var engineering = treeService.createChild(acme.id(), createCommand("Engineering", "engineering", OWNER));
+
+        var moved = treeService.changeParent(
+                engineering.id(),
+                new ChangeWorkspaceParentCommand(null, OWNER));
+
+        assertThat(moved.parentId()).isNull();
+        assertThat(moved.rootId()).isEqualTo(engineering.id());
+        assertThat(moved.path()).isEqualTo("engineering");
+        assertThat(moved.depth()).isZero();
+        assertThat(closureRepository.findAncestorIds(engineering.id()))
+                .containsExactly(engineering.id());
+    }
+
+    @Test
+    void changeParentRejectsCyclesAndDuplicateSiblingSlug() {
+        var acme = createRoot("Acme", "acme", OWNER);
+        var engineering = treeService.createChild(acme.id(), createCommand("Engineering", "engineering", OWNER));
+        var backend = treeService.createChild(engineering.id(), createCommand("Backend", "backend", OWNER));
+        var design = treeService.createChild(acme.id(), createCommand("Design", "design", OWNER));
+        treeService.createChild(design.id(), createCommand("Backend", "backend", OWNER));
+
+        assertThatThrownBy(() -> treeService.changeParent(
+                engineering.id(),
+                new ChangeWorkspaceParentCommand(backend.id(), OWNER)))
+                .isInstanceOf(WorkspaceConflictException.class);
+        assertThatThrownBy(() -> treeService.changeParent(
+                engineering.id(),
+                new ChangeWorkspaceParentCommand(engineering.id(), OWNER)))
+                .isInstanceOf(WorkspaceConflictException.class);
+        assertThatThrownBy(() -> treeService.changeParent(
+                backend.id(),
+                new ChangeWorkspaceParentCommand(design.id(), OWNER)))
+                .isInstanceOf(WorkspaceConflictException.class);
+    }
+
+    @Test
+    void changeParentEnforcesPermissionAndParentExistence() {
+        var acme = createRoot("Acme", "acme", OWNER);
+        var engineering = treeService.createChild(acme.id(), createCommand("Engineering", "engineering", OWNER));
+        var beta = createRoot("Beta", "beta", OWNER);
+        memberService.addMember(acme.id(), new WorkspaceMemberCommand(VIEWER.userId(), WorkspaceRole.VIEWER, OWNER));
+
+        assertThatThrownBy(() -> treeService.changeParent(
+                engineering.id(),
+                new ChangeWorkspaceParentCommand(beta.id(), VIEWER)))
+                .isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(() -> treeService.changeParent(
+                engineering.id(),
+                new ChangeWorkspaceParentCommand(999L, OWNER)))
+                .isInstanceOf(WorkspaceNotFoundException.class);
+    }
+
+    @Test
+    void changeParentRejectsArchivedWorkspaceMutation() {
+        var acme = createRoot("Acme", "acme", OWNER);
+        var engineering = treeService.createChild(acme.id(), createCommand("Engineering", "engineering", OWNER));
+        var beta = createRoot("Beta", "beta", OWNER);
+        treeService.archive(engineering.id(), OWNER);
+
+        assertThatThrownBy(() -> treeService.changeParent(
+                engineering.id(),
+                new ChangeWorkspaceParentCommand(beta.id(), OWNER)))
+                .isInstanceOf(AccessDeniedException.class);
+        assertThat(workspaceRepository.findById(engineering.id()).orElseThrow().getParentId())
+                .isEqualTo(acme.id());
     }
 
     @Test

--- a/studio-platform-workspace-default/src/test/java/studio/one/platform/workspace/web/controller/WorkspaceControllerTest.java
+++ b/studio-platform-workspace-default/src/test/java/studio/one/platform/workspace/web/controller/WorkspaceControllerTest.java
@@ -22,6 +22,7 @@ import studio.one.platform.workspace.model.WorkspaceRole;
 import studio.one.platform.workspace.model.WorkspaceRef;
 import studio.one.platform.workspace.model.WorkspaceVisibility;
 import studio.one.platform.workspace.permission.WorkspacePermissionActions;
+import studio.one.platform.workspace.service.ChangeWorkspaceParentCommand;
 import studio.one.platform.workspace.service.CreateWorkspaceCommand;
 import studio.one.platform.workspace.service.WorkspaceAccessContext;
 import studio.one.platform.workspace.service.WorkspaceListQuery;
@@ -29,6 +30,7 @@ import studio.one.platform.workspace.service.WorkspaceMemberService;
 import studio.one.platform.workspace.service.WorkspacePermissionService;
 import studio.one.platform.workspace.service.WorkspaceTreeService;
 import studio.one.platform.workspace.web.dto.WorkspaceCreateRequest;
+import studio.one.platform.workspace.web.dto.WorkspaceParentChangeRequest;
 
 class WorkspaceControllerTest {
 
@@ -120,6 +122,48 @@ class WorkspaceControllerTest {
         verify(treeService).list(queryCaptor.capture(), eq(pageable), contextCaptor.capture());
         assertThat(queryCaptor.getValue()).isEqualTo(new WorkspaceListQuery("acme", 3L, false, true));
         assertThat(contextCaptor.getValue().platformAdmin()).isTrue();
+    }
+
+    @Test
+    void parentChangeUsesAccessContextAndRequestParentId() {
+        WorkspaceTreeService treeService = org.mockito.Mockito.mock(WorkspaceTreeService.class);
+        WorkspaceMemberService memberService = org.mockito.Mockito.mock(WorkspaceMemberService.class);
+        WorkspacePermissionService permissionService = org.mockito.Mockito.mock(WorkspacePermissionService.class);
+        when(treeService.changeParent(eq(1L), any())).thenReturn(workspace());
+        WorkspaceController controller = new WorkspaceController(
+                treeService,
+                memberService,
+                permissionService,
+                principalProvider("user", false));
+
+        controller.changeParent(1L, new WorkspaceParentChangeRequest(2L));
+
+        ArgumentCaptor<ChangeWorkspaceParentCommand> captor =
+                ArgumentCaptor.forClass(ChangeWorkspaceParentCommand.class);
+        verify(treeService).changeParent(eq(1L), captor.capture());
+        assertThat(captor.getValue().newParentId()).isEqualTo(2L);
+        assertThat(captor.getValue().actor().platformAdmin()).isFalse();
+    }
+
+    @Test
+    void mgmtParentChangeUsesPlatformAdminContext() {
+        WorkspaceTreeService treeService = org.mockito.Mockito.mock(WorkspaceTreeService.class);
+        WorkspaceMemberService memberService = org.mockito.Mockito.mock(WorkspaceMemberService.class);
+        WorkspacePermissionService permissionService = org.mockito.Mockito.mock(WorkspacePermissionService.class);
+        when(treeService.changeParent(eq(1L), any())).thenReturn(workspace());
+        WorkspaceMgmtController controller = new WorkspaceMgmtController(
+                treeService,
+                memberService,
+                permissionService,
+                principalProvider("admin", false));
+
+        controller.changeParent(1L, new WorkspaceParentChangeRequest(null));
+
+        ArgumentCaptor<ChangeWorkspaceParentCommand> captor =
+                ArgumentCaptor.forClass(ChangeWorkspaceParentCommand.class);
+        verify(treeService).changeParent(eq(1L), captor.capture());
+        assertThat(captor.getValue().newParentId()).isNull();
+        assertThat(captor.getValue().actor().platformAdmin()).isTrue();
     }
 
     @Test

--- a/studio-platform-workspace/README.md
+++ b/studio-platform-workspace/README.md
@@ -3,7 +3,7 @@
 Workspace 공통 계약 모듈입니다. 트리형 workspace, member role, effective permission 계산에 필요한 public contract만 제공합니다.
 
 ## 범위
-- `WorkspaceTreeService`: root/child 생성, id/path 조회, children/tree/ancestors/descendants 조회, name/visibility 변경, archive
+- `WorkspaceTreeService`: root/child 생성, parent 변경, id/path 조회, children/tree/ancestors/descendants 조회, name/visibility 변경, archive
 - `WorkspaceMemberService`: direct/effective member 조회, member 추가/역할 변경/제거
 - `WorkspacePermissionService`: role/visibility/ancestor 상속 기반 권한 계산
 - `WorkspacePermissionContributor`: 모듈별 action과 기본 role mapping 확장

--- a/studio-platform-workspace/src/main/java/studio/one/platform/workspace/service/ChangeWorkspaceParentCommand.java
+++ b/studio-platform-workspace/src/main/java/studio/one/platform/workspace/service/ChangeWorkspaceParentCommand.java
@@ -1,0 +1,6 @@
+package studio.one.platform.workspace.service;
+
+public record ChangeWorkspaceParentCommand(
+        Long newParentId,
+        WorkspaceAccessContext actor) {
+}

--- a/studio-platform-workspace/src/main/java/studio/one/platform/workspace/service/WorkspaceTreeService.java
+++ b/studio-platform-workspace/src/main/java/studio/one/platform/workspace/service/WorkspaceTreeService.java
@@ -16,6 +16,8 @@ public interface WorkspaceTreeService {
 
     WorkspaceRef update(Long workspaceId, UpdateWorkspaceCommand command);
 
+    WorkspaceRef changeParent(Long workspaceId, ChangeWorkspaceParentCommand command);
+
     WorkspaceRef getById(Long workspaceId, WorkspaceAccessContext actor);
 
     WorkspaceRef getByPath(String path, WorkspaceAccessContext actor);


### PR DESCRIPTION
## Summary
- Workspace parent 변경 서비스 계약과 사용자용/관리용 API를 추가했습니다.
- `newParentId=null` root 이동을 지원하고, subtree의 `rootId`, `path`, `depth`, closure table을 재계산합니다.
- 자기 자신 또는 descendant 아래 이동, 중복 sibling slug, archived mutation을 거부합니다.

## Issue
- Closes #417

## Permission / Policy
- 사용자용 API는 기존 endpoint write 권한 통과 후 service layer에서 대상 workspace `workspace.update` 권한을 검사합니다.
- 새 parent가 있으면 parent에 `workspace.create` 권한을 추가로 요구합니다.
- 관리용 API는 기존 `features:workspace/manage` 또는 platform `ADMIN` 정책을 유지합니다.

## Validation
- `./gradlew :studio-platform-workspace:build :studio-platform-workspace-default:build :starter:studio-platform-starter-workspace:build`
- `git diff --check`

## AI-Assisted
- Yes
