### PR TITLE
[codex] Workspace parent 변경 500 오류 수정

### DIFF
--- a/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/persistence/jpa/WorkspaceClosureJpaRepository.java
+++ b/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/persistence/jpa/WorkspaceClosureJpaRepository.java
@@ -37,11 +37,10 @@ public interface WorkspaceClosureJpaRepository extends JpaRepository<WorkspaceCl
             """)
     List<WorkspaceClosureEntity> findByDescendantIds(@Param("workspaceIds") Collection<Long> workspaceIds);
 
-    @Modifying
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("""
             delete from WorkspaceClosureEntity c
             where c.id.descendantId in :descendantIds
-              and c.id.ancestorId not in :descendantIds
             """)
-    void deleteExternalAncestorsForDescendants(@Param("descendantIds") Collection<Long> descendantIds);
+    void deleteByDescendantIds(@Param("descendantIds") Collection<Long> descendantIds);
 }

--- a/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/service/impl/DefaultWorkspaceTreeService.java
+++ b/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/service/impl/DefaultWorkspaceTreeService.java
@@ -166,12 +166,12 @@ public class DefaultWorkspaceTreeService implements WorkspaceTreeService {
             return entity.toRef();
         }
 
-        List<WorkspaceClosureEntity> subtreeClosures = closureRepository.findByIdAncestorIdOrderByDepthAsc(workspaceId);
-        Set<Long> subtreeIds = new HashSet<>();
+        List<WorkspaceEntity> subtree = new ArrayList<>();
         Map<Long, Integer> relativeDepths = new HashMap<>();
-        for (WorkspaceClosureEntity closure : subtreeClosures) {
-            subtreeIds.add(closure.descendantId());
-            relativeDepths.put(closure.descendantId(), closure.getDepth());
+        collectSubtree(entity, 0, subtree, relativeDepths, new HashSet<>());
+        Set<Long> subtreeIds = new HashSet<>();
+        for (WorkspaceEntity descendant : subtree) {
+            subtreeIds.add(descendant.getWorkspaceId());
         }
         if (newParentId != null && subtreeIds.contains(newParentId)) {
             throw new WorkspaceConflictException("Workspace cannot be moved under itself or its descendant");
@@ -203,9 +203,6 @@ public class DefaultWorkspaceTreeService implements WorkspaceTreeService {
         Long newRootId = newParent == null ? entity.getWorkspaceId() : newParent.getRootId();
         int newPosition = newParent == null ? 0 : (int) workspaceRepository.countByParentId(newParentId);
 
-        List<WorkspaceEntity> subtree = workspaceRepository.findByWorkspaceIdIn(subtreeIds).stream()
-                .sorted(Comparator.comparing(WorkspaceEntity::getDepth))
-                .toList();
         Long updatedBy = actor.requireUserId();
         for (WorkspaceEntity descendant : subtree) {
             String suffix = descendant.getPath().substring(oldBasePath.length());
@@ -220,21 +217,14 @@ public class DefaultWorkspaceTreeService implements WorkspaceTreeService {
         }
         workspaceRepository.saveAll(subtree);
 
-        closureRepository.deleteExternalAncestorsForDescendants(subtreeIds);
-        if (newParent != null) {
-            List<WorkspaceClosureEntity> newParentAncestors =
-                    closureRepository.findByIdDescendantIdOrderByDepthDesc(newParentId);
-            List<WorkspaceClosureEntity> newClosures = new ArrayList<>();
-            for (WorkspaceClosureEntity parentAncestor : newParentAncestors) {
-                for (WorkspaceClosureEntity subtreeClosure : subtreeClosures) {
-                    newClosures.add(new WorkspaceClosureEntity(
-                            parentAncestor.ancestorId(),
-                            subtreeClosure.descendantId(),
-                            parentAncestor.getDepth() + subtreeClosure.getDepth() + 1));
-                }
-            }
-            closureRepository.saveAll(newClosures);
-        }
+        List<WorkspaceAncestor> newParentAncestors = newParent == null
+                ? List.of()
+                : collectAncestorDistances(newParent);
+        closureRepository.deleteByDescendantIds(subtreeIds);
+        List<WorkspaceClosureEntity> rebuiltClosures = new ArrayList<>();
+        rebuiltClosures.addAll(rebuildAncestorClosureRows(newParentAncestors));
+        rebuiltClosures.addAll(rebuildClosureRows(subtree, relativeDepths, newParentAncestors));
+        closureRepository.saveAll(rebuiltClosures);
         return entity.toRef();
     }
 
@@ -487,6 +477,93 @@ public class DefaultWorkspaceTreeService implements WorkspaceTreeService {
 
     private boolean isReadable(WorkspaceEntity entity, WorkspaceAccessContext actor) {
         return permissionService.isGranted(entity.getWorkspaceId(), actor, WorkspacePermissionActions.READ);
+    }
+
+    private void collectSubtree(
+            WorkspaceEntity entity,
+            int relativeDepth,
+            List<WorkspaceEntity> subtree,
+            Map<Long, Integer> relativeDepths,
+            Set<Long> visited) {
+        if (!visited.add(entity.getWorkspaceId())) {
+            throw new WorkspaceConflictException("Workspace tree contains a cycle");
+        }
+        subtree.add(entity);
+        relativeDepths.put(entity.getWorkspaceId(), relativeDepth);
+        for (WorkspaceEntity child : workspaceRepository.findByParentIdOrderByPositionAscWorkspaceIdAsc(
+                entity.getWorkspaceId())) {
+            collectSubtree(child, relativeDepth + 1, subtree, relativeDepths, visited);
+        }
+    }
+
+    private List<WorkspaceAncestor> collectAncestorDistances(WorkspaceEntity entity) {
+        List<WorkspaceAncestor> ancestors = new ArrayList<>();
+        Set<Long> visited = new HashSet<>();
+        WorkspaceEntity current = entity;
+        int depth = 0;
+        while (current != null) {
+            if (!visited.add(current.getWorkspaceId())) {
+                throw new WorkspaceConflictException("Workspace tree contains a cycle");
+            }
+            ancestors.add(new WorkspaceAncestor(current.getWorkspaceId(), depth));
+            Long parentId = current.getParentId();
+            current = parentId == null ? null : workspace(parentId);
+            depth++;
+        }
+        return ancestors;
+    }
+
+    private List<WorkspaceClosureEntity> rebuildClosureRows(
+            List<WorkspaceEntity> subtree,
+            Map<Long, Integer> relativeDepths,
+            List<WorkspaceAncestor> newParentAncestors) {
+        Map<Long, WorkspaceEntity> subtreeById = new HashMap<>();
+        for (WorkspaceEntity descendant : subtree) {
+            subtreeById.put(descendant.getWorkspaceId(), descendant);
+        }
+
+        List<WorkspaceClosureEntity> closures = new ArrayList<>();
+        for (WorkspaceEntity descendant : subtree) {
+            Long descendantId = descendant.getWorkspaceId();
+            int descendantRelativeDepth = relativeDepths.get(descendantId);
+            closures.add(new WorkspaceClosureEntity(descendantId, descendantId, 0));
+
+            Long ancestorId = descendant.getParentId();
+            while (ancestorId != null && subtreeById.containsKey(ancestorId)) {
+                int ancestorRelativeDepth = relativeDepths.get(ancestorId);
+                closures.add(new WorkspaceClosureEntity(
+                        ancestorId,
+                        descendantId,
+                        descendantRelativeDepth - ancestorRelativeDepth));
+                ancestorId = subtreeById.get(ancestorId).getParentId();
+            }
+
+            for (WorkspaceAncestor ancestor : newParentAncestors) {
+                closures.add(new WorkspaceClosureEntity(
+                        ancestor.workspaceId(),
+                        descendantId,
+                        ancestor.depthToNewParent() + descendantRelativeDepth + 1));
+            }
+        }
+        return closures;
+    }
+
+    private List<WorkspaceClosureEntity> rebuildAncestorClosureRows(List<WorkspaceAncestor> ancestors) {
+        List<WorkspaceClosureEntity> closures = new ArrayList<>();
+        for (WorkspaceAncestor descendant : ancestors) {
+            for (WorkspaceAncestor ancestor : ancestors) {
+                if (ancestor.depthToNewParent() >= descendant.depthToNewParent()) {
+                    closures.add(new WorkspaceClosureEntity(
+                            ancestor.workspaceId(),
+                            descendant.workspaceId(),
+                            ancestor.depthToNewParent() - descendant.depthToNewParent()));
+                }
+            }
+        }
+        return closures;
+    }
+
+    private record WorkspaceAncestor(Long workspaceId, int depthToNewParent) {
     }
 
     private static final class WorkspaceTreeNodeBuilder {

--- a/studio-platform-workspace-default/src/test/java/studio/one/platform/workspace/service/impl/DefaultWorkspaceServiceTest.java
+++ b/studio-platform-workspace-default/src/test/java/studio/one/platform/workspace/service/impl/DefaultWorkspaceServiceTest.java
@@ -176,6 +176,53 @@ class DefaultWorkspaceServiceTest {
     }
 
     @Test
+    void changeParentRebuildsMissingClosureRowsFromParentTree() {
+        var acme = createRoot("Acme", "acme", OWNER);
+        var engineering = treeService.createChild(acme.id(), createCommand("Engineering", "engineering", OWNER));
+        var backend = treeService.createChild(engineering.id(), createCommand("Backend", "backend", OWNER));
+        var beta = createRoot("Beta", "beta", OWNER);
+        closureRepository.deleteAll();
+
+        var moved = treeService.changeParent(
+                engineering.id(),
+                new ChangeWorkspaceParentCommand(beta.id(), PLATFORM_ADMIN));
+
+        assertThat(moved.parentId()).isEqualTo(beta.id());
+        assertThat(moved.rootId()).isEqualTo(beta.id());
+        assertThat(moved.path()).isEqualTo("beta/engineering");
+        assertThat(treeService.getById(backend.id(), PLATFORM_ADMIN).path())
+                .isEqualTo("beta/engineering/backend");
+        assertThat(closureRepository.findAncestorIds(beta.id()))
+                .containsExactly(beta.id());
+        assertThat(closureRepository.findAncestorIds(backend.id()))
+                .containsExactly(beta.id(), engineering.id(), backend.id());
+        assertThat(treeService.getTree(beta.id(), PLATFORM_ADMIN).children())
+                .extracting(node -> node.workspace().id())
+                .containsExactly(engineering.id());
+    }
+
+    @Test
+    void changeParentMovesRootLeafWhenClosureRowsAreMissing() {
+        var acme = createRoot("Acme", "acme", OWNER);
+        var beta = createRoot("Beta", "beta", OWNER);
+        closureRepository.deleteAll();
+
+        var moved = treeService.changeParent(
+                acme.id(),
+                new ChangeWorkspaceParentCommand(beta.id(), PLATFORM_ADMIN));
+
+        assertThat(moved.parentId()).isEqualTo(beta.id());
+        assertThat(moved.rootId()).isEqualTo(beta.id());
+        assertThat(moved.path()).isEqualTo("beta/acme");
+        assertThat(moved.depth()).isEqualTo(1);
+        assertThat(closureRepository.findAncestorIds(acme.id()))
+                .containsExactly(beta.id(), acme.id());
+        assertThat(treeService.getTree(beta.id(), PLATFORM_ADMIN).children())
+                .extracting(node -> node.workspace().id())
+                .containsExactly(acme.id());
+    }
+
+    @Test
     void changeParentAllowsMovingWorkspaceToRoot() {
         var acme = createRoot("Acme", "acme", OWNER);
         var engineering = treeService.createChild(acme.id(), createCommand("Engineering", "engineering", OWNER));


### PR DESCRIPTION
## Why

- Workspace parent 변경 API가 기존 `TB_PLATFORM_WORKSPACE_CLOSURE` row 상태에 의존해 정상 parent 이동에서도 500으로 실패할 수 있었습니다.
- 이슈 #419의 재현 케이스처럼 child 없는 root workspace 이동과 `newParentId: null` root 이동이 명확한 4xx 또는 정상 응답으로 처리되어야 합니다.

## What

- `DefaultWorkspaceTreeService.changeParent`가 closure table 대신 `parentId` 기반 트리에서 subtree를 수집하도록 변경했습니다.
- parent 변경 후 이동된 subtree의 closure row를 삭제하고 현재 parent 관계 기준으로 재생성하도록 보강했습니다.
- 새 parent 쪽 ancestor closure row가 누락된 데이터도 함께 복구해 후속 tree 조회가 정상 동작하도록 했습니다.
- closure row가 누락된 상태의 subtree 이동과 root leaf 이동 회귀 테스트를 추가했습니다.

## Related Issues

- Closes #419

## Validation

- Command: `./gradlew :studio-platform-workspace-default:test --tests 'studio.one.platform.workspace.service.impl.DefaultWorkspaceServiceTest'`
- Result: PASS
- Command: `./gradlew :studio-platform-workspace:build :studio-platform-workspace-default:build :starter:studio-platform-starter-workspace:build`
- Result: PASS
- Command: `git diff --check`
- Result: PASS

## Risk / Rollback

- Risk: parent 변경 시 subtree와 새 parent ancestor의 closure row를 재생성하므로, parentId 데이터 자체가 이미 순환 상태인 경우 409 계열 충돌로 처리됩니다.
- Rollback: 이 커밋을 revert하면 기존 closure table 기반 parent 변경 로직으로 돌아갑니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope:
- Main author validation: 위 Gradle 테스트, workspace starter 빌드, `git diff --check`를 실행했습니다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
