### PR TITLE
[codex] Workspace 멤버 목록 서버 페이징 API 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### 변경됨
+- 이슈 #421 대응으로 Workspace direct/effective member 목록 조회 API를 서버 페이징 응답으로 전환했다. `q`/`keyword`, `role`, `inherited`, pagination, sort를 지원하고 `keyword`는 사용자 `username`/`name`/`email` 및 숫자 `userId` 검색에 사용한다.
 - 이슈 #417 대응으로 Workspace parent 변경 API `PATCH /api/workspaces/{workspaceId}/parent`, `PATCH /api/mgmt/workspaces/{workspaceId}/parent`를 추가했다. `newParentId=null`은 root 이동으로 처리하고, subtree의 `rootId`/`path`/`depth`와 closure table을 재계산하며 자기 자신 또는 descendant 아래 이동은 거부한다.
 - 이슈 #415 대응으로 `studio-application-modules:wiki-service`와 `starter:studio-application-starter-wiki`를 추가해 workspace 단위 Wiki page/revision MVP, 사용자용/관리용 API, markdown render/sanitize, 기존 page write의 `baseRevisionId` 충돌 검증, JPA schema `V1400`을 제공한다.
 - 이슈 #412 대응으로 Workspace 관리 화면 진입용 `GET /api/mgmt/workspaces` 목록 조회 API를 추가했다. `q`, `parentId`, `rootOnly`, `archived`, pagination, sort를 지원하고 기존 관리용 권한 정책을 적용한다.

--- a/starter/studio-platform-starter-workspace/README.md
+++ b/starter/studio-platform-starter-workspace/README.md
@@ -47,6 +47,13 @@ studio:
 
 관리 화면에서 전체 workspace 목록을 시작점으로 조회할 때는 `GET /api/mgmt/workspaces`를 사용합니다. `q`, `parentId`, `rootOnly`, `archived`, `page`, `size`, `sort` query parameter를 지원하며 기본 정렬은 `path ASC`입니다.
 
+Workspace member 목록은 사용자용/관리용 경로 모두에서 서버 페이징으로 조회합니다.
+
+- `GET {base-path}/{workspaceId}/members`
+- `GET {base-path}/{workspaceId}/members/effective`
+
+지원 query parameter는 `q`, `keyword`, `role`, `inherited`, `page`, `size`, `sort`입니다. `keyword`는 `q`보다 우선하며 사용자 `username`, `name`, `email`과 숫자 `userId`를 검색합니다. direct member 목록은 항상 `inherited=false`이므로 `inherited=true` 요청 시 빈 페이지를 반환합니다. 응답은 `content`, `totalElements`, `totalPages`, `number`, `size`를 포함하는 `Page<WorkspaceMemberRef>` 형태입니다.
+
 Workspace parent 변경은 사용자용/관리용 경로 모두에서 `PATCH {base-path}/{workspaceId}/parent`로 제공합니다. 요청 body의 `newParentId`가 `null`이면 root로 이동합니다.
 
 ```json

--- a/starter/studio-platform-starter-workspace/src/main/java/studio/one/platform/workspace/autoconfigure/WorkspaceAutoConfiguration.java
+++ b/starter/studio-platform-starter-workspace/src/main/java/studio/one/platform/workspace/autoconfigure/WorkspaceAutoConfiguration.java
@@ -2,6 +2,7 @@ package studio.one.platform.workspace.autoconfigure;
 
 import java.util.List;
 
+import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 
 import org.springframework.beans.factory.ObjectProvider;
@@ -95,12 +96,14 @@ public class WorkspaceAutoConfiguration {
             WorkspaceJpaRepository workspaceRepository,
             WorkspaceClosureJpaRepository closureRepository,
             WorkspaceMemberJpaRepository memberRepository,
-            WorkspacePermissionService permissionService) {
+            WorkspacePermissionService permissionService,
+            EntityManager entityManager) {
         return new DefaultWorkspaceMemberService(
                 workspaceRepository,
                 closureRepository,
                 memberRepository,
-                permissionService);
+                permissionService,
+                entityManager);
     }
 
     @Configuration

--- a/studio-platform-workspace-default/README.md
+++ b/studio-platform-workspace-default/README.md
@@ -44,6 +44,15 @@ parent 변경 시 대상 subtree의 `parentId`, `rootId`, `path`, `depth`와 clo
 
 관리용 기본 경로는 `/api/mgmt/workspaces`이며 같은 endpoint shape를 제공합니다. 관리용 API는 `features:workspace/manage` 또는 platform `ADMIN` role을 요구합니다.
 
+member 목록 조회는 사용자용/관리용 경로 모두 서버 페이징 응답을 반환합니다.
+
+- `GET {base-path}/{workspaceId}/members`
+- `GET {base-path}/{workspaceId}/members/effective`
+
+지원 query parameter는 `q`, `keyword`, `role`, `inherited`, `page`, `size`, `sort`입니다. `keyword`가 있으면 `q`보다 우선하며 사용자 `username`, `name`, `email`과 숫자 `userId`를 검색합니다. `role`은 `VIEWER`, `EDITOR`, `ADMIN`, `OWNER` 중 하나입니다. `inherited=true`는 inherited effective member만 조회할 때 사용하며 direct member 목록에서는 결과가 없습니다. 정렬은 `userId`, `workspaceId`, `role`을 지원하고 effective member 목록은 `inherited` 정렬도 지원합니다.
+
+응답은 Spring Data `Page<WorkspaceMemberRef>` 형태이며 `content`, `totalElements`, `totalPages`, `number`, `size`를 포함합니다. `WorkspaceMemberRef` item은 `workspaceId`, `userId`, `role`, `inherited`를 포함합니다.
+
 parent 변경 request body:
 
 ```json

--- a/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/persistence/jpa/WorkspaceMemberJpaRepository.java
+++ b/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/persistence/jpa/WorkspaceMemberJpaRepository.java
@@ -5,8 +5,10 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface WorkspaceMemberJpaRepository extends JpaRepository<WorkspaceMemberEntity, Long> {
+public interface WorkspaceMemberJpaRepository
+        extends JpaRepository<WorkspaceMemberEntity, Long>, JpaSpecificationExecutor<WorkspaceMemberEntity> {
 
     Optional<WorkspaceMemberEntity> findByWorkspaceIdAndUserId(Long workspaceId, Long userId);
 

--- a/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/service/impl/DefaultWorkspaceMemberService.java
+++ b/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/service/impl/DefaultWorkspaceMemberService.java
@@ -1,9 +1,24 @@
 package studio.one.platform.workspace.service.impl;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.Predicate;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
@@ -19,16 +34,33 @@ import studio.one.platform.workspace.persistence.jpa.WorkspaceMemberEntity;
 import studio.one.platform.workspace.persistence.jpa.WorkspaceMemberJpaRepository;
 import studio.one.platform.workspace.service.WorkspaceAccessContext;
 import studio.one.platform.workspace.service.WorkspaceMemberCommand;
+import studio.one.platform.workspace.service.WorkspaceMemberListQuery;
 import studio.one.platform.workspace.service.WorkspaceMemberService;
 import studio.one.platform.workspace.service.WorkspacePermissionService;
 
 @RequiredArgsConstructor
 public class DefaultWorkspaceMemberService implements WorkspaceMemberService {
 
+    private static final int DEFAULT_PAGE_SIZE = 20;
+    private static final int MAX_PAGE_SIZE = 200;
+    private static final Sort DEFAULT_MEMBER_SORT = Sort.by("userId").ascending();
+    private static final Map<String, String> JPA_SORT_PROPERTIES = Map.ofEntries(
+            Map.entry("id", "userId"),
+            Map.entry("userId", "userId"),
+            Map.entry("workspaceId", "workspaceId"),
+            Map.entry("role", "role"));
+    private static final Map<String, String> REF_SORT_PROPERTIES = Map.ofEntries(
+            Map.entry("id", "userId"),
+            Map.entry("userId", "userId"),
+            Map.entry("workspaceId", "workspaceId"),
+            Map.entry("role", "role"),
+            Map.entry("inherited", "inherited"));
+
     private final WorkspaceJpaRepository workspaceRepository;
     private final WorkspaceClosureJpaRepository closureRepository;
     private final WorkspaceMemberJpaRepository memberRepository;
     private final WorkspacePermissionService permissionService;
+    private final EntityManager entityManager;
 
     @Override
     @Transactional
@@ -83,12 +115,75 @@ public class DefaultWorkspaceMemberService implements WorkspaceMemberService {
 
     @Override
     @Transactional(readOnly = true)
+    public Page<WorkspaceMemberRef> getDirectMembers(
+            Long workspaceId,
+            WorkspaceMemberListQuery query,
+            Pageable pageable,
+            WorkspaceAccessContext actor) {
+        requireWorkspace(workspaceId);
+        permissionService.assertGranted(workspaceId, actor, WorkspacePermissionActions.MEMBER_READ);
+        WorkspaceMemberListQuery resolved = queryOrAll(query);
+        Pageable safePageable = safeMemberPageable(pageable, false);
+        if (Boolean.TRUE.equals(resolved.inherited())) {
+            return Page.empty(safePageable);
+        }
+        Set<Long> matchedUserIds = matchedUserIds(resolved, List.of(workspaceId));
+        if (resolved.hasKeyword() && matchedUserIds.isEmpty()) {
+            return Page.empty(safePageable);
+        }
+        return memberRepository.findAll(
+                        directMemberSpecification(workspaceId, resolved, matchedUserIds),
+                        safePageable)
+                .map(member -> member.toRef(false));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public List<WorkspaceMemberRef> getEffectiveMembers(Long workspaceId, WorkspaceAccessContext actor) {
         requireWorkspace(workspaceId);
         permissionService.assertGranted(workspaceId, actor, WorkspacePermissionActions.MEMBER_READ);
+        return effectiveMemberList(workspaceId, WorkspaceMemberListQuery.all(), null);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<WorkspaceMemberRef> getEffectiveMembers(
+            Long workspaceId,
+            WorkspaceMemberListQuery query,
+            Pageable pageable,
+            WorkspaceAccessContext actor) {
+        requireWorkspace(workspaceId);
+        permissionService.assertGranted(workspaceId, actor, WorkspacePermissionActions.MEMBER_READ);
+        WorkspaceMemberListQuery resolved = queryOrAll(query);
+        Pageable safePageable = safeMemberPageable(pageable, true);
         List<Long> ancestorIds = closureRepository.findAncestorIds(workspaceId);
+        Set<Long> matchedUserIds = matchedUserIds(resolved, ancestorIds);
+        if (resolved.hasKeyword() && matchedUserIds.isEmpty()) {
+            return Page.empty(safePageable);
+        }
+        List<WorkspaceMemberRef> filtered = effectiveMemberList(workspaceId, ancestorIds, resolved, matchedUserIds).stream()
+                .sorted(memberRefComparator(safePageable.getSort()))
+                .toList();
+        return page(filtered, safePageable);
+    }
+
+    private List<WorkspaceMemberRef> effectiveMemberList(
+            Long workspaceId,
+            WorkspaceMemberListQuery query,
+            Set<Long> matchedUserIds) {
+        return effectiveMemberList(workspaceId, closureRepository.findAncestorIds(workspaceId), query, matchedUserIds);
+    }
+
+    private List<WorkspaceMemberRef> effectiveMemberList(
+            Long workspaceId,
+            List<Long> ancestorIds,
+            WorkspaceMemberListQuery query,
+            Set<Long> matchedUserIds) {
         Map<Long, WorkspaceMemberRef> strongest = new LinkedHashMap<>();
         for (WorkspaceMemberEntity member : memberRepository.findByWorkspaceIdIn(ancestorIds)) {
+            if (matchedUserIds != null && !matchedUserIds.contains(member.getUserId())) {
+                continue;
+            }
             WorkspaceMemberRef existing = strongest.get(member.getUserId());
             boolean inherited = !workspaceId.equals(member.getWorkspaceId());
             if (existing == null
@@ -102,8 +197,123 @@ public class DefaultWorkspaceMemberService implements WorkspaceMemberService {
             }
         }
         return strongest.values().stream()
+                .filter(member -> query.role() == null || member.role() == query.role())
+                .filter(member -> query.inherited() == null || member.inherited() == query.inherited())
                 .sorted((left, right) -> Long.compare(left.userId(), right.userId()))
                 .toList();
+    }
+
+    private Specification<WorkspaceMemberEntity> directMemberSpecification(
+            Long workspaceId,
+            WorkspaceMemberListQuery query,
+            Set<Long> matchedUserIds) {
+        return (root, criteria, builder) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            predicates.add(builder.equal(root.get("workspaceId"), workspaceId));
+            if (query.role() != null) {
+                predicates.add(builder.equal(root.get("role"), query.role()));
+            }
+            if (matchedUserIds != null) {
+                predicates.add(root.get("userId").in(matchedUserIds));
+            }
+            return builder.and(predicates.toArray(Predicate[]::new));
+        };
+    }
+
+    private Set<Long> matchedUserIds(WorkspaceMemberListQuery query, Collection<Long> workspaceIds) {
+        String keyword = query.normalizedKeyword();
+        if (keyword == null) {
+            return null;
+        }
+        if (workspaceIds == null || workspaceIds.isEmpty()) {
+            return Set.of();
+        }
+        Set<Long> result = new LinkedHashSet<>();
+        try {
+            result.add(Long.parseLong(keyword));
+        } catch (NumberFormatException ignored) {
+            // Numeric keyword support is additive; non-numeric keywords use user metadata search.
+        }
+        String pattern = "%" + escapeLike(keyword.toLowerCase(Locale.ROOT)) + "%";
+        @SuppressWarnings("unchecked")
+        List<Number> rows = entityManager.createNativeQuery("""
+                        select distinct m.USER_ID
+                          from TB_PLATFORM_WORKSPACE_MEMBER m
+                          left join TB_APPLICATION_USER u on u.USER_ID = m.USER_ID
+                         where m.WORKSPACE_ID in (:workspaceIds)
+                           and (lower(coalesce(u.USERNAME, '')) like :pattern escape '!'
+                            or lower(coalesce(u.NAME, '')) like :pattern escape '!'
+                            or lower(coalesce(u.EMAIL, '')) like :pattern escape '!')
+                        """)
+                .setParameter("workspaceIds", workspaceIds)
+                .setParameter("pattern", pattern)
+                .getResultList();
+        rows.forEach(row -> result.add(row.longValue()));
+        return result;
+    }
+
+    private WorkspaceMemberListQuery queryOrAll(WorkspaceMemberListQuery query) {
+        return query == null ? WorkspaceMemberListQuery.all() : query;
+    }
+
+    private Pageable safeMemberPageable(Pageable pageable, boolean includeInheritedSort) {
+        if (pageable == null || pageable.isUnpaged()) {
+            return PageRequest.of(0, DEFAULT_PAGE_SIZE, DEFAULT_MEMBER_SORT);
+        }
+        int page = Math.max(pageable.getPageNumber(), 0);
+        int size = Math.min(Math.max(pageable.getPageSize(), 1), MAX_PAGE_SIZE);
+        Sort sort = includeInheritedSort
+                ? safeSort(pageable.getSort(), REF_SORT_PROPERTIES)
+                : safeSort(pageable.getSort(), JPA_SORT_PROPERTIES);
+        return PageRequest.of(page, size, sort);
+    }
+
+    private Sort safeSort(Sort requested, Map<String, String> properties) {
+        if (requested == null || requested.isUnsorted()) {
+            return DEFAULT_MEMBER_SORT;
+        }
+        List<Sort.Order> orders = requested.stream()
+                .map(order -> {
+                    String property = properties.get(order.getProperty());
+                    if (property == null) {
+                        return null;
+                    }
+                    return new Sort.Order(order.getDirection(), property);
+                })
+                .filter(order -> order != null)
+                .toList();
+        return orders.isEmpty() ? DEFAULT_MEMBER_SORT : Sort.by(orders);
+    }
+
+    private Comparator<WorkspaceMemberRef> memberRefComparator(Sort sort) {
+        Comparator<WorkspaceMemberRef> comparator = null;
+        for (Sort.Order order : sort) {
+            Comparator<WorkspaceMemberRef> next = switch (order.getProperty()) {
+                case "workspaceId" -> Comparator.comparing(WorkspaceMemberRef::workspaceId);
+                case "role" -> Comparator.comparing(member -> member.role().rank());
+                case "inherited" -> Comparator.comparing(WorkspaceMemberRef::inherited);
+                case "userId" -> Comparator.comparing(WorkspaceMemberRef::userId);
+                default -> Comparator.comparing(WorkspaceMemberRef::userId);
+            };
+            if (order.isDescending()) {
+                next = next.reversed();
+            }
+            comparator = comparator == null ? next : comparator.thenComparing(next);
+        }
+        return comparator == null ? Comparator.comparing(WorkspaceMemberRef::userId) : comparator;
+    }
+
+    private Page<WorkspaceMemberRef> page(List<WorkspaceMemberRef> members, Pageable pageable) {
+        int start = Math.toIntExact(Math.min(pageable.getOffset(), members.size()));
+        int end = Math.min(start + pageable.getPageSize(), members.size());
+        return new PageImpl<>(members.subList(start, end), pageable, members.size());
+    }
+
+    private String escapeLike(String value) {
+        return value
+                .replace("!", "!!")
+                .replace("%", "!%")
+                .replace("_", "!_");
     }
 
     private WorkspaceAccessContext requireActor(WorkspaceAccessContext actor) {

--- a/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/web/controller/WorkspaceController.java
+++ b/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/web/controller/WorkspaceController.java
@@ -5,6 +5,10 @@ import java.util.List;
 import jakarta.validation.Valid;
 
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
@@ -23,6 +27,7 @@ import studio.one.platform.identity.PrincipalResolver;
 import studio.one.platform.web.dto.ApiResponse;
 import studio.one.platform.workspace.model.WorkspaceMemberRef;
 import studio.one.platform.workspace.model.WorkspaceRef;
+import studio.one.platform.workspace.model.WorkspaceRole;
 import studio.one.platform.workspace.model.WorkspaceTreeNode;
 import studio.one.platform.workspace.permission.WorkspacePermissionDefinition;
 import studio.one.platform.workspace.service.WorkspaceMemberService;
@@ -122,14 +127,40 @@ public class WorkspaceController extends WorkspaceControllerSupport {
 
     @GetMapping("/{workspaceId:[\\p{Digit}]+}/members")
     @PreAuthorize("@endpointAuthz.can('features:workspace','read')")
-    public ResponseEntity<ApiResponse<List<WorkspaceMemberRef>>> members(@PathVariable Long workspaceId) {
-        return ResponseEntity.ok(ApiResponse.ok(directMembers(workspaceId, false)));
+    public ResponseEntity<ApiResponse<Page<WorkspaceMemberRef>>> members(
+            @PathVariable Long workspaceId,
+            @RequestParam(value = "q", required = false) String q,
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam(value = "role", required = false) WorkspaceRole role,
+            @RequestParam(value = "inherited", required = false) Boolean inherited,
+            @PageableDefault(size = 20, sort = "userId", direction = Sort.Direction.ASC) Pageable pageable) {
+        return ResponseEntity.ok(ApiResponse.ok(directMembers(
+                workspaceId,
+                q,
+                keyword,
+                role,
+                inherited,
+                pageable,
+                false)));
     }
 
     @GetMapping("/{workspaceId:[\\p{Digit}]+}/members/effective")
     @PreAuthorize("@endpointAuthz.can('features:workspace','read')")
-    public ResponseEntity<ApiResponse<List<WorkspaceMemberRef>>> effectiveMembers(@PathVariable Long workspaceId) {
-        return ResponseEntity.ok(ApiResponse.ok(effectiveMembers(workspaceId, false)));
+    public ResponseEntity<ApiResponse<Page<WorkspaceMemberRef>>> effectiveMembers(
+            @PathVariable Long workspaceId,
+            @RequestParam(value = "q", required = false) String q,
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam(value = "role", required = false) WorkspaceRole role,
+            @RequestParam(value = "inherited", required = false) Boolean inherited,
+            @PageableDefault(size = 20, sort = "userId", direction = Sort.Direction.ASC) Pageable pageable) {
+        return ResponseEntity.ok(ApiResponse.ok(effectiveMembers(
+                workspaceId,
+                q,
+                keyword,
+                role,
+                inherited,
+                pageable,
+                false)));
     }
 
     @PostMapping("/{workspaceId:[\\p{Digit}]+}/members")

--- a/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/web/controller/WorkspaceControllerSupport.java
+++ b/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/web/controller/WorkspaceControllerSupport.java
@@ -11,6 +11,7 @@ import studio.one.platform.identity.ApplicationPrincipal;
 import studio.one.platform.identity.PrincipalResolver;
 import studio.one.platform.workspace.model.WorkspaceMemberRef;
 import studio.one.platform.workspace.model.WorkspaceRef;
+import studio.one.platform.workspace.model.WorkspaceRole;
 import studio.one.platform.workspace.model.WorkspaceTreeNode;
 import studio.one.platform.workspace.permission.WorkspacePermissionActions;
 import studio.one.platform.workspace.permission.WorkspacePermissionDefinition;
@@ -20,6 +21,7 @@ import studio.one.platform.workspace.service.UpdateWorkspaceCommand;
 import studio.one.platform.workspace.service.WorkspaceAccessContext;
 import studio.one.platform.workspace.service.WorkspaceListQuery;
 import studio.one.platform.workspace.service.WorkspaceMemberCommand;
+import studio.one.platform.workspace.service.WorkspaceMemberListQuery;
 import studio.one.platform.workspace.service.WorkspaceMemberService;
 import studio.one.platform.workspace.service.WorkspacePermissionService;
 import studio.one.platform.workspace.service.WorkspaceTreeService;
@@ -134,6 +136,36 @@ abstract class WorkspaceControllerSupport {
         return memberService.getEffectiveMembers(workspaceId, context(platformAdmin));
     }
 
+    Page<WorkspaceMemberRef> directMembers(
+            Long workspaceId,
+            String q,
+            String keyword,
+            WorkspaceRole role,
+            Boolean inherited,
+            Pageable pageable,
+            boolean platformAdmin) {
+        return memberService.getDirectMembers(
+                workspaceId,
+                memberListQuery(q, keyword, role, inherited),
+                pageable,
+                context(platformAdmin));
+    }
+
+    Page<WorkspaceMemberRef> effectiveMembers(
+            Long workspaceId,
+            String q,
+            String keyword,
+            WorkspaceRole role,
+            Boolean inherited,
+            Pageable pageable,
+            boolean platformAdmin) {
+        return memberService.getEffectiveMembers(
+                workspaceId,
+                memberListQuery(q, keyword, role, inherited),
+                pageable,
+                context(platformAdmin));
+    }
+
     WorkspacePermissionSummaryDto myPermissions(Long workspaceId, boolean platformAdmin) {
         WorkspaceAccessContext context = context(platformAdmin);
         permissionService.assertGranted(workspaceId, context, WorkspacePermissionActions.READ);
@@ -146,6 +178,15 @@ abstract class WorkspaceControllerSupport {
 
     List<WorkspacePermissionDefinition> permissionActions() {
         return permissionService.getPermissionDefinitions();
+    }
+
+    private WorkspaceMemberListQuery memberListQuery(
+            String q,
+            String keyword,
+            WorkspaceRole role,
+            Boolean inherited) {
+        String resolvedKeyword = keyword != null && !keyword.isBlank() ? keyword : q;
+        return new WorkspaceMemberListQuery(resolvedKeyword, role, inherited);
     }
 
     WorkspaceAccessContext context(boolean platformAdmin) {

--- a/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/web/controller/WorkspaceMgmtController.java
+++ b/studio-platform-workspace-default/src/main/java/studio/one/platform/workspace/web/controller/WorkspaceMgmtController.java
@@ -27,6 +27,7 @@ import studio.one.platform.identity.PrincipalResolver;
 import studio.one.platform.web.dto.ApiResponse;
 import studio.one.platform.workspace.model.WorkspaceMemberRef;
 import studio.one.platform.workspace.model.WorkspaceRef;
+import studio.one.platform.workspace.model.WorkspaceRole;
 import studio.one.platform.workspace.model.WorkspaceTreeNode;
 import studio.one.platform.workspace.permission.WorkspacePermissionDefinition;
 import studio.one.platform.workspace.service.WorkspaceListQuery;
@@ -129,13 +130,39 @@ public class WorkspaceMgmtController extends WorkspaceControllerSupport {
     }
 
     @GetMapping("/{workspaceId:[\\p{Digit}]+}/members")
-    public ResponseEntity<ApiResponse<List<WorkspaceMemberRef>>> members(@PathVariable Long workspaceId) {
-        return ResponseEntity.ok(ApiResponse.ok(directMembers(workspaceId, true)));
+    public ResponseEntity<ApiResponse<Page<WorkspaceMemberRef>>> members(
+            @PathVariable Long workspaceId,
+            @RequestParam(value = "q", required = false) String q,
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam(value = "role", required = false) WorkspaceRole role,
+            @RequestParam(value = "inherited", required = false) Boolean inherited,
+            @PageableDefault(size = 20, sort = "userId", direction = Sort.Direction.ASC) Pageable pageable) {
+        return ResponseEntity.ok(ApiResponse.ok(directMembers(
+                workspaceId,
+                q,
+                keyword,
+                role,
+                inherited,
+                pageable,
+                true)));
     }
 
     @GetMapping("/{workspaceId:[\\p{Digit}]+}/members/effective")
-    public ResponseEntity<ApiResponse<List<WorkspaceMemberRef>>> effectiveMembers(@PathVariable Long workspaceId) {
-        return ResponseEntity.ok(ApiResponse.ok(effectiveMembers(workspaceId, true)));
+    public ResponseEntity<ApiResponse<Page<WorkspaceMemberRef>>> effectiveMembers(
+            @PathVariable Long workspaceId,
+            @RequestParam(value = "q", required = false) String q,
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam(value = "role", required = false) WorkspaceRole role,
+            @RequestParam(value = "inherited", required = false) Boolean inherited,
+            @PageableDefault(size = 20, sort = "userId", direction = Sort.Direction.ASC) Pageable pageable) {
+        return ResponseEntity.ok(ApiResponse.ok(effectiveMembers(
+                workspaceId,
+                q,
+                keyword,
+                role,
+                inherited,
+                pageable,
+                true)));
     }
 
     @PostMapping("/{workspaceId:[\\p{Digit}]+}/members")

--- a/studio-platform-workspace-default/src/test/java/studio/one/platform/workspace/service/impl/DefaultWorkspaceServiceTest.java
+++ b/studio-platform-workspace-default/src/test/java/studio/one/platform/workspace/service/impl/DefaultWorkspaceServiceTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 
+import jakarta.persistence.EntityManager;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.SpringBootConfiguration;
@@ -33,6 +35,7 @@ import studio.one.platform.workspace.service.UpdateWorkspaceCommand;
 import studio.one.platform.workspace.service.WorkspaceAccessContext;
 import studio.one.platform.workspace.service.WorkspaceListQuery;
 import studio.one.platform.workspace.service.WorkspaceMemberCommand;
+import studio.one.platform.workspace.service.WorkspaceMemberListQuery;
 import studio.one.platform.workspace.service.WorkspaceMemberService;
 import studio.one.platform.workspace.service.WorkspacePermissionService;
 import studio.one.platform.workspace.service.WorkspaceTreeService;
@@ -60,6 +63,9 @@ class DefaultWorkspaceServiceTest {
 
     @jakarta.annotation.Resource
     private WorkspaceJpaRepository workspaceRepository;
+
+    @jakarta.annotation.Resource
+    private EntityManager entityManager;
 
     @Test
     void createsRootAndChildWithPathClosureAndOwner() {
@@ -117,6 +123,82 @@ class DefaultWorkspaceServiceTest {
                 .filteredOn(member -> member.userId().equals(EDITOR.userId()))
                 .singleElement()
                 .satisfies(member -> assertThat(member.inherited()).isFalse());
+    }
+
+    @Test
+    void directMembersSupportServerPagingRoleAndKeywordSearch() {
+        var root = createRoot("Acme", "acme", OWNER);
+        insertUser(20L, "alice", "Alice Park", "alice@example.com");
+        insertUser(21L, "bob", "Bob Lee", "bob@example.com");
+        insertUser(22L, "carol", "Carol Kim", "carol@example.com");
+        memberService.addMember(root.id(), new WorkspaceMemberCommand(20L, WorkspaceRole.EDITOR, OWNER));
+        memberService.addMember(root.id(), new WorkspaceMemberCommand(21L, WorkspaceRole.VIEWER, OWNER));
+        memberService.addMember(root.id(), new WorkspaceMemberCommand(22L, WorkspaceRole.VIEWER, OWNER));
+
+        var secondPage = memberService.getDirectMembers(
+                root.id(),
+                WorkspaceMemberListQuery.all(),
+                PageRequest.of(1, 2, Sort.by("userId").ascending()),
+                OWNER);
+        assertThat(secondPage.getTotalElements()).isEqualTo(4);
+        assertThat(secondPage.getContent())
+                .extracting(studio.one.platform.workspace.model.WorkspaceMemberRef::userId)
+                .containsExactly(21L, 22L);
+
+        var viewerPage = memberService.getDirectMembers(
+                root.id(),
+                new WorkspaceMemberListQuery(null, WorkspaceRole.VIEWER, null),
+                PageRequest.of(0, 10, Sort.by("userId").ascending()),
+                OWNER);
+        assertThat(viewerPage.getContent())
+                .extracting(studio.one.platform.workspace.model.WorkspaceMemberRef::userId)
+                .containsExactly(21L, 22L);
+
+        var keywordPage = memberService.getDirectMembers(
+                root.id(),
+                new WorkspaceMemberListQuery("alice", null, null),
+                PageRequest.of(0, 10),
+                OWNER);
+        assertThat(keywordPage.getTotalElements()).isOne();
+        assertThat(keywordPage.getContent())
+                .extracting(studio.one.platform.workspace.model.WorkspaceMemberRef::userId)
+                .containsExactly(20L);
+
+        assertThat(memberService.getDirectMembers(
+                root.id(),
+                new WorkspaceMemberListQuery(null, null, true),
+                PageRequest.of(0, 10),
+                OWNER).getTotalElements()).isZero();
+    }
+
+    @Test
+    void effectiveMembersSupportServerPagingInheritedAndKeywordSearch() {
+        var root = createRoot("Acme", "acme", OWNER);
+        var engineering = treeService.createChild(root.id(), createCommand("Engineering", "engineering", OWNER));
+        var backend = treeService.createChild(engineering.id(), createCommand("Backend", "backend", OWNER));
+        insertUser(20L, "alice", "Alice Park", "alice@example.com");
+        insertUser(21L, "bob", "Bob Lee", "bob@example.com");
+        memberService.addMember(root.id(), new WorkspaceMemberCommand(20L, WorkspaceRole.EDITOR, OWNER));
+        memberService.addMember(backend.id(), new WorkspaceMemberCommand(21L, WorkspaceRole.VIEWER, OWNER));
+
+        var inheritedPage = memberService.getEffectiveMembers(
+                backend.id(),
+                new WorkspaceMemberListQuery(null, null, true),
+                PageRequest.of(0, 10, Sort.by("userId").ascending()),
+                OWNER);
+        assertThat(inheritedPage.getContent())
+                .extracting(studio.one.platform.workspace.model.WorkspaceMemberRef::userId)
+                .contains(OWNER.userId(), 20L)
+                .doesNotContain(21L);
+
+        var keywordPage = memberService.getEffectiveMembers(
+                backend.id(),
+                new WorkspaceMemberListQuery("bob", null, false),
+                PageRequest.of(0, 10),
+                OWNER);
+        assertThat(keywordPage.getTotalElements()).isOne();
+        assertThat(keywordPage.getContent().get(0).userId()).isEqualTo(21L);
+        assertThat(keywordPage.getContent().get(0).inherited()).isFalse();
     }
 
     @Test
@@ -413,7 +495,9 @@ class DefaultWorkspaceServiceTest {
     }
 
     @SpringBootConfiguration
-    @EntityScan(basePackageClasses = WorkspaceClosureEntity.class)
+    @EntityScan(basePackageClasses = {
+            WorkspaceClosureEntity.class,
+            DefaultWorkspaceServiceTest.TestApplicationUserEntity.class })
     @EnableJpaRepositories(basePackageClasses = {
             WorkspaceJpaRepository.class,
             WorkspaceClosureJpaRepository.class,
@@ -479,12 +563,46 @@ class DefaultWorkspaceServiceTest {
                 WorkspaceJpaRepository workspaceRepository,
                 WorkspaceClosureJpaRepository closureRepository,
                 WorkspaceMemberJpaRepository memberRepository,
-                WorkspacePermissionService permissionService) {
+                WorkspacePermissionService permissionService,
+                EntityManager entityManager) {
             return new DefaultWorkspaceMemberService(
                     workspaceRepository,
                     closureRepository,
                     memberRepository,
-                    permissionService);
+                    permissionService,
+                    entityManager);
         }
+    }
+
+    private void insertUser(Long userId, String username, String name, String email) {
+        entityManager.createNativeQuery("delete from TB_APPLICATION_USER where USER_ID = :userId")
+                .setParameter("userId", userId)
+                .executeUpdate();
+        entityManager.createNativeQuery("""
+                insert into TB_APPLICATION_USER (USER_ID, USERNAME, NAME, EMAIL)
+                values (:userId, :username, :name, :email)
+                """)
+                .setParameter("userId", userId)
+                .setParameter("username", username)
+                .setParameter("name", name)
+                .setParameter("email", email)
+                .executeUpdate();
+    }
+
+    @jakarta.persistence.Entity
+    @jakarta.persistence.Table(name = "TB_APPLICATION_USER")
+    static class TestApplicationUserEntity {
+        @jakarta.persistence.Id
+        @jakarta.persistence.Column(name = "USER_ID")
+        private Long userId;
+
+        @jakarta.persistence.Column(name = "USERNAME")
+        private String username;
+
+        @jakarta.persistence.Column(name = "NAME")
+        private String name;
+
+        @jakarta.persistence.Column(name = "EMAIL")
+        private String email;
     }
 }

--- a/studio-platform-workspace-default/src/test/java/studio/one/platform/workspace/web/controller/WorkspaceControllerTest.java
+++ b/studio-platform-workspace-default/src/test/java/studio/one/platform/workspace/web/controller/WorkspaceControllerTest.java
@@ -27,6 +27,7 @@ import studio.one.platform.workspace.service.CreateWorkspaceCommand;
 import studio.one.platform.workspace.service.WorkspaceAccessContext;
 import studio.one.platform.workspace.service.WorkspaceListQuery;
 import studio.one.platform.workspace.service.WorkspaceMemberService;
+import studio.one.platform.workspace.service.WorkspaceMemberListQuery;
 import studio.one.platform.workspace.service.WorkspacePermissionService;
 import studio.one.platform.workspace.service.WorkspaceTreeService;
 import studio.one.platform.workspace.web.dto.WorkspaceCreateRequest;
@@ -167,6 +168,54 @@ class WorkspaceControllerTest {
     }
 
     @Test
+    void memberListUsesPageableQueryAndNonAdminContext() {
+        WorkspaceTreeService treeService = org.mockito.Mockito.mock(WorkspaceTreeService.class);
+        WorkspaceMemberService memberService = org.mockito.Mockito.mock(WorkspaceMemberService.class);
+        WorkspacePermissionService permissionService = org.mockito.Mockito.mock(WorkspacePermissionService.class);
+        var pageable = PageRequest.of(1, 5);
+        when(memberService.getDirectMembers(eq(1L), any(), eq(pageable), any()))
+                .thenReturn(new PageImpl<>(List.of(member()), pageable, 1));
+        WorkspaceController controller = new WorkspaceController(
+                treeService,
+                memberService,
+                permissionService,
+                principalProvider("user", false));
+
+        controller.members(1L, "ali", null, WorkspaceRole.VIEWER, false, pageable);
+
+        ArgumentCaptor<WorkspaceMemberListQuery> queryCaptor =
+                ArgumentCaptor.forClass(WorkspaceMemberListQuery.class);
+        ArgumentCaptor<WorkspaceAccessContext> contextCaptor = ArgumentCaptor.forClass(WorkspaceAccessContext.class);
+        verify(memberService).getDirectMembers(eq(1L), queryCaptor.capture(), eq(pageable), contextCaptor.capture());
+        assertThat(queryCaptor.getValue()).isEqualTo(new WorkspaceMemberListQuery("ali", WorkspaceRole.VIEWER, false));
+        assertThat(contextCaptor.getValue().platformAdmin()).isFalse();
+    }
+
+    @Test
+    void mgmtEffectiveMemberListUsesKeywordAliasAndPlatformAdminContext() {
+        WorkspaceTreeService treeService = org.mockito.Mockito.mock(WorkspaceTreeService.class);
+        WorkspaceMemberService memberService = org.mockito.Mockito.mock(WorkspaceMemberService.class);
+        WorkspacePermissionService permissionService = org.mockito.Mockito.mock(WorkspacePermissionService.class);
+        var pageable = PageRequest.of(0, 20);
+        when(memberService.getEffectiveMembers(eq(1L), any(), eq(pageable), any()))
+                .thenReturn(new PageImpl<>(List.of(member()), pageable, 1));
+        WorkspaceMgmtController controller = new WorkspaceMgmtController(
+                treeService,
+                memberService,
+                permissionService,
+                principalProvider("admin", false));
+
+        controller.effectiveMembers(1L, "ignored", "bob", WorkspaceRole.EDITOR, true, pageable);
+
+        ArgumentCaptor<WorkspaceMemberListQuery> queryCaptor =
+                ArgumentCaptor.forClass(WorkspaceMemberListQuery.class);
+        ArgumentCaptor<WorkspaceAccessContext> contextCaptor = ArgumentCaptor.forClass(WorkspaceAccessContext.class);
+        verify(memberService).getEffectiveMembers(eq(1L), queryCaptor.capture(), eq(pageable), contextCaptor.capture());
+        assertThat(queryCaptor.getValue()).isEqualTo(new WorkspaceMemberListQuery("bob", WorkspaceRole.EDITOR, true));
+        assertThat(contextCaptor.getValue().platformAdmin()).isTrue();
+    }
+
+    @Test
     void permissionsMeChecksReadPermission() {
         WorkspaceTreeService treeService = org.mockito.Mockito.mock(WorkspaceTreeService.class);
         WorkspaceMemberService memberService = org.mockito.Mockito.mock(WorkspaceMemberService.class);
@@ -191,6 +240,10 @@ class WorkspaceControllerTest {
 
     private WorkspaceRef workspace() {
         return new WorkspaceRef(1L, null, 1L, "Acme", "acme", "acme", 0, WorkspaceVisibility.PRIVATE, false);
+    }
+
+    private studio.one.platform.workspace.model.WorkspaceMemberRef member() {
+        return new studio.one.platform.workspace.model.WorkspaceMemberRef(1L, 10L, WorkspaceRole.OWNER, false);
     }
 
     @SuppressWarnings("unchecked")

--- a/studio-platform-workspace/README.md
+++ b/studio-platform-workspace/README.md
@@ -4,7 +4,7 @@ Workspace 공통 계약 모듈입니다. 트리형 workspace, member role, effec
 
 ## 범위
 - `WorkspaceTreeService`: root/child 생성, parent 변경, id/path 조회, children/tree/ancestors/descendants 조회, name/visibility 변경, archive
-- `WorkspaceMemberService`: direct/effective member 조회, member 추가/역할 변경/제거
+- `WorkspaceMemberService`: direct/effective member 조회, pageable member 조회, member 추가/역할 변경/제거
 - `WorkspacePermissionService`: role/visibility/ancestor 상속 기반 권한 계산
 - `WorkspacePermissionContributor`: 모듈별 action과 기본 role mapping 확장
 

--- a/studio-platform-workspace/src/main/java/studio/one/platform/workspace/service/WorkspaceMemberListQuery.java
+++ b/studio-platform-workspace/src/main/java/studio/one/platform/workspace/service/WorkspaceMemberListQuery.java
@@ -1,0 +1,21 @@
+package studio.one.platform.workspace.service;
+
+import studio.one.platform.workspace.model.WorkspaceRole;
+
+public record WorkspaceMemberListQuery(
+        String keyword,
+        WorkspaceRole role,
+        Boolean inherited) {
+
+    public static WorkspaceMemberListQuery all() {
+        return new WorkspaceMemberListQuery(null, null, null);
+    }
+
+    public String normalizedKeyword() {
+        return keyword == null || keyword.isBlank() ? null : keyword.trim();
+    }
+
+    public boolean hasKeyword() {
+        return normalizedKeyword() != null;
+    }
+}

--- a/studio-platform-workspace/src/main/java/studio/one/platform/workspace/service/WorkspaceMemberService.java
+++ b/studio-platform-workspace/src/main/java/studio/one/platform/workspace/service/WorkspaceMemberService.java
@@ -2,6 +2,10 @@ package studio.one.platform.workspace.service;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
 import studio.one.platform.workspace.model.WorkspaceMemberRef;
 
 public interface WorkspaceMemberService {
@@ -15,4 +19,30 @@ public interface WorkspaceMemberService {
     List<WorkspaceMemberRef> getDirectMembers(Long workspaceId, WorkspaceAccessContext actor);
 
     List<WorkspaceMemberRef> getEffectiveMembers(Long workspaceId, WorkspaceAccessContext actor);
+
+    default Page<WorkspaceMemberRef> getDirectMembers(
+            Long workspaceId,
+            WorkspaceMemberListQuery query,
+            Pageable pageable,
+            WorkspaceAccessContext actor) {
+        return page(getDirectMembers(workspaceId, actor), pageable);
+    }
+
+    default Page<WorkspaceMemberRef> getEffectiveMembers(
+            Long workspaceId,
+            WorkspaceMemberListQuery query,
+            Pageable pageable,
+            WorkspaceAccessContext actor) {
+        return page(getEffectiveMembers(workspaceId, actor), pageable);
+    }
+
+    private static Page<WorkspaceMemberRef> page(List<WorkspaceMemberRef> members, Pageable pageable) {
+        Pageable resolved = pageable == null ? Pageable.unpaged() : pageable;
+        if (resolved.isUnpaged()) {
+            return new PageImpl<>(members);
+        }
+        int start = Math.toIntExact(Math.min(resolved.getOffset(), members.size()));
+        int end = Math.min(start + resolved.getPageSize(), members.size());
+        return new PageImpl<>(members.subList(start, end), resolved, members.size());
+    }
 }


### PR DESCRIPTION
## Why

Workspace 상세 화면의 direct/effective member 목록이 전체 배열 응답에 의존하면 멤버 수가 많을 때 초기 로딩과 grid 렌더링 비용이 커집니다. 이슈 #421의 요구대로 서버에서 `page`, `size`, `sort`, 검색 조건을 처리해 클라이언트가 서버 페이징 grid로 전환할 수 있게 합니다.

## What

- `WorkspaceMemberListQuery`와 pageable member 조회 계약을 추가했습니다.
- 기존 `WorkspaceMemberService` 구현체 호환을 위해 새 pageable 메서드는 default method를 제공하고, JPA 기본 구현에서 실제 서버 페이징/필터링을 override했습니다.
- direct/effective member 조회 API를 `ApiResponse<Page<WorkspaceMemberRef>>` 응답으로 전환했습니다.
- `q`/`keyword`, `role`, `inherited`, `page`, `size`, `sort` query parameter를 지원합니다.
- `keyword` 검색은 현재 workspace 또는 ancestor member 범위에서 사용자 `username`, `name`, `email`과 숫자 `userId`를 매칭합니다.
- README와 `CHANGELOG.md`에 API 계약을 문서화했습니다.
- direct/effective member 페이징, role/inherited, keyword 검색, controller query 전달 테스트를 추가했습니다.

## Related Issues

- Closes #421

## Validation

- Command: `./gradlew :studio-platform-workspace-default:test --tests 'studio.one.platform.workspace.service.impl.DefaultWorkspaceServiceTest' --tests 'studio.one.platform.workspace.web.controller.WorkspaceControllerTest'`
- Result: 성공
- Command: `./gradlew :studio-platform-workspace:build :studio-platform-workspace-default:build :starter:studio-platform-starter-workspace:build`
- Result: 성공
- Command: `git diff --check`
- Result: 성공

## Risk / Rollback

- Risk: 기존 member 조회 endpoint 응답이 배열에서 `Page` 응답으로 바뀌므로 클라이언트가 `data.content` 기반으로 읽도록 전환해야 합니다.
- Rollback: 이 PR을 revert하면 기존 배열 응답과 기존 member 조회 구현으로 복귀합니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: Gradle build/test와 `git diff --check`를 실행하고, 자체 리뷰에서 public contract 호환성과 keyword 검색 범위를 보완했습니다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
