### PR TITLE
[codex] Company 목록 API 500 오류 수정

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### 변경됨
+- 이슈 #433 대응으로 Company 목록/단건 조회가 DTO 변환 시 lazy `properties` 접근으로 500이 발생하지 않도록 `ApplicationCompanyService`에서 properties를 transaction 안에서 초기화한다.
 - 이슈 #425 대응으로 Workspace 활성화 API `POST /api/workspaces/{workspaceId}/activate`, `POST /api/mgmt/workspaces/{workspaceId}/activate`를 추가하고, archive/activate 요청 body에 `cascade` 정책을 문서화했다. 활성 descendant가 있는 workspace archive는 `cascade=true`가 필요하며, archived ancestor 아래 child 단독 활성화는 거부한다.
 - Company → Workspace → Wiki 단계별 작업 리뷰 보완으로 Company 관리 API에 tenant 객체 권한 검사를 추가하고, workspace company scope 적용 시 `ApplicationCompanyService` 기반 company 존재 검증과 `V1303__add_workspace_company_fk.sql`을 추가했다. V1302 schema가 적용된 환경은 `studio.features.workspace.company-scope-enforced=true` 설정 없이는 기동하지 않도록 보강했다. Company 객체 권한 검사가 필요한 endpoint는 `IdentityService`로 actor를 해석하지 못하면 fail-closed로 거부하며, workspace member keyword 검색은 `ApplicationUserService`를 우선 사용하고 없으면 기존 user table DB fallback을 유지한다.
 - 이슈 #430 대응으로 Workspace Company scope 운영 강제 전환용 `V1302__enforce_workspace_company_scope.sql`을 postgres/mysql/mariadb에 추가했다. `COMPANY_ID NOT NULL`, company-scoped path/root slug/parent slug unique 제약과 MySQL/MariaDB `PARENT_KEY` generated column 전략, `studio.features.workspace.company-scope-enforced` runtime 전환 설정, backfill/duplicate 검증 운영 문서를 제공한다.

--- a/studio-platform-user/src/main/java/studio/one/base/user/service/impl/ApplicationCompanyServiceImpl.java
+++ b/studio-platform-user/src/main/java/studio/one/base/user/service/impl/ApplicationCompanyServiceImpl.java
@@ -48,8 +48,10 @@ public class ApplicationCompanyServiceImpl implements ApplicationCompanyService 
     @Override
     @Transactional(readOnly = true)
     public ApplicationCompany get(Long companyId) {
-        return companyRepo.findById(companyId)
+        ApplicationCompany company = companyRepo.findById(companyId)
                 .orElseThrow(() -> new NotFoundException("Company", companyId));
+        initializeProperties(company);
+        return company;
     }
 
     @Override
@@ -107,7 +109,9 @@ public class ApplicationCompanyServiceImpl implements ApplicationCompanyService 
     @Override
     @Transactional(readOnly = true)
     public Page<ApplicationCompany> search(String q, Pageable pageable) {
-        return companyRepo.search(q, pageable);
+        Page<ApplicationCompany> page = companyRepo.search(q, pageable);
+        page.forEach(this::initializeProperties);
+        return page;
     }
 
     @Override
@@ -125,5 +129,11 @@ public class ApplicationCompanyServiceImpl implements ApplicationCompanyService 
         Objects.requireNonNull(name, "property name");
         c.getProperties().remove(name);
         companyRepo.save(c);
+    }
+
+    private void initializeProperties(ApplicationCompany company) {
+        if (company != null && company.getProperties() != null) {
+            company.getProperties().size();
+        }
     }
 }

--- a/studio-platform-user/src/test/java/studio/one/base/user/service/impl/ApplicationCompanyServiceImplJpaTest.java
+++ b/studio-platform-user/src/test/java/studio/one/base/user/service/impl/ApplicationCompanyServiceImplJpaTest.java
@@ -1,0 +1,90 @@
+package studio.one.base.user.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.transaction.TestTransaction;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import jakarta.persistence.EntityManager;
+import studio.one.base.user.domain.entity.ApplicationCompany;
+import studio.one.base.user.persistence.jpa.ApplicationCompanyJpaRepository;
+import studio.one.base.user.service.ApplicationCompanyService;
+
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+class ApplicationCompanyServiceImplJpaTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @Autowired
+    EntityManager entityManager;
+
+    @Autowired
+    ApplicationCompanyService companyService;
+
+    @Test
+    void searchReturnsCompaniesWithPropertiesReadableAfterServiceTransaction() {
+        Long companyId = persistCompany("acme-list", "Acme List", Map.of("tier", "enterprise"));
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        var result = companyService.search("", PageRequest.of(0, 15, Sort.by(Sort.Order.desc("companyId"))));
+
+        assertThat(result.getContent())
+                .extracting(ApplicationCompany::getCompanyId)
+                .contains(companyId);
+        ApplicationCompany company = result.getContent().stream()
+                .filter(item -> companyId.equals(item.getCompanyId()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(company.getProperties()).containsEntry("tier", "enterprise");
+    }
+
+    @Test
+    void getReturnsCompanyWithPropertiesReadableAfterServiceTransaction() {
+        Long companyId = persistCompany("acme-get", "Acme Get", Map.of("tier", "standard"));
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        ApplicationCompany company = companyService.get(companyId);
+
+        assertThat(company.getProperties()).containsEntry("tier", "standard");
+    }
+
+    private Long persistCompany(String name, String displayName, Map<String, String> properties) {
+        ApplicationCompany company = new ApplicationCompany();
+        company.setName(name);
+        company.setDisplayName(displayName);
+        company.setProperties(properties);
+        entityManager.persist(company);
+        entityManager.flush();
+        return company.getCompanyId();
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    @EntityScan(basePackageClasses = ApplicationCompany.class)
+    @EnableJpaRepositories(basePackageClasses = ApplicationCompanyJpaRepository.class)
+    @Import(ApplicationCompanyServiceImpl.class)
+    static class TestBootConfig {
+    }
+}

--- a/studio-platform-user/src/test/java/studio/one/base/user/web/controller/CompanyMgmtControllerWebTest.java
+++ b/studio-platform-user/src/test/java/studio/one/base/user/web/controller/CompanyMgmtControllerWebTest.java
@@ -1,0 +1,131 @@
+package studio.one.base.user.web.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import studio.one.base.user.company.model.CompanyStatus;
+import studio.one.base.user.domain.entity.ApplicationCompany;
+import studio.one.base.user.service.ApplicationCompanyMemberService;
+import studio.one.base.user.service.ApplicationCompanyPermissionService;
+import studio.one.base.user.service.ApplicationCompanyService;
+
+class CompanyMgmtControllerWebTest {
+
+    @Test
+    void listBindsEmptyQueryPagingSortAndSerializesProperties() throws Exception {
+        ApplicationCompanyService companyService = mock(ApplicationCompanyService.class);
+        ApplicationCompany company = company(10L, "acme", "Acme", Map.of("tier", "enterprise"));
+        when(companyService.search(eq(""), any(Pageable.class)))
+                .thenAnswer(invocation -> {
+                    Pageable pageable = invocation.getArgument(1);
+                    return new PageImpl<>(List.of(company), pageable, 1);
+                });
+        MockMvc mvc = mockMvc(companyService);
+
+        mvc.perform(get("/api/mgmt/companies")
+                        .param("q", "")
+                        .param("page", "0")
+                        .param("size", "15")
+                        .param("sort", "displayName,asc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].companyId").value(10))
+                .andExpect(jsonPath("$.data.content[0].properties.tier").value("enterprise"))
+                .andExpect(jsonPath("$.data.size").value(15))
+                .andExpect(jsonPath("$.data.totalElements").value(1));
+
+        ArgumentCaptor<Pageable> pageable = ArgumentCaptor.forClass(Pageable.class);
+        verify(companyService).search(eq(""), pageable.capture());
+        org.assertj.core.api.Assertions.assertThat(pageable.getValue().getPageNumber()).isZero();
+        org.assertj.core.api.Assertions.assertThat(pageable.getValue().getPageSize()).isEqualTo(15);
+        org.assertj.core.api.Assertions.assertThat(pageable.getValue().getSort())
+                .containsExactly(Sort.Order.asc("displayName"));
+    }
+
+    @Test
+    void listUsesDefaultCompanyIdDescSortWhenSortIsOmitted() throws Exception {
+        ApplicationCompanyService companyService = mock(ApplicationCompanyService.class);
+        ApplicationCompany company = company(20L, "beta", "Beta", Map.of());
+        when(companyService.search(eq(null), any(Pageable.class)))
+                .thenAnswer(invocation -> {
+                    Pageable pageable = invocation.getArgument(1);
+                    return new PageImpl<>(List.of(company), pageable, 1);
+                });
+        MockMvc mvc = mockMvc(companyService);
+
+        mvc.perform(get("/api/mgmt/companies")
+                        .param("page", "0")
+                        .param("size", "15"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].companyId").value(20));
+
+        ArgumentCaptor<Pageable> pageable = ArgumentCaptor.forClass(Pageable.class);
+        verify(companyService).search(eq(null), pageable.capture());
+        org.assertj.core.api.Assertions.assertThat(pageable.getValue())
+                .isEqualTo(PageRequest.of(0, 15, Sort.by(Sort.Order.desc("companyId"))));
+    }
+
+    private MockMvc mockMvc(ApplicationCompanyService companyService) {
+        CompanyMgmtController controller = new CompanyMgmtController(
+                companyService,
+                mock(ApplicationCompanyMemberService.class),
+                mock(ApplicationCompanyPermissionService.class),
+                new EmptyObjectProvider<>(),
+                new EmptyObjectProvider<>());
+        return MockMvcBuilders.standaloneSetup(controller)
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
+                .addPlaceholderValue("studio.features.user.web.base-path", "/api/mgmt")
+                .build();
+    }
+
+    private ApplicationCompany company(Long companyId, String name, String displayName, Map<String, String> properties) {
+        ApplicationCompany company = new ApplicationCompany();
+        company.setCompanyId(companyId);
+        company.setName(name);
+        company.setDisplayName(displayName);
+        company.setStatus(CompanyStatus.ACTIVE);
+        company.setProperties(properties);
+        return company;
+    }
+
+    private static class EmptyObjectProvider<T> implements ObjectProvider<T> {
+        @Override
+        public T getObject(Object... args) {
+            return null;
+        }
+
+        @Override
+        public T getIfAvailable() {
+            return null;
+        }
+
+        @Override
+        public T getIfUnique() {
+            return null;
+        }
+
+        @Override
+        public T getObject() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Why

관리 콘솔 Company 목록에서 `GET /api/mgmt/companies` 응답 DTO 변환 시 JPA lazy `properties` 접근이 transaction 밖에서 발생하면 `500 Internal Server Error`가 날 수 있습니다. 목록 화면은 `content`와 page metadata를 받아야 하므로 서버 목록 조회 경로에서 lazy 초기화 문제를 제거합니다.

## What

- `ApplicationCompanyServiceImpl.get/search`가 read transaction 안에서 `ApplicationCompany.properties`를 초기화하도록 보완했습니다.
- JPA transaction 경계가 닫힌 뒤에도 `properties`를 읽을 수 있는지 검증하는 회귀 테스트를 추가했습니다.
- `GET /api/mgmt/companies?q=&page=&size=&sort=` endpoint binding/serialization 테스트를 추가했습니다.
- `CHANGELOG.md`에 이슈 #433 수정 내역을 기록했습니다.

## Related Issues

- Closes #433

## Validation

- `./gradlew :studio-platform-user:test :starter:studio-platform-starter-user:test` 성공
- `git diff --check` 성공

## Risk / Rollback

주요 위험은 Company 조회 시 properties 초기화로 인해 JPA 경로에서 추가 lazy load가 발생할 수 있다는 점입니다. 문제가 있으면 커밋 `3634fbf9`를 revert하면 기존 동작으로 돌아갑니다.

## AI / Subagent Usage

- AI-Assisted: Yes
- Usage type: 이슈 분석, 코드 수정, 테스트/문서화, 검증 준비, 반복 리뷰 보완
- Subagent used: Yes
- Delegated scope: code-reviewer, security-reviewer, test-engineer가 PR diff를 반복 검토했고 지적 사항을 반영한 뒤 최종 no findings를 확인했습니다.

## Checklist

- [x] 커밋 메시지가 정책 형식을 따른다.
- [x] Issue template이 사용된 이슈 #433과 연결했다.
- [x] AI-Assisted 값을 기록했다.
- [x] validation command/result를 기록했다.
- [x] subagent 사용 여부를 기록했다.
- [x] repository verification을 실행했다.
- [x] human review가 merge 전에 필요하다.
- [x] unrelated change는 제외했다.
