### PR TITLE
[Feature] 회원 목록 Company 소속 필터 API 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### 변경됨
+- 이슈 #438 대응으로 관리용 회원 목록 API `GET /api/mgmt/users`에 `companyId` 필터를 추가했다. `companyId`와 `q`를 함께 사용하면 Company 멤버 범위 안에서 `username`/`name`/`email` 검색을 수행하며, platform admin이 아닌 호출자는 대상 Company의 `company.member.read` 권한이 필요하고 pagination/sort는 기존 사용자 목록과 동일하게 적용된다. JDBC pagination 정렬은 allowlist에 없는 sort 필드를 SQL에 반영하지 않고 기본 정렬로 대체하도록 보강했다.
 - 이슈 #436 대응으로 Company별 권한 정책 관리 API `GET/PUT /api/mgmt/companies/{companyId}/permissions/policy`를 추가했다. 정책은 role별 action override를 저장하고, 정책이 없거나 `override=false`이면 기존 `CompanyPermissionActions.actionsFor(role)` 기본 mapping으로 fallback한다. 저장된 정책은 `permissions/me`와 service-level 권한 판정에 반영되며, 정책 수정은 Company `OWNER` 또는 platform admin으로 제한하고 `V304__create_company_permission_policy.sql` migration을 제공한다.
 - 이슈 #435 대응으로 Company 멤버 키 발급과 인증 사용자 가입 요청/승인/거절 API를 추가했다. 멤버 키는 생성 응답에서만 평문으로 반환하고 저장소에는 SHA-256 hash만 보존하며, email-only 비로그인 요청은 계정 소유권을 검증할 수 없어 노출하지 않는다. `POST /api/self/company-join-requests`, `POST /api/mgmt/companies/{companyId}/member-keys`, `GET/approve/reject /api/mgmt/companies/{companyId}/member-join-requests` 흐름을 제공한다. Company 목록 조회는 `features:company/admin` 권한으로 제한하고, 마지막 `OWNER` 강등/삭제는 거부한다.
 - 이슈 #433 대응으로 Company 목록/단건 조회가 DTO 변환 시 lazy `properties` 접근으로 500이 발생하지 않도록 `ApplicationCompanyService`에서 properties를 transaction 안에서 초기화한다.

--- a/starter/studio-platform-starter-user/README.md
+++ b/starter/studio-platform-starter-user/README.md
@@ -146,6 +146,15 @@ studio:
 - `/api/self`
 - `/api/self/company-join-requests`
 
+기본 `UserMgmtController`의 `GET /api/mgmt/users`는 `q`, `companyId`, pagination, sort를 함께 지원한다.
+`companyId`를 지정하면 `TB_APPLICATION_COMPANY_MEMBERS` 기준으로 해당 Company 멤버 사용자만 반환하고,
+`q`가 함께 있으면 그 Company 범위 안에서 `username`, `name`, `email`을 검색한다.
+Company 필터 조회는 platform admin이 아니면 대상 Company의 `company.member.read` 권한을 요구한다.
+존재하지 않거나 접근할 수 없는 Company는 기존 Company permission 흐름에 따라 거부/오류 처리되며, `companyId <= 0`은 `400 Bad Request`로 거부된다.
+Company 권한/identity service가 없는 커스텀 구성에서는 기본 컨트롤러가 `501 Not Implemented`로 응답한다.
+`GET /api/mgmt/users/basic`과 `/api/mgmt/users/find`도 같은 `companyId` 필터를 사용할 수 있다.
+커스텀 `UserMgmtApi` 컨트롤러를 제공하는 애플리케이션은 이 `companyId` 필터 동작을 직접 구현해야 한다.
+
 Company endpoint는 `features:company/*` 권한을 먼저 확인하고, 단일 Company 조회/수정,
 member 조회/변경, permission 조회에는 Company 객체 권한을 추가로 적용한다.
 이 객체 권한 검사는 `IdentityService`가 principal을 userId로 해석할 수 있어야 하며,

--- a/starter/studio-platform-starter-user/src/main/java/studio/one/platform/user/autoconfigure/UserEndpointsAutoConfiguration.java
+++ b/starter/studio-platform-starter-user/src/main/java/studio/one/platform/user/autoconfigure/UserEndpointsAutoConfiguration.java
@@ -148,14 +148,20 @@ public class UserEndpointsAutoConfiguration {
             ApplicationUserService svc,
             ApplicationUserMapper mapper,
             ApplicationRoleMapper roleMapper,
-            ObjectProvider<PasswordPolicyService> passwordPolicyServiceProvider) {
+            ObjectProvider<PasswordPolicyService> passwordPolicyServiceProvider,
+            ObjectProvider<ApplicationCompanyPermissionService> companyPermissionServiceProvider,
+            ObjectProvider<IdentityService> identityServiceProvider,
+            ObjectProvider<Environment> environmentProvider) {
         log.info(LogUtils.format(i18n, I18nKeys.AutoConfig.Feature.EndPoint.REGISTERED, UserServicesAutoConfiguration.FEATURE_NAME,
                 LogUtils.blue(ApplicationUserService.class, true),
                 LogUtils.blue(UserMgmtController.class, true),
                 webProperties.normalizedBasePath() + "/users",
                 LogUtils.blue("ACL-managed")));
         return new UserMgmtController(svc, mapper, roleMapper,
-                passwordPolicyServiceProvider.getIfAvailable(() -> new PasswordPolicyValidator(null, i18n)));
+                passwordPolicyServiceProvider.getIfAvailable(() -> new PasswordPolicyValidator(null, i18n)),
+                companyPermissionServiceProvider,
+                identityServiceProvider,
+                environmentProvider);
     }
 
     @Bean

--- a/studio-platform-user-default/build.gradle.kts
+++ b/studio-platform-user-default/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     testImplementation("org.springframework.security:spring-security-core")
     testImplementation(project(":studio-platform"))
     testImplementation(project(":studio-platform-user"))
+    testImplementation(project(":studio-platform-identity"))
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:postgresql")

--- a/studio-platform-user-default/src/main/java/studio/one/base/user/persistence/ApplicationUserRepository.java
+++ b/studio-platform-user-default/src/main/java/studio/one/base/user/persistence/ApplicationUserRepository.java
@@ -39,6 +39,14 @@ public interface ApplicationUserRepository {
 
     List<ApplicationUser> findUsersByGroupId(Long groupId);
 
+    default Page<ApplicationUser> findUsersByCompanyId(Long companyId, Pageable pageable) {
+        throw new UnsupportedOperationException("Company-scoped user listing is not supported");
+    }
+
+    default Page<ApplicationUser> searchByCompanyId(Long companyId, String keyword, Pageable pageable) {
+        throw new UnsupportedOperationException("Company-scoped user search is not supported");
+    }
+
     Page<ApplicationUser> search(String keyword, Pageable pageable);
 
     List<ApplicationGroup> findGroupsByUserId(Long userId);

--- a/studio-platform-user-default/src/main/java/studio/one/base/user/persistence/jdbc/ApplicationUserJdbcRepository.java
+++ b/studio-platform-user-default/src/main/java/studio/one/base/user/persistence/jdbc/ApplicationUserJdbcRepository.java
@@ -34,9 +34,30 @@ public class ApplicationUserJdbcRepository extends BaseJdbcRepository implements
             Map.entry("firstName", "FIRST_NAME"),
             Map.entry("lastName", "LAST_NAME"),
             Map.entry("email", "EMAIL"),
+            Map.entry("enabled", "USER_ENABLED"),
+            Map.entry("external", "USER_EXTERNAL"),
             Map.entry("creationDate", "CREATION_DATE"),
             Map.entry("modifiedDate", "MODIFIED_DATE"),
-            Map.entry("status", "STATUS"));
+            Map.entry("status", "STATUS"),
+            Map.entry("failedAttempts", "FAILED_ATTEMPTS"),
+            Map.entry("lastFailedAt", "LAST_FAILED_AT"),
+            Map.entry("accountLockedUntil", "ACCOUNT_LOCKED_UNTIL"));
+
+    private static final Map<String, String> USER_ALIAS_SORT_COLUMNS = Map.ofEntries(
+            Map.entry("userId", "u.USER_ID"),
+            Map.entry("username", "u.USERNAME"),
+            Map.entry("name", "u.NAME"),
+            Map.entry("firstName", "u.FIRST_NAME"),
+            Map.entry("lastName", "u.LAST_NAME"),
+            Map.entry("email", "u.EMAIL"),
+            Map.entry("enabled", "u.USER_ENABLED"),
+            Map.entry("external", "u.USER_EXTERNAL"),
+            Map.entry("creationDate", "u.CREATION_DATE"),
+            Map.entry("modifiedDate", "u.MODIFIED_DATE"),
+            Map.entry("status", "u.STATUS"),
+            Map.entry("failedAttempts", "u.FAILED_ATTEMPTS"),
+            Map.entry("lastFailedAt", "u.LAST_FAILED_AT"),
+            Map.entry("accountLockedUntil", "u.ACCOUNT_LOCKED_UNTIL"));
 
     private static final RowMapper<ApplicationUser> USER_ROW_MAPPER = JdbcUserMapper::mapBasicUser;
 
@@ -215,6 +236,58 @@ public class ApplicationUserJdbcRepository extends BaseJdbcRepository implements
         List<ApplicationUser> users = namedTemplate.query(sql, Map.of("groupId", groupId), USER_ROW_MAPPER);
         loadProperties(users);
         return users;
+    }
+
+    @Override
+    public Page<ApplicationUser> findUsersByCompanyId(Long companyId, Pageable pageable) {
+        Map<String, Object> params = Map.of("companyId", companyId);
+        String select = """
+                select u.USER_ID, u.USERNAME, u.NAME, u.FIRST_NAME, u.LAST_NAME, u.PASSWORD_HASH,
+                       u.NAME_VISIBLE, u.EMAIL, u.EMAIL_VISIBLE, u.USER_ENABLED, u.USER_EXTERNAL, u.STATUS,
+                       u.FAILED_ATTEMPTS, u.LAST_FAILED_AT, u.ACCOUNT_LOCKED_UNTIL, u.CREATION_DATE, u.MODIFIED_DATE
+                  from TB_APPLICATION_USER u
+                  join TB_APPLICATION_COMPANY_MEMBERS cm on cm.USER_ID = u.USER_ID
+                 where cm.COMPANY_ID = :companyId
+                """;
+        String count = """
+                select count(*)
+                  from TB_APPLICATION_COMPANY_MEMBERS cm
+                  join TB_APPLICATION_USER u on u.USER_ID = cm.USER_ID
+                 where cm.COMPANY_ID = :companyId
+                """;
+        Page<ApplicationUser> page = queryPage(select, count, params, pageable, USER_ROW_MAPPER, "u.USER_ID", USER_ALIAS_SORT_COLUMNS);
+        loadProperties(page.getContent());
+        return page;
+    }
+
+    @Override
+    public Page<ApplicationUser> searchByCompanyId(Long companyId, String keyword, Pageable pageable) {
+        Map<String, Object> params = Map.of("companyId", companyId, "q", normalize(keyword));
+        String select = """
+                select u.USER_ID, u.USERNAME, u.NAME, u.FIRST_NAME, u.LAST_NAME, u.PASSWORD_HASH,
+                       u.NAME_VISIBLE, u.EMAIL, u.EMAIL_VISIBLE, u.USER_ENABLED, u.USER_EXTERNAL, u.STATUS,
+                       u.FAILED_ATTEMPTS, u.LAST_FAILED_AT, u.ACCOUNT_LOCKED_UNTIL, u.CREATION_DATE, u.MODIFIED_DATE
+                  from TB_APPLICATION_USER u
+                  join TB_APPLICATION_COMPANY_MEMBERS cm on cm.USER_ID = u.USER_ID
+                 where cm.COMPANY_ID = :companyId
+                   and (:q = '' or
+                       lower(u.USERNAME) like :q or
+                       lower(u.NAME) like :q or
+                       lower(u.EMAIL) like :q)
+                """;
+        String count = """
+                select count(*)
+                  from TB_APPLICATION_USER u
+                  join TB_APPLICATION_COMPANY_MEMBERS cm on cm.USER_ID = u.USER_ID
+                 where cm.COMPANY_ID = :companyId
+                   and (:q = '' or
+                       lower(u.USERNAME) like :q or
+                       lower(u.NAME) like :q or
+                       lower(u.EMAIL) like :q)
+                """;
+        Page<ApplicationUser> page = queryPage(select, count, params, pageable, USER_ROW_MAPPER, "u.USER_ID", USER_ALIAS_SORT_COLUMNS);
+        loadProperties(page.getContent());
+        return page;
     }
 
     @Override

--- a/studio-platform-user-default/src/main/java/studio/one/base/user/persistence/jpa/ApplicationUserJpaRepository.java
+++ b/studio-platform-user-default/src/main/java/studio/one/base/user/persistence/jpa/ApplicationUserJpaRepository.java
@@ -54,6 +54,51 @@ public interface ApplicationUserJpaRepository extends JpaRepository<ApplicationU
                     "where gm.group.groupId = :groupId")
     List<ApplicationUser> findUsersByGroupId(@Param("groupId") Long groupId);
 
+    @Override
+    @Query(
+        value = "select u " +
+                "from ApplicationUser u " +
+                "where exists (" +
+                "   select 1 from ApplicationCompanyMember cm " +
+                "   where cm.id.userId = u.userId and cm.id.companyId = :companyId" +
+                ")",
+        countQuery = "select count(u) " +
+                "from ApplicationUser u " +
+                "where exists (" +
+                "   select 1 from ApplicationCompanyMember cm " +
+                "   where cm.id.userId = u.userId and cm.id.companyId = :companyId" +
+                ")"
+    )
+    Page<ApplicationUser> findUsersByCompanyId(@Param("companyId") Long companyId, Pageable pageable);
+
+    @Override
+    @Query(
+        value = "select u " +
+                "from ApplicationUser u " +
+                "where exists (" +
+                "   select 1 from ApplicationCompanyMember cm " +
+                "   where cm.id.userId = u.userId and cm.id.companyId = :companyId" +
+                ") and " +
+                "      (:q is null or :q = '' or " +
+                "       lower(u.username) like lower(concat('%', :q, '%')) or " +
+                "       lower(u.name) like lower(concat('%', :q, '%')) or " +
+                "       lower(u.email) like lower(concat('%', :q, '%')))",
+        countQuery = "select count(u) " +
+                "from ApplicationUser u " +
+                "where exists (" +
+                "   select 1 from ApplicationCompanyMember cm " +
+                "   where cm.id.userId = u.userId and cm.id.companyId = :companyId" +
+                ") and " +
+                "      (:q is null or :q = '' or " +
+                "       lower(u.username) like lower(concat('%', :q, '%')) or " +
+                "       lower(u.name) like lower(concat('%', :q, '%')) or " +
+                "       lower(u.email) like lower(concat('%', :q, '%')))"
+    )
+    Page<ApplicationUser> searchByCompanyId(
+            @Param("companyId") Long companyId,
+            @Param("q") String q,
+            Pageable pageable);
+
     // --- 사용자 검색 (엔터티 Page) ---
     @Override
     @Query(value = "select u from ApplicationUser u " +

--- a/studio-platform-user-default/src/main/java/studio/one/base/user/service/impl/ApplicationUserServiceImpl.java
+++ b/studio-platform-user-default/src/main/java/studio/one/base/user/service/impl/ApplicationUserServiceImpl.java
@@ -114,6 +114,20 @@ public class ApplicationUserServiceImpl implements ApplicationUserService<Applic
         return userRepo.search(keyword, pageable);
     }
 
+    @Override
+    @Transactional(propagation = Propagation.SUPPORTS)
+    public Page<ApplicationUser> findAllByCompanyId(Long companyId, Pageable pageable) {
+        requirePositiveCompanyId(companyId);
+        return userRepo.findUsersByCompanyId(companyId, pageable);
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.SUPPORTS)
+    public Page<ApplicationUser> findByCompanyIdAndNameOrUsernameOrEmail(Long companyId, String keyword, Pageable pageable) {
+        requirePositiveCompanyId(companyId);
+        return userRepo.searchByCompanyId(companyId, keyword, pageable);
+    }
+
     @Cacheable(cacheNames = CacheNames.User.BY_USER_ID, key = "#userId", unless = "#result == null")
     @Transactional(propagation = Propagation.SUPPORTS)
     public ApplicationUser get(Long userId) {
@@ -124,6 +138,12 @@ public class ApplicationUserServiceImpl implements ApplicationUserService<Applic
     @Transactional(propagation = Propagation.SUPPORTS)
     public Optional<ApplicationUser> findEnabledById(Long userId) {
         return userRepo.findEnabledById(userId);
+    }
+
+    private void requirePositiveCompanyId(Long companyId) {
+        if (companyId == null || companyId <= 0) {
+            throw new IllegalArgumentException("companyId must be positive");
+        }
     }
 
     @Cacheable(cacheNames = CacheNames.User.BY_USERNAME, key = "#username", unless = "#result == null")

--- a/studio-platform-user-default/src/main/java/studio/one/base/user/web/controller/UserMgmtController.java
+++ b/studio-platform-user-default/src/main/java/studio/one/base/user/web/controller/UserMgmtController.java
@@ -15,15 +15,20 @@ import java.util.stream.Collectors;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.core.env.Environment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.lang.Nullable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,12 +39,15 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import studio.one.base.user.company.permission.CompanyPermissionActions;
 import studio.one.base.user.domain.model.Role;
 import studio.one.base.user.domain.model.User;
+import studio.one.base.user.service.ApplicationCompanyPermissionService;
 import studio.one.base.user.service.ApplicationUserService;
 import studio.one.base.user.service.BatchResult;
 import studio.one.base.user.service.PasswordPolicyService;
@@ -58,6 +66,7 @@ import studio.one.base.user.web.mapper.ApplicationRoleMapper;
 import studio.one.base.user.web.mapper.ApplicationUserMapper;
 import studio.one.base.user.web.util.RequestParamUtils;
 import studio.one.platform.constant.PropertyKeys;
+import studio.one.platform.identity.IdentityService;
 import studio.one.platform.web.dto.ApiResponse;
 
 /**
@@ -86,6 +95,9 @@ public class UserMgmtController extends AbstractPasswordPolicyControllerSupport 
         private final ApplicationUserMapper userMapper;
         private final ApplicationRoleMapper roleMapper;
         private final PasswordPolicyService passwordPolicyService;
+        private final ObjectProvider<ApplicationCompanyPermissionService> companyPermissionServiceProvider;
+        private final ObjectProvider<IdentityService> identityServiceProvider;
+        private final ObjectProvider<Environment> environmentProvider;
 
         @PostMapping
         @PreAuthorize("@endpointAuthz.can('features:user','admin')")
@@ -103,11 +115,13 @@ public class UserMgmtController extends AbstractPasswordPolicyControllerSupport 
         @Override
         public ResponseEntity<ApiResponse<Page<UserDto>>> list(
                         @RequestParam(value = "q", required = false) Optional<String> q,
+                        @RequestParam(value = "companyId", required = false) Optional<Long> companyId,
+                        @AuthenticationPrincipal UserDetails principal,
                         @PageableDefault(size = 15, sort = "userId", direction = Sort.Direction.DESC) Pageable pageable) {
 
-                Page<User> page = RequestParamUtils.normalizeQuery(q)
-                                .map(value -> userService.findByNameOrUsernameOrEmail(value, pageable))
-                                .orElseGet(() -> userService.findAll(pageable));
+                Optional<Long> normalizedCompanyId = normalizeCompanyId(companyId);
+                assertCompanyMemberReadable(normalizedCompanyId, principal);
+                Page<User> page = findUsers(q, normalizedCompanyId, pageable);
                 Page<UserDto> dtoPage = page.map(userMapper::toDto);
                 return ok(ApiResponse.ok(dtoPage));
         }
@@ -117,10 +131,12 @@ public class UserMgmtController extends AbstractPasswordPolicyControllerSupport 
         @Override
         public ResponseEntity<ApiResponse<Page<UserBasicDto>>> listBasic(
                         @RequestParam(value = "q", required = false) Optional<String> q,
+                        @RequestParam(value = "companyId", required = false) Optional<Long> companyId,
+                        @AuthenticationPrincipal UserDetails principal,
                         @PageableDefault(size = 15, sort = "userId", direction = Sort.Direction.DESC) Pageable pageable) {
-                Page<User> page = RequestParamUtils.normalizeQuery(q)
-                                .map(value -> userService.findByNameOrUsernameOrEmail(value, pageable))
-                                .orElseGet(() -> userService.findAll(pageable));
+                Optional<Long> normalizedCompanyId = normalizeCompanyId(companyId);
+                assertCompanyMemberReadable(normalizedCompanyId, principal);
+                Page<User> page = findUsers(q, normalizedCompanyId, pageable);
                 Page<UserBasicDto> dtoPage = page.map(userMapper::toBasicDto);
                 return ok(ApiResponse.ok(dtoPage));
         }
@@ -130,21 +146,112 @@ public class UserMgmtController extends AbstractPasswordPolicyControllerSupport 
         @Override
         public ResponseEntity<ApiResponse<Page<UserDto>>> find(
                         @RequestParam(value = "q", required = false) Optional<String> q,
+                        @RequestParam(value = "companyId", required = false) Optional<Long> companyId,
                         @RequestParam(value = "requireQuery", required = false, defaultValue = "true") boolean requireQuery,
+                        @AuthenticationPrincipal UserDetails principal,
                         @PageableDefault(size = 15, sort = "userId", direction = Sort.Direction.DESC) Pageable pageable) {
 
                 Optional<String> keyword = RequestParamUtils.normalizeQuery(q);
-                if (keyword.isEmpty() && requireQuery)
+                Optional<Long> normalizedCompanyId = normalizeCompanyId(companyId);
+                if (keyword.isEmpty() && normalizedCompanyId.isEmpty() && requireQuery)
                         return ok(ApiResponse.ok(Page.empty(pageable)));
-                Page<User> page;
-                if (keyword.isEmpty()) {
-                        page = userService.findAll(pageable);
-                } else {
-                        page = userService.findByNameOrUsernameOrEmail(keyword.get(), pageable);
-                }
+                assertCompanyMemberReadable(normalizedCompanyId, principal);
+                Page<User> page = findUsers(keyword, normalizedCompanyId, pageable);
                 Page<UserDto> dtoPage = page.map(userMapper::toDto);
 
                 return ok(ApiResponse.ok(dtoPage));
+        }
+
+        @Override
+        public ResponseEntity<ApiResponse<Page<UserDto>>> list(Optional<String> q, Pageable pageable) {
+                return list(q, Optional.empty(), null, pageable);
+        }
+
+        @Override
+        public ResponseEntity<ApiResponse<Page<UserBasicDto>>> listBasic(Optional<String> q, Pageable pageable) {
+                return listBasic(q, Optional.empty(), null, pageable);
+        }
+
+        @Override
+        public ResponseEntity<ApiResponse<Page<UserDto>>> find(Optional<String> q, boolean requireQuery, Pageable pageable) {
+                return find(q, Optional.empty(), requireQuery, null, pageable);
+        }
+
+        private Page<User> findUsers(Optional<String> q, Optional<Long> companyId, Pageable pageable) {
+                Optional<String> keyword = RequestParamUtils.normalizeQuery(q);
+                Optional<Long> normalizedCompanyId = normalizeCompanyId(companyId);
+                if (normalizedCompanyId.isPresent()) {
+                        Long resolvedCompanyId = normalizedCompanyId.get();
+                        try {
+                                return keyword
+                                                .map(value -> userService.findByCompanyIdAndNameOrUsernameOrEmail(
+                                                                resolvedCompanyId, value, pageable))
+                                                .orElseGet(() -> userService.findAllByCompanyId(resolvedCompanyId, pageable));
+                        } catch (UnsupportedOperationException ex) {
+                                throw new ResponseStatusException(
+                                                HttpStatus.NOT_IMPLEMENTED,
+                                                "Company-scoped user listing is not supported",
+                                                ex);
+                        }
+                }
+                return keyword
+                                .map(value -> userService.findByNameOrUsernameOrEmail(value, pageable))
+                                .orElseGet(() -> userService.findAll(pageable));
+        }
+
+        private Optional<Long> normalizeCompanyId(Optional<Long> companyId) {
+                if (companyId == null || companyId.isEmpty()) {
+                        return Optional.empty();
+                }
+                Long value = companyId.get();
+                if (value == null || value <= 0) {
+                        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "companyId must be positive");
+                }
+                return Optional.of(value);
+        }
+
+        private void assertCompanyMemberReadable(Optional<Long> companyId, UserDetails principal) {
+                if (companyId.isEmpty() || isPlatformAdmin()) {
+                        return;
+                }
+                ApplicationCompanyPermissionService permissionService = companyPermissionServiceProvider.getIfAvailable();
+                if (permissionService == null) {
+                        throw new ResponseStatusException(
+                                        HttpStatus.NOT_IMPLEMENTED,
+                                        "Company-scoped user listing is not supported");
+                }
+                permissionService.assertGranted(companyId.get(), actorUserId(principal), CompanyPermissionActions.MEMBER_READ);
+        }
+
+        private boolean isPlatformAdmin() {
+                Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+                if (authentication == null || authentication.getAuthorities() == null) {
+                        return false;
+                }
+                String configuredAdminRole = Optional.ofNullable(environmentProvider.getIfAvailable())
+                                .map(environment -> environment.getProperty(PropertyKeys.Security.Acl.PREFIX + ".admin-role"))
+                                .filter(role -> !role.isBlank())
+                                .orElse("ROLE_ADMIN");
+                return authentication.getAuthorities().stream()
+                                .map(org.springframework.security.core.GrantedAuthority::getAuthority)
+                                .anyMatch(configuredAdminRole::equals);
+        }
+
+        private Long actorUserId(UserDetails principal) {
+                if (principal == null) {
+                        throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "No authenticated user");
+                }
+                IdentityService identityService = identityServiceProvider.getIfAvailable();
+                if (identityService == null) {
+                        throw new ResponseStatusException(
+                                        HttpStatus.NOT_IMPLEMENTED,
+                                        "Company-scoped user listing is not supported");
+                }
+                Optional<studio.one.platform.identity.UserRef> user = identityService.findByUsername(principal.getUsername());
+                return user.map(studio.one.platform.identity.UserRef::userId)
+                                .orElseThrow(() -> new ResponseStatusException(
+                                                HttpStatus.UNAUTHORIZED,
+                                                "No authenticated user"));
         }
 
         @GetMapping("/{id}")

--- a/studio-platform-user-default/src/test/java/studio/one/base/user/persistence/jdbc/ApplicationUserJdbcRepositoryCompanyFilterTest.java
+++ b/studio-platform-user-default/src/test/java/studio/one/base/user/persistence/jdbc/ApplicationUserJdbcRepositoryCompanyFilterTest.java
@@ -1,0 +1,134 @@
+package studio.one.base.user.persistence.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.SQLException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class ApplicationUserJdbcRepositoryCompanyFilterTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    private NamedParameterJdbcTemplate template;
+    private DriverManagerDataSource dataSource;
+    private ApplicationUserJdbcRepository repository;
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        dataSource = new DriverManagerDataSource(
+                postgres.getJdbcUrl(),
+                postgres.getUsername(),
+                postgres.getPassword());
+        template = new NamedParameterJdbcTemplate(dataSource);
+        repository = new ApplicationUserJdbcRepository(template);
+        recreateSchema();
+    }
+
+    @Test
+    void findUsersByCompanyIdFiltersCompanyMembersAndAppliesAllowlistedSort() {
+        var page = repository.findUsersByCompanyId(
+                10L,
+                PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "username")));
+
+        assertThat(page.getContent())
+                .extracting(user -> user.getUsername())
+                .containsExactly("kim.viewer", "kim.owner");
+    }
+
+    @Test
+    void searchByCompanyIdFiltersKeywordAndSortsByMappedColumn() {
+        var page = repository.searchByCompanyId(
+                10L,
+                "owner",
+                PageRequest.of(0, 10, Sort.by("email")));
+
+        assertThat(page.getContent())
+                .extracting(user -> user.getUsername())
+                .containsExactly("kim.owner");
+    }
+
+    @Test
+    void findUsersByCompanyIdAllowsApplicationUserStateSorts() {
+        var page = repository.findUsersByCompanyId(
+                10L,
+                PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "failedAttempts")));
+
+        assertThat(page.getContent())
+                .extracting(user -> user.getUsername())
+                .containsExactly("kim.viewer", "kim.owner");
+    }
+
+    private void recreateSchema() throws SQLException {
+        template.getJdbcTemplate().execute("drop table if exists TB_APPLICATION_USER_PROPERTY");
+        template.getJdbcTemplate().execute("drop table if exists TB_APPLICATION_COMPANY_MEMBERS");
+        template.getJdbcTemplate().execute("drop table if exists TB_APPLICATION_COMPANY");
+        template.getJdbcTemplate().execute("drop table if exists TB_APPLICATION_USER");
+        template.getJdbcTemplate().execute("""
+                create table TB_APPLICATION_USER (
+                    USER_ID bigint primary key,
+                    USERNAME varchar(255) not null,
+                    NAME varchar(255),
+                    FIRST_NAME varchar(255),
+                    LAST_NAME varchar(255),
+                    PASSWORD_HASH varchar(255),
+                    NAME_VISIBLE boolean not null default true,
+                    EMAIL varchar(255) not null,
+                    EMAIL_VISIBLE boolean not null default true,
+                    USER_ENABLED boolean not null default true,
+                    USER_EXTERNAL boolean not null default false,
+                    STATUS integer,
+                    FAILED_ATTEMPTS integer not null default 0,
+                    LAST_FAILED_AT timestamp,
+                    ACCOUNT_LOCKED_UNTIL timestamp,
+                    CREATION_DATE timestamp,
+                    MODIFIED_DATE timestamp
+                )
+                """);
+        template.getJdbcTemplate().execute("""
+                create table TB_APPLICATION_USER_PROPERTY (
+                    USER_ID bigint not null,
+                    PROPERTY_NAME varchar(100) not null,
+                    PROPERTY_VALUE varchar(1024) not null
+                )
+                """);
+        template.getJdbcTemplate().execute("create table TB_APPLICATION_COMPANY (COMPANY_ID bigint primary key)");
+        template.getJdbcTemplate().execute("""
+                create table TB_APPLICATION_COMPANY_MEMBERS (
+                    COMPANY_ID bigint not null,
+                    USER_ID bigint not null,
+                    ROLE varchar(30) not null,
+                    STATUS varchar(30) not null,
+                    JOINED_AT timestamp not null,
+                    primary key (COMPANY_ID, USER_ID)
+                )
+                """);
+        template.getJdbcTemplate().update("""
+                insert into TB_APPLICATION_USER
+                    (USER_ID, USERNAME, NAME, EMAIL, STATUS, FAILED_ATTEMPTS, CREATION_DATE, MODIFIED_DATE)
+                values
+                    (1, 'kim.owner', 'Kim Owner', 'owner@test.com', 0, 1, now(), now()),
+                    (2, 'kim.viewer', 'Kim Viewer', 'viewer@test.com', 0, 5, now(), now()),
+                    (3, 'lee.other', 'Lee Other', 'other@test.com', 0, 9, now(), now())
+                """);
+        template.getJdbcTemplate().update("insert into TB_APPLICATION_COMPANY (COMPANY_ID) values (10), (20)");
+        template.getJdbcTemplate().update("""
+                insert into TB_APPLICATION_COMPANY_MEMBERS
+                    (COMPANY_ID, USER_ID, ROLE, STATUS, JOINED_AT)
+                values
+                    (10, 1, 'OWNER', 'ACTIVE', now()),
+                    (10, 2, 'VIEWER', 'ACTIVE', now()),
+                    (20, 3, 'OWNER', 'ACTIVE', now())
+                """);
+    }
+}

--- a/studio-platform-user-default/src/test/java/studio/one/base/user/persistence/jpa/ApplicationUserJpaRepositoryCompanyFilterTest.java
+++ b/studio-platform-user-default/src/test/java/studio/one/base/user/persistence/jpa/ApplicationUserJpaRepositoryCompanyFilterTest.java
@@ -1,0 +1,139 @@
+package studio.one.base.user.persistence.jpa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import studio.one.base.user.company.model.CompanyRole;
+import studio.one.base.user.company.model.CompanyStatus;
+import studio.one.base.user.domain.entity.ApplicationCompany;
+import studio.one.base.user.domain.entity.ApplicationCompanyMember;
+import studio.one.base.user.domain.entity.ApplicationCompanyMemberId;
+import studio.one.base.user.domain.entity.ApplicationUser;
+
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+class ApplicationUserJpaRepositoryCompanyFilterTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @Autowired
+    TestEntityManager em;
+
+    @Autowired
+    ApplicationUserJpaRepository repository;
+
+    @Test
+    void findUsersByCompanyIdFiltersCompanyMembersAndAppliesSort() {
+        TestData data = persistTestData();
+        em.flush();
+        em.clear();
+
+        var page = repository.findUsersByCompanyId(
+                data.companyId(),
+                PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "username")));
+
+        assertThat(page.getContent())
+                .extracting(ApplicationUser::getUsername)
+                .containsExactly("kim.viewer", "kim.owner");
+    }
+
+    @Test
+    void searchByCompanyIdFiltersKeywordAndAppliesSort() {
+        TestData data = persistTestData();
+        em.flush();
+        em.clear();
+
+        var page = repository.searchByCompanyId(
+                data.companyId(),
+                "owner",
+                PageRequest.of(0, 10, Sort.by("email")));
+
+        assertThat(page.getContent())
+                .extracting(ApplicationUser::getUsername)
+                .containsExactly("kim.owner");
+    }
+
+    private TestData persistTestData() {
+        ApplicationCompany company = company("company-a");
+        em.persist(company);
+        ApplicationCompany otherCompany = company("company-b");
+        em.persist(otherCompany);
+
+        ApplicationUser owner = user("kim.owner", "Kim Owner", "owner@test.com");
+        em.persist(owner);
+        ApplicationUser viewer = user("kim.viewer", "Kim Viewer", "viewer@test.com");
+        em.persist(viewer);
+        ApplicationUser other = user("lee.other", "Lee Other", "other@test.com");
+        em.persist(other);
+
+        em.flush();
+
+        em.persist(member(company, owner, CompanyRole.OWNER));
+        em.persist(member(company, viewer, CompanyRole.MEMBER));
+        em.persist(member(otherCompany, other, CompanyRole.OWNER));
+        return new TestData(company.getCompanyId());
+    }
+
+    private ApplicationCompany company(String name) {
+        ApplicationCompany company = new ApplicationCompany();
+        company.setName(name);
+        company.setDisplayName(name);
+        company.setStatus(CompanyStatus.ACTIVE);
+        return company;
+    }
+
+    private ApplicationUser user(String username, String name, String email) {
+        return ApplicationUser.builder()
+                .username(username)
+                .name(name)
+                .email(email)
+                .enabled(true)
+                .nameVisible(true)
+                .emailVisible(true)
+                .external(false)
+                .build();
+    }
+
+    private ApplicationCompanyMember member(ApplicationCompany company, ApplicationUser user, CompanyRole role) {
+        ApplicationCompanyMember member = new ApplicationCompanyMember();
+        member.setId(new ApplicationCompanyMemberId(company.getCompanyId(), user.getUserId()));
+        member.setCompany(company);
+        member.setRole(role);
+        member.setJoinedAt(Instant.now());
+        return member;
+    }
+
+    private record TestData(Long companyId) {
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    @EntityScan(basePackageClasses = {
+            ApplicationCompany.class,
+            ApplicationCompanyMember.class,
+            ApplicationUser.class
+    })
+    @EnableJpaRepositories(basePackageClasses = ApplicationUserJpaRepository.class)
+    static class TestBootConfig {
+    }
+}

--- a/studio-platform-user-default/src/test/java/studio/one/base/user/service/impl/ApplicationUserServiceImplTest.java
+++ b/studio-platform-user-default/src/test/java/studio/one/base/user/service/impl/ApplicationUserServiceImplTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import studio.one.base.user.domain.entity.ApplicationUser;
@@ -121,6 +122,32 @@ class ApplicationUserServiceImplTest {
         assertEquals("{bcrypt}next-hash", user.getPassword());
         verify(passwordPolicyService).validate("NextPassword123!");
         verify(userRepo).save(user);
+    }
+
+    @Test
+    void findAllByCompanyIdDelegatesToRepository() {
+        Pageable pageable = Pageable.unpaged();
+
+        service().findAllByCompanyId(20L, pageable);
+
+        verify(userRepo).findUsersByCompanyId(20L, pageable);
+    }
+
+    @Test
+    void findByCompanyIdAndKeywordDelegatesToRepository() {
+        Pageable pageable = Pageable.unpaged();
+
+        service().findByCompanyIdAndNameOrUsernameOrEmail(20L, "kim", pageable);
+
+        verify(userRepo).searchByCompanyId(20L, "kim", pageable);
+    }
+
+    @Test
+    void findAllByCompanyIdRejectsInvalidCompanyId() {
+        assertThrows(IllegalArgumentException.class,
+                () -> service().findAllByCompanyId(0L, Pageable.unpaged()));
+
+        verify(userRepo, never()).findUsersByCompanyId(any(), any());
     }
 
     // ---------- property tests ----------

--- a/studio-platform-user-default/src/test/java/studio/one/base/user/web/controller/UserMgmtControllerAuthorizationTest.java
+++ b/studio-platform-user-default/src/test/java/studio/one/base/user/web/controller/UserMgmtControllerAuthorizationTest.java
@@ -15,14 +15,22 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.core.env.Environment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.server.ResponseStatusException;
 
+import studio.one.base.user.company.permission.CompanyPermissionActions;
 import studio.one.base.user.domain.model.Role;
+import studio.one.base.user.service.ApplicationCompanyPermissionService;
 import studio.one.base.user.service.ApplicationUserService;
 import studio.one.base.user.service.BatchResult;
 import studio.one.base.user.service.PasswordPolicyService;
@@ -31,6 +39,8 @@ import studio.one.base.user.web.dto.RoleDto;
 import studio.one.base.user.web.dto.UpdateRolesRequest;
 import studio.one.base.user.web.mapper.ApplicationRoleMapper;
 import studio.one.base.user.web.mapper.ApplicationUserMapper;
+import studio.one.platform.identity.IdentityService;
+import studio.one.platform.identity.UserRef;
 
 @ExtendWith(MockitoExtension.class)
 class UserMgmtControllerAuthorizationTest {
@@ -46,6 +56,21 @@ class UserMgmtControllerAuthorizationTest {
 
     @Mock
     private PasswordPolicyService passwordPolicyService;
+
+    @Mock
+    private ObjectProvider<ApplicationCompanyPermissionService> companyPermissionServiceProvider;
+
+    @Mock
+    private ApplicationCompanyPermissionService companyPermissionService;
+
+    @Mock
+    private ObjectProvider<IdentityService> identityServiceProvider;
+
+    @Mock
+    private IdentityService identityService;
+
+    @Mock
+    private ObjectProvider<Environment> environmentProvider;
 
     @Test
     void passwordResetRejectsMissingActor() {
@@ -69,11 +94,134 @@ class UserMgmtControllerAuthorizationTest {
     void findReturnsEmptyPageWithoutServiceCallWhenQueryRequired() {
         UserMgmtController controller = controller();
 
-        Page<?> result = controller.find(Optional.empty(), true, Pageable.unpaged()).getBody().getData();
+        Page<?> result = controller.find(Optional.empty(), Optional.empty(), true, null, Pageable.unpaged()).getBody().getData();
 
         assertEquals(0, result.getTotalElements());
         verify(userService, never()).findAll(any());
         verify(userService, never()).findByNameOrUsernameOrEmail(any(), any());
+    }
+
+    @Test
+    void listDelegatesCompanyAndKeywordFilter() {
+        UserMgmtController controller = controller();
+        Pageable pageable = Pageable.unpaged();
+        UserDetails actor = User.withUsername("manager").password("n/a").authorities("ROLE_USER").build();
+        when(companyPermissionServiceProvider.getIfAvailable()).thenReturn(companyPermissionService);
+        when(identityServiceProvider.getIfAvailable()).thenReturn(identityService);
+        when(identityService.findByUsername("manager")).thenReturn(Optional.of(new UserRef(99L, "manager", java.util.Set.of())));
+        when(userService.findByCompanyIdAndNameOrUsernameOrEmail(20L, "kim", pageable))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        controller.list(Optional.of(" kim "), Optional.of(20L), actor, pageable);
+
+        verify(companyPermissionService).assertGranted(20L, 99L, CompanyPermissionActions.MEMBER_READ);
+        verify(userService).findByCompanyIdAndNameOrUsernameOrEmail(20L, "kim", pageable);
+        verify(userService, never()).findByNameOrUsernameOrEmail(any(), any());
+        verify(userService, never()).findAll(any());
+    }
+
+    @Test
+    void findAllowsCompanyFilterWhenQueryIsRequired() {
+        UserMgmtController controller = controller();
+        Pageable pageable = Pageable.unpaged();
+        UserDetails actor = User.withUsername("manager").password("n/a").authorities("ROLE_USER").build();
+        when(companyPermissionServiceProvider.getIfAvailable()).thenReturn(companyPermissionService);
+        when(identityServiceProvider.getIfAvailable()).thenReturn(identityService);
+        when(identityService.findByUsername("manager")).thenReturn(Optional.of(new UserRef(99L, "manager", java.util.Set.of())));
+        when(userService.findAllByCompanyId(20L, pageable)).thenReturn(new PageImpl<>(List.of()));
+
+        controller.find(Optional.empty(), Optional.of(20L), true, actor, pageable);
+
+        verify(userService).findAllByCompanyId(20L, pageable);
+    }
+
+    @Test
+    void companyFilterMapsUnsupportedServiceCapabilityToNotImplemented() {
+        UserMgmtController controller = controller();
+        Pageable pageable = Pageable.unpaged();
+        UserDetails actor = User.withUsername("manager").password("n/a").authorities("ROLE_USER").build();
+        when(companyPermissionServiceProvider.getIfAvailable()).thenReturn(companyPermissionService);
+        when(identityServiceProvider.getIfAvailable()).thenReturn(identityService);
+        when(identityService.findByUsername("manager")).thenReturn(Optional.of(new UserRef(99L, "manager", java.util.Set.of())));
+        when(userService.findAllByCompanyId(20L, pageable)).thenThrow(new UnsupportedOperationException("not supported"));
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+                () -> controller.list(Optional.empty(), Optional.of(20L), actor, pageable));
+
+        assertEquals(HttpStatus.NOT_IMPLEMENTED, exception.getStatusCode());
+    }
+
+    @Test
+    void companyFilterWithoutPermissionServiceReturnsNotImplemented() {
+        UserMgmtController controller = controller();
+        UserDetails actor = User.withUsername("manager").password("n/a").authorities("ROLE_USER").build();
+        when(companyPermissionServiceProvider.getIfAvailable()).thenReturn(null);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+                () -> controller.list(Optional.empty(), Optional.of(20L), actor, Pageable.unpaged()));
+
+        assertEquals(HttpStatus.NOT_IMPLEMENTED, exception.getStatusCode());
+        verify(userService, never()).findAllByCompanyId(any(), any());
+    }
+
+    @Test
+    void companyFilterWithoutIdentityServiceReturnsNotImplemented() {
+        UserMgmtController controller = controller();
+        UserDetails actor = User.withUsername("manager").password("n/a").authorities("ROLE_USER").build();
+        when(companyPermissionServiceProvider.getIfAvailable()).thenReturn(companyPermissionService);
+        when(identityServiceProvider.getIfAvailable()).thenReturn(null);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+                () -> controller.list(Optional.empty(), Optional.of(20L), actor, Pageable.unpaged()));
+
+        assertEquals(HttpStatus.NOT_IMPLEMENTED, exception.getStatusCode());
+        verify(userService, never()).findAllByCompanyId(any(), any());
+    }
+
+    @Test
+    void companyFilterWithoutResolvedActorReturnsUnauthorized() {
+        UserMgmtController controller = controller();
+        UserDetails actor = User.withUsername("manager").password("n/a").authorities("ROLE_USER").build();
+        when(companyPermissionServiceProvider.getIfAvailable()).thenReturn(companyPermissionService);
+        when(identityServiceProvider.getIfAvailable()).thenReturn(identityService);
+        when(identityService.findByUsername("manager")).thenReturn(Optional.empty());
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+                () -> controller.list(Optional.empty(), Optional.of(20L), actor, Pageable.unpaged()));
+
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+        verify(userService, never()).findAllByCompanyId(any(), any());
+    }
+
+    @Test
+    void companyFilterRejectsInvalidCompanyIdAsBadRequest() {
+        UserMgmtController controller = controller();
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+                () -> controller.list(Optional.empty(), Optional.of(0L), null, Pageable.unpaged()));
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        verify(userService, never()).findAllByCompanyId(any(), any());
+    }
+
+    @Test
+    void companyFilterPlatformAdminBypassesCompanyPermissionCheck() {
+        UserMgmtController controller = controller();
+        Pageable pageable = Pageable.unpaged();
+        UserDetails actor = User.withUsername("admin").password("n/a").authorities("ROLE_ADMIN").build();
+        SecurityContextHolder.getContext().setAuthentication(
+                new TestingAuthenticationToken(actor, "n/a", "ROLE_ADMIN"));
+        when(environmentProvider.getIfAvailable()).thenReturn(null);
+        when(userService.findAllByCompanyId(20L, pageable)).thenReturn(new PageImpl<>(List.of()));
+
+        try {
+            controller.list(Optional.empty(), Optional.of(20L), actor, pageable);
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
+
+        verify(companyPermissionServiceProvider, never()).getIfAvailable();
+        verify(userService).findAllByCompanyId(20L, pageable);
     }
 
     @Test
@@ -110,7 +258,14 @@ class UserMgmtControllerAuthorizationTest {
     }
 
     private UserMgmtController controller() {
-        return new UserMgmtController(userService, userMapper, roleMapper, passwordPolicyService);
+        return new UserMgmtController(
+                userService,
+                userMapper,
+                roleMapper,
+                passwordPolicyService,
+                companyPermissionServiceProvider,
+                identityServiceProvider,
+                environmentProvider);
     }
 
     private ChangePasswordRequest changePasswordRequest(String newPassword) {

--- a/studio-platform-user/README.md
+++ b/studio-platform-user/README.md
@@ -80,6 +80,7 @@ Password policy is defined by configuration and enforced on:
 - **Self password change**: `PUT /api/self/password`
 - **Admin reset**: `POST /api/mgmt/users/{id}/password`
 - **Admin delete**: `DELETE /api/mgmt/users/{id}` removes the user through the configured `ApplicationUserService` implementation.
+- **Admin list Company filter**: `GET /api/mgmt/users?companyId={companyId}&q={keyword}` limits the user list to Company members before applying the keyword search.
 
 ### Policy Config (YAML)
 ```yaml

--- a/studio-platform-user/src/main/java/studio/one/base/user/persistence/jdbc/ApplicationGroupMembershipJdbcRepository.java
+++ b/studio-platform-user/src/main/java/studio/one/base/user/persistence/jdbc/ApplicationGroupMembershipJdbcRepository.java
@@ -26,6 +26,12 @@ import studio.one.base.user.persistence.ApplicationGroupMembershipRepository;
 public class ApplicationGroupMembershipJdbcRepository extends BaseJdbcRepository
         implements ApplicationGroupMembershipRepository {
 
+    private static final Map<String, String> MEMBERSHIP_SORT_COLUMNS = Map.of(
+            "groupId", "GROUP_ID",
+            "userId", "USER_ID",
+            "joinedAt", "JOINED_AT",
+            "joinedBy", "JOINED_BY");
+
     private static final RowMapper<ApplicationGroupMembership> MEMBERSHIP_ROW_MAPPER = (rs, rowNum) -> {
         ApplicationGroupMembership membership = new ApplicationGroupMembership();
         ApplicationGroupMembershipId id = new ApplicationGroupMembershipId(rs.getLong("GROUP_ID"), rs.getLong("USER_ID"));
@@ -56,7 +62,7 @@ public class ApplicationGroupMembershipJdbcRepository extends BaseJdbcRepository
     public Page<ApplicationGroupMembership> findAll(Pageable pageable) {
         String select = "select GROUP_ID, USER_ID, JOINED_AT, JOINED_BY from TB_APPLICATION_GROUP_MEMBERS";
         String count = "select count(*) from TB_APPLICATION_GROUP_MEMBERS";
-        return queryPage(select, count, Map.of(), pageable, MEMBERSHIP_ROW_MAPPER, "GROUP_ID", Map.of());
+        return queryPage(select, count, Map.of(), pageable, MEMBERSHIP_ROW_MAPPER, "GROUP_ID", MEMBERSHIP_SORT_COLUMNS);
     }
 
     @Override
@@ -68,7 +74,7 @@ public class ApplicationGroupMembershipJdbcRepository extends BaseJdbcRepository
                  where GROUP_ID = :groupId
                 """;
         String count = "select count(*) from TB_APPLICATION_GROUP_MEMBERS where GROUP_ID = :groupId";
-        return queryPage(select, count, params, pageable, MEMBERSHIP_ROW_MAPPER, "USER_ID", Map.of());
+        return queryPage(select, count, params, pageable, MEMBERSHIP_ROW_MAPPER, "USER_ID", MEMBERSHIP_SORT_COLUMNS);
     }
 
     @Override
@@ -81,7 +87,7 @@ public class ApplicationGroupMembershipJdbcRepository extends BaseJdbcRepository
                 """;
         String count = "select count(*) from TB_APPLICATION_GROUP_MEMBERS where GROUP_ID = :groupId";
         return queryPage(select, count, params, pageable, (rs, rowNum) -> rs.getLong("USER_ID"), "USER_ID",
-                Map.of());
+                MEMBERSHIP_SORT_COLUMNS);
     }
 
     @Override
@@ -118,7 +124,7 @@ public class ApplicationGroupMembershipJdbcRepository extends BaseJdbcRepository
                  where USER_ID = :userId
                 """;
         String count = "select count(*) from TB_APPLICATION_GROUP_MEMBERS where USER_ID = :userId";
-        return queryPage(select, count, params, pageable, MEMBERSHIP_ROW_MAPPER, "GROUP_ID", Map.of());
+        return queryPage(select, count, params, pageable, MEMBERSHIP_ROW_MAPPER, "GROUP_ID", MEMBERSHIP_SORT_COLUMNS);
     }
 
     @Override

--- a/studio-platform-user/src/main/java/studio/one/base/user/persistence/jdbc/ApplicationUserRoleJdbcRepository.java
+++ b/studio-platform-user/src/main/java/studio/one/base/user/persistence/jdbc/ApplicationUserRoleJdbcRepository.java
@@ -25,6 +25,19 @@ import studio.one.base.user.persistence.ApplicationUserRoleRepository;
 @Repository(ApplicationUserRoleRepository.SERVICE_NAME)
 public class ApplicationUserRoleJdbcRepository extends BaseJdbcRepository implements ApplicationUserRoleRepository {
 
+    private static final Map<String, String> USER_ROLE_SORT_COLUMNS = Map.of(
+            "userId", "USER_ID",
+            "roleId", "ROLE_ID",
+            "assignedAt", "ASSIGNED_AT",
+            "assignedBy", "ASSIGNED_BY");
+
+    private static final Map<String, String> ROLE_SORT_COLUMNS = Map.of(
+            "roleId", "r.ROLE_ID",
+            "name", "r.NAME",
+            "description", "r.DESCRIPTION",
+            "creationDate", "r.CREATION_DATE",
+            "modifiedDate", "r.MODIFIED_DATE");
+
     private static final RowMapper<ApplicationUserRole> USER_ROLE_ROW_MAPPER = (rs, rowNum) -> {
         ApplicationUserRole userRole = new ApplicationUserRole();
         ApplicationUserRoleId id = new ApplicationUserRoleId(rs.getLong("USER_ID"), rs.getLong("ROLE_ID"));
@@ -75,7 +88,7 @@ public class ApplicationUserRoleJdbcRepository extends BaseJdbcRepository implem
                  where USER_ID = :userId
                 """;
         String count = "select count(*) from TB_APPLICATION_USER_ROLES where USER_ID = :userId";
-        return queryPage(select, count, params, pageable, USER_ROLE_ROW_MAPPER, "USER_ID", Map.of());
+        return queryPage(select, count, params, pageable, USER_ROLE_ROW_MAPPER, "USER_ID", USER_ROLE_SORT_COLUMNS);
     }
 
     @Override
@@ -97,7 +110,7 @@ public class ApplicationUserRoleJdbcRepository extends BaseJdbcRepository implem
                  where ROLE_ID = :roleId
                 """;
         String count = "select count(*) from TB_APPLICATION_USER_ROLES where ROLE_ID = :roleId";
-        return queryPage(select, count, params, pageable, USER_ROLE_ROW_MAPPER, "USER_ID", Map.of());
+        return queryPage(select, count, params, pageable, USER_ROLE_ROW_MAPPER, "USER_ID", USER_ROLE_SORT_COLUMNS);
     }
 
     @Override
@@ -158,9 +171,7 @@ public class ApplicationUserRoleJdbcRepository extends BaseJdbcRepository implem
                  where ur.USER_ID = :userId
                 """;
         String count = "select count(*) from TB_APPLICATION_USER_ROLES where USER_ID = :userId";
-        return queryPage(select, count, params, pageable, ROLE_ROW_MAPPER, "r.ROLE_ID", Map.of(
-                "roleId", "r.ROLE_ID",
-                "name", "r.NAME"));
+        return queryPage(select, count, params, pageable, ROLE_ROW_MAPPER, "r.ROLE_ID", ROLE_SORT_COLUMNS);
     }
 
     @Override

--- a/studio-platform-user/src/main/java/studio/one/base/user/persistence/jdbc/BaseJdbcRepository.java
+++ b/studio-platform-user/src/main/java/studio/one/base/user/persistence/jdbc/BaseJdbcRepository.java
@@ -2,7 +2,6 @@ package studio.one.base.user.persistence.jdbc;
 
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -133,17 +132,10 @@ abstract class BaseJdbcRepository {
     }
 
     private Optional<String> resolveColumn(String property, Map<String, String> mapping) {
-        if (mapping != null && mapping.containsKey(property)) {
-            return Optional.of(mapping.get(property));
-        }
-        if (property == null || property.isBlank()) {
+        if (mapping == null || property == null || property.isBlank()) {
             return Optional.empty();
         }
-        String snake = property
-                .replaceAll("([a-z0-9])([A-Z])", "$1_$2")
-                .replace('-', '_')
-                .toUpperCase(Locale.ROOT);
-        return Optional.of(snake);
+        return Optional.ofNullable(mapping.get(property));
     }
 
     protected <T> Optional<T> queryOptional(String sql, Map<String, ?> params, RowMapper<T> mapper) {

--- a/studio-platform-user/src/main/java/studio/one/base/user/service/ApplicationUserService.java
+++ b/studio-platform-user/src/main/java/studio/one/base/user/service/ApplicationUserService.java
@@ -62,6 +62,14 @@ public interface ApplicationUserService<T extends User, R extends Role> {
 
     Page<T> findByNameOrUsernameOrEmail(String keyword, Pageable pageable);
 
+    default Page<T> findAllByCompanyId(Long companyId, Pageable pageable) {
+        throw new UnsupportedOperationException("Company-scoped user listing is not supported");
+    }
+
+    default Page<T> findByCompanyIdAndNameOrUsernameOrEmail(Long companyId, String keyword, Pageable pageable) {
+        throw new UnsupportedOperationException("Company-scoped user search is not supported");
+    }
+
     User get(Long userId);
 
     Optional<T> findByUsername(String username);

--- a/studio-platform-user/src/main/java/studio/one/base/user/web/controller/UserMgmtApi.java
+++ b/studio-platform-user/src/main/java/studio/one/base/user/web/controller/UserMgmtApi.java
@@ -35,14 +35,39 @@ public interface UserMgmtApi {
             @RequestParam(value = "q", required = false) Optional<String> q,
             Pageable pageable);
 
+    default ResponseEntity<ApiResponse<Page<UserDto>>> list(
+            @RequestParam(value = "q", required = false) Optional<String> q,
+            @RequestParam(value = "companyId", required = false) Optional<Long> companyId,
+            UserDetails principal,
+            Pageable pageable) {
+        return list(q, pageable);
+    }
+
     ResponseEntity<ApiResponse<Page<UserBasicDto>>> listBasic(
             @RequestParam(value = "q", required = false) Optional<String> q,
             Pageable pageable);
+
+    default ResponseEntity<ApiResponse<Page<UserBasicDto>>> listBasic(
+            @RequestParam(value = "q", required = false) Optional<String> q,
+            @RequestParam(value = "companyId", required = false) Optional<Long> companyId,
+            UserDetails principal,
+            Pageable pageable) {
+        return listBasic(q, pageable);
+    }
 
     ResponseEntity<ApiResponse<Page<UserDto>>> find(
             @RequestParam(value = "q", required = false) Optional<String> q,
             @RequestParam(value = "requireQuery", required = false, defaultValue = "true") boolean requireQuery,
             Pageable pageable);
+
+    default ResponseEntity<ApiResponse<Page<UserDto>>> find(
+            @RequestParam(value = "q", required = false) Optional<String> q,
+            @RequestParam(value = "companyId", required = false) Optional<Long> companyId,
+            @RequestParam(value = "requireQuery", required = false, defaultValue = "true") boolean requireQuery,
+            UserDetails principal,
+            Pageable pageable) {
+        return find(q, requireQuery, pageable);
+    }
 
     ResponseEntity<ApiResponse<UserDto>> get(Long id);
 

--- a/studio-platform/src/main/java/studio/one/platform/web/advice/GlobalExceptionHandler.java
+++ b/studio-platform/src/main/java/studio/one/platform/web/advice/GlobalExceptionHandler.java
@@ -18,6 +18,7 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 
 import lombok.RequiredArgsConstructor;
@@ -265,6 +266,25 @@ public class GlobalExceptionHandler extends AbstractExceptionHandler {
                 .detail(ex.getMessage())
                 .build();
         log.debug("HTTP 4xx: {}", ex.toString());
+        return withContentType(status, body);
+    }
+
+    /**
+     * Handles framework-level exceptions that already carry the intended HTTP
+     * status.
+     *
+     * @param ex  the exception
+     * @param req the current HTTP request
+     * @return a {@code ResponseEntity} with the problem details
+     */
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<ProblemDetails> handleResponseStatus(ResponseStatusException ex, HttpServletRequest req) {
+        HttpStatus status = HttpStatus.valueOf(ex.getStatusCode().value());
+        ProblemDetails body = baseProblem(status, req)
+                .type("urn:error:http-status")
+                .detail(ex.getReason() == null ? status.getReasonPhrase() : ex.getReason())
+                .build();
+        logByStatus(status, ex, "http-status");
         return withContentType(status, body);
     }
 

--- a/studio-platform/src/test/java/studio/one/platform/web/advice/GlobalExceptionHandlerTest.java
+++ b/studio-platform/src/test/java/studio/one/platform/web/advice/GlobalExceptionHandlerTest.java
@@ -5,10 +5,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.server.ResponseStatusException;
 
 import studio.one.platform.service.I18n;
 
@@ -39,5 +41,19 @@ class GlobalExceptionHandlerTest {
         assertThat(response.getStatusCode().value()).isEqualTo(415);
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody().getStatus()).isEqualTo(415);
+    }
+
+    @Test
+    void preservesResponseStatusExceptionStatus() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/test");
+
+        var response = handler.handleResponseStatus(
+                new ResponseStatusException(HttpStatus.NOT_IMPLEMENTED, "Company-scoped user listing is not supported"),
+                request);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(501);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(501);
+        assertThat(response.getBody().getDetail()).isEqualTo("Company-scoped user listing is not supported");
     }
 }


### PR DESCRIPTION
# Summary

회원 목록 관리 API에 Company 소속 필터를 추가합니다.

- `GET /api/mgmt/users`, `/basic`, `/find`에서 `companyId` query parameter를 지원합니다.
- 기본 컨트롤러는 `companyId` 지정 시 Company `MEMBER_READ` 권한을 확인하고, 플랫폼 관리자 role은 우회합니다.
- JPA/JDBC repository에 Company member join 기반 사용자 조회와 검색을 추가했습니다.
- JDBC pageable sort는 명시 allowlist 기반으로 제한하고, 기존 membership/role 정렬 호환 필드는 allowlist로 보강했습니다.
- `ResponseStatusException`이 전역 예외 처리에서 원래 HTTP status로 응답되도록 보강했습니다.
- README/CHANGELOG에 `companyId` 필터와 권한 요구사항을 문서화했습니다.

# Issue

- Closes #438

# Validation

- [x] `./gradlew :studio-platform-user:build :studio-platform-user-default:test :starter:studio-platform-starter-user:test`
- [x] `git diff --check`

# Review / AI-Assisted

- AI-Assisted: Yes
- Subagent used: Yes
- Delegated scope: security/auth review, controller/API review, backend repository/JPA/JDBC query review
- 반복 리뷰 결과 조치:
  - Company filter 권한 검사를 추가했습니다.
  - `UserMgmtApi`에 company-aware overload를 추가해 HTTP 계약을 드러냈습니다.
  - `ResponseStatusException` 전역 매핑을 추가해 `400/401/501`이 catch-all `500`으로 바뀌지 않도록 했습니다.
  - JDBC sort fallback 제거에 따른 호환성 위험을 allowlist 보강으로 처리했습니다.
  - JPA/JDBC 실제 company filter 쿼리 테스트를 추가했습니다.

# Policy Notes

- 브랜치명은 기존 로컬 작업 흐름에 맞춰 `codex/company-user-list-filter`를 사용했습니다. 저장소 정책의 `feature/*` 선호와 다른 점은 PR 본문에 예외로 기록합니다.
