### PR TITLE
fix: register attachment mgmt endpoint in starter auto-configuration

### DIFF
--- a/starter/studio-application-starter-attachment/src/main/java/studio/one/application/attachment/autoconfigure/AttachmentEndpointAutoConfiguration.java
+++ b/starter/studio-application-starter-attachment/src/main/java/studio/one/application/attachment/autoconfigure/AttachmentEndpointAutoConfiguration.java
@@ -39,11 +39,13 @@ import studio.one.application.attachment.application.usecase.AttachmentOwnerAcce
 import studio.one.application.attachment.application.usecase.AttachmentService;
 import studio.one.application.attachment.application.usecase.ThumbnailService;
 import studio.one.application.attachment.web.controller.AttachmentController;
+import studio.one.application.attachment.web.controller.AttachmentMgmtController;
 import studio.one.application.attachment.web.controller.MeAttachmentController;
 import studio.one.application.attachment.web.controller.AttachmentUrlIssueRequestDetailsResolver;
 
 import studio.one.platform.autoconfigure.I18nKeys;
 import studio.one.platform.constant.PropertyKeys;
+import studio.one.platform.textract.application.usecase.FileContentExtractionService;
 import studio.one.platform.identity.PrincipalResolver;
 import studio.one.platform.service.I18n;
 import studio.one.platform.util.LogUtils;
@@ -108,6 +110,35 @@ public class AttachmentEndpointAutoConfiguration {
                                 requestDetailsResolver,
                                 thumbnailServiceProvider,
                                 principalResolverProvider,
+                                ownerAccessAuthorizers);
+        }
+
+        @Bean
+        @Lazy
+        @ConditionalOnMissingBean(AttachmentMgmtController.class)
+        AttachmentMgmtController attachmentMgmtController(
+                        AttachmentService attachmentService,
+                        AttachmentDownloadUrlService downloadUrlService,
+                        AttachmentUrlIssueRequestDetailsResolver requestDetailsResolver,
+                        ObjectProvider<studio.one.platform.identity.IdentityService> identityServiceProvider,
+                        ObjectProvider<PrincipalResolver> principalResolverProvider,
+                        ObjectProvider<FileContentExtractionService> textExtractionProvider,
+                        ObjectProvider<ThumbnailService> thumbnailServiceProvider,
+                        ObjectProvider<AttachmentOwnerAccessAuthorizer> ownerAccessAuthorizers) {
+                log.info(LogUtils.format(i18n, I18nKeys.AutoConfig.Feature.EndPoint.REGISTERED,
+                                AttachmentAutoConfiguration.FEATURE_NAME,
+                                LogUtils.blue(AttachmentService.class, true),
+                                LogUtils.blue(AttachmentMgmtController.class, true),
+                                props.getWeb().getMgmtBasePath(),
+                                "CRUD+thumbnail"));
+                return new AttachmentMgmtController(
+                                attachmentService,
+                                downloadUrlService,
+                                requestDetailsResolver,
+                                identityServiceProvider,
+                                principalResolverProvider,
+                                textExtractionProvider,
+                                thumbnailServiceProvider,
                                 ownerAccessAuthorizers);
         }
 

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/web/controller/AttachmentMgmtController.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/web/controller/AttachmentMgmtController.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -33,10 +34,12 @@ import studio.one.application.attachment.domain.model.Attachment;
 import studio.one.application.attachment.application.error.AttachmentDownloadUrlUnavailableException;
 import studio.one.application.attachment.application.result.AttachmentDownloadUrl;
 import studio.one.application.attachment.application.result.AttachmentDownloadUrlEndpointKind;
+import studio.one.application.attachment.application.result.ThumbnailData;
 import studio.one.application.attachment.application.usecase.AttachmentDownloadUrlService;
 import studio.one.application.attachment.application.result.AttachmentOwnerAccessAction;
 import studio.one.application.attachment.application.usecase.AttachmentOwnerAccessAuthorizer;
 import studio.one.application.attachment.application.usecase.AttachmentService;
+import studio.one.application.attachment.application.usecase.ThumbnailService;
 import studio.one.application.attachment.web.dto.response.AttachmentDownloadUrlDto;
 import studio.one.application.attachment.web.dto.request.AttachmentDownloadUrlIssueRequestDto;
 import studio.one.application.attachment.web.dto.response.AttachmentDto;
@@ -61,6 +64,7 @@ public class AttachmentMgmtController {
     private final ObjectProvider<IdentityService> identityServiceProvider;
     private final ObjectProvider<PrincipalResolver> principalResolverProvider;
     private final ObjectProvider<FileContentExtractionService> textExtractionProvider;
+    private final ObjectProvider<ThumbnailService> thumbnailServiceProvider;
     private final ObjectProvider<AttachmentOwnerAccessAuthorizer> ownerAccessAuthorizers;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -218,6 +222,50 @@ public class AttachmentMgmtController {
             }
         }
         return ResponseEntity.ok(ApiResponse.ok(page.map(this::toDto)));
+    }
+
+    @GetMapping("/{attachmentId:[\\p{Digit}]+}/thumbnail")
+    @PreAuthorize("@endpointAuthz.can('features:attachment','download')")
+    public ResponseEntity<StreamingResponseBody> thumbnail(
+            @PathVariable("attachmentId") long attachmentId,
+            @RequestParam(value = "size", required = false) Integer size,
+            @RequestParam(value = "format", required = false) String format)
+            throws NotFoundException {
+        ThumbnailService thumbnailService = thumbnailServiceProvider.getIfAvailable();
+        if (thumbnailService == null) {
+            return ResponseEntity.status(501).build();
+        }
+        Attachment attachment = attachmentService.getAttachmentById(attachmentId);
+        AttachmentAccessSupport.requireAttachmentAccess(
+                attachment,
+                requirePrincipal(),
+                ownerAccessAuthorizers,
+                AttachmentOwnerAccessAction.DOWNLOAD);
+        int requestedSize = size == null ? 0 : size;
+        var result = thumbnailService.getOrCreate(attachment, requestedSize, format);
+        if (result.isEmpty()) {
+            HttpHeaders headers = new HttpHeaders();
+            headers.add("X-Thumbnail-Status", "unavailable");
+            headers.setCacheControl(CacheControl.noStore().getHeaderValue());
+            return ResponseEntity.noContent()
+                    .headers(headers)
+                    .build();
+        }
+        ThumbnailData data = result.get();
+        StreamingResponseBody body = out -> out.write(data.getBytes());
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("X-Thumbnail-Status", data.getStatus());
+        if (data.isPending()) {
+            headers.setCacheControl(CacheControl.noStore().getHeaderValue());
+            headers.add(HttpHeaders.RETRY_AFTER, "3");
+        } else {
+            headers.setCacheControl(CacheControl.maxAge(3600, java.util.concurrent.TimeUnit.SECONDS).getHeaderValue());
+        }
+        headers.setContentType(AttachmentWebSupport.resolveMediaType(data.getContentType()));
+        headers.setContentLength(data.getBytes().length);
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(body);
     }
 
     @GetMapping("/objects/{objectType:[\\p{Digit}]+}/{objectId:[\\p{Digit}]+}")

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/web/controller/AttachmentMgmtControllerAuthorizationTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/web/controller/AttachmentMgmtControllerAuthorizationTest.java
@@ -28,6 +28,7 @@ import studio.one.platform.identity.ApplicationPrincipal;
 import studio.one.platform.identity.IdentityService;
 import studio.one.platform.identity.PrincipalResolver;
 import studio.one.platform.objecttype.application.WellKnownAttachmentObjectTypes;
+import studio.one.application.attachment.application.usecase.ThumbnailService;
 import studio.one.platform.textract.domain.error.FileParseException;
 import studio.one.platform.textract.application.usecase.FileContentExtractionService;
 
@@ -51,6 +52,9 @@ class AttachmentMgmtControllerAuthorizationTest {
 
     @Mock
     private ObjectProvider<FileContentExtractionService> textExtractionProvider;
+
+    @Mock
+    private ObjectProvider<ThumbnailService> thumbnailServiceProvider;
 
     @Mock
     private ObjectProvider<AttachmentOwnerAccessAuthorizer> ownerAccessAuthorizers;
@@ -172,6 +176,7 @@ class AttachmentMgmtControllerAuthorizationTest {
                 identityServiceProvider,
                 principalResolverProvider,
                 textExtractionProvider,
+                thumbnailServiceProvider,
                 ownerAccessAuthorizers);
     }
 


### PR DESCRIPTION
## Why

관리 화면에서 파일 첨부 목록/썸네일 경로가 노출될 때, 관리용 첨부 API에 썸네일 라우트가 등록되지 않아 `/api/mgmt/{...}/thumbnail` 호출이 컨트롤러에서 처리되지 않았습니다.

## What

- `studio-application-starter-attachment`의 `AttachmentEndpointAutoConfiguration`에 `AttachmentMgmtController` 빈을 등록해 관리 라우트가 스프링 컨텍스트에 노출되도록 수정했습니다.
- `AttachmentMgmtController`에 관리용 썸네일 조회 엔드포인트(`GET /api/mgmt/attachments/{attachmentId}/thumbnail`)를 추가해 기존 `ThumbnailService.getOrCreate(...)` 경로를 재사용했습니다.
- 썸네일 엔드포인트의 접근 제어는 기존 `features:attachment/download` 권한/검증 흐름을 유지했습니다.

## Related Issues

- 없음

## Validation

- Command: `./gradlew :studio-application-modules:attachment-service:test --tests "*AttachmentMgmtControllerAuthorizationTest*"`
- Result: 실행되지 않음 (현재 환경 제약으로 로컬 빌드/네트워크 확인 불가)

## Risk / Rollback

- Risk: 관리 컨트롤러 빈 등록 시 기존 사용자 경로(`/api/attachments`)와 충돌이 발생할 경우 404/라우트 우선순위 이슈가 생길 수 있습니다.
- Rollback: `AttachmentEndpointAutoConfiguration`에서 `AttachmentMgmtController` 빈 등록만 제거하면 즉시 이전 상태로 되돌릴 수 있습니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: Yes
- Delegated scope: 리뷰 반복 확인(로컬 코드 점검 및 PR 템플릿 정합성 반영)
- Main author validation: 템플릿 정합성 반영 후 재요청

## Checklist

- [ ] commit message follows policy
- [ ] issue template used or exception recorded
- [ ] AI-Assisted value is correct
- [ ] validation recorded
- [ ] subagent usage recorded when used
- [ ] CI / repository verification passed
- [ ] human review completed before merge
- [ ] no unrelated changes included
