### PR TITLE
fix(objecttype): register objecttype web controllers without endpointAuthz

### DIFF
--- a/starter/studio-platform-starter-objecttype/src/main/java/studio/one/platform/autoconfigure/objecttype/ObjectTypeWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-objecttype/src/main/java/studio/one/platform/autoconfigure/objecttype/ObjectTypeWebAutoConfiguration.java
@@ -59,21 +59,21 @@ public class ObjectTypeWebAutoConfiguration {
     }
 
     @Configuration
-    @ConditionalOnBean(name = { ObjectTypeRuntimeService.SERVICE_NAME, "endpointAuthz" })
+    @ConditionalOnBean(name = { ObjectTypeRuntimeService.SERVICE_NAME })
     @Import(ObjectTypeController.class)
     static class ObjectTypeRuntimeWebConfig {
 
     }
 
     @Configuration
-    @ConditionalOnBean(name = { ObjectTypeRuntimeService.SERVICE_NAME, "endpointAuthz" })
+    @ConditionalOnBean(name = { ObjectTypeRuntimeService.SERVICE_NAME })
     @Import(ObjectTypeKeyController.class)
     static class ObjectTypeKeyRuntimeWebConfig {
 
     }
 
     @Configuration
-    @ConditionalOnBean(name = { ObjectTypeAdminService.SERVICE_NAME, "endpointAuthz" })
+    @ConditionalOnBean(name = { ObjectTypeAdminService.SERVICE_NAME })
     @Import(ObjectTypeMgmtController.class)
     static class ObjectTypeAdminWebConfig {
 


### PR DESCRIPTION
## 해결 내용
- `studio.features.objecttype.web`의 오브젝트타입 API가 `endpointAuthz` 빈 유무 조건에서 누락되어 `/api/mgmt/object-types` 매핑이 생성되지 않던 문제를 수정했습니다.
- `ObjectTypeWebAutoConfiguration`에서 `ObjectTypeRuntimeController`, `ObjectTypeKeyController`, `ObjectTypeMgmtController`의 `@ConditionalOnBean`에서 `endpointAuthz` 조건을 제거했습니다.

## 검증
- 서버 재기동 후 `actuator/mappings`에서 `/api/mgmt/object-types` 및 `/api/mgmt/files/{id}/thumbnail` 매핑이 모두 노출됨을 확인했습니다.
- 인증 미기입 시 응답은 `401`로, 더 이상 정적 리소스 500이 아닌 보안 진입점 처리입니다.

## 이슈
- Closes #457