### PR TITLE
[ai-assisted] refactor(attachment): objectType 메타데이터 기반 권한 판별 적용

### DIFF
--- a/starter/studio-application-starter-attachment/src/main/java/studio/one/application/attachment/autoconfigure/AttachmentAutoConfiguration.java
+++ b/starter/studio-application-starter-attachment/src/main/java/studio/one/application/attachment/autoconfigure/AttachmentAutoConfiguration.java
@@ -74,6 +74,7 @@ import studio.one.application.attachment.application.service.AttachmentDownloadU
 import studio.one.application.attachment.application.service.AttachmentObjectTypeResolver;
 import studio.one.application.attachment.application.usecase.AttachmentService;
 import studio.one.application.attachment.application.service.AttachmentServiceImpl;
+import studio.one.application.attachment.web.controller.MetadataBasedAttachmentObjectTypeResolver;
 import studio.one.application.attachment.infrastructure.storage.AttachmentFileStorageResolver;
 import studio.one.application.attachment.infrastructure.storage.AttachmentStorageBackend;
 import studio.one.application.attachment.infrastructure.storage.AttachmentStorageType;
@@ -95,6 +96,7 @@ import studio.one.platform.constant.PropertyKeys;
 import studio.one.platform.constant.ServiceNames;
 import studio.one.platform.identity.PrincipalResolver;
 import studio.one.platform.objecttype.application.usecase.ObjectTypeRuntimeService;
+import studio.one.platform.objecttype.registry.ObjectTypeRegistry;
 import studio.one.platform.service.I18n;
 import studio.one.platform.service.Repository;
 import studio.one.platform.storage.application.usecase.ObjectStorageRegistry;
@@ -318,6 +320,14 @@ public class AttachmentAutoConfiguration {
     AttachmentObjectTypeResolver attachmentObjectTypeResolver(
             ObjectProvider<ObjectTypeRuntimeService> objectTypeRuntimeServiceProvider) {
         return new AttachmentObjectTypeResolver(objectTypeRuntimeServiceProvider);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(studio.one.application.attachment.application.usecase.AttachmentObjectTypeResolver.class)
+    studio.one.application.attachment.application.usecase.AttachmentObjectTypeResolver attachmentPermissionObjectTypeResolver(
+            ObjectProvider<ObjectTypeRuntimeService> objectTypeRuntimeServiceProvider,
+            ObjectProvider<ObjectTypeRegistry> objectTypeRegistryProvider) {
+        return new MetadataBasedAttachmentObjectTypeResolver(objectTypeRuntimeServiceProvider, objectTypeRegistryProvider);
     }
 
     @Bean

--- a/starter/studio-application-starter-attachment/src/main/java/studio/one/application/attachment/autoconfigure/AttachmentEndpointAutoConfiguration.java
+++ b/starter/studio-application-starter-attachment/src/main/java/studio/one/application/attachment/autoconfigure/AttachmentEndpointAutoConfiguration.java
@@ -36,6 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 import studio.one.application.attachment.application.usecase.AttachmentDownloadAuditLogService;
 import studio.one.application.attachment.application.usecase.AttachmentDownloadUrlService;
 import studio.one.application.attachment.application.usecase.AttachmentOwnerAccessAuthorizer;
+import studio.one.application.attachment.application.usecase.AttachmentObjectTypeResolver;
 import studio.one.application.attachment.application.usecase.AttachmentService;
 import studio.one.application.attachment.application.usecase.ThumbnailService;
 import studio.one.application.attachment.web.controller.AttachmentController;
@@ -95,7 +96,8 @@ public class AttachmentEndpointAutoConfiguration {
                         AttachmentUrlIssueRequestDetailsResolver requestDetailsResolver,
                         ObjectProvider<ThumbnailService> thumbnailServiceProvider,
                         ObjectProvider<PrincipalResolver> principalResolverProvider,
-                        ObjectProvider<AttachmentOwnerAccessAuthorizer> ownerAccessAuthorizers) {
+                        ObjectProvider<AttachmentOwnerAccessAuthorizer> ownerAccessAuthorizers,
+                        AttachmentObjectTypeResolver objectTypeResolver) {
 
                 log.info(LogUtils.format(i18n, I18nKeys.AutoConfig.Feature.EndPoint.REGISTERED,
                                 AttachmentAutoConfiguration.FEATURE_NAME,
@@ -110,7 +112,8 @@ public class AttachmentEndpointAutoConfiguration {
                                 requestDetailsResolver,
                                 thumbnailServiceProvider,
                                 principalResolverProvider,
-                                ownerAccessAuthorizers);
+                                ownerAccessAuthorizers,
+                                objectTypeResolver);
         }
 
         @Bean
@@ -124,7 +127,8 @@ public class AttachmentEndpointAutoConfiguration {
                         ObjectProvider<PrincipalResolver> principalResolverProvider,
                         ObjectProvider<FileContentExtractionService> textExtractionProvider,
                         ObjectProvider<ThumbnailService> thumbnailServiceProvider,
-                        ObjectProvider<AttachmentOwnerAccessAuthorizer> ownerAccessAuthorizers) {
+                        ObjectProvider<AttachmentOwnerAccessAuthorizer> ownerAccessAuthorizers,
+                        AttachmentObjectTypeResolver objectTypeResolver) {
                 log.info(LogUtils.format(i18n, I18nKeys.AutoConfig.Feature.EndPoint.REGISTERED,
                                 AttachmentAutoConfiguration.FEATURE_NAME,
                                 LogUtils.blue(AttachmentService.class, true),
@@ -139,7 +143,8 @@ public class AttachmentEndpointAutoConfiguration {
                                 principalResolverProvider,
                                 textExtractionProvider,
                                 thumbnailServiceProvider,
-                                ownerAccessAuthorizers);
+                                ownerAccessAuthorizers,
+                                objectTypeResolver);
         }
 
         @Bean
@@ -150,13 +155,15 @@ public class AttachmentEndpointAutoConfiguration {
                         ObjectProvider<studio.one.platform.identity.IdentityService> identityServiceProvider,
                         ObjectProvider<studio.one.platform.textract.application.usecase.FileContentExtractionService> textExtractionProvider,
                         ObjectProvider<AttachmentOwnerAccessAuthorizer> ownerAccessAuthorizers,
-                        ObjectProvider<PrincipalResolver> principalResolverProvider) {
+                        ObjectProvider<PrincipalResolver> principalResolverProvider,
+                        AttachmentObjectTypeResolver objectTypeResolver) {
                 return new MeAttachmentController(
                                 attachmentService,
                                 identityServiceProvider,
                                 textExtractionProvider,
                                 ownerAccessAuthorizers,
-                                principalResolverProvider);
+                                principalResolverProvider,
+                                objectTypeResolver);
         }
 
 }

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/application/result/AttachmentObjectTypeDescriptor.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/application/result/AttachmentObjectTypeDescriptor.java
@@ -1,0 +1,16 @@
+package studio.one.application.attachment.application.result;
+
+public record AttachmentObjectTypeDescriptor(
+        int objectType,
+        boolean attachmentDomain,
+        boolean attachmentEnabled,
+        String attachmentType) {
+
+    public boolean isAttachmentDomainType() {
+        return attachmentDomain || attachmentEnabled || hasAttachmentType();
+    }
+
+    public boolean hasAttachmentType() {
+        return attachmentType != null && !attachmentType.isBlank();
+    }
+}

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/application/usecase/AttachmentObjectTypeResolver.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/application/usecase/AttachmentObjectTypeResolver.java
@@ -1,0 +1,11 @@
+package studio.one.application.attachment.application.usecase;
+
+import java.util.Optional;
+
+import studio.one.application.attachment.application.result.AttachmentObjectTypeDescriptor;
+
+public interface AttachmentObjectTypeResolver {
+
+    Optional<AttachmentObjectTypeDescriptor> resolve(int objectType);
+
+}

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/web/controller/AttachmentAccessSupport.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/web/controller/AttachmentAccessSupport.java
@@ -132,11 +132,12 @@ final class AttachmentAccessSupport {
         if (objectType == WellKnownAttachmentObjectTypes.GENERIC_ATTACHMENT) {
             return false;
         }
+        boolean fallbackAttachmentType = isFallbackWellKnownDomainAttachmentType(objectType);
         Optional<AttachmentObjectTypeDescriptor> resolved = resolveAttachmentTypeDescriptor(objectType, objectTypeResolver);
         if (resolved.isPresent() && resolved.get().isAttachmentDomainType()) {
             return true;
         }
-        return isFallbackWellKnownDomainAttachmentType(objectType);
+        return fallbackAttachmentType;
     }
 
     private static boolean isFallbackWellKnownDomainAttachmentType(int objectType) {
@@ -155,7 +156,10 @@ final class AttachmentAccessSupport {
         try {
             return objectTypeResolver.resolve(objectType);
         } catch (Exception ex) {
-            return Optional.empty();
+            if (isFallbackWellKnownDomainAttachmentType(objectType)) {
+                return Optional.empty();
+            }
+            throw new AccessDeniedException("Forbidden attachment access", ex);
         }
     }
 }

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/web/controller/AttachmentAccessSupport.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/web/controller/AttachmentAccessSupport.java
@@ -1,5 +1,6 @@
 package studio.one.application.attachment.web.controller;
 
+import java.util.Optional;
 import java.util.Objects;
 import java.util.Set;
 
@@ -9,7 +10,9 @@ import org.springframework.security.authentication.AuthenticationCredentialsNotF
 
 import studio.one.application.attachment.domain.model.Attachment;
 import studio.one.application.attachment.application.result.AttachmentOwnerAccessAction;
+import studio.one.application.attachment.application.result.AttachmentObjectTypeDescriptor;
 import studio.one.application.attachment.application.usecase.AttachmentOwnerAccessAuthorizer;
+import studio.one.application.attachment.application.usecase.AttachmentObjectTypeResolver;
 import studio.one.platform.identity.ApplicationPrincipal;
 import studio.one.platform.identity.PrincipalResolver;
 import studio.one.platform.objecttype.application.WellKnownAttachmentObjectTypes;
@@ -60,15 +63,25 @@ final class AttachmentAccessSupport {
             ApplicationPrincipal principal,
             ObjectProvider<AttachmentOwnerAccessAuthorizer> ownerAccessAuthorizers,
             AttachmentOwnerAccessAction action) {
+        requireAttachmentAccess(attachment, principal, ownerAccessAuthorizers, null, action);
+    }
+
+    static void requireAttachmentAccess(
+            Attachment attachment,
+            ApplicationPrincipal principal,
+            ObjectProvider<AttachmentOwnerAccessAuthorizer> ownerAccessAuthorizers,
+            AttachmentObjectTypeResolver objectTypeResolver,
+            AttachmentOwnerAccessAction action) {
         if (isAdmin(principal)) {
             return;
         }
-        if (isWellKnownDomainAttachmentType(attachment.getObjectType())) {
+        if (isWellKnownDomainAttachmentType(attachment.getObjectType(), objectTypeResolver)) {
             requireOwnerAccess(
                     attachment.getObjectType(),
                     attachment.getObjectId(),
                     principal,
                     ownerAccessAuthorizers,
+                    objectTypeResolver,
                     action);
             return;
         }
@@ -84,10 +97,20 @@ final class AttachmentAccessSupport {
             ApplicationPrincipal principal,
             ObjectProvider<AttachmentOwnerAccessAuthorizer> ownerAccessAuthorizers,
             AttachmentOwnerAccessAction action) {
+        requireOwnerAccess(objectType, objectId, principal, ownerAccessAuthorizers, null, action);
+    }
+
+    static void requireOwnerAccess(
+            int objectType,
+            long objectId,
+            ApplicationPrincipal principal,
+            ObjectProvider<AttachmentOwnerAccessAuthorizer> ownerAccessAuthorizers,
+            AttachmentObjectTypeResolver objectTypeResolver,
+            AttachmentOwnerAccessAction action) {
         if (isAdmin(principal)) {
             return;
         }
-        if (!isWellKnownDomainAttachmentType(objectType)) {
+        if (!isWellKnownDomainAttachmentType(objectType, objectTypeResolver)) {
             return;
         }
         if (ownerAccessAuthorizers == null) {
@@ -102,9 +125,37 @@ final class AttachmentAccessSupport {
     }
 
     static boolean isWellKnownDomainAttachmentType(int objectType) {
+        return isWellKnownDomainAttachmentType(objectType, null);
+    }
+
+    static boolean isWellKnownDomainAttachmentType(int objectType, AttachmentObjectTypeResolver objectTypeResolver) {
+        if (objectType == WellKnownAttachmentObjectTypes.GENERIC_ATTACHMENT) {
+            return false;
+        }
+        Optional<AttachmentObjectTypeDescriptor> resolved = resolveAttachmentTypeDescriptor(objectType, objectTypeResolver);
+        if (resolved.isPresent() && resolved.get().isAttachmentDomainType()) {
+            return true;
+        }
+        return isFallbackWellKnownDomainAttachmentType(objectType);
+    }
+
+    private static boolean isFallbackWellKnownDomainAttachmentType(int objectType) {
         return objectType == WellKnownAttachmentObjectTypes.POST_ATTACHMENT
                 || objectType == WellKnownAttachmentObjectTypes.MAIL_ATTACHMENT
                 || objectType == WellKnownAttachmentObjectTypes.WORKSPACE_ATTACHMENT
                 || objectType == WellKnownAttachmentObjectTypes.WIKI_ATTACHMENT;
+    }
+
+    private static Optional<AttachmentObjectTypeDescriptor> resolveAttachmentTypeDescriptor(
+            int objectType,
+            AttachmentObjectTypeResolver objectTypeResolver) {
+        if (objectTypeResolver == null) {
+            return Optional.empty();
+        }
+        try {
+            return objectTypeResolver.resolve(objectType);
+        } catch (Exception ex) {
+            return Optional.empty();
+        }
     }
 }

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/web/controller/AttachmentController.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/web/controller/AttachmentController.java
@@ -41,6 +41,7 @@ import studio.one.application.attachment.application.result.AttachmentDownloadTo
 import studio.one.application.attachment.application.result.AttachmentDownloadUrl;
 import studio.one.application.attachment.application.result.AttachmentDownloadTokenClaims;
 import studio.one.application.attachment.application.result.AttachmentDownloadUrlEndpointKind;
+import studio.one.application.attachment.application.usecase.AttachmentObjectTypeResolver;
 import studio.one.application.attachment.application.usecase.AttachmentDownloadUrlService;
 import studio.one.application.attachment.application.result.AttachmentOwnerAccessAction;
 import studio.one.application.attachment.application.usecase.AttachmentOwnerAccessAuthorizer;
@@ -71,6 +72,7 @@ public class AttachmentController {
     private final ObjectProvider<ThumbnailService> thumbnailServiceProvider;
     private final ObjectProvider<PrincipalResolver> principalResolverProvider;
     private final ObjectProvider<AttachmentOwnerAccessAuthorizer> ownerAccessAuthorizers;
+    private final AttachmentObjectTypeResolver objectTypeResolver;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("@endpointAuthz.can('features:attachment','service-upload')")
@@ -311,18 +313,19 @@ public class AttachmentController {
     }
 
     private void requireAttachmentAccess(Attachment attachment, AttachmentOwnerAccessAction action) {
-        if (!AttachmentAccessSupport.isWellKnownDomainAttachmentType(attachment.getObjectType())) {
+        if (!AttachmentAccessSupport.isWellKnownDomainAttachmentType(attachment.getObjectType(), objectTypeResolver)) {
             return;
         }
         AttachmentAccessSupport.requireAttachmentAccess(
                 attachment,
                 AttachmentAccessSupport.requirePrincipal(principalResolverProvider),
                 ownerAccessAuthorizers,
+                objectTypeResolver,
                 action);
     }
 
     private void requireOwnerAccess(int objectType, long objectId, AttachmentOwnerAccessAction action) {
-        if (!AttachmentAccessSupport.isWellKnownDomainAttachmentType(objectType)) {
+        if (!AttachmentAccessSupport.isWellKnownDomainAttachmentType(objectType, objectTypeResolver)) {
             return;
         }
         AttachmentAccessSupport.requireOwnerAccess(
@@ -330,6 +333,7 @@ public class AttachmentController {
                 objectId,
                 AttachmentAccessSupport.requirePrincipal(principalResolverProvider),
                 ownerAccessAuthorizers,
+                objectTypeResolver,
                 action);
     }
 

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/web/controller/AttachmentMgmtController.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/web/controller/AttachmentMgmtController.java
@@ -38,6 +38,7 @@ import studio.one.application.attachment.application.result.ThumbnailData;
 import studio.one.application.attachment.application.usecase.AttachmentDownloadUrlService;
 import studio.one.application.attachment.application.result.AttachmentOwnerAccessAction;
 import studio.one.application.attachment.application.usecase.AttachmentOwnerAccessAuthorizer;
+import studio.one.application.attachment.application.usecase.AttachmentObjectTypeResolver;
 import studio.one.application.attachment.application.usecase.AttachmentService;
 import studio.one.application.attachment.application.usecase.ThumbnailService;
 import studio.one.application.attachment.web.dto.response.AttachmentDownloadUrlDto;
@@ -66,6 +67,7 @@ public class AttachmentMgmtController {
     private final ObjectProvider<FileContentExtractionService> textExtractionProvider;
     private final ObjectProvider<ThumbnailService> thumbnailServiceProvider;
     private final ObjectProvider<AttachmentOwnerAccessAuthorizer> ownerAccessAuthorizers;
+    private final AttachmentObjectTypeResolver objectTypeResolver;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("@endpointAuthz.can('features:attachment','upload')")
@@ -85,6 +87,7 @@ public class AttachmentMgmtController {
                 objectId,
                 principal,
                 ownerAccessAuthorizers,
+                objectTypeResolver,
                 AttachmentOwnerAccessAction.UPLOAD);
 
         Attachment saved = attachmentService.createAttachment(
@@ -103,7 +106,7 @@ public class AttachmentMgmtController {
             throws NotFoundException {
         Attachment attachment = attachmentService.getAttachmentById(attachmentId);
         AttachmentAccessSupport.requireAttachmentAccess(
-                attachment, requirePrincipal(), ownerAccessAuthorizers, AttachmentOwnerAccessAction.READ);
+                attachment, requirePrincipal(), ownerAccessAuthorizers, objectTypeResolver, AttachmentOwnerAccessAction.READ);
         return ResponseEntity.ok(ApiResponse.ok(toDto(attachment)));
     }
 
@@ -120,7 +123,7 @@ public class AttachmentMgmtController {
         }
         Attachment attachment = attachmentService.getAttachmentById(attachmentId);
         AttachmentAccessSupport.requireAttachmentAccess(
-                attachment, requirePrincipal(), ownerAccessAuthorizers, AttachmentOwnerAccessAction.READ);
+                attachment, requirePrincipal(), ownerAccessAuthorizers, objectTypeResolver, AttachmentOwnerAccessAction.READ);
         try (InputStream in = attachmentService.getInputStream(attachment)) {
             String text = extractor.extractText(attachment.getContentType(), attachment.getName(), in);
             return ResponseEntity.ok(ApiResponse.ok(text));
@@ -133,7 +136,7 @@ public class AttachmentMgmtController {
             throws IOException, NotFoundException {
         Attachment attachment = attachmentService.getAttachmentById(attachmentId);
         AttachmentAccessSupport.requireAttachmentAccess(
-                attachment, requirePrincipal(), ownerAccessAuthorizers, AttachmentOwnerAccessAction.DOWNLOAD);
+                attachment, requirePrincipal(), ownerAccessAuthorizers, objectTypeResolver, AttachmentOwnerAccessAction.DOWNLOAD);
         return AttachmentWebSupport.downloadResponse(
                 attachment,
                 attachmentService.getInputStream(attachment),
@@ -149,7 +152,7 @@ public class AttachmentMgmtController {
         Attachment attachment = attachmentService.getAttachmentById(attachmentId);
         ApplicationPrincipal principal = requirePrincipal();
         AttachmentAccessSupport.requireAttachmentAccess(
-                attachment, principal, ownerAccessAuthorizers, AttachmentOwnerAccessAction.ISSUE_DOWNLOAD_URL);
+                attachment, principal, ownerAccessAuthorizers, objectTypeResolver, AttachmentOwnerAccessAction.ISSUE_DOWNLOAD_URL);
         AttachmentUrlIssueRequestDetails details = requestDetailsResolver.resolve(httpRequest);
         try {
             AttachmentDownloadUrl issued = downloadUrlService.issueDownloadUrl(
@@ -186,12 +189,13 @@ public class AttachmentMgmtController {
                 } else {
                     page = attachmentService.findAttachments(objectType, objectId, keyword, pageable);
                 }
-            } else if (AttachmentAccessSupport.isWellKnownDomainAttachmentType(objectType)) {
+            } else if (AttachmentAccessSupport.isWellKnownDomainAttachmentType(objectType, objectTypeResolver)) {
                 AttachmentAccessSupport.requireOwnerAccess(
                         objectType,
                         objectId,
                         principal,
                         ownerAccessAuthorizers,
+                        objectTypeResolver,
                         AttachmentOwnerAccessAction.LIST);
                 if (keyword == null || keyword.isBlank()) {
                     page = attachmentService.findAttachments(objectType, objectId, pageable);
@@ -240,6 +244,7 @@ public class AttachmentMgmtController {
                 attachment,
                 requirePrincipal(),
                 ownerAccessAuthorizers,
+                objectTypeResolver,
                 AttachmentOwnerAccessAction.DOWNLOAD);
         int requestedSize = size == null ? 0 : size;
         var result = thumbnailService.getOrCreate(attachment, requestedSize, format);
@@ -277,12 +282,13 @@ public class AttachmentMgmtController {
         List<Attachment> attachments;
         if (AttachmentAccessSupport.isAdmin(principal)) {
             attachments = attachmentService.getAttachments(objectType, objectId);
-        } else if (AttachmentAccessSupport.isWellKnownDomainAttachmentType(objectType)) {
+        } else if (AttachmentAccessSupport.isWellKnownDomainAttachmentType(objectType, objectTypeResolver)) {
             AttachmentAccessSupport.requireOwnerAccess(
                     objectType,
                     objectId,
                     principal,
                     ownerAccessAuthorizers,
+                    objectTypeResolver,
                     AttachmentOwnerAccessAction.LIST);
             attachments = attachmentService.getAttachments(objectType, objectId);
         } else {
@@ -300,7 +306,7 @@ public class AttachmentMgmtController {
             throws NotFoundException, IOException {
         Attachment attachment = attachmentService.getAttachmentById(attachmentId);
         AttachmentAccessSupport.requireAttachmentAccess(
-                attachment, requirePrincipal(), ownerAccessAuthorizers, AttachmentOwnerAccessAction.DELETE);
+                attachment, requirePrincipal(), ownerAccessAuthorizers, objectTypeResolver, AttachmentOwnerAccessAction.DELETE);
         attachmentService.removeAttachment(attachment);
         return ResponseEntity.ok(ApiResponse.ok());
     }

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/web/controller/MeAttachmentController.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/web/controller/MeAttachmentController.java
@@ -31,6 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 import studio.one.application.attachment.domain.model.Attachment;
 import studio.one.application.attachment.application.result.AttachmentOwnerAccessAction;
 import studio.one.application.attachment.application.usecase.AttachmentOwnerAccessAuthorizer;
+import studio.one.application.attachment.application.usecase.AttachmentObjectTypeResolver;
 import studio.one.application.attachment.application.usecase.AttachmentService;
 import studio.one.application.attachment.web.dto.response.AttachmentDto;
 import studio.one.platform.constant.PropertyKeys;
@@ -54,6 +55,7 @@ public class MeAttachmentController {
     private final ObjectProvider<FileContentExtractionService> textExtractionProvider;
     private final ObjectProvider<AttachmentOwnerAccessAuthorizer> ownerAccessAuthorizers;
     private final ObjectProvider<PrincipalResolver> principalResolverProvider;
+    private final AttachmentObjectTypeResolver objectTypeResolver;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<AttachmentDto>> upload(
@@ -186,13 +188,14 @@ public class MeAttachmentController {
             Attachment attachment,
             ApplicationPrincipal principal,
             AttachmentOwnerAccessAction action) {
-        if (!AttachmentAccessSupport.isWellKnownDomainAttachmentType(attachment.getObjectType())) {
+        if (!AttachmentAccessSupport.isWellKnownDomainAttachmentType(attachment.getObjectType(), objectTypeResolver)) {
             return;
         }
         AttachmentAccessSupport.requireAttachmentAccess(
                 attachment,
                 principal,
                 ownerAccessAuthorizers,
+                objectTypeResolver,
                 action);
     }
 
@@ -201,7 +204,7 @@ public class MeAttachmentController {
             long objectId,
             ApplicationPrincipal principal,
             AttachmentOwnerAccessAction action) {
-        if (!AttachmentAccessSupport.isWellKnownDomainAttachmentType(objectType)) {
+        if (!AttachmentAccessSupport.isWellKnownDomainAttachmentType(objectType, objectTypeResolver)) {
             return;
         }
         AttachmentAccessSupport.requireOwnerAccess(
@@ -209,6 +212,7 @@ public class MeAttachmentController {
                 objectId,
                 principal,
                 ownerAccessAuthorizers,
+                objectTypeResolver,
                 action);
     }
 

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/web/controller/MetadataBasedAttachmentObjectTypeResolver.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/web/controller/MetadataBasedAttachmentObjectTypeResolver.java
@@ -1,0 +1,128 @@
+package studio.one.application.attachment.web.controller;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.beans.factory.ObjectProvider;
+
+import studio.one.application.attachment.application.result.AttachmentObjectTypeDescriptor;
+import studio.one.application.attachment.application.usecase.AttachmentObjectTypeResolver;
+import studio.one.platform.objecttype.application.usecase.ObjectTypeRuntimeService;
+import studio.one.platform.objecttype.application.result.ObjectTypeDefinition;
+import studio.one.platform.objecttype.model.ObjectTypeMetadata;
+import studio.one.platform.objecttype.registry.ObjectTypeRegistry;
+
+public class MetadataBasedAttachmentObjectTypeResolver implements AttachmentObjectTypeResolver {
+
+    private final ObjectProvider<ObjectTypeRuntimeService> objectTypeRuntimeServiceProvider;
+    private final ObjectProvider<ObjectTypeRegistry> objectTypeRegistryProvider;
+
+    public MetadataBasedAttachmentObjectTypeResolver(
+            ObjectProvider<ObjectTypeRuntimeService> objectTypeRuntimeServiceProvider,
+            ObjectProvider<ObjectTypeRegistry> objectTypeRegistryProvider) {
+        this.objectTypeRuntimeServiceProvider = objectTypeRuntimeServiceProvider;
+        this.objectTypeRegistryProvider = objectTypeRegistryProvider;
+    }
+
+    @Override
+    public Optional<AttachmentObjectTypeDescriptor> resolve(int objectType) {
+        return resolveFromMetadata(objectType)
+                .or(() -> resolveFromRuntimeDefinition(objectType));
+    }
+
+    private Optional<AttachmentObjectTypeDescriptor> resolveFromMetadata(int objectType) {
+        ObjectTypeRegistry registry = objectTypeRegistryProvider.getIfAvailable();
+        if (registry == null) {
+            return Optional.empty();
+        }
+        return registry.findByType(objectType).map(this::resolveFromMetadata);
+    }
+
+    private Optional<AttachmentObjectTypeDescriptor> resolveFromRuntimeDefinition(int objectType) {
+        ObjectTypeRuntimeService runtimeService = objectTypeRuntimeServiceProvider.getIfAvailable();
+        if (runtimeService == null) {
+            return Optional.empty();
+        }
+        try {
+            ObjectTypeDefinition definition = runtimeService.definition(objectType);
+            return Optional.of(resolveFromRuntimeDefinition(definition));
+        } catch (RuntimeException ex) {
+            return Optional.empty();
+        }
+    }
+
+    private AttachmentObjectTypeDescriptor resolveFromMetadata(ObjectTypeMetadata metadata) {
+        Map<String, Object> attrs = metadata.getAttributes();
+        if (attrs == null) {
+            return new AttachmentObjectTypeDescriptor(metadata.getObjectType(), false, false, null);
+        }
+        String domain = asString(attrs.get("domain"));
+        boolean attachmentEnabled = attachmentEnabled(attrs);
+        String attachmentType = attachmentType(attrs);
+        boolean domainFlag = "attachment".equalsIgnoreCase(domain) || attachmentEnabled || attachmentType != null;
+        return new AttachmentObjectTypeDescriptor(metadata.getObjectType(), domainFlag, attachmentEnabled, attachmentType);
+    }
+
+    private AttachmentObjectTypeDescriptor resolveFromRuntimeDefinition(ObjectTypeDefinition definition) {
+        String domain = definition != null && definition.type() != null ? definition.type().domain() : null;
+        return new AttachmentObjectTypeDescriptor(
+                definition != null && definition.type() != null ? definition.type().objectType() : -1,
+                "attachment".equalsIgnoreCase(domain),
+                false,
+                null);
+    }
+
+    private boolean attachmentEnabled(Map<String, Object> attrs) {
+        Object raw = attrs.get("attachment");
+        if (raw instanceof Map<?, ?> attachmentMap) {
+            Object enabled = attachmentMap.get("enabled");
+            Boolean parsed = asBoolean(enabled);
+            if (parsed != null) {
+                return parsed;
+            }
+            return false;
+        }
+        Boolean parsed = asBoolean(attrs.get("attachment.enabled"));
+        return parsed != null && parsed;
+    }
+
+    private String attachmentType(Map<String, Object> attrs) {
+        Object raw = attrs.get("attachment");
+        if (raw instanceof Map<?, ?> attachmentMap) {
+            Object typeValue = attachmentMap.get("type");
+            return asString(typeValue);
+        }
+        return asString(attrs.get("attachment.type"));
+    }
+
+    private String asString(Object value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = String.valueOf(value).trim();
+        return normalized.isBlank() ? null : normalized;
+    }
+
+    private Boolean asBoolean(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Boolean bool) {
+            return bool;
+        }
+        if (value instanceof Number number) {
+            return number.intValue() != 0;
+        }
+        String raw = String.valueOf(value).trim();
+        if (raw.isBlank()) {
+            return null;
+        }
+        if ("true".equalsIgnoreCase(raw) || "1".equals(raw)) {
+            return true;
+        }
+        if ("false".equalsIgnoreCase(raw) || "0".equals(raw)) {
+            return false;
+        }
+        return null;
+    }
+}

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/web/controller/MetadataBasedAttachmentObjectTypeResolver.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/web/controller/MetadataBasedAttachmentObjectTypeResolver.java
@@ -43,33 +43,40 @@ public class MetadataBasedAttachmentObjectTypeResolver implements AttachmentObje
         if (runtimeService == null) {
             return Optional.empty();
         }
-        try {
-            ObjectTypeDefinition definition = runtimeService.definition(objectType);
-            return Optional.of(resolveFromRuntimeDefinition(definition));
-        } catch (RuntimeException ex) {
-            return Optional.empty();
-        }
+        ObjectTypeDefinition definition = runtimeService.definition(objectType);
+        return Optional.of(resolveFromRuntimeDefinition(definition));
     }
 
     private AttachmentObjectTypeDescriptor resolveFromMetadata(ObjectTypeMetadata metadata) {
         Map<String, Object> attrs = metadata.getAttributes();
         if (attrs == null) {
-            return new AttachmentObjectTypeDescriptor(metadata.getObjectType(), false, false, null);
+            String keyAttachmentType = attachmentTypeFromKey(metadata.getKey());
+            return new AttachmentObjectTypeDescriptor(
+                    metadata.getObjectType(),
+                    keyAttachmentType != null,
+                    false,
+                    keyAttachmentType);
         }
         String domain = asString(attrs.get("domain"));
         boolean attachmentEnabled = attachmentEnabled(attrs);
         String attachmentType = attachmentType(attrs);
+        if (attachmentType == null) {
+            attachmentType = attachmentTypeFromKey(metadata.getKey());
+        }
         boolean domainFlag = "attachment".equalsIgnoreCase(domain) || attachmentEnabled || attachmentType != null;
         return new AttachmentObjectTypeDescriptor(metadata.getObjectType(), domainFlag, attachmentEnabled, attachmentType);
     }
 
     private AttachmentObjectTypeDescriptor resolveFromRuntimeDefinition(ObjectTypeDefinition definition) {
         String domain = definition != null && definition.type() != null ? definition.type().domain() : null;
+        String attachmentType = definition != null && definition.type() != null
+                ? attachmentTypeFromKey(definition.type().code())
+                : null;
         return new AttachmentObjectTypeDescriptor(
                 definition != null && definition.type() != null ? definition.type().objectType() : -1,
-                "attachment".equalsIgnoreCase(domain),
+                "attachment".equalsIgnoreCase(domain) || attachmentType != null,
                 false,
-                null);
+                attachmentType);
     }
 
     private boolean attachmentEnabled(Map<String, Object> attrs) {
@@ -101,6 +108,23 @@ public class MetadataBasedAttachmentObjectTypeResolver implements AttachmentObje
         }
         String normalized = String.valueOf(value).trim();
         return normalized.isBlank() ? null : normalized;
+    }
+
+    private String attachmentTypeFromKey(String key) {
+        String normalized = asString(key);
+        if (normalized == null) {
+            return null;
+        }
+        String lower = normalized.toLowerCase();
+        if (lower.equals("attachment")
+                || lower.endsWith("-attachment")
+                || lower.endsWith("_attachment")
+                || lower.endsWith(".attachment")
+                || lower.endsWith(":attachment")
+                || lower.endsWith("/attachment")) {
+            return normalized;
+        }
+        return null;
     }
 
     private Boolean asBoolean(Object value) {

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/web/controller/AttachmentAccessSupportTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/web/controller/AttachmentAccessSupportTest.java
@@ -1,12 +1,24 @@
 package studio.one.application.attachment.web.controller;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.security.access.AccessDeniedException;
 
+import studio.one.application.attachment.application.result.AttachmentOwnerAccessAction;
+import studio.one.application.attachment.application.result.AttachmentObjectTypeDescriptor;
+import studio.one.application.attachment.application.usecase.AttachmentOwnerAccessAuthorizer;
+import studio.one.application.attachment.domain.model.Attachment;
 import studio.one.platform.identity.ApplicationPrincipal;
+import studio.one.platform.objecttype.application.WellKnownAttachmentObjectTypes;
 
 class AttachmentAccessSupportTest {
 
@@ -14,6 +26,45 @@ class AttachmentAccessSupportTest {
     void isAdminAcceptsLegacyAndSpringSecurityRoleNames() {
         assertTrue(AttachmentAccessSupport.isAdmin(principal("ADMIN")));
         assertTrue(AttachmentAccessSupport.isAdmin(principal("ROLE_ADMIN")));
+    }
+
+    @Test
+    void metadataAttachmentDomainIsRecognizedBeforeLegacyFallback() {
+        assertTrue(AttachmentAccessSupport.isWellKnownDomainAttachmentType(
+                9001,
+                objectType -> java.util.Optional.of(new AttachmentObjectTypeDescriptor(objectType, true, false, null))));
+    }
+
+    @Test
+    void genericAttachmentIsExcludedFromDomainAuthorizerEvenWhenMetadataMatches() {
+        assertFalse(AttachmentAccessSupport.isWellKnownDomainAttachmentType(
+                WellKnownAttachmentObjectTypes.GENERIC_ATTACHMENT,
+                objectType -> java.util.Optional.of(new AttachmentObjectTypeDescriptor(objectType, true, true, "generic"))));
+    }
+
+    @Test
+    void legacyFallbackStillAppliesWhenMetadataDoesNotMarkAttachmentDomain() {
+        assertTrue(AttachmentAccessSupport.isWellKnownDomainAttachmentType(
+                WellKnownAttachmentObjectTypes.WORKSPACE_ATTACHMENT,
+                objectType -> java.util.Optional.of(new AttachmentObjectTypeDescriptor(objectType, false, false, null))));
+    }
+
+    @Test
+    void metadataAttachmentDomainRequiresOwnerAuthorizer() {
+        Attachment attachment = mock(Attachment.class);
+        @SuppressWarnings("unchecked")
+        ObjectProvider<AttachmentOwnerAccessAuthorizer> authorizers = mock(ObjectProvider.class);
+
+        when(attachment.getObjectType()).thenReturn(9001);
+        when(attachment.getObjectId()).thenReturn(20L);
+        when(authorizers.orderedStream()).thenReturn(Stream.empty());
+
+        assertThrows(AccessDeniedException.class, () -> AttachmentAccessSupport.requireAttachmentAccess(
+                attachment,
+                principal("USER"),
+                authorizers,
+                objectType -> java.util.Optional.of(new AttachmentObjectTypeDescriptor(objectType, true, false, null)),
+                AttachmentOwnerAccessAction.READ));
     }
 
     private ApplicationPrincipal principal(String role) {

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/web/controller/AttachmentAccessSupportTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/web/controller/AttachmentAccessSupportTest.java
@@ -67,6 +67,22 @@ class AttachmentAccessSupportTest {
                 AttachmentOwnerAccessAction.READ));
     }
 
+    @Test
+    void metadataResolverFailureDoesNotDowngradeUnknownTypeToCreatorOnly() {
+        Attachment attachment = mock(Attachment.class);
+
+        when(attachment.getObjectType()).thenReturn(9001);
+
+        assertThrows(AccessDeniedException.class, () -> AttachmentAccessSupport.requireAttachmentAccess(
+                attachment,
+                principal("USER"),
+                null,
+                objectType -> {
+                    throw new IllegalStateException("metadata unavailable");
+                },
+                AttachmentOwnerAccessAction.READ));
+    }
+
     private ApplicationPrincipal principal(String role) {
         return new ApplicationPrincipal() {
             @Override

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/web/controller/AttachmentControllerTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/web/controller/AttachmentControllerTest.java
@@ -395,6 +395,7 @@ class AttachmentControllerTest {
                 requestDetailsResolver,
                 thumbnailServiceProvider,
                 principalResolverProvider,
-                ownerAccessAuthorizers);
+                ownerAccessAuthorizers,
+                objectType -> java.util.Optional.empty());
     }
 }

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/web/controller/AttachmentMgmtControllerAuthorizationTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/web/controller/AttachmentMgmtControllerAuthorizationTest.java
@@ -177,7 +177,8 @@ class AttachmentMgmtControllerAuthorizationTest {
                 principalResolverProvider,
                 textExtractionProvider,
                 thumbnailServiceProvider,
-                ownerAccessAuthorizers);
+                ownerAccessAuthorizers,
+                objectType -> java.util.Optional.empty());
     }
 
     private ApplicationPrincipal principal(Long userId, String role) {

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/web/controller/MeAttachmentControllerTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/web/controller/MeAttachmentControllerTest.java
@@ -59,7 +59,8 @@ class MeAttachmentControllerTest {
                 identityServiceProvider,
                 textExtractionProvider,
                 ownerAccessAuthorizers,
-                principalResolverProvider);
+                principalResolverProvider,
+                objectType -> java.util.Optional.empty());
         Attachment attachment = mock(Attachment.class);
 
         when(attachmentService.getAttachmentById(44L)).thenReturn(attachment);
@@ -77,7 +78,8 @@ class MeAttachmentControllerTest {
                 identityServiceProvider,
                 textExtractionProvider,
                 ownerAccessAuthorizers,
-                principalResolverProvider);
+                principalResolverProvider,
+                objectType -> java.util.Optional.empty());
         MockMultipartFile file = new MockMultipartFile(
                 "file",
                 "/tmp/report.txt",
@@ -112,7 +114,8 @@ class MeAttachmentControllerTest {
                 identityServiceProvider,
                 textExtractionProvider,
                 ownerAccessAuthorizers,
-                principalResolverProvider);
+                principalResolverProvider,
+                objectType -> java.util.Optional.empty());
         Attachment attachment = mock(Attachment.class);
         AttachmentOwnerAccessAuthorizer authorizer = mock(AttachmentOwnerAccessAuthorizer.class);
         ApplicationPrincipal principal = principal(7L, "alice", "WORKSPACE_MEMBER");

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/web/controller/MetadataBasedAttachmentObjectTypeResolverTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/web/controller/MetadataBasedAttachmentObjectTypeResolverTest.java
@@ -1,0 +1,62 @@
+package studio.one.application.attachment.web.controller;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+import studio.one.application.attachment.application.result.AttachmentObjectTypeDescriptor;
+import studio.one.platform.objecttype.application.usecase.ObjectTypeRuntimeService;
+import studio.one.platform.objecttype.infrastructure.yaml.YamlObjectTypeMetadata;
+import studio.one.platform.objecttype.registry.ObjectTypeRegistry;
+
+class MetadataBasedAttachmentObjectTypeResolverTest {
+
+    @Test
+    void keySuffixMarksAdminCreatedAttachmentTypeWhenAttributesDoNotContainAttachmentFlag() {
+        ObjectTypeRegistry registry = mock(ObjectTypeRegistry.class);
+        @SuppressWarnings("unchecked")
+        ObjectProvider<ObjectTypeRegistry> registryProvider = mock(ObjectProvider.class);
+        @SuppressWarnings("unchecked")
+        ObjectProvider<ObjectTypeRuntimeService> runtimeServiceProvider = mock(ObjectProvider.class);
+        MetadataBasedAttachmentObjectTypeResolver resolver = new MetadataBasedAttachmentObjectTypeResolver(
+                runtimeServiceProvider,
+                registryProvider);
+
+        when(registryProvider.getIfAvailable()).thenReturn(registry);
+        when(registry.findByType(9001)).thenReturn(Optional.of(new YamlObjectTypeMetadata(
+                9001,
+                "forum-attachment",
+                "Forum Attachment",
+                Map.of("domain", "forum"))));
+
+        Optional<AttachmentObjectTypeDescriptor> descriptor = resolver.resolve(9001);
+
+        assertTrue(descriptor.isPresent());
+        assertTrue(descriptor.get().isAttachmentDomainType());
+    }
+
+    @Test
+    void runtimeDefinitionFailureIsPropagatedForAccessSupportFailClosedHandling() {
+        ObjectTypeRuntimeService runtimeService = mock(ObjectTypeRuntimeService.class);
+        @SuppressWarnings("unchecked")
+        ObjectProvider<ObjectTypeRegistry> registryProvider = mock(ObjectProvider.class);
+        @SuppressWarnings("unchecked")
+        ObjectProvider<ObjectTypeRuntimeService> runtimeServiceProvider = mock(ObjectProvider.class);
+        MetadataBasedAttachmentObjectTypeResolver resolver = new MetadataBasedAttachmentObjectTypeResolver(
+                runtimeServiceProvider,
+                registryProvider);
+
+        when(registryProvider.getIfAvailable()).thenReturn(null);
+        when(runtimeServiceProvider.getIfAvailable()).thenReturn(runtimeService);
+        when(runtimeService.definition(9001)).thenThrow(new IllegalStateException("metadata unavailable"));
+
+        assertThrows(IllegalStateException.class, () -> resolver.resolve(9001));
+    }
+}


### PR DESCRIPTION
## Why
신규 attachment object type 추가 시 `WellKnownAttachmentObjectTypes` 상수 변경 없이 `ObjectTypeMetadata` 기준으로 attachment domain owner authorizer 분기를 결정하기 위해 변경합니다.

## What
- `AttachmentObjectTypeResolver`와 `AttachmentObjectTypeDescriptor`를 추가했습니다.
- `AttachmentAccessSupport`가 metadata 기반 판별을 먼저 사용하고 legacy `WellKnownAttachmentObjectTypes` fallback을 유지하도록 변경했습니다.
- `GENERIC_ATTACHMENT`는 기존처럼 domain owner authorizer 대상에서 제외했습니다.
- `AttachmentController`, `AttachmentMgmtController`, `MeAttachmentController`에 resolver 기반 권한 분기를 연결했습니다.
- starter auto-configuration에 metadata 기반 resolver bean과 endpoint controller 주입 경로를 추가했습니다.
- DB/admin-created object type도 `forum-attachment` 같은 `key/code` suffix로 attachment domain 판별이 가능하도록 보강했습니다.
- resolver runtime 조회 실패가 unknown metadata-only type에서 creator-only 접근으로 조용히 downgrade되지 않도록 fail-closed 경로를 유지했습니다.
- metadata 기반 판별, legacy fallback, metadata-only domain owner authorizer 강제, suffix 기반 판별, resolver failure 경로 테스트를 보강했습니다.

## Related Issues
별도 Issue 없음. 사용자가 중단된 작업 이어서 진행 및 PR 등록을 요청한 예외 케이스입니다.

## Validation
- Subagent review 1차: Critical/High 권한 회귀 2건 발견.
- 처리 결과: legacy fallback 유지 및 metadata-only domain owner authorizer 강제 경로 수정.
- Subagent review 2차: No findings.
- PR 생성 후 Subagent review: High/Medium 지적 2건 발견.
- 처리 결과: `key/code` suffix 기반 attachment 판별 추가 및 resolver runtime exception 전파.
- 최종 Subagent review: No findings.
- Subagent 실행: `./gradlew :starter:studio-application-starter-attachment:compileJava` -> passed.
- Subagent 실행: `./gradlew :studio-application-modules:attachment-service:test --tests 'studio.one.application.attachment.web.controller.AttachmentAccessSupportTest' --tests 'studio.one.application.attachment.web.controller.AttachmentControllerTest' --tests 'studio.one.application.attachment.web.controller.AttachmentMgmtControllerAuthorizationTest' --tests 'studio.one.application.attachment.web.controller.MeAttachmentControllerTest'` -> passed.
- Subagent 실행: `./gradlew :starter:studio-application-starter-attachment:test --tests 'studio.one.application.attachment.autoconfigure.AttachmentAutoConfigurationTest'` -> passed.
- Subagent 실행: `./gradlew :studio-application-modules:attachment-service:test --tests 'studio.one.application.attachment.web.controller.MetadataBasedAttachmentObjectTypeResolverTest' --tests 'studio.one.application.attachment.web.controller.AttachmentAccessSupportTest'` -> passed.

## Risk / Rollback
주요 위험은 attachment object type metadata 해석이 실제 운영 registry 구성과 다를 때 권한 분기 경로가 기대와 달라질 수 있다는 점입니다. 현재 PR은 `domain == "attachment"`, `attachment.enabled`, `attachment.type`, 그리고 `key/code` attachment suffix를 지원합니다. 문제가 발생하면 이 PR의 커밋을 revert하여 기존 상수 기반 판별로 되돌릴 수 있습니다.

## AI / Subagent Usage
AI가 작업 재개, 구현 보강, commit/PR 문안 작성, PR 업데이트를 수행했습니다. `code-reviewer` subagent를 반복 사용했습니다. 1차 리뷰에서 Critical/High 권한 회귀를 발견했고, PR 생성 후 리뷰에서 추가 High/Medium 지적을 발견했습니다. main author가 각 지적사항을 수정했고, 최종 subagent review에서 `No findings`를 확인했습니다.

## Checklist
- [x] commit message follows policy
- [x] issue template was used or exception was recorded
- [x] `AI-Assisted` value is correct
- [x] validation is recorded
- [x] subagent usage is recorded when used
- [x] CI or repository verification passed
- [x] human review is required before merge
- [x] unrelated changes are excluded
