### PR TITLE
[1.x] 로그인 실패 감사 응답 필드 노출 수정

### DIFF
--- a/studio-platform-security/src/main/java/studio/one/base/security/web/dto/response/LoginFailureLogDto.java
+++ b/studio-platform-security/src/main/java/studio/one/base/security/web/dto/response/LoginFailureLogDto.java
@@ -26,4 +26,12 @@ public class LoginFailureLogDto {
     public String failureType() { return failureType; }
     public String message() { return message; }
     public String userAgent() { return userAgent; }
+
+    public Long getId() { return id; }
+    public OffsetDateTime getOccurredAt() { return occurredAt; }
+    public String getUsername() { return username; }
+    public String getRemoteIp() { return remoteIp; }
+    public String getFailureType() { return failureType; }
+    public String getMessage() { return message; }
+    public String getUserAgent() { return userAgent; }
 }

--- a/studio-platform-security/src/test/java/studio/one/base/security/web/controller/LoginFailureLogControllerTest.java
+++ b/studio-platform-security/src/test/java/studio/one/base/security/web/controller/LoginFailureLogControllerTest.java
@@ -2,11 +2,14 @@ package studio.one.base.security.web.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.time.OffsetDateTime;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -15,8 +18,13 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
 import studio.one.base.security.audit.application.command.LoginFailQuery;
 import studio.one.base.security.audit.application.usecase.LoginFailureQueryService;
+import studio.one.base.security.web.dto.response.LoginFailureLogDto;
 import studio.one.base.security.web.mapper.LoginFailureLogMapper;
 
 class LoginFailureLogControllerTest {
@@ -74,5 +82,28 @@ class LoginFailureLogControllerTest {
         verify(service).find(query.capture(), any());
         assertEquals("kim owner", query.getValue().getUsernameLike());
         assertEquals("Bad  Credentials", query.getValue().getFailureType());
+    }
+
+    @Test
+    void serializesLoginFailureLogDtoFieldsForAdminAuditList() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        LoginFailureLogDto dto = new LoginFailureLogDto(
+                7L,
+                OffsetDateTime.parse("2026-04-08T02:02:26.932Z"),
+                "kim.owner",
+                "192.0.2.10",
+                "BAD_CREDENTIALS",
+                "Bad credentials",
+                "JUnit Agent");
+
+        JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(dto));
+
+        assertEquals(7L, json.get("id").asLong());
+        assertTrue(json.hasNonNull("occurredAt"));
+        assertEquals("kim.owner", json.get("username").asText());
+        assertEquals("192.0.2.10", json.get("remoteIp").asText());
+        assertEquals("BAD_CREDENTIALS", json.get("failureType").asText());
+        assertEquals("Bad credentials", json.get("message").asText());
+        assertEquals("JUnit Agent", json.get("userAgent").asText());
     }
 }


### PR DESCRIPTION
## Summary
- Fixes #462
- `LoginFailureLogDto`에 JavaBean getter를 추가해 Jackson 응답 JSON에 `id`, `username`, `remoteIp`, `failureType`, `message`, `userAgent`가 포함되도록 수정
- DTO 직렬화 회귀 테스트 추가

## Validation
- `./gradlew :studio-platform-security:test --tests 'studio.one.base.security.web.controller.LoginFailureLogControllerTest'`\n\n## Review\n- 변경 범위는 로그인 실패 감사 응답 DTO와 관련 controller test로 제한\n- 기존 query/filter/sort 경로는 변경하지 않음\n\n## Issue\n- #462\n\n## AI-Assisted\n- Yes