### PR TITLE
[1.x] 일반 첨부파일 다운로드 감사 로그 적재

### DIFF
--- a/starter/studio-application-starter-attachment/README.md
+++ b/starter/studio-application-starter-attachment/README.md
@@ -146,7 +146,7 @@ studio:
 | 메서드 | 경로 | 설명 | 권한 |
 |--------|------|------|------|
 | `GET` | `/attachment-download-url-issues` | signed download URL 발급 감사 로그 페이지 조회. `attachmentId`, `objectType`, `objectId`, `endpointKind`, `issuedByPrincipalName`, `from`, `to` 필터와 `page`/`size`/`sort` 지원 | `features:attachment_download_url_issue_audit/read` |
-| `GET` | `/attachment-downloads` | signed download URL 실제 접근 감사 로그 페이지 조회. `attachmentId`, `objectType`, `objectId`, `tokenHash`, `result`, `from`, `to`, `clientIp` 필터와 `page`/`size`/`sort` 지원 | `features:attachment_download_audit/read` |
+| `GET` | `/attachment-downloads` | 실제 다운로드 접근 감사 로그 페이지 조회. signed download 접근과 `/api/mgmt/attachments/{attachmentId}/download`, `/api/attachments/{attachmentId}/download` 직접 다운로드 접근을 함께 조회한다. `attachmentId`, `objectType`, `objectId`, `tokenHash`, `result`, `from`, `to`, `clientIp` 필터와 `page`/`size`/`sort` 지원 | `features:attachment_download_audit/read` |
 
 발급 감사 응답은 `logId`, `attachmentId`, `objectType`, `objectId`, `endpointKind`, `issuedByUserId`, `issuedByPrincipalName`, `issuedAt`, `expiresAt`, `ttlSeconds`, `linkType`, `tokenHash`, `downloadCount`, `storageProviderId`, `bucket`, `objectKeyHash`, `clientIp`, `userAgent`를 포함한다. `downloadCount`는 해당 발급 로그의 실제 signed-download 접근 감사 로그 수이며, 접근 이력이 없으면 `0`이다. signed URL, raw token, raw object key는 응답에 포함하지 않는다. 기본 정렬은 `issuedAt desc`, `logId desc`이다.
 다운로드 접근 감사 응답은 `downloadLogId`, `issueLogId`, `tokenHash`, `attachmentId`, `objectType`, `objectId`, `linkType`, `requestedAt`, `result`, `httpStatus`, `downloadedBytes`, `clientIp`, `userAgent`, `errorCode`를 포함한다. raw token과 signed URL은 저장/응답하지 않으며 기본 정렬은 `requestedAt desc`, `downloadLogId desc`이다.

--- a/starter/studio-application-starter-attachment/src/main/java/studio/one/application/attachment/autoconfigure/AttachmentEndpointAutoConfiguration.java
+++ b/starter/studio-application-starter-attachment/src/main/java/studio/one/application/attachment/autoconfigure/AttachmentEndpointAutoConfiguration.java
@@ -122,6 +122,7 @@ public class AttachmentEndpointAutoConfiguration {
         AttachmentMgmtController attachmentMgmtController(
                         AttachmentService attachmentService,
                         AttachmentDownloadUrlService downloadUrlService,
+                        AttachmentDownloadAuditLogService downloadAuditLogService,
                         AttachmentUrlIssueRequestDetailsResolver requestDetailsResolver,
                         ObjectProvider<studio.one.platform.identity.IdentityService> identityServiceProvider,
                         ObjectProvider<PrincipalResolver> principalResolverProvider,
@@ -138,6 +139,7 @@ public class AttachmentEndpointAutoConfiguration {
                 return new AttachmentMgmtController(
                                 attachmentService,
                                 downloadUrlService,
+                                downloadAuditLogService,
                                 requestDetailsResolver,
                                 identityServiceProvider,
                                 principalResolverProvider,

--- a/studio-application-modules/attachment-service/README.md
+++ b/studio-application-modules/attachment-service/README.md
@@ -107,7 +107,7 @@ studio:
 - 응답 필드: `logId`, `attachmentId`, `objectType`, `objectId`, `endpointKind`, `issuedByUserId`, `issuedByPrincipalName`, `issuedAt`, `expiresAt`, `ttlSeconds`, `linkType`, `tokenHash`, `downloadCount`, `storageProviderId`, `bucket`, `objectKeyHash`, `clientIp`, `userAgent`.
 - signed URL, raw token, raw object key는 응답하지 않는다. 신규 application link는 `tokenHash`만 저장하고, `storageProviderId`/`bucket`/`objectKeyHash`는 legacy objectstorage presigned 로그 호환 필드다. 기본 정렬은 `issuedAt desc`, `logId desc`이다.
 - `downloadCount`는 해당 발급 로그의 실제 signed-download 접근 감사 로그 수다. `issueLogId`와 `tokenHash`를 기준으로 페이지 단위 bulk 집계하며, 접근 이력이 없으면 `0`을 반환한다.
-- `GET /attachment-downloads`: signed download URL 실제 접근 감사 로그를 페이지로 조회한다. 권한 `features:attachment_download_audit/read`.
+- `GET /attachment-downloads`: 실제 다운로드 접근 감사 로그를 페이지로 조회한다. signed download 접근과 `/api/mgmt/attachments/{attachmentId}/download`, `/api/attachments/{attachmentId}/download` 직접 다운로드 접근을 함께 조회한다. 권한 `features:attachment_download_audit/read`.
 - 필터: `attachmentId`, `objectType`, `objectId`, `tokenHash`, `result`(`SUCCEEDED`/`FAILED`/`EXPIRED`/`INVALID_TOKEN`), `from`, `to`, `clientIp`. `from`은 포함, `to`는 제외 기준으로 `requestedAt`에 적용한다.
 - 응답 필드: `downloadLogId`, `issueLogId`, `tokenHash`, `attachmentId`, `objectType`, `objectId`, `linkType`, `requestedAt`, `result`, `httpStatus`, `downloadedBytes`, `clientIp`, `userAgent`, `errorCode`.
 - signed download 접근 감사 로그도 raw token과 signed URL은 저장/응답하지 않는다. malformed token은 attachment/object 정보를 복원할 수 없어 nullable로 남을 수 있다. 기본 정렬은 `requestedAt desc`, `downloadLogId desc`이다.

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/web/controller/AttachmentController.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/web/controller/AttachmentController.java
@@ -110,14 +110,61 @@ public class AttachmentController {
 
     @GetMapping("/{attachmentId:[\\p{Digit}]+}/download")
     @PreAuthorize("@endpointAuthz.can('features:attachment','service-download')")
-    public ResponseEntity<StreamingResponseBody> download(@PathVariable("attachmentId") long attachmentId)
+    public ResponseEntity<StreamingResponseBody> download(
+            @PathVariable("attachmentId") long attachmentId,
+            HttpServletRequest httpRequest)
             throws IOException, NotFoundException {
-        Attachment attachment = attachmentService.getAttachmentById(attachmentId);
-        requireAttachmentAccess(attachment, AttachmentOwnerAccessAction.DOWNLOAD);
-        return AttachmentWebSupport.downloadResponse(
-                attachment,
-                attachmentService.getInputStream(attachment),
-                CacheControl.noCache());
+        Instant requestedAt = Instant.now();
+        AttachmentUrlIssueRequestDetails details = requestDetailsResolver.resolve(httpRequest);
+        Attachment attachment = null;
+        try {
+            attachment = attachmentService.getAttachmentById(attachmentId);
+            requireAttachmentAccess(attachment, AttachmentOwnerAccessAction.DOWNLOAD);
+            return AttachmentWebSupport.auditedDownloadResponse(
+                    attachment,
+                    attachmentService.getInputStream(attachment),
+                    CacheControl.noCache(),
+                    "SERVICE_DIRECT",
+                    requestedAt,
+                    details,
+                    this::recordDownloadAudit);
+        } catch (NotFoundException ex) {
+            recordDownloadAudit(AttachmentWebSupport.downloadAuditCommand(
+                    null,
+                    attachmentId,
+                    "SERVICE_DIRECT",
+                    requestedAt,
+                    AttachmentDownloadAuditResult.FAILED,
+                    HttpStatus.NOT_FOUND.value(),
+                    null,
+                    details,
+                    "ATTACHMENT_NOT_FOUND"));
+            throw ex;
+        } catch (org.springframework.security.access.AccessDeniedException ex) {
+            recordDownloadAudit(AttachmentWebSupport.downloadAuditCommand(
+                    attachment,
+                    attachmentId,
+                    "SERVICE_DIRECT",
+                    requestedAt,
+                    AttachmentDownloadAuditResult.FAILED,
+                    HttpStatus.FORBIDDEN.value(),
+                    null,
+                    details,
+                    "ACCESS_DENIED"));
+            throw ex;
+        } catch (IOException | RuntimeException ex) {
+            recordDownloadAudit(AttachmentWebSupport.downloadAuditCommand(
+                    attachment,
+                    attachmentId,
+                    "SERVICE_DIRECT",
+                    requestedAt,
+                    AttachmentDownloadAuditResult.FAILED,
+                    HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                    null,
+                    details,
+                    "STREAM_OPEN_FAILED"));
+            throw ex;
+        }
     }
 
     @PostMapping("/{attachmentId:[\\p{Digit}]+}/download-url")

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/web/controller/AttachmentMgmtController.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/web/controller/AttachmentMgmtController.java
@@ -2,6 +2,7 @@ package studio.one.application.attachment.web.controller;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
@@ -16,6 +17,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,12 +32,15 @@ import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBo
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import studio.one.application.attachment.domain.model.Attachment;
+import studio.one.application.attachment.application.command.AttachmentDownloadAuditLogCommand;
 import studio.one.application.attachment.application.error.AttachmentDownloadUrlUnavailableException;
+import studio.one.application.attachment.application.result.AttachmentDownloadAuditResult;
 import studio.one.application.attachment.application.result.AttachmentDownloadUrl;
 import studio.one.application.attachment.application.result.AttachmentDownloadUrlEndpointKind;
 import studio.one.application.attachment.application.result.ThumbnailData;
+import studio.one.application.attachment.application.usecase.AttachmentDownloadAuditLogService;
 import studio.one.application.attachment.application.usecase.AttachmentDownloadUrlService;
+import studio.one.application.attachment.domain.model.Attachment;
 import studio.one.application.attachment.application.result.AttachmentOwnerAccessAction;
 import studio.one.application.attachment.application.usecase.AttachmentOwnerAccessAuthorizer;
 import studio.one.application.attachment.application.usecase.AttachmentObjectTypeResolver;
@@ -64,6 +69,7 @@ public class AttachmentMgmtController {
 
     private final AttachmentService attachmentService;
     private final AttachmentDownloadUrlService downloadUrlService;
+    private final AttachmentDownloadAuditLogService downloadAuditLogService;
     private final AttachmentUrlIssueRequestDetailsResolver requestDetailsResolver;
     private final ObjectProvider<IdentityService> identityServiceProvider;
     private final ObjectProvider<PrincipalResolver> principalResolverProvider;
@@ -135,15 +141,62 @@ public class AttachmentMgmtController {
 
     @GetMapping("/{attachmentId:[\\p{Digit}]+}/download")
     @PreAuthorize("@endpointAuthz.can('features:attachment','download')")
-    public ResponseEntity<StreamingResponseBody> download(@PathVariable("attachmentId") long attachmentId)
+    public ResponseEntity<StreamingResponseBody> download(
+            @PathVariable("attachmentId") long attachmentId,
+            HttpServletRequest httpRequest)
             throws IOException, NotFoundException {
-        Attachment attachment = attachmentService.getAttachmentById(attachmentId);
-        AttachmentAccessSupport.requireAttachmentAccess(
-                attachment, requirePrincipal(), ownerAccessAuthorizers, objectTypeResolver, AttachmentOwnerAccessAction.DOWNLOAD);
-        return AttachmentWebSupport.downloadResponse(
-                attachment,
-                attachmentService.getInputStream(attachment),
-                CacheControl.noCache());
+        Instant requestedAt = Instant.now();
+        AttachmentUrlIssueRequestDetails details = requestDetailsResolver.resolve(httpRequest);
+        Attachment attachment = null;
+        try {
+            attachment = attachmentService.getAttachmentById(attachmentId);
+            AttachmentAccessSupport.requireAttachmentAccess(
+                    attachment, requirePrincipal(), ownerAccessAuthorizers, objectTypeResolver, AttachmentOwnerAccessAction.DOWNLOAD);
+            return AttachmentWebSupport.auditedDownloadResponse(
+                    attachment,
+                    attachmentService.getInputStream(attachment),
+                    CacheControl.noCache(),
+                    "MGMT_DIRECT",
+                    requestedAt,
+                    details,
+                    this::recordDownloadAudit);
+        } catch (NotFoundException ex) {
+            recordDownloadAudit(AttachmentWebSupport.downloadAuditCommand(
+                    null,
+                    attachmentId,
+                    "MGMT_DIRECT",
+                    requestedAt,
+                    AttachmentDownloadAuditResult.FAILED,
+                    HttpStatus.NOT_FOUND.value(),
+                    null,
+                    details,
+                    "ATTACHMENT_NOT_FOUND"));
+            throw ex;
+        } catch (AccessDeniedException ex) {
+            recordDownloadAudit(AttachmentWebSupport.downloadAuditCommand(
+                    attachment,
+                    attachmentId,
+                    "MGMT_DIRECT",
+                    requestedAt,
+                    AttachmentDownloadAuditResult.FAILED,
+                    HttpStatus.FORBIDDEN.value(),
+                    null,
+                    details,
+                    "ACCESS_DENIED"));
+            throw ex;
+        } catch (IOException | RuntimeException ex) {
+            recordDownloadAudit(AttachmentWebSupport.downloadAuditCommand(
+                    attachment,
+                    attachmentId,
+                    "MGMT_DIRECT",
+                    requestedAt,
+                    AttachmentDownloadAuditResult.FAILED,
+                    HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                    null,
+                    details,
+                    "STREAM_OPEN_FAILED"));
+            throw ex;
+        }
     }
 
     @PostMapping("/{attachmentId:[\\p{Digit}]+}/download-url")
@@ -320,5 +373,13 @@ public class AttachmentMgmtController {
 
     private AttachmentDto toDto(Attachment attachment) {
         return AttachmentWebSupport.toDto(attachment, identityServiceProvider);
+    }
+
+    private void recordDownloadAudit(AttachmentDownloadAuditLogCommand command) {
+        try {
+            downloadAuditLogService.record(command);
+        } catch (RuntimeException ex) {
+            log.warn("Failed to record attachment management download audit log: {}", ex.getMessage());
+        }
     }
 }

--- a/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/web/controller/AttachmentWebSupport.java
+++ b/studio-application-modules/attachment-service/src/main/java/studio/one/application/attachment/web/controller/AttachmentWebSupport.java
@@ -1,6 +1,8 @@
 package studio.one.application.attachment.web.controller;
 
 import java.io.InputStream;
+import java.time.Instant;
+import java.util.function.Consumer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -8,6 +10,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.http.CacheControl;
 import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -16,6 +19,8 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
+import studio.one.application.attachment.application.command.AttachmentDownloadAuditLogCommand;
+import studio.one.application.attachment.application.result.AttachmentDownloadAuditResult;
 import studio.one.application.attachment.domain.model.Attachment;
 import studio.one.application.attachment.application.result.AttachmentDownloadUrlIssueActor;
 import studio.one.application.attachment.web.dto.response.AttachmentDto;
@@ -60,6 +65,82 @@ final class AttachmentWebSupport {
                 in.transferTo(out);
             }
         };
+        return downloadResponse(attachment, body, cacheControl);
+    }
+
+    static ResponseEntity<StreamingResponseBody> auditedDownloadResponse(
+            Attachment attachment,
+            InputStream in,
+            CacheControl cacheControl,
+            String linkType,
+            Instant requestedAt,
+            AttachmentUrlIssueRequestDetails details,
+            Consumer<AttachmentDownloadAuditLogCommand> auditRecorder) {
+        StreamingResponseBody body = out -> {
+            long downloadedBytes = 0L;
+            byte[] buffer = new byte[8192];
+            try (in) {
+                int read;
+                while ((read = in.read(buffer)) != -1) {
+                    out.write(buffer, 0, read);
+                    downloadedBytes += read;
+                }
+                auditRecorder.accept(downloadAuditCommand(
+                        attachment,
+                        attachment.getAttachmentId(),
+                        linkType,
+                        requestedAt,
+                        AttachmentDownloadAuditResult.SUCCEEDED,
+                        HttpStatus.OK.value(),
+                        downloadedBytes,
+                        details,
+                        null));
+            } catch (java.io.IOException | RuntimeException ex) {
+                auditRecorder.accept(downloadAuditCommand(
+                        attachment,
+                        attachment.getAttachmentId(),
+                        linkType,
+                        requestedAt,
+                        AttachmentDownloadAuditResult.FAILED,
+                        HttpStatus.OK.value(),
+                        downloadedBytes,
+                        details,
+                        "STREAM_FAILED"));
+                throw ex;
+            }
+        };
+        return downloadResponse(attachment, body, cacheControl);
+    }
+
+    static AttachmentDownloadAuditLogCommand downloadAuditCommand(
+            Attachment attachment,
+            Long fallbackAttachmentId,
+            String linkType,
+            Instant requestedAt,
+            AttachmentDownloadAuditResult result,
+            int httpStatus,
+            Long downloadedBytes,
+            AttachmentUrlIssueRequestDetails details,
+            String errorCode) {
+        return new AttachmentDownloadAuditLogCommand(
+                null,
+                attachment == null ? fallbackAttachmentId : attachment.getAttachmentId(),
+                attachment == null ? null : attachment.getObjectType(),
+                attachment == null ? null : attachment.getObjectId(),
+                linkType,
+                requestedAt,
+                result,
+                httpStatus,
+                downloadedBytes,
+                details == null ? null : details.clientIp(),
+                details == null ? null : details.userAgent(),
+                errorCode);
+    }
+
+    private static ResponseEntity<StreamingResponseBody> downloadResponse(
+            Attachment attachment,
+            StreamingResponseBody body,
+            CacheControl cacheControl) {
         HttpHeaders headers = new HttpHeaders();
         headers.setCacheControl(cacheControl.getHeaderValue());
         headers.setContentType(resolveMediaType(attachment.getContentType()));

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/web/controller/AttachmentControllerTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/web/controller/AttachmentControllerTest.java
@@ -101,19 +101,39 @@ class AttachmentControllerTest {
     void downloadBuildsAttachmentHeaders() throws Exception {
         AttachmentController controller = controller();
         Attachment attachment = mock(Attachment.class);
+        MockHttpServletRequest request = new MockHttpServletRequest();
 
         when(attachmentService.getAttachmentById(88L)).thenReturn(attachment);
         when(attachmentService.getInputStream(attachment)).thenReturn(new ByteArrayInputStream(new byte[] { 1, 2 }));
         when(attachment.getContentType()).thenReturn("application/pdf");
         when(attachment.getSize()).thenReturn(2L);
         when(attachment.getName()).thenReturn("report.pdf");
+        when(attachment.getAttachmentId()).thenReturn(88L);
+        when(attachment.getObjectType()).thenReturn(12);
+        when(attachment.getObjectId()).thenReturn(34L);
+        when(requestDetailsResolver.resolve(request)).thenReturn(new AttachmentUrlIssueRequestDetails("10.0.0.2", "JUnit"));
 
-        ResponseEntity<?> response = controller.download(88L);
+        ResponseEntity<org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody> response =
+                controller.download(88L, request);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        response.getBody().writeTo(out);
 
         assertEquals("application/pdf", response.getHeaders().getContentType().toString());
         assertEquals(2L, response.getHeaders().getContentLength());
         assertEquals("attachment; filename=\"report.pdf\"",
                 response.getHeaders().getFirst("Content-Disposition"));
+        assertEquals(2, out.toByteArray().length);
+        verify(downloadAuditLogService).record(org.mockito.ArgumentMatchers.argThat(command ->
+                command.result() == AttachmentDownloadAuditResult.SUCCEEDED
+                        && command.httpStatus() == 200
+                        && command.downloadedBytes() == 2L
+                        && command.tokenHash() == null
+                        && "SERVICE_DIRECT".equals(command.linkType())
+                        && command.attachmentId() == 88L
+                        && command.objectType() == 12
+                        && command.objectId() == 34L
+                        && "10.0.0.2".equals(command.clientIp())
+                        && "JUnit".equals(command.userAgent())));
     }
 
     @Test

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/web/controller/AttachmentMgmtControllerAuthorizationTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/web/controller/AttachmentMgmtControllerAuthorizationTest.java
@@ -1,10 +1,13 @@
 package studio.one.application.attachment.web.controller;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayOutputStream;
 import java.io.ByteArrayInputStream;
 import java.util.Collections;
 import java.util.Set;
@@ -17,10 +20,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 import studio.one.application.attachment.domain.model.Attachment;
+import studio.one.application.attachment.application.result.AttachmentDownloadAuditResult;
 import studio.one.application.attachment.application.usecase.AttachmentDownloadUrlService;
+import studio.one.application.attachment.application.usecase.AttachmentDownloadAuditLogService;
 import studio.one.application.attachment.application.result.AttachmentOwnerAccessAction;
 import studio.one.application.attachment.application.usecase.AttachmentOwnerAccessAuthorizer;
 import studio.one.application.attachment.application.usecase.AttachmentService;
@@ -40,6 +48,9 @@ class AttachmentMgmtControllerAuthorizationTest {
 
     @Mock
     private AttachmentDownloadUrlService downloadUrlService;
+
+    @Mock
+    private AttachmentDownloadAuditLogService downloadAuditLogService;
 
     @Mock
     private AttachmentUrlIssueRequestDetailsResolver requestDetailsResolver;
@@ -168,10 +179,47 @@ class AttachmentMgmtControllerAuthorizationTest {
         assertThrows(FileParseException.class, () -> controller.extractText(10L));
     }
 
+    @Test
+    void downloadRecordsManagementAuditLog() throws Exception {
+        AttachmentMgmtController controller = controller();
+        Attachment attachment = mock(Attachment.class);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        when(principalResolverProvider.getIfAvailable()).thenReturn(principalResolver);
+        when(principalResolver.currentOrNull()).thenReturn(principal(1L, "ROLE_ADMIN"));
+        when(requestDetailsResolver.resolve(request)).thenReturn(new AttachmentUrlIssueRequestDetails("10.0.0.3", "JUnit"));
+        when(attachmentService.getAttachmentById(10L)).thenReturn(attachment);
+        when(attachmentService.getInputStream(attachment)).thenReturn(new ByteArrayInputStream(new byte[] { 1, 2, 3 }));
+        when(attachment.getAttachmentId()).thenReturn(10L);
+        when(attachment.getObjectType()).thenReturn(20);
+        when(attachment.getObjectId()).thenReturn(30L);
+        when(attachment.getContentType()).thenReturn("application/pdf");
+        when(attachment.getName()).thenReturn("report.pdf");
+        when(attachment.getSize()).thenReturn(3L);
+
+        ResponseEntity<StreamingResponseBody> response = controller.download(10L, request);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        response.getBody().writeTo(out);
+
+        assertEquals(3, out.toByteArray().length);
+        verify(downloadAuditLogService).record(org.mockito.ArgumentMatchers.argThat(command ->
+                command.result() == AttachmentDownloadAuditResult.SUCCEEDED
+                        && command.httpStatus() == 200
+                        && command.downloadedBytes() == 3L
+                        && command.tokenHash() == null
+                        && "MGMT_DIRECT".equals(command.linkType())
+                        && command.attachmentId() == 10L
+                        && command.objectType() == 20
+                        && command.objectId() == 30L
+                        && "10.0.0.3".equals(command.clientIp())
+                        && "JUnit".equals(command.userAgent())));
+    }
+
     private AttachmentMgmtController controller() {
         return new AttachmentMgmtController(
                 attachmentService,
                 downloadUrlService,
+                downloadAuditLogService,
                 requestDetailsResolver,
                 identityServiceProvider,
                 principalResolverProvider,


### PR DESCRIPTION
## Summary
- Fixes #464
- `/api/mgmt/attachments/{attachmentId}/download` 관리 직접 다운로드 성공/실패 감사 로그 기록 추가
- `/api/attachments/{attachmentId}/download` 서비스 직접 다운로드 성공/실패 감사 로그 기록 추가
- 실제 전송 byte 수, clientIp, userAgent, attachment/object metadata 기록
- signed download URL 발급 이력과 실제 다운로드 접근 이력의 문서 설명 구분

## Validation
- `./gradlew :studio-application-modules:attachment-service:test --tests 'studio.one.application.attachment.web.controller.AttachmentControllerTest' --tests 'studio.one.application.attachment.web.controller.AttachmentMgmtControllerAuthorizationTest'`\n- `./gradlew :starter:studio-application-starter-attachment:test`\n\n## Review\n- 직접 다운로드 경로에만 감사 기록을 추가했고 signed download 감사 동작은 유지\n- 다운로드 응답 헤더 생성은 기존 `AttachmentWebSupport.downloadResponse` 경로를 재사용\n\n## Issue\n- #464\n\n## AI-Assisted\n- Yes