### PR TITLE
[1.x] 직접 다운로드 감사 실패 케이스 회귀 테스트 추가

### DIFF
--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/web/controller/AttachmentControllerTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/web/controller/AttachmentControllerTest.java
@@ -137,6 +137,28 @@ class AttachmentControllerTest {
     }
 
     @Test
+    void downloadRecordsNotFoundAuditLog() throws Exception {
+        AttachmentController controller = controller();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        when(requestDetailsResolver.resolve(request)).thenReturn(new AttachmentUrlIssueRequestDetails("10.0.0.4", "JUnit"));
+        when(attachmentService.getAttachmentById(404L)).thenThrow(AttachmentNotFoundException.byId(404L));
+
+        assertThrows(AttachmentNotFoundException.class, () -> controller.download(404L, request));
+
+        verify(downloadAuditLogService).record(org.mockito.ArgumentMatchers.argThat(command ->
+                command.result() == AttachmentDownloadAuditResult.FAILED
+                        && command.httpStatus() == 404
+                        && command.downloadedBytes() == null
+                        && command.tokenHash() == null
+                        && "SERVICE_DIRECT".equals(command.linkType())
+                        && command.attachmentId() == 404L
+                        && "10.0.0.4".equals(command.clientIp())
+                        && "JUnit".equals(command.userAgent())
+                        && "ATTACHMENT_NOT_FOUND".equals(command.errorCode())));
+    }
+
+    @Test
     void thumbnailReturnsSameResponseShape() throws Exception {
         AttachmentController controller = controller();
         Attachment attachment = mock(Attachment.class);

--- a/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/web/controller/AttachmentMgmtControllerAuthorizationTest.java
+++ b/studio-application-modules/attachment-service/src/test/java/studio/one/application/attachment/web/controller/AttachmentMgmtControllerAuthorizationTest.java
@@ -215,6 +215,37 @@ class AttachmentMgmtControllerAuthorizationTest {
                         && "JUnit".equals(command.userAgent())));
     }
 
+    @Test
+    void downloadRecordsAccessDeniedAuditLog() throws Exception {
+        AttachmentMgmtController controller = controller();
+        Attachment attachment = mock(Attachment.class);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        when(principalResolverProvider.getIfAvailable()).thenReturn(principalResolver);
+        when(principalResolver.currentOrNull()).thenReturn(principal(7L, "USER"));
+        when(requestDetailsResolver.resolve(request)).thenReturn(new AttachmentUrlIssueRequestDetails("10.0.0.5", "JUnit"));
+        when(attachmentService.getAttachmentById(10L)).thenReturn(attachment);
+        when(attachment.getAttachmentId()).thenReturn(10L);
+        when(attachment.getObjectType()).thenReturn(20);
+        when(attachment.getObjectId()).thenReturn(30L);
+        when(attachment.getCreatedBy()).thenReturn(99L);
+
+        assertThrows(AccessDeniedException.class, () -> controller.download(10L, request));
+
+        verify(downloadAuditLogService).record(org.mockito.ArgumentMatchers.argThat(command ->
+                command.result() == AttachmentDownloadAuditResult.FAILED
+                        && command.httpStatus() == 403
+                        && command.downloadedBytes() == null
+                        && command.tokenHash() == null
+                        && "MGMT_DIRECT".equals(command.linkType())
+                        && command.attachmentId() == 10L
+                        && command.objectType() == 20
+                        && command.objectId() == 30L
+                        && "10.0.0.5".equals(command.clientIp())
+                        && "JUnit".equals(command.userAgent())
+                        && "ACCESS_DENIED".equals(command.errorCode())));
+    }
+
     private AttachmentMgmtController controller() {
         return new AttachmentMgmtController(
                 attachmentService,


### PR DESCRIPTION
## Summary
- 직접 다운로드 감사 로그 변경분 리뷰 결과에 따라 실패 케이스 회귀 테스트를 추가했습니다.
- 서비스 직접 다운로드에서 attachment not found 발생 시 `FAILED`, `404`, `ATTACHMENT_NOT_FOUND` 감사 로그가 기록되는지 검증합니다.
- 관리 직접 다운로드에서 access denied 발생 시 `FAILED`, `403`, `ACCESS_DENIED` 감사 로그가 기록되는지 검증합니다.

## Review Notes
- 로컬 수정안은 stream 성공/실패 기록은 단순화했지만 조회 실패/권한 거부/stream open 실패 감사 로그가 누락될 수 있어 그대로 반영하지 않았습니다.
- 최신 `1.x` 구현은 유지하고, 누락되기 쉬운 실패 감사 로그 경로를 테스트로 고정했습니다.

## Validation
- 요청 범위에 따라 Gradle 테스트는 실행하지 않았습니다.

## AI-Assisted
- Yes