### PR TITLE
[codex] Tokenizer 자동 선택 및 token 기반 RAG chunking 적용

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -42,6 +42,7 @@ caffeineVersion=3.1.8
 pgvectorVersion=0.1.4
 testcontainersVersion=1.20.1
 mustacheVersion=0.9.10
+jtokkitVersion=1.1.0
 # LOCAL CRYPTO 
 jasyptVersion=3.0.4
 bouncycastleVersion=1.79

--- a/starter/studio-platform-starter-ai/README.md
+++ b/starter/studio-platform-starter-ai/README.md
@@ -324,6 +324,7 @@ studio:
   chunking:
     enabled: true
     strategy: recursive
+    unit: character
     max-size: 800
     overlap: 100
 ```
@@ -332,8 +333,10 @@ studio:
 |---|---:|---|
 | `studio.chunking.enabled` | `true` | chunking starter 기본 bean 등록 여부 |
 | `studio.chunking.strategy` | `recursive` | Phase 1 전략. `recursive`, `fixed-size` 지원 |
-| `studio.chunking.max-size` | `800` | chunk 최대 문자 수 |
-| `studio.chunking.overlap` | `100` | 이전 chunk tail을 다음 chunk에 포함할 문자 수 |
+| `studio.chunking.unit` | `character` | chunk size/overlap 단위. `token`이면 tokenizer-aware chunking을 사용 |
+| `studio.chunking.max-size` | `800` | configured unit 기준 chunk 최대 크기 |
+| `studio.chunking.overlap` | `100` | 이전 chunk tail을 다음 chunk에 포함할 configured unit 수 |
+| `studio.ai.rag.retrieval.max-context-tokens` | `0` | `0`이면 비활성화. 양수이면 검색 결과를 token budget 이내로 제한 |
 
 기존 `studio.ai.pipeline.chunk-size`, `studio.ai.pipeline.chunk-overlap`는 deprecated legacy `TextChunker` fallback 설정이다.
 신규 `ChunkingOrchestrator` 경로에서는 `studio.chunking.*`가 기준이다.

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineConfiguration.java
@@ -258,7 +258,8 @@ public class RagPipelineConfiguration {
                                 retrieval.isSemanticFallbackEnabled(),
                                 retrieval.getTopK(),
                                 objectScope.getDefaultListLimit(),
-                                objectScope.getMaxListLimit());
+                                objectScope.getMaxListLimit(),
+                                retrieval.getMaxContextTokens());
         }
 
         private RagPipelineDiagnosticsOptions ragPipelineDiagnosticsOptions(RagPipelineProperties properties) {

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineProperties.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/RagPipelineProperties.java
@@ -184,6 +184,7 @@ public class RagPipelineProperties implements EnvironmentAware, InitializingBean
         private double minRelevanceScore = RagPipelineOptions.DEFAULT_MIN_RELEVANCE_SCORE;
         private boolean keywordFallbackEnabled = RagPipelineOptions.DEFAULT_KEYWORD_FALLBACK_ENABLED;
         private boolean semanticFallbackEnabled = RagPipelineOptions.DEFAULT_SEMANTIC_FALLBACK_ENABLED;
+        private int maxContextTokens = RagPipelineOptions.DEFAULT_MAX_CONTEXT_TOKENS;
         private final QueryExpansionProperties queryExpansion = new QueryExpansionProperties();
 
         public int getTopK() {
@@ -244,6 +245,14 @@ public class RagPipelineProperties implements EnvironmentAware, InitializingBean
 
         public QueryExpansionProperties getQueryExpansion() {
             return queryExpansion;
+        }
+
+        public int getMaxContextTokens() {
+            return maxContextTokens;
+        }
+
+        public void setMaxContextTokens(int maxContextTokens) {
+            this.maxContextTokens = maxContextTokens;
         }
     }
 

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagPipelineService.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagPipelineService.java
@@ -228,7 +228,8 @@ public class DefaultRagPipelineService implements RagPipelineService {
         TextCleaningResult cleaning = cleanText(request.text());
         String indexedText = cleaning.text() == null ? request.text() : cleaning.text();
         progress.onStep(RagIndexJobStep.CHUNKING);
-        List<RagPipelineChunk> chunks = chunk(indexedText, request);
+        RagIndexRequest chunkingRequest = withResolvedEmbeddingForChunking(request);
+        List<RagPipelineChunk> chunks = chunk(indexedText, chunkingRequest);
         progress.onChunkCount(chunks.size());
         List<VectorRecord> records = new ArrayList<>(chunks.size());
         List<String> documentKeywords = keywordOptions.scope().includesDocument()
@@ -317,6 +318,29 @@ public class DefaultRagPipelineService implements RagPipelineService {
         return ragChunker.chunk(indexedText, request);
     }
 
+    private RagIndexRequest withResolvedEmbeddingForChunking(RagIndexRequest request) {
+        ResolvedRagEmbedding resolvedEmbedding = embeddingProfileResolver.resolve(new RagEmbeddingSelection(
+                request.embeddingProfileId(),
+                request.embeddingProvider(),
+                request.embeddingModel(),
+                EmbeddingInputType.TEXT));
+        Map<String, Object> metadata = new HashMap<>(request.metadata());
+        metadata.putAll(resolvedEmbedding.metadata());
+        return new RagIndexRequest(
+                request.documentId(),
+                request.text(),
+                metadata,
+                request.keywords(),
+                request.useLlmKeywordExtraction(),
+                firstText(request.embeddingProfileId(), resolvedEmbedding.profileId()),
+                firstText(request.embeddingProvider(), resolvedEmbedding.provider()),
+                firstText(request.embeddingModel(), resolvedEmbedding.model()));
+    }
+
+    private String firstText(String preferred, String fallback) {
+        return preferred == null || preferred.isBlank() ? fallback : preferred;
+    }
+
     private void mergeChunkMetadata(Map<String, Object> metadata, Map<String, Object> chunkMetadata) {
         chunkMetadata.forEach((key, value) -> {
             if (value != null && (!(value instanceof String text) || !text.isBlank())) {
@@ -403,7 +427,7 @@ public class DefaultRagPipelineService implements RagPipelineService {
                 null,
                 request.requestedTopK(),
                 request.requestedMinScore());
-        return toRagSearchResults(results);
+        return toRagSearchResults(applyContextBudget(results));
     }
 
     @Override
@@ -441,7 +465,7 @@ public class DefaultRagPipelineService implements RagPipelineService {
                 searchFilter.objectId(),
                 request.requestedTopK(),
                 request.requestedMinScore());
-        return toRagSearchResults(results);
+        return toRagSearchResults(applyContextBudget(results));
     }
 
     @Override
@@ -704,6 +728,57 @@ public class DefaultRagPipelineService implements RagPipelineService {
         return results.stream()
                 .limit(Math.max(topK, 0))
                 .toList();
+    }
+
+    private List<VectorSearchResult> applyContextBudget(List<VectorSearchResult> results) {
+        if (options.maxContextTokens() <= 0 || results == null || results.isEmpty()) {
+            return results == null ? List.of() : results;
+        }
+        List<VectorSearchResult> budgeted = new ArrayList<>();
+        int usedTokens = 0;
+        for (VectorSearchResult result : results) {
+            int chunkTokens = chunkTokenCount(result);
+            if (chunkTokens <= 0) {
+                chunkTokens = estimateTokens(result.document().content());
+            }
+            if (chunkTokens > options.maxContextTokens() || usedTokens + chunkTokens > options.maxContextTokens()) {
+                continue;
+            }
+            usedTokens += chunkTokens;
+            budgeted.add(withBudgetMetadata(result, chunkTokens, usedTokens));
+        }
+        return budgeted;
+    }
+
+    private VectorSearchResult withBudgetMetadata(
+            VectorSearchResult result,
+            int chunkTokens,
+            int usedTokens) {
+        Map<String, Object> metadata = new HashMap<>(result.document().metadata());
+        metadata.put("contextBudgetUsedTokens", usedTokens);
+        metadata.put("contextBudgetMaxTokens", options.maxContextTokens());
+        metadata.put("contextBudgetChunkTokens", chunkTokens);
+        return new VectorSearchResult(new studio.one.platform.ai.core.vector.VectorDocument(
+                result.document().id(),
+                result.document().content(),
+                metadata,
+                result.document().embedding()), result.score());
+    }
+
+    private int chunkTokenCount(VectorSearchResult result) {
+        Object value = firstPresent(result.document().metadata(),
+                VectorRecord.KEY_CHUNK_TOKEN_COUNT,
+                ChunkMetadata.KEY_CHUNK_TOKEN_COUNT,
+                ChunkMetadata.KEY_TOKEN_COUNT);
+        Integer integer = integer(value);
+        return integer == null ? 0 : integer;
+    }
+
+    private int estimateTokens(String text) {
+        if (text == null || text.isBlank()) {
+            return 0;
+        }
+        return Math.max(1, (int) Math.ceil(text.replaceAll("\\s+", " ").trim().length() / 4.0d));
     }
 
     private RagSearchRequest withDefaults(RagSearchRequest request) {

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/OrchestratedRagChunker.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/OrchestratedRagChunker.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import studio.one.platform.ai.core.rag.RagIndexRequest;
+import studio.one.platform.ai.core.vector.VectorRecord;
 import studio.one.platform.chunking.core.Chunk;
 import studio.one.platform.chunking.core.ChunkingContext;
 import studio.one.platform.chunking.core.ChunkingOrchestrator;
@@ -19,7 +20,10 @@ final class OrchestratedRagChunker implements RagChunker {
 
     @Override
     public List<RagPipelineChunk> chunk(String indexedText, RagIndexRequest request) {
-        Map<String, Object> metadata = request.metadata();
+        Map<String, Object> metadata = new java.util.LinkedHashMap<>(request.metadata());
+        putIfPresent(metadata, VectorRecord.KEY_EMBEDDING_PROFILE_ID, request.embeddingProfileId());
+        putIfPresent(metadata, VectorRecord.KEY_EMBEDDING_PROVIDER, request.embeddingProvider());
+        putIfPresent(metadata, VectorRecord.KEY_EMBEDDING_MODEL, request.embeddingModel());
         ChunkingContext context = ChunkingContext.configuredDefaults(indexedText)
                 .sourceDocumentId(request.documentId())
                 .contentType(RagChunkingMetadata.normalizeObjectScope(metadata.get("contentType")))
@@ -31,6 +35,12 @@ final class OrchestratedRagChunker implements RagChunker {
         return chunkingOrchestrator.chunk(context).stream()
                 .map(this::toPipelineChunk)
                 .toList();
+    }
+
+    private void putIfPresent(Map<String, Object> metadata, String key, String value) {
+        if (value != null && !value.isBlank()) {
+            metadata.putIfAbsent(key, value);
+        }
     }
 
     private RagPipelineChunk toPipelineChunk(Chunk chunk) {

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
@@ -100,6 +100,55 @@ class RagPipelineServiceTest {
     }
 
     @Test
+    void searchAppliesConfiguredContextTokenBudget() {
+        ragPipelineService = DefaultRagPipelineService.create(
+                embeddingPort,
+                vectorStorePort,
+                textChunker,
+                cache,
+                retry,
+                keywordExtractor,
+                null,
+                new RagPipelineOptions(0.7d, 0.3d, 0.15d, 0.15d, false, false, 5, 20, 100, 10));
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("query", List.of(0.1, 0.2)))));
+        when(vectorStorePort.hybridSearch(anyString(), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(
+                        searchResult("doc-1", "first", 0.9d, 4),
+                        searchResult("doc-2", "second", 0.8d, 5),
+                        searchResult("doc-3", "third", 0.7d, 6)));
+
+        List<RagSearchResult> results = ragPipelineService.search(new RagSearchRequest("query", 5));
+
+        assertThat(results).hasSize(2);
+        assertThat(results).extracting(RagSearchResult::documentId).containsExactly("doc-1", "doc-2");
+        assertThat(results.get(1).metadata())
+                .containsEntry("contextBudgetUsedTokens", 9)
+                .containsEntry("contextBudgetMaxTokens", 10);
+    }
+
+    @Test
+    void searchExcludesSingleChunkLargerThanContextTokenBudget() {
+        ragPipelineService = DefaultRagPipelineService.create(
+                embeddingPort,
+                vectorStorePort,
+                textChunker,
+                cache,
+                retry,
+                keywordExtractor,
+                null,
+                new RagPipelineOptions(0.7d, 0.3d, 0.15d, 0.15d, false, false, 5, 20, 100, 5));
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("query", List.of(0.1, 0.2)))));
+        when(vectorStorePort.hybridSearch(anyString(), any(VectorSearchRequest.class), anyDouble(), anyDouble()))
+                .thenReturn(List.of(searchResult("doc-oversized", "oversized", 0.9d, 8)));
+
+        List<RagSearchResult> results = ragPipelineService.search(new RagSearchRequest("query", 5));
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
     void shouldIndexChunksAndPersistVectors() {
         RagIndexRequest request = new RagIndexRequest("doc-1", "hello world", Map.of("author", "test"));
         when(textChunker.chunk("doc-1", "hello world"))
@@ -185,6 +234,54 @@ class RagPipelineServiceTest {
                 .containsEntry(VectorRecord.KEY_EMBEDDING_MODEL, "gemini-embedding-001")
                 .containsEntry(VectorRecord.KEY_EMBEDDING_DIMENSION, 768)
                 .containsEntry(VectorRecord.KEY_EMBEDDING_INPUT_TYPE, "TABLE_TEXT");
+    }
+
+    @Test
+    void shouldPassResolvedEmbeddingMetadataToChunkingWhenRequestUsesProfileOnly() {
+        RagEmbeddingProfileResolver resolver = selection -> new ResolvedRagEmbedding(
+                embeddingPort,
+                selection.profileId(),
+                "openai",
+                "text-embedding-3-small",
+                1536,
+                selection.inputType());
+        ragPipelineService = DefaultRagPipelineService.create(
+                embeddingPort,
+                vectorStorePort,
+                textChunker,
+                chunkingOrchestrator,
+                cache,
+                retry,
+                keywordExtractor,
+                null,
+                RagPipelineOptions.defaults(),
+                RagPipelineDiagnosticsOptions.defaults(),
+                RagKeywordOptions.defaults(),
+                resolver);
+        when(chunkingOrchestrator.chunk(any(ChunkingContext.class)))
+                .thenReturn(List.of(Chunk.of(
+                        "doc-profile-0",
+                        "profile text",
+                        ChunkMetadata.builder(ChunkingStrategyType.RECURSIVE, 0).build())));
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(List.of(new EmbeddingVector("doc-profile-0", List.of(0.1, 0.2)))));
+
+        ragPipelineService.index(new RagIndexRequest(
+                "doc-profile",
+                "profile text",
+                Map.of(),
+                List.of(),
+                false,
+                "retrieval-openai",
+                null,
+                null));
+
+        ArgumentCaptor<ChunkingContext> chunkingContext = ArgumentCaptor.forClass(ChunkingContext.class);
+        verify(chunkingOrchestrator).chunk(chunkingContext.capture());
+        assertThat(chunkingContext.getValue().metadata())
+                .containsEntry(VectorRecord.KEY_EMBEDDING_PROFILE_ID, "retrieval-openai")
+                .containsEntry(VectorRecord.KEY_EMBEDDING_PROVIDER, "openai")
+                .containsEntry(VectorRecord.KEY_EMBEDDING_MODEL, "text-embedding-3-small");
     }
 
     @Test
@@ -1469,5 +1566,13 @@ class RagPipelineServiceTest {
         private List<VectorDocument> upsertedDocuments() {
             return upsertedDocuments;
         }
+    }
+
+    private VectorSearchResult searchResult(String id, String content, double score, int tokenCount) {
+        return new VectorSearchResult(new VectorDocument(
+                id,
+                content,
+                Map.of(VectorRecord.KEY_CHUNK_TOKEN_COUNT, tokenCount),
+                List.of(0.1, 0.2)), score);
     }
 }

--- a/starter/studio-platform-starter-chunking/README.md
+++ b/starter/studio-platform-starter-chunking/README.md
@@ -29,16 +29,30 @@ studio:
   chunking:
     enabled: true
     strategy: recursive
+    unit: character
     max-size: 800
     overlap: 100
+    tokenizer:
+      auto-detect: true
+      fallback: approximate
+      fail-on-unknown-model: false
+      mappings:
+        text-embedding-3-small:
+          provider: tiktoken
+          encoding: cl100k_base
 ```
 
 | Property | Default | 설명 |
 | --- | --- | --- |
 | `studio.chunking.enabled` | `true` | 기본 chunking bean 등록 여부입니다. |
 | `studio.chunking.strategy` | `recursive` | 기본 순수 chunking 전략입니다. 지원값: `recursive`, `fixed-size`, `structure-based`. |
-| `studio.chunking.max-size` | `800` | character 기준 최대 chunk size입니다. |
-| `studio.chunking.overlap` | `100` | 이전 chunk에서 이어받는 character overlap입니다. |
+| `studio.chunking.unit` | `character` | `max-size`와 `overlap` 해석 단위입니다. 지원값: `character`, `token`. |
+| `studio.chunking.max-size` | `800` | configured unit 기준 최대 chunk size입니다. |
+| `studio.chunking.overlap` | `100` | 이전 chunk에서 이어받는 configured unit 기준 overlap입니다. |
+| `studio.chunking.tokenizer.auto-detect` | `true` | embedding provider/model metadata로 tokenizer를 자동 선택합니다. |
+| `studio.chunking.tokenizer.fallback` | `approximate` | 정확한 tokenizer가 없을 때 사용할 fallback tokenizer입니다. |
+| `studio.chunking.tokenizer.fail-on-unknown-model` | `false` | 알 수 없는 model에서 fallback 대신 실패할지 결정합니다. |
+| `studio.chunking.tokenizer.mappings.*` | `{}` | model별 explicit tokenizer mapping입니다. |
 
 `max-size <= 0`, `overlap < 0`, `overlap >= max-size` 설정은 auto-configuration 단계에서 fail-fast 됩니다.
 
@@ -208,6 +222,8 @@ ChunkContextExpansion expansion = windowChunkContextExpander.expand(request);
 
 ## Size Policy
 
-기본 size 정책은 character 기준입니다.
-`ChunkUnit.TOKEN`은 외부 tokenizer를 호출하지 않고 compacted character length 기반 deterministic estimate를 사용합니다.
+기본 size 정책은 character 기준입니다. `studio.chunking.unit=token`을 설정하면 `DefaultChunkingOrchestrator`가
+tokenizer-aware chunker를 사용해 token 기준 `max-size`와 `overlap`을 적용합니다.
+OpenAI embedding/chat model은 `jtokkit` 기반 tiktoken-compatible adapter로 계산하고, 알 수 없는 model은
+`ApproximateTokenizer`를 사용하며 `tokenizerFallbackUsed`, `tokenizerWarnings` metadata를 남깁니다.
 structure-based overlap은 보수적으로 동작하며 heading, table, OCR, image-caption boundary는 overlap tail로 넘기지 않습니다.

--- a/starter/studio-platform-starter-chunking/build.gradle.kts
+++ b/starter/studio-platform-starter-chunking/build.gradle.kts
@@ -24,6 +24,8 @@ dependencies {
     compileOnly("org.springframework.boot:spring-boot-autoconfigure")
     compileOnly("org.springframework:spring-context")
 
+    implementation("com.knuddels:jtokkit:${property("jtokkitVersion")}")
+
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("org.assertj:assertj-core")
     testImplementation(project(":studio-platform-textract"))

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/autoconfigure/ChunkingAutoConfiguration.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/autoconfigure/ChunkingAutoConfiguration.java
@@ -12,7 +12,11 @@ import org.springframework.context.annotation.Configuration;
 
 import studio.one.platform.chunking.core.Chunker;
 import studio.one.platform.chunking.core.ChunkingOrchestrator;
+import studio.one.platform.chunking.core.TokenizerPort;
+import studio.one.platform.chunking.core.TokenizerResolver;
+import studio.one.platform.chunking.service.ApproximateTokenizer;
 import studio.one.platform.chunking.service.DefaultChunkingOrchestrator;
+import studio.one.platform.chunking.service.DefaultTokenizerResolver;
 import studio.one.platform.chunking.service.FixedSizeChunker;
 import studio.one.platform.chunking.service.HeadingChunkContextExpander;
 import studio.one.platform.chunking.service.ParentChildChunkContextExpander;
@@ -20,6 +24,7 @@ import studio.one.platform.chunking.service.RecursiveChunker;
 import studio.one.platform.chunking.service.StructureBasedChunker;
 import studio.one.platform.chunking.service.TableChunkContextExpander;
 import studio.one.platform.chunking.service.TextractNormalizedDocumentAdapter;
+import studio.one.platform.chunking.service.TokenBasedChunker;
 import studio.one.platform.chunking.service.WindowChunkContextExpander;
 
 @AutoConfiguration
@@ -45,6 +50,28 @@ public class ChunkingAutoConfiguration {
             ChunkingProperties properties,
             RecursiveChunker recursiveChunker) {
         return new StructureBasedChunker(properties.getMaxSize(), properties.getOverlap(), recursiveChunker);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ApproximateTokenizer approximateTokenizer() {
+        return new ApproximateTokenizer();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public TokenizerResolver tokenizerResolver(
+            ChunkingProperties properties,
+            List<TokenizerPort> tokenizers) {
+        return new DefaultTokenizerResolver(properties.getTokenizer(), tokenizers);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public TokenBasedChunker tokenBasedChunker(
+            ChunkingProperties properties,
+            TokenizerResolver tokenizerResolver) {
+        return new TokenBasedChunker(properties.getMaxSize(), properties.getOverlap(), tokenizerResolver);
     }
 
     @Bean
@@ -75,9 +102,10 @@ public class ChunkingAutoConfiguration {
     @ConditionalOnMissingBean(ChunkingOrchestrator.class)
     public ChunkingOrchestrator chunkingOrchestrator(
             ChunkingProperties properties,
-            List<Chunker> chunkers) {
+            List<Chunker> chunkers,
+            TokenBasedChunker tokenBasedChunker) {
         properties.validate();
-        return new DefaultChunkingOrchestrator(properties, chunkers);
+        return new DefaultChunkingOrchestrator(properties, chunkers, tokenBasedChunker);
     }
 
     @Configuration(proxyBeanMethods = false)

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/autoconfigure/ChunkingProperties.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/autoconfigure/ChunkingProperties.java
@@ -2,6 +2,10 @@ package studio.one.platform.chunking.autoconfigure;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import studio.one.platform.chunking.core.ChunkUnit;
 import studio.one.platform.chunking.core.ChunkingStrategyType;
 
 @ConfigurationProperties(prefix = "studio.chunking")
@@ -14,6 +18,10 @@ public class ChunkingProperties {
     private int maxSize = 800;
 
     private int overlap = 100;
+
+    private String unit = "character";
+
+    private final TokenizerProperties tokenizer = new TokenizerProperties();
 
     public boolean isEnabled() {
         return enabled;
@@ -53,8 +61,24 @@ public class ChunkingProperties {
         this.overlap = overlap;
     }
 
+    public String getUnit() {
+        return unit;
+    }
+
+    public void setUnit(String unit) {
+        this.unit = unit;
+    }
+
+    public TokenizerProperties getTokenizer() {
+        return tokenizer;
+    }
+
     public ChunkingStrategyType strategyType() {
         return ChunkingStrategyType.from(strategy);
+    }
+
+    public ChunkUnit unitType() {
+        return ChunkUnit.from(unit);
     }
 
     public void validate() {
@@ -68,6 +92,7 @@ public class ChunkingProperties {
             throw new IllegalArgumentException("studio.chunking.overlap must be less than studio.chunking.max-size");
         }
         strategyType();
+        unitType();
     }
 
     public int effectiveMaxSize(int requestedMaxSize) {
@@ -76,5 +101,70 @@ public class ChunkingProperties {
 
     public int effectiveOverlap(int requestedOverlap) {
         return requestedOverlap < 0 ? overlap : requestedOverlap;
+    }
+
+    public static class TokenizerProperties {
+        private boolean autoDetect = true;
+        private String fallback = "approximate";
+        private boolean failOnUnknownModel = false;
+        private final Map<String, TokenizerMappingProperties> mappings = new LinkedHashMap<>();
+
+        public boolean isAutoDetect() {
+            return autoDetect;
+        }
+
+        public void setAutoDetect(boolean autoDetect) {
+            this.autoDetect = autoDetect;
+        }
+
+        public String getFallback() {
+            return fallback;
+        }
+
+        public void setFallback(String fallback) {
+            this.fallback = fallback;
+        }
+
+        public boolean isFailOnUnknownModel() {
+            return failOnUnknownModel;
+        }
+
+        public void setFailOnUnknownModel(boolean failOnUnknownModel) {
+            this.failOnUnknownModel = failOnUnknownModel;
+        }
+
+        public Map<String, TokenizerMappingProperties> getMappings() {
+            return mappings;
+        }
+    }
+
+    public static class TokenizerMappingProperties {
+        private String provider;
+        private String encoding;
+        private String tokenizerModel;
+
+        public String getProvider() {
+            return provider;
+        }
+
+        public void setProvider(String provider) {
+            this.provider = provider;
+        }
+
+        public String getEncoding() {
+            return encoding;
+        }
+
+        public void setEncoding(String encoding) {
+            this.encoding = encoding;
+        }
+
+        public String getTokenizerModel() {
+            return tokenizerModel;
+        }
+
+        public void setTokenizerModel(String tokenizerModel) {
+            this.tokenizerModel = tokenizerModel;
+        }
     }
 }

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/ApproximateTokenizer.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/ApproximateTokenizer.java
@@ -1,0 +1,85 @@
+package studio.one.platform.chunking.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import studio.one.platform.chunking.core.TokenizerPort;
+
+public class ApproximateTokenizer implements TokenizerPort {
+
+    private static final int AVERAGE_LATIN_CHARS_PER_TOKEN = 4;
+
+    @Override
+    public String provider() {
+        return "approximate";
+    }
+
+    @Override
+    public String encodingName() {
+        return "approximate";
+    }
+
+    @Override
+    public int countTokens(String text) {
+        return encode(text).size();
+    }
+
+    @Override
+    public List<Integer> encode(String text) {
+        if (text == null || text.isBlank()) {
+            return List.of();
+        }
+        List<Integer> tokens = new ArrayList<>();
+        int latinRunLength = 0;
+        for (int i = 0; i < text.length(); i++) {
+            char ch = text.charAt(i);
+            if (Character.isWhitespace(ch)) {
+                latinRunLength = flushLatin(tokens, latinRunLength);
+                continue;
+            }
+            if (isConservativeSingleToken(ch)) {
+                latinRunLength = flushLatin(tokens, latinRunLength);
+                tokens.add((int) ch);
+                continue;
+            }
+            latinRunLength++;
+            if (latinRunLength >= AVERAGE_LATIN_CHARS_PER_TOKEN) {
+                tokens.add((int) ch);
+                latinRunLength = 0;
+            }
+        }
+        flushLatin(tokens, latinRunLength);
+        return tokens;
+    }
+
+    @Override
+    public String decode(List<Integer> tokens) {
+        if (tokens == null || tokens.isEmpty()) {
+            return "";
+        }
+        StringBuilder builder = new StringBuilder(tokens.size());
+        for (Integer token : tokens) {
+            if (token != null && token > 0) {
+                builder.appendCodePoint(token);
+            }
+        }
+        return builder.toString();
+    }
+
+    private int flushLatin(List<Integer> tokens, int latinRunLength) {
+        if (latinRunLength > 0) {
+            tokens.add(1);
+        }
+        return 0;
+    }
+
+    private boolean isConservativeSingleToken(char ch) {
+        Character.UnicodeBlock block = Character.UnicodeBlock.of(ch);
+        return block == Character.UnicodeBlock.HANGUL_SYLLABLES
+                || block == Character.UnicodeBlock.HANGUL_JAMO
+                || block == Character.UnicodeBlock.HANGUL_COMPATIBILITY_JAMO
+                || Character.getType(ch) == Character.OTHER_PUNCTUATION
+                || Character.getType(ch) == Character.MATH_SYMBOL
+                || Character.getType(ch) == Character.CURRENCY_SYMBOL;
+    }
+}

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/DefaultChunkingOrchestrator.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/DefaultChunkingOrchestrator.java
@@ -10,6 +10,7 @@ import studio.one.platform.chunking.core.Chunker;
 import studio.one.platform.chunking.core.ChunkingContext;
 import studio.one.platform.chunking.core.ChunkingOrchestrator;
 import studio.one.platform.chunking.core.ChunkingStrategyType;
+import studio.one.platform.chunking.core.ChunkUnit;
 import studio.one.platform.chunking.core.NormalizedDocument;
 import studio.one.platform.chunking.core.NormalizedDocumentChunker;
 
@@ -19,16 +20,29 @@ public class DefaultChunkingOrchestrator implements ChunkingOrchestrator {
 
     private final Map<ChunkingStrategyType, Chunker> chunkers = new EnumMap<>(ChunkingStrategyType.class);
 
+    private final TokenBasedChunker tokenBasedChunker;
+
     public DefaultChunkingOrchestrator(
             ChunkingProperties properties,
             List<Chunker> chunkers) {
+        this(properties, chunkers, null);
+    }
+
+    public DefaultChunkingOrchestrator(
+            ChunkingProperties properties,
+            List<Chunker> chunkers,
+            TokenBasedChunker tokenBasedChunker) {
         this.properties = properties;
         chunkers.forEach(chunker -> this.chunkers.put(chunker.strategy(), chunker));
+        this.tokenBasedChunker = tokenBasedChunker;
     }
 
     @Override
     public List<Chunk> chunk(ChunkingContext context) {
         ChunkingContext effectiveContext = applyDefaults(context);
+        if (effectiveContext.unit() == ChunkUnit.TOKEN && tokenBasedChunker != null) {
+            return tokenBasedChunker.chunk(effectiveContext);
+        }
         return selectChunker(effectiveContext).chunk(effectiveContext);
     }
 
@@ -76,7 +90,13 @@ public class DefaultChunkingOrchestrator implements ChunkingOrchestrator {
                 context.strategy() == null ? properties.strategyType() : context.strategy(),
                 properties.effectiveMaxSize(context.maxSize()),
                 properties.effectiveOverlap(context.overlap()),
-                context.unit(),
+                shouldUseConfiguredDefaults(context) ? properties.unitType() : context.unit(),
                 context.metadata());
+    }
+
+    private boolean shouldUseConfiguredDefaults(ChunkingContext context) {
+        return context.strategy() == null
+                && context.maxSize() == ChunkingContext.USE_CONFIGURED_MAX_SIZE
+                && context.overlap() == ChunkingContext.USE_CONFIGURED_OVERLAP;
     }
 }

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/DefaultChunkingOrchestrator.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/DefaultChunkingOrchestrator.java
@@ -55,6 +55,7 @@ public class DefaultChunkingOrchestrator implements ChunkingOrchestrator {
                 .strategy(ChunkingStrategyType.STRUCTURE_BASED)
                 .maxSize(properties.getMaxSize())
                 .overlap(properties.getOverlap())
+                .unit(properties.unitType())
                 .build();
         Chunker chunker = selectChunker(context);
         if (chunker instanceof NormalizedDocumentChunker normalizedDocumentChunker) {

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/DefaultTokenizerResolver.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/DefaultTokenizerResolver.java
@@ -1,0 +1,163 @@
+package studio.one.platform.chunking.service;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import studio.one.platform.chunking.autoconfigure.ChunkingProperties;
+import studio.one.platform.chunking.core.ChunkMetadata;
+import studio.one.platform.chunking.core.ResolvedTokenizer;
+import studio.one.platform.chunking.core.TokenizerPort;
+import studio.one.platform.chunking.core.TokenizerResolver;
+
+public class DefaultTokenizerResolver implements TokenizerResolver {
+
+    private static final String EMBEDDING_PROVIDER = "embeddingProvider";
+    private static final String EMBEDDING_MODEL = "embeddingModel";
+
+    private final ChunkingProperties.TokenizerProperties properties;
+    private final Map<String, TokenizerPort> tokenizersByProvider;
+    private final TokenizerPort approximateTokenizer;
+
+    public DefaultTokenizerResolver(
+            ChunkingProperties.TokenizerProperties properties,
+            List<TokenizerPort> tokenizers) {
+        this.properties = Objects.requireNonNull(properties, "properties");
+        this.tokenizersByProvider = new LinkedHashMap<>();
+        for (TokenizerPort tokenizer : tokenizers) {
+            tokenizersByProvider.putIfAbsent(normalize(tokenizer.provider()), tokenizer);
+        }
+        this.approximateTokenizer = tokenizersByProvider.getOrDefault("approximate", new ApproximateTokenizer());
+    }
+
+    @Override
+    public ResolvedTokenizer resolve(Map<String, Object> metadata) {
+        Map<String, Object> values = metadata == null ? Map.of() : metadata;
+        Optional<ResolvedTokenizer> explicit = explicit(values);
+        if (explicit.isPresent()) {
+            return explicit.get();
+        }
+        String model = text(values.get(EMBEDDING_MODEL));
+        Optional<ResolvedTokenizer> configured = configuredMapping(model);
+        if (configured.isPresent()) {
+            return configured.get();
+        }
+        Optional<ResolvedTokenizer> modelMapping = modelMapping(model);
+        if (modelMapping.isPresent()) {
+            return modelMapping.get();
+        }
+        Optional<ResolvedTokenizer> providerDefault = providerDefault(text(values.get(EMBEDDING_PROVIDER)));
+        if (providerDefault.isPresent()) {
+            return providerDefault.get();
+        }
+        if (properties.isFailOnUnknownModel()) {
+            throw new IllegalArgumentException("Tokenizer mapping is not available for embedding model: " + model);
+        }
+        return fallback("No tokenizer mapping is available for embedding model: " + (model == null ? "unknown" : model));
+    }
+
+    private Optional<ResolvedTokenizer> explicit(Map<String, Object> metadata) {
+        String provider = text(metadata.get(ChunkMetadata.KEY_TOKENIZER_PROVIDER));
+        String encoding = text(metadata.get(ChunkMetadata.KEY_TOKENIZER_ENCODING));
+        if (provider == null && encoding == null) {
+            return Optional.empty();
+        }
+        return Optional.of(resolve(provider, encoding, text(metadata.get(ChunkMetadata.KEY_TOKENIZER_MODEL)),
+                "explicit-config", "high"));
+    }
+
+    private Optional<ResolvedTokenizer> configuredMapping(String model) {
+        if (model == null) {
+            return Optional.empty();
+        }
+        ChunkingProperties.TokenizerMappingProperties mapping = properties.getMappings().get(model);
+        if (mapping == null) {
+            mapping = properties.getMappings().get(model.toLowerCase(Locale.ROOT));
+        }
+        if (mapping == null) {
+            return Optional.empty();
+        }
+        return Optional.of(resolve(mapping.getProvider(), mapping.getEncoding(), mapping.getTokenizerModel(),
+                "explicit-config", "high"));
+    }
+
+    private Optional<ResolvedTokenizer> modelMapping(String model) {
+        if (!properties.isAutoDetect() || model == null) {
+            return Optional.empty();
+        }
+        String normalized = model.toLowerCase(Locale.ROOT);
+        if (normalized.equals("text-embedding-3-small")
+                || normalized.equals("text-embedding-3-large")
+                || normalized.equals("text-embedding-ada-002")) {
+            return Optional.of(resolve("tiktoken", "cl100k_base", model, "model-mapping", "high"));
+        }
+        if (normalized.equals("gpt-4o") || normalized.equals("gpt-4o-mini")) {
+            return Optional.of(resolve("tiktoken", "o200k_base", model, "model-mapping", "high"));
+        }
+        if (normalized.contains("kure") || normalized.contains("bge") || normalized.contains("kosimcse")) {
+            return Optional.of(fallback("HuggingFace tokenizer adapter is not registered for model: " + model,
+                    model, "auto-detected"));
+        }
+        return Optional.empty();
+    }
+
+    private Optional<ResolvedTokenizer> providerDefault(String provider) {
+        if (!properties.isAutoDetect() || provider == null) {
+            return Optional.empty();
+        }
+        if (provider.equalsIgnoreCase("openai")) {
+            return Optional.of(resolve("tiktoken", "cl100k_base", null, "provider-default", "medium"));
+        }
+        if (provider.equalsIgnoreCase("huggingface") || provider.equalsIgnoreCase("local")) {
+            return Optional.of(fallback("HuggingFace tokenizer adapter is not registered for provider: " + provider,
+                    null, "provider-default"));
+        }
+        return Optional.empty();
+    }
+
+    private ResolvedTokenizer resolve(
+            String provider,
+            String encoding,
+            String tokenizerModel,
+            String selectionSource,
+            String confidence) {
+        String normalizedProvider = normalize(provider);
+        if (normalizedProvider == null && encoding != null) {
+            normalizedProvider = "tiktoken";
+        }
+        if ("tiktoken".equals(normalizedProvider) && encoding != null) {
+            return new ResolvedTokenizer(new TiktokenTokenizerAdapter(encoding), "tiktoken", encoding, tokenizerModel,
+                    selectionSource, confidence, false, List.of());
+        }
+        TokenizerPort tokenizer = tokenizersByProvider.get(normalizedProvider);
+        if (tokenizer != null) {
+            return new ResolvedTokenizer(tokenizer, tokenizer.provider(), tokenizer.encodingName(), tokenizerModel,
+                    selectionSource, confidence, false, List.of());
+        }
+        return fallback("Tokenizer provider is not registered: " + provider, tokenizerModel, selectionSource);
+    }
+
+    private ResolvedTokenizer fallback(String warning) {
+        return fallback(warning, null, "fallback");
+    }
+
+    private ResolvedTokenizer fallback(String warning, String tokenizerModel, String selectionSource) {
+        return new ResolvedTokenizer(approximateTokenizer, approximateTokenizer.provider(),
+                approximateTokenizer.encodingName(), tokenizerModel, selectionSource, "low", true, List.of(warning));
+    }
+
+    private String text(Object value) {
+        if (value == null) {
+            return null;
+        }
+        String text = value.toString().trim();
+        return text.isBlank() ? null : text;
+    }
+
+    private String normalize(String value) {
+        return value == null || value.isBlank() ? null : value.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/TiktokenTokenizerAdapter.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/TiktokenTokenizerAdapter.java
@@ -1,0 +1,67 @@
+package studio.one.platform.chunking.service;
+
+import java.util.List;
+
+import com.knuddels.jtokkit.Encodings;
+import com.knuddels.jtokkit.api.Encoding;
+import com.knuddels.jtokkit.api.EncodingRegistry;
+import com.knuddels.jtokkit.api.IntArrayList;
+
+import studio.one.platform.chunking.core.TokenizerPort;
+
+public class TiktokenTokenizerAdapter implements TokenizerPort {
+
+    private static final EncodingRegistry REGISTRY = Encodings.newLazyEncodingRegistry();
+
+    private final String encodingName;
+    private final Encoding encoding;
+
+    public TiktokenTokenizerAdapter(String encodingName) {
+        if (encodingName == null || encodingName.isBlank()) {
+            throw new IllegalArgumentException("encodingName must not be blank");
+        }
+        this.encodingName = encodingName.trim();
+        this.encoding = REGISTRY.getEncoding(this.encodingName)
+                .orElseThrow(() -> new IllegalArgumentException("Unsupported tiktoken encoding: " + encodingName));
+    }
+
+    @Override
+    public String provider() {
+        return "tiktoken";
+    }
+
+    @Override
+    public String encodingName() {
+        return encodingName;
+    }
+
+    @Override
+    public int countTokens(String text) {
+        if (text == null || text.isBlank()) {
+            return 0;
+        }
+        return encoding.countTokens(text);
+    }
+
+    @Override
+    public List<Integer> encode(String text) {
+        if (text == null || text.isBlank()) {
+            return List.of();
+        }
+        return encoding.encode(text).boxed();
+    }
+
+    @Override
+    public String decode(List<Integer> tokens) {
+        if (tokens == null || tokens.isEmpty()) {
+            return "";
+        }
+        IntArrayList values = new IntArrayList(tokens.size());
+        for (Integer token : tokens) {
+            if (token != null) {
+                values.add(token);
+            }
+        }
+        return encoding.decode(values);
+    }
+}

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/TokenBasedChunker.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/TokenBasedChunker.java
@@ -1,0 +1,176 @@
+package studio.one.platform.chunking.service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import studio.one.platform.chunking.core.Chunk;
+import studio.one.platform.chunking.core.ChunkMetadata;
+import studio.one.platform.chunking.core.ChunkType;
+import studio.one.platform.chunking.core.ChunkUnit;
+import studio.one.platform.chunking.core.ChunkingContext;
+import studio.one.platform.chunking.core.ChunkingStrategyType;
+import studio.one.platform.chunking.core.ResolvedTokenizer;
+import studio.one.platform.chunking.core.TokenizerResolver;
+
+public class TokenBasedChunker {
+
+    private static final int APPROXIMATE_CHARS_PER_TOKEN = 4;
+
+    private final int defaultMaxSize;
+    private final int defaultOverlap;
+    private final TokenizerResolver tokenizerResolver;
+
+    public TokenBasedChunker(int defaultMaxSize, int defaultOverlap, TokenizerResolver tokenizerResolver) {
+        if (defaultMaxSize <= 0) {
+            throw new IllegalArgumentException("defaultMaxSize must be positive");
+        }
+        if (defaultOverlap < 0) {
+            throw new IllegalArgumentException("defaultOverlap cannot be negative");
+        }
+        this.defaultMaxSize = defaultMaxSize;
+        this.defaultOverlap = Math.min(defaultOverlap, defaultMaxSize - 1);
+        this.tokenizerResolver = tokenizerResolver;
+    }
+
+    public List<Chunk> chunk(ChunkingContext context) {
+        String text = normalize(context.text());
+        if (text.isBlank()) {
+            return List.of();
+        }
+        int maxSize = ChunkSizing.effectiveMaxSize(context.maxSize(), defaultMaxSize);
+        int overlap = ChunkSizing.effectiveOverlap(context.overlap(), defaultOverlap, maxSize);
+        ResolvedTokenizer resolvedTokenizer = tokenizerResolver.resolve(context.metadata());
+        if (resolvedTokenizer.fallbackUsed() && "approximate".equals(resolvedTokenizer.provider())) {
+            return approximateChunks(context, text, maxSize, overlap, resolvedTokenizer);
+        }
+        return tokenChunks(context, text, maxSize, overlap, resolvedTokenizer);
+    }
+
+    private List<Chunk> tokenChunks(
+            ChunkingContext context,
+            String text,
+            int maxSize,
+            int overlap,
+            ResolvedTokenizer resolvedTokenizer) {
+        List<Integer> tokens = resolvedTokenizer.tokenizer().encode(text);
+        if (tokens.isEmpty()) {
+            return List.of();
+        }
+        List<Chunk> chunks = new ArrayList<>();
+        int start = 0;
+        int order = 0;
+        while (start < tokens.size()) {
+            int end = Math.min(start + maxSize, tokens.size());
+            String content = resolvedTokenizer.tokenizer().decode(tokens.subList(start, end)).trim();
+            if (!content.isBlank()) {
+                chunks.add(chunk(context, content, order++, start, end, tokens.size(), maxSize, overlap,
+                        resolvedTokenizer));
+            }
+            if (end == tokens.size()) {
+                break;
+            }
+            start = Math.max(end - overlap, start + 1);
+        }
+        return linkNeighbors(context, chunks);
+    }
+
+    private List<Chunk> approximateChunks(
+            ChunkingContext context,
+            String text,
+            int maxSize,
+            int overlap,
+            ResolvedTokenizer resolvedTokenizer) {
+        int charMaxSize = Math.max(1, maxSize * APPROXIMATE_CHARS_PER_TOKEN);
+        int charOverlap = Math.min(Math.max(0, overlap * APPROXIMATE_CHARS_PER_TOKEN), charMaxSize - 1);
+        List<Chunk> chunks = new ArrayList<>();
+        int start = 0;
+        int order = 0;
+        int totalTokens = resolvedTokenizer.tokenizer().countTokens(text);
+        while (start < text.length()) {
+            int end = Math.min(start + charMaxSize, text.length());
+            String content = text.substring(start, end).trim();
+            if (!content.isBlank()) {
+                int tokenStart = Math.max(0, start / APPROXIMATE_CHARS_PER_TOKEN);
+                int tokenEnd = Math.min(totalTokens, tokenStart + resolvedTokenizer.tokenizer().countTokens(content));
+                chunks.add(chunk(context, content, order++, tokenStart, tokenEnd, totalTokens, maxSize, overlap,
+                        resolvedTokenizer));
+            }
+            if (end == text.length()) {
+                break;
+            }
+            start = Math.max(end - charOverlap, start + 1);
+        }
+        return linkNeighbors(context, chunks);
+    }
+
+    private Chunk chunk(
+            ChunkingContext context,
+            String content,
+            int order,
+            int tokenStart,
+            int tokenEnd,
+            int totalTokens,
+            int maxSize,
+            int overlap,
+            ResolvedTokenizer resolvedTokenizer) {
+        String id = chunkId(context.sourceDocumentId(), order);
+        int chunkTokenCount = Math.max(0, tokenEnd - tokenStart);
+        Map<String, Object> attributes = new LinkedHashMap<>(context.metadata());
+        attributes.put(ChunkMetadata.KEY_CHUNK_UNIT, ChunkUnit.TOKEN.value());
+        attributes.put(ChunkMetadata.KEY_MAX_SIZE, maxSize);
+        attributes.put(ChunkMetadata.KEY_OVERLAP, overlap);
+        attributes.put(ChunkMetadata.KEY_ORIGINAL_TOKEN_COUNT, totalTokens);
+        attributes.put(ChunkMetadata.KEY_INDEXED_TOKEN_COUNT, totalTokens);
+        attributes.put(ChunkMetadata.KEY_CHUNK_TOKEN_COUNT, chunkTokenCount);
+        attributes.put(ChunkMetadata.KEY_CHUNK_TOKEN_START, tokenStart);
+        attributes.put(ChunkMetadata.KEY_CHUNK_TOKEN_END, tokenEnd);
+        attributes.put(ChunkMetadata.KEY_TOKENIZER_PROVIDER, resolvedTokenizer.provider());
+        attributes.put(ChunkMetadata.KEY_TOKENIZER_ENCODING, resolvedTokenizer.encoding());
+        attributes.put(ChunkMetadata.KEY_TOKENIZER_MODEL, resolvedTokenizer.tokenizerModel());
+        attributes.put(ChunkMetadata.KEY_TOKENIZER_SELECTION_SOURCE, resolvedTokenizer.selectionSource());
+        attributes.put(ChunkMetadata.KEY_TOKENIZER_CONFIDENCE, resolvedTokenizer.confidence());
+        attributes.put(ChunkMetadata.KEY_TOKENIZER_FALLBACK_USED, resolvedTokenizer.fallbackUsed());
+        attributes.put(ChunkMetadata.KEY_TOKENIZER_WARNINGS, resolvedTokenizer.warnings());
+        ChunkMetadata metadata = ChunkMetadata.builder(ChunkingStrategyType.RECURSIVE, order)
+                .sourceDocumentId(context.sourceDocumentId())
+                .chunkType(ChunkType.CHILD)
+                .objectType(context.objectType())
+                .objectId(context.objectId())
+                .tokenCount(chunkTokenCount)
+                .charCount(content.length())
+                .attributes(attributes)
+                .build();
+        return Chunk.of(id, content, metadata);
+    }
+
+    private List<Chunk> linkNeighbors(ChunkingContext context, List<Chunk> chunks) {
+        List<Chunk> linked = new ArrayList<>(chunks.size());
+        for (int i = 0; i < chunks.size(); i++) {
+            Chunk chunk = chunks.get(i);
+            ChunkMetadata metadata = ChunkMetadata.builder(chunk.metadata().strategy(), chunk.metadata().order())
+                    .sourceDocumentId(chunk.metadata().sourceDocumentId())
+                    .chunkType(chunk.metadata().chunkType())
+                    .previousChunkId(i == 0 ? null : chunkId(context.sourceDocumentId(), i - 1))
+                    .nextChunkId(i == chunks.size() - 1 ? null : chunkId(context.sourceDocumentId(), i + 1))
+                    .objectType(chunk.metadata().objectType())
+                    .objectId(chunk.metadata().objectId())
+                    .tokenCount(chunk.metadata().tokenCount())
+                    .charCount(chunk.metadata().charCount())
+                    .attributes(chunk.metadata().attributes())
+                    .build();
+            linked.add(Chunk.of(chunk.id(), chunk.content(), metadata));
+        }
+        return linked;
+    }
+
+    private String chunkId(String sourceDocumentId, int order) {
+        String prefix = sourceDocumentId == null || sourceDocumentId.isBlank() ? "document" : sourceDocumentId;
+        return prefix + "-" + order;
+    }
+
+    private String normalize(String text) {
+        return text == null ? "" : text.replace("\r\n", "\n").replace('\r', '\n').trim();
+    }
+}

--- a/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/DefaultChunkingOrchestratorTest.java
+++ b/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/DefaultChunkingOrchestratorTest.java
@@ -108,6 +108,30 @@ class DefaultChunkingOrchestratorTest {
     }
 
     @Test
+    void appliesConfiguredUnitToNormalizedDocumentChunking() {
+        ChunkingProperties properties = new ChunkingProperties();
+        properties.setUnit("token");
+        properties.setMaxSize(5);
+        properties.setOverlap(1);
+        RecursiveChunker recursiveChunker = new RecursiveChunker(80, 0);
+        DefaultChunkingOrchestrator orchestrator = new DefaultChunkingOrchestrator(
+                properties,
+                List.of(new FixedSizeChunker(80, 0), recursiveChunker,
+                        new StructureBasedChunker(80, 0, recursiveChunker)));
+        NormalizedDocument document = NormalizedDocument.builder("doc")
+                .blocks(List.of(
+                        NormalizedBlock.builder(NormalizedBlockType.HEADING, "Title").order(0).build(),
+                        NormalizedBlock.builder(NormalizedBlockType.PARAGRAPH, "한국어 English text").order(1).build()))
+                .build();
+
+        var chunks = orchestrator.chunk(document);
+
+        assertThat(chunks).isNotEmpty();
+        assertThat(chunks.get(0).metadata().toMap())
+                .containsEntry(ChunkMetadata.KEY_CHUNK_UNIT, "token");
+    }
+
+    @Test
     void returnsEmptyChunksForBlankNormalizedDocument() {
         ChunkingProperties properties = new ChunkingProperties();
         RecursiveChunker recursiveChunker = new RecursiveChunker(80, 0);

--- a/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/DefaultChunkingOrchestratorTest.java
+++ b/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/DefaultChunkingOrchestratorTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import studio.one.platform.chunking.autoconfigure.ChunkingProperties;
 import studio.one.platform.chunking.core.ChunkingContext;
 import studio.one.platform.chunking.core.ChunkingStrategyType;
+import studio.one.platform.chunking.core.ChunkMetadata;
 import studio.one.platform.chunking.core.NormalizedBlock;
 import studio.one.platform.chunking.core.NormalizedBlockType;
 import studio.one.platform.chunking.core.NormalizedDocument;
@@ -117,5 +118,34 @@ class DefaultChunkingOrchestratorTest {
 
         assertThat(orchestrator.chunk(NormalizedDocument.builder("doc").build())).isEmpty();
         assertThat(orchestrator.chunk((NormalizedDocument) null)).isEmpty();
+    }
+
+    @Test
+    void usesTokenBasedChunkerWhenConfiguredUnitIsToken() {
+        ChunkingProperties properties = new ChunkingProperties();
+        properties.setUnit("token");
+        properties.setMaxSize(4);
+        properties.setOverlap(1);
+        TokenBasedChunker tokenBasedChunker = new TokenBasedChunker(
+                4,
+                1,
+                new DefaultTokenizerResolver(properties.getTokenizer(), List.of(new ApproximateTokenizer())));
+        DefaultChunkingOrchestrator orchestrator = new DefaultChunkingOrchestrator(
+                properties,
+                List.of(new FixedSizeChunker(10, 0), new RecursiveChunker(10, 0),
+                        new StructureBasedChunker(10, 0, new RecursiveChunker(10, 0))),
+                tokenBasedChunker);
+
+        var chunks = orchestrator.chunk(ChunkingContext.configuredDefaults("한국어 English 1234567890 text")
+                .sourceDocumentId("doc")
+                .metadata(java.util.Map.of("embeddingModel", "unknown-model"))
+                .build());
+
+        assertThat(chunks).isNotEmpty();
+        assertThat(chunks.get(0).metadata().toMap())
+                .containsEntry(ChunkMetadata.KEY_CHUNK_UNIT, "token")
+                .containsEntry(ChunkMetadata.KEY_TOKENIZER_PROVIDER, "approximate")
+                .containsEntry(ChunkMetadata.KEY_TOKENIZER_FALLBACK_USED, true);
+        assertThat(chunks.get(0).metadata().tokenCount()).isNotNull();
     }
 }

--- a/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/DefaultTokenizerResolverTest.java
+++ b/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/DefaultTokenizerResolverTest.java
@@ -1,0 +1,76 @@
+package studio.one.platform.chunking.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.chunking.autoconfigure.ChunkingProperties;
+import studio.one.platform.chunking.core.ChunkMetadata;
+
+class DefaultTokenizerResolverTest {
+
+    @Test
+    void resolvesOpenAiEmbeddingModelsToCl100k() {
+        DefaultTokenizerResolver resolver = resolver(new ChunkingProperties.TokenizerProperties());
+
+        var resolved = resolver.resolve(Map.of("embeddingProvider", "openai", "embeddingModel", "text-embedding-3-small"));
+
+        assertThat(resolved.provider()).isEqualTo("tiktoken");
+        assertThat(resolved.encoding()).isEqualTo("cl100k_base");
+        assertThat(resolved.selectionSource()).isEqualTo("model-mapping");
+        assertThat(resolved.fallbackUsed()).isFalse();
+    }
+
+    @Test
+    void resolvesGpt4oModelsToO200k() {
+        DefaultTokenizerResolver resolver = resolver(new ChunkingProperties.TokenizerProperties());
+
+        var resolved = resolver.resolve(Map.of("embeddingProvider", "openai", "embeddingModel", "gpt-4o-mini"));
+
+        assertThat(resolved.encoding()).isEqualTo("o200k_base");
+    }
+
+    @Test
+    void explicitMetadataOverridesModelMapping() {
+        DefaultTokenizerResolver resolver = resolver(new ChunkingProperties.TokenizerProperties());
+
+        var resolved = resolver.resolve(Map.of(
+                "embeddingModel", "text-embedding-3-small",
+                ChunkMetadata.KEY_TOKENIZER_PROVIDER, "tiktoken",
+                ChunkMetadata.KEY_TOKENIZER_ENCODING, "p50k_base"));
+
+        assertThat(resolved.encoding()).isEqualTo("p50k_base");
+        assertThat(resolved.selectionSource()).isEqualTo("explicit-config");
+    }
+
+    @Test
+    void unknownModelFallsBackToApproximateTokenizer() {
+        DefaultTokenizerResolver resolver = resolver(new ChunkingProperties.TokenizerProperties());
+
+        var resolved = resolver.resolve(Map.of("embeddingModel", "custom-korean-embedding"));
+
+        assertThat(resolved.provider()).isEqualTo("approximate");
+        assertThat(resolved.confidence()).isEqualTo("low");
+        assertThat(resolved.fallbackUsed()).isTrue();
+        assertThat(resolved.warnings()).isNotEmpty();
+    }
+
+    @Test
+    void failOnUnknownModelRejectsFallback() {
+        ChunkingProperties.TokenizerProperties properties = new ChunkingProperties.TokenizerProperties();
+        properties.setFailOnUnknownModel(true);
+        DefaultTokenizerResolver resolver = resolver(properties);
+
+        assertThatThrownBy(() -> resolver.resolve(Map.of("embeddingModel", "custom-korean-embedding")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Tokenizer mapping is not available");
+    }
+
+    private DefaultTokenizerResolver resolver(ChunkingProperties.TokenizerProperties properties) {
+        return new DefaultTokenizerResolver(properties, List.of(new ApproximateTokenizer()));
+    }
+}

--- a/studio-platform-ai/README.md
+++ b/studio-platform-ai/README.md
@@ -83,6 +83,9 @@ Adapter는 아래 key를 `metadata` map에서 읽을 수 있어야 한다.
 | `chunkOrder` | legacy persisted chunk 순서 | 기존 pgvector schema와 chunking Phase 1 호환을 위해 유지한다. |
 | `chunkType` | `child`, `parent`, `table`, `ocr`, `image-caption` 등 chunk 역할 | retrieval hit와 context expansion strategy 선택에 사용한다. |
 | `chunkLength` | 개별 chunk content 길이 | starter-ai 기본 pipeline이 기록한다. |
+| `chunkingUnit` | chunk size/overlap 적용 단위 | `character` 또는 `token`이다. |
+| `chunkTokenCount` | chunk의 token 수 | token 기반 context budget 계산에 사용한다. |
+| `chunkTokenStart` / `chunkTokenEnd` | 원문 token 범위 | token 기반 chunking 경계 추적에 사용한다. |
 | `chunkCount` | 한 index 요청에서 생성된 chunk 수 | starter-ai 기본 pipeline이 기록한다. |
 
 신규 코드는 `chunkIndex`를 우선 기록한다.
@@ -114,6 +117,9 @@ Adapter는 아래 key를 `metadata` map에서 읽을 수 있어야 한다.
 | `embeddingModel` | embedding 생성 model 이름 | provider가 값을 제공하지 않으면 일부 pipeline은 `unknown` placeholder를 기록한다. |
 | `embeddingDimension` | embedding vector dimension | Java `Integer`로 저장될 수 있으나 adapter는 `Number`로 읽어야 한다. |
 | `embeddingInputType` | embedding 입력의 논리 유형 | `TEXT`, `TABLE_TEXT`, `IMAGE_CAPTION`, `OCR_TEXT` 중 하나다. 현재는 모두 텍스트 기반 embedding 입력이다. |
+| `tokenizerProvider` / `tokenizerEncoding` / `tokenizerModel` | chunk token 계산에 사용한 tokenizer 정보 | 운영 화면과 재색인 진단에서 사용한다. |
+| `tokenizerSelectionSource` / `tokenizerConfidence` | tokenizer 선택 출처와 신뢰도 | `explicit-config`, `model-mapping`, `provider-default`, `fallback` 등을 기록한다. |
+| `tokenizerFallbackUsed` / `tokenizerWarnings` | fallback 사용 여부와 경고 | 정확한 tokenizer가 없을 때 운영자가 확인할 수 있도록 기록한다. |
 | `createdAt` | record 생성 시각 | adapter 또는 pipeline이 필요할 때 기록한다. |
 | `indexedAt` | index 요청 처리 시각 | content pipeline 같은 조립 모듈이 기록한다. |
 

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorRecord.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorRecord.java
@@ -37,6 +37,19 @@ public final class VectorRecord {
     public static final String KEY_EMBEDDING_MODEL = "embeddingModel";
     public static final String KEY_EMBEDDING_DIMENSION = "embeddingDimension";
     public static final String KEY_EMBEDDING_INPUT_TYPE = "embeddingInputType";
+    public static final String KEY_ORIGINAL_TOKEN_COUNT = "originalTokenCount";
+    public static final String KEY_INDEXED_TOKEN_COUNT = "indexedTokenCount";
+    public static final String KEY_CHUNK_TOKEN_COUNT = "chunkTokenCount";
+    public static final String KEY_CHUNK_TOKEN_START = "chunkTokenStart";
+    public static final String KEY_CHUNK_TOKEN_END = "chunkTokenEnd";
+    public static final String KEY_TOKENIZER_PROVIDER = "tokenizerProvider";
+    public static final String KEY_TOKENIZER_ENCODING = "tokenizerEncoding";
+    public static final String KEY_TOKENIZER_MODEL = "tokenizerModel";
+    public static final String KEY_TOKENIZER_SELECTION_SOURCE = "tokenizerSelectionSource";
+    public static final String KEY_TOKENIZER_CONFIDENCE = "tokenizerConfidence";
+    public static final String KEY_TOKENIZER_FALLBACK_USED = "tokenizerFallbackUsed";
+    public static final String KEY_TOKENIZER_WARNINGS = "tokenizerWarnings";
+    public static final String KEY_CHUNKING_UNIT = "chunkingUnit";
     public static final String KEY_CREATED_AT = "createdAt";
     public static final String KEY_INDEXED_AT = "indexedAt";
 

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineOptions.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineOptions.java
@@ -14,7 +14,8 @@ public record RagPipelineOptions(
         boolean semanticFallbackEnabled,
         int topK,
         int defaultListLimit,
-        int maxListLimit) {
+        int maxListLimit,
+        int maxContextTokens) {
 
     public static final double DEFAULT_VECTOR_WEIGHT = 0.7;
     public static final double DEFAULT_LEXICAL_WEIGHT = 0.3;
@@ -26,6 +27,7 @@ public record RagPipelineOptions(
     public static final boolean DEFAULT_SEMANTIC_FALLBACK_ENABLED = true;
     public static final int DEFAULT_LIST_LIMIT = 20;
     public static final int DEFAULT_MAX_LIST_LIMIT = 200;
+    public static final int DEFAULT_MAX_CONTEXT_TOKENS = 0;
 
     public RagPipelineOptions {
         if (vectorWeight < 0.0d) {
@@ -58,6 +60,9 @@ public record RagPipelineOptions(
         if (defaultListLimit > maxListLimit) {
             throw new IllegalArgumentException("defaultListLimit must be less than or equal to maxListLimit");
         }
+        if (maxContextTokens < 0) {
+            throw new IllegalArgumentException("maxContextTokens must not be negative");
+        }
     }
 
     public static RagPipelineOptions defaults() {
@@ -70,7 +75,8 @@ public record RagPipelineOptions(
                 DEFAULT_SEMANTIC_FALLBACK_ENABLED,
                 DEFAULT_TOP_K,
                 DEFAULT_LIST_LIMIT,
-                DEFAULT_MAX_LIST_LIMIT);
+                DEFAULT_MAX_LIST_LIMIT,
+                DEFAULT_MAX_CONTEXT_TOKENS);
     }
 
     public RagPipelineOptions(
@@ -82,7 +88,22 @@ public record RagPipelineOptions(
             int defaultListLimit,
             int maxListLimit) {
         this(vectorWeight, lexicalWeight, minRelevanceScore, minRelevanceScore,
-                keywordFallbackEnabled, semanticFallbackEnabled, DEFAULT_TOP_K, defaultListLimit, maxListLimit);
+                keywordFallbackEnabled, semanticFallbackEnabled, DEFAULT_TOP_K, defaultListLimit, maxListLimit,
+                DEFAULT_MAX_CONTEXT_TOKENS);
+    }
+
+    public RagPipelineOptions(
+            double vectorWeight,
+            double lexicalWeight,
+            double minScore,
+            double minRelevanceScore,
+            boolean keywordFallbackEnabled,
+            boolean semanticFallbackEnabled,
+            int topK,
+            int defaultListLimit,
+            int maxListLimit) {
+        this(vectorWeight, lexicalWeight, minScore, minRelevanceScore, keywordFallbackEnabled, semanticFallbackEnabled,
+                topK, defaultListLimit, maxListLimit, DEFAULT_MAX_CONTEXT_TOKENS);
     }
 
     public int clampListLimit(Integer requestedLimit) {

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkMetadata.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkMetadata.java
@@ -60,6 +60,18 @@ public record ChunkMetadata(
     public static final String KEY_CHUNK_UNIT = "chunkUnit";
     public static final String KEY_MAX_SIZE = "maxSize";
     public static final String KEY_OVERLAP = "overlap";
+    public static final String KEY_ORIGINAL_TOKEN_COUNT = "originalTokenCount";
+    public static final String KEY_INDEXED_TOKEN_COUNT = "indexedTokenCount";
+    public static final String KEY_CHUNK_TOKEN_COUNT = "chunkTokenCount";
+    public static final String KEY_CHUNK_TOKEN_START = "chunkTokenStart";
+    public static final String KEY_CHUNK_TOKEN_END = "chunkTokenEnd";
+    public static final String KEY_TOKENIZER_PROVIDER = "tokenizerProvider";
+    public static final String KEY_TOKENIZER_ENCODING = "tokenizerEncoding";
+    public static final String KEY_TOKENIZER_MODEL = "tokenizerModel";
+    public static final String KEY_TOKENIZER_SELECTION_SOURCE = "tokenizerSelectionSource";
+    public static final String KEY_TOKENIZER_CONFIDENCE = "tokenizerConfidence";
+    public static final String KEY_TOKENIZER_FALLBACK_USED = "tokenizerFallbackUsed";
+    public static final String KEY_TOKENIZER_WARNINGS = "tokenizerWarnings";
 
     public ChunkMetadata {
         if (order < 0) {

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ResolvedTokenizer.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ResolvedTokenizer.java
@@ -1,0 +1,50 @@
+package studio.one.platform.chunking.core;
+
+import java.util.List;
+
+/**
+ * Tokenizer selected for a chunking or RAG operation.
+ */
+public record ResolvedTokenizer(
+        TokenizerPort tokenizer,
+        String provider,
+        String encoding,
+        String tokenizerModel,
+        String selectionSource,
+        String confidence,
+        boolean fallbackUsed,
+        List<String> warnings) {
+
+    public ResolvedTokenizer {
+        if (tokenizer == null) {
+            throw new IllegalArgumentException("tokenizer must not be null");
+        }
+        provider = normalize(provider);
+        encoding = normalize(encoding);
+        tokenizerModel = normalize(tokenizerModel);
+        selectionSource = normalize(selectionSource);
+        confidence = normalize(confidence);
+        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+    }
+
+    public static ResolvedTokenizer of(
+            TokenizerPort tokenizer,
+            String selectionSource,
+            String confidence,
+            boolean fallbackUsed,
+            List<String> warnings) {
+        return new ResolvedTokenizer(
+                tokenizer,
+                tokenizer.provider(),
+                tokenizer.encodingName(),
+                null,
+                selectionSource,
+                confidence,
+                fallbackUsed,
+                warnings);
+    }
+
+    private static String normalize(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+}

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/TokenCounter.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/TokenCounter.java
@@ -1,0 +1,13 @@
+package studio.one.platform.chunking.core;
+
+/**
+ * Minimal tokenizer contract for metadata and budget calculations.
+ */
+public interface TokenCounter {
+
+    String provider();
+
+    String encodingName();
+
+    int countTokens(String text);
+}

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/TokenizerPort.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/TokenizerPort.java
@@ -1,0 +1,13 @@
+package studio.one.platform.chunking.core;
+
+import java.util.List;
+
+/**
+ * Tokenizer contract used when chunk boundaries must follow token boundaries.
+ */
+public interface TokenizerPort extends TokenCounter {
+
+    List<Integer> encode(String text);
+
+    String decode(List<Integer> tokens);
+}

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/TokenizerResolver.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/TokenizerResolver.java
@@ -1,0 +1,12 @@
+package studio.one.platform.chunking.core;
+
+import java.util.Map;
+
+/**
+ * Resolves a tokenizer from operation metadata such as embedding provider/model
+ * and explicit tokenizer settings.
+ */
+public interface TokenizerResolver {
+
+    ResolvedTokenizer resolve(Map<String, Object> metadata);
+}


### PR DESCRIPTION
## Why

RAG 색인과 검색 context 구성에서 문자 수 기준 chunking만 사용하면 embedding/LLM model별 token 제한과 비용을 정확히 제어하기 어렵습니다. Issue #467의 요구에 따라 tokenizer 자동 선택, token 기반 chunking, context token budget 제어를 추가합니다.

## What

- `studio-platform-chunking`에 tokenizer 계약(`TokenCounter`, `TokenizerPort`, `TokenizerResolver`, `ResolvedTokenizer`)과 token/tokenizer metadata key를 추가했습니다.
- `starter:studio-platform-starter-chunking`에 `jtokkit` 기반 tiktoken adapter, approximate fallback tokenizer, resolver, token 기반 chunker, auto-configuration을 추가했습니다.
- `starter:studio-platform-starter-ai`에서 RAG indexing 시 resolved embedding metadata를 chunking에 전달하고, retrieval 결과에 `max-context-tokens` budget을 적용했습니다.
- README에 `studio.chunking.unit`, tokenizer 설정, RAG context token budget metadata를 문서화했습니다.
- resolver precedence, fallback, token chunk metadata, profile-only indexing, oversized context budget 제외를 테스트했습니다.

## Validation

- [x] `./gradlew :studio-platform-ai:compileJava :studio-platform-chunking:compileJava :starter:studio-platform-starter-chunking:compileJava :starter:studio-platform-starter-ai:compileJava`
- [x] `./gradlew :studio-platform-ai:test :studio-platform-chunking:test :starter:studio-platform-starter-chunking:test :starter:studio-platform-starter-ai:test`
- [x] `git diff --cached --check`

## AI Usage

- AI-Assisted: Yes
- Usage type: 구현, 리뷰, 검증 준비
- Subagent used: No
- Main author validation: 위 compile/test/diff check 명령으로 검증

## Notes

- Repository policy는 GitLab 템플릿을 기준으로 하지만 현재 원격 저장소가 GitHub이므로 GitHub PR로 등록합니다.
- 현재 작업트리에 있던 `studio-platform-security/.../SecurityJdbcRepositoryPostgresTest.java` 변경과 `.omx/`는 이 PR에 포함하지 않았습니다.

Closes #467
