### PR TITLE
[codex] RAG token-aware chunking simulation API 추가

### DIFF
--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -104,6 +104,7 @@ studio:
 | `GET` | `{mgmtBasePath}/rag/objects/{objectType}/{objectId}/metadata` | object scope 기준 RAG metadata 조회 | `services:ai_rag read` |
 | `POST` | `{mgmtBasePath}/rag/chunks/preview` | 색인 전 text chunk preview | `services:ai_rag read` |
 | `GET` | `{mgmtBasePath}/rag/chunks/config` | chunk/RAG 설정 조회 | `services:ai_rag read` |
+| `POST` | `{mgmtBasePath}/rag/simulations/chunking` | token-aware chunking simulation | `services:ai_rag read` |
 
 > `studio.ai.endpoints.enabled=false`이면 위 AI web endpoint 전체가 등록되지 않는다.
 
@@ -324,6 +325,32 @@ API key, raw environment 값, provider secret은 노출하지 않는다.
 `studio.chunking.strategy`가 `semantic` 또는 `llm-based`처럼 preview에서 실행하지 않는 전략이면
 config API는 원래 설정값을 `strategy`로 보여주되 `defaultStrategyPreviewSupported=false`를 반환하고,
 preview 요청에서 `strategy`를 생략하면 `400 Bad Request`가 반환된다.
+
+운영 화면이 tokenizer 선택과 token budget을 색인 전에 확인해야 할 때는
+`POST {mgmtBasePath}/rag/simulations/chunking`을 사용한다. 이 API는 `text`, `objectType`, `objectId`,
+`attachmentId`, `embeddingProvider`, `embeddingModel`, `chunkUnit`, `chunkSize`, `chunkOverlap`, `maxChunkSize`를 받아
+현재 `ChunkingOrchestrator`로 simulation을 실행하고 tokenizer 상태, chunk별 token count, token distribution,
+fallback 여부, warning을 반환한다. `ChunkingOrchestrator`가 없으면 `503 Service Unavailable`을 반환한다.
+
+```http
+POST /api/mgmt/ai/rag/simulations/chunking
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "text": "첫 번째 문단입니다.\n\n두 번째 문단입니다.",
+  "objectType": "attachment",
+  "objectId": "101",
+  "attachmentId": "101",
+  "embeddingProvider": "openai",
+  "embeddingModel": "text-embedding-3-small",
+  "tokenizerAutoDetect": true,
+  "chunkUnit": "token",
+  "chunkSize": 500,
+  "chunkOverlap": 80,
+  "maxChunkSize": 800
+}
+```
 
 Attachment 파일을 직접 읽어 `parseStructured` 결과를 preview하는 기능과 `NormalizedDocument` JSON preview는
 후속 PR 범위이다. 현재 attachment RAG 색인은 기존 attachment RAG index/job API를 사용한다.

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
@@ -311,10 +311,12 @@ public class AiWebAutoConfiguration {
     @Bean
     RagChunkingSimulationController ragChunkingSimulationController(
             ObjectProvider<ChunkingOrchestrator> chunkingOrchestratorProvider,
-            AiWebRagProperties ragProperties) {
+            AiWebRagProperties ragProperties,
+            Environment environment) {
         return new RagChunkingSimulationController(
                 chunkingOrchestratorProvider.getIfAvailable(),
-                ragProperties);
+                ragProperties,
+                environment);
     }
 
     @Bean(name = "ragIndexJobEndpointSecurity")

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
@@ -57,6 +57,7 @@ import studio.one.platform.ai.web.controller.ChatController;
 import studio.one.platform.ai.web.controller.EmbeddingController;
 import studio.one.platform.ai.web.controller.QueryRewriteController;
 import studio.one.platform.ai.web.controller.RagChunkPreviewController;
+import studio.one.platform.ai.web.controller.RagChunkingSimulationController;
 import studio.one.platform.ai.web.controller.RagController;
 import studio.one.platform.ai.web.controller.RagContextBuilder;
 import studio.one.platform.ai.web.controller.RagIndexJobController;
@@ -305,6 +306,15 @@ public class AiWebAutoConfiguration {
                 ragPipelineProperties,
                 ragProperties,
                 environment);
+    }
+
+    @Bean
+    RagChunkingSimulationController ragChunkingSimulationController(
+            ObjectProvider<ChunkingOrchestrator> chunkingOrchestratorProvider,
+            AiWebRagProperties ragProperties) {
+        return new RagChunkingSimulationController(
+                chunkingOrchestratorProvider.getIfAvailable(),
+                ragProperties);
     }
 
     @Bean(name = "ragIndexJobEndpointSecurity")

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/AiWebExceptionHandler.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/AiWebExceptionHandler.java
@@ -20,6 +20,7 @@ import studio.one.platform.web.dto.ProblemDetails;
         VectorVisualizationMgmtController.class,
         RagController.class,
         RagChunkPreviewController.class,
+        RagChunkingSimulationController.class,
         RagIndexJobController.class,
         QueryRewriteController.class,
         AiInfoController.class

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagChunkingSimulationController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagChunkingSimulationController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.core.env.Environment;
 import org.springframework.lang.Nullable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
@@ -36,15 +37,20 @@ import studio.one.platform.web.dto.ApiResponse;
 @Validated
 public class RagChunkingSimulationController {
 
+    private static final String CHUNKING_PREFIX = "studio.chunking";
+
     @Nullable
     private final ChunkingOrchestrator chunkingOrchestrator;
     private final AiWebRagProperties ragProperties;
+    private final Environment environment;
 
     public RagChunkingSimulationController(
             @Nullable ChunkingOrchestrator chunkingOrchestrator,
-            AiWebRagProperties ragProperties) {
+            AiWebRagProperties ragProperties,
+            Environment environment) {
         this.chunkingOrchestrator = chunkingOrchestrator;
         this.ragProperties = Objects.requireNonNull(ragProperties, "ragProperties");
+        this.environment = Objects.requireNonNull(environment, "environment");
     }
 
     @PostMapping("/chunking")
@@ -206,11 +212,15 @@ public class RagChunkingSimulationController {
     }
 
     private int effectiveSize(int value) {
-        return value == ChunkingContext.USE_CONFIGURED_MAX_SIZE ? ChunkingContext.DEFAULT_MAX_SIZE : value;
+        return value == ChunkingContext.USE_CONFIGURED_MAX_SIZE
+                ? environment.getProperty(CHUNKING_PREFIX + ".max-size", Integer.class, ChunkingContext.DEFAULT_MAX_SIZE)
+                : value;
     }
 
     private int effectiveOverlap(int value) {
-        return value == ChunkingContext.USE_CONFIGURED_OVERLAP ? ChunkingContext.DEFAULT_OVERLAP : value;
+        return value == ChunkingContext.USE_CONFIGURED_OVERLAP
+                ? environment.getProperty(CHUNKING_PREFIX + ".overlap", Integer.class, ChunkingContext.DEFAULT_OVERLAP)
+                : value;
     }
 
     private void put(Map<String, Object> metadata, String key, String value) {

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagChunkingSimulationController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagChunkingSimulationController.java
@@ -1,0 +1,280 @@
+package studio.one.platform.ai.web.controller;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import studio.one.platform.ai.autoconfigure.AiWebRagProperties;
+import studio.one.platform.ai.core.vector.VectorRecord;
+import studio.one.platform.ai.web.dto.RagChunkingSimulationRequestDto;
+import studio.one.platform.ai.web.dto.RagChunkingSimulationResponseDto;
+import studio.one.platform.chunking.core.Chunk;
+import studio.one.platform.chunking.core.ChunkMetadata;
+import studio.one.platform.chunking.core.ChunkUnit;
+import studio.one.platform.chunking.core.ChunkingContext;
+import studio.one.platform.chunking.core.ChunkingOrchestrator;
+import studio.one.platform.constant.PropertyKeys;
+import studio.one.platform.web.dto.ApiResponse;
+
+@RestController
+@RequestMapping("${" + PropertyKeys.AI.Endpoints.MGMT_BASE_PATH + ":/api/mgmt/ai}/rag/simulations")
+@Validated
+public class RagChunkingSimulationController {
+
+    @Nullable
+    private final ChunkingOrchestrator chunkingOrchestrator;
+    private final AiWebRagProperties ragProperties;
+
+    public RagChunkingSimulationController(
+            @Nullable ChunkingOrchestrator chunkingOrchestrator,
+            AiWebRagProperties ragProperties) {
+        this.chunkingOrchestrator = chunkingOrchestrator;
+        this.ragProperties = Objects.requireNonNull(ragProperties, "ragProperties");
+    }
+
+    @PostMapping("/chunking")
+    @PreAuthorize("@endpointAuthz.can('services:ai_rag','read')")
+    public ResponseEntity<ApiResponse<RagChunkingSimulationResponseDto>> simulateChunking(
+            @Valid @RequestBody RagChunkingSimulationRequestDto request) {
+        if (chunkingOrchestrator == null) {
+            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "ChunkingOrchestrator is not configured");
+        }
+        if (!hasText(request.text())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "text must not be blank");
+        }
+        if (request.text().length() > ragProperties.getChunkPreview().getMaxInputChars()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "text exceeds max chunking simulation input length");
+        }
+        try {
+            ChunkingContext context = toContext(request);
+            List<Chunk> chunks = chunkingOrchestrator.chunk(context);
+            int maxPreviewChunks = ragProperties.getChunkPreview().getMaxPreviewChunks();
+            List<String> warnings = new ArrayList<>();
+            if (chunks.size() > maxPreviewChunks) {
+                warnings.add("Chunking simulation truncated to " + maxPreviewChunks + " chunks.");
+            }
+            List<Chunk> returned = chunks.size() > maxPreviewChunks ? chunks.subList(0, maxPreviewChunks) : chunks;
+            List<RagChunkingSimulationResponseDto.ChunkDto> chunkDtos = returned.stream()
+                    .map(chunk -> toChunkDto(chunk, request.maxChunkSize()))
+                    .toList();
+            warnings.addAll(tokenizerWarnings(returned));
+            warnings.addAll(maxChunkSizeWarnings(returned, request.maxChunkSize()));
+            int totalTokens = chunks.stream().mapToInt(this::tokenCount).sum();
+            return ResponseEntity.ok(ApiResponse.ok(new RagChunkingSimulationResponseDto(
+                    tokenizerStatus(request, context, returned),
+                    chunkDtos,
+                    tokenDistribution(chunks),
+                    chunks.size(),
+                    chunks.stream().mapToInt(chunk -> chunk.content().length()).sum(),
+                    totalTokens,
+                    warnings.stream().distinct().toList())));
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+        } catch (RuntimeException ex) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                    "Chunking simulation failed: " + ex.getMessage(), ex);
+        }
+    }
+
+    private ChunkingContext toContext(RagChunkingSimulationRequestDto request) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        put(metadata, VectorRecord.KEY_OBJECT_TYPE, request.objectType());
+        put(metadata, VectorRecord.KEY_OBJECT_ID, request.objectId());
+        put(metadata, "attachmentId", request.attachmentId());
+        put(metadata, VectorRecord.KEY_EMBEDDING_PROVIDER, request.embeddingProvider());
+        put(metadata, VectorRecord.KEY_EMBEDDING_MODEL, request.embeddingModel());
+        if (request.tokenizerAutoDetect() != null) {
+            metadata.put("tokenizerAutoDetect", request.tokenizerAutoDetect());
+        }
+        ChunkingContext.Builder builder = ChunkingContext.configuredDefaults(request.text())
+                .objectType(text(request.objectType()))
+                .objectId(text(request.objectId()))
+                .metadata(metadata)
+                .unit(ChunkUnit.from(request.chunkUnit()));
+        if (request.chunkSize() != null) {
+            builder.maxSize(request.chunkSize());
+        }
+        if (request.chunkOverlap() != null) {
+            builder.overlap(request.chunkOverlap());
+        }
+        return builder.build();
+    }
+
+    private RagChunkingSimulationResponseDto.TokenizerStatusDto tokenizerStatus(
+            RagChunkingSimulationRequestDto request,
+            ChunkingContext context,
+            List<Chunk> chunks) {
+        Map<String, Object> metadata = mergedMetadata(chunks);
+        return new RagChunkingSimulationResponseDto.TokenizerStatusDto(
+                request.embeddingProvider(),
+                request.embeddingModel(),
+                text(metadata.get(ChunkMetadata.KEY_TOKENIZER_PROVIDER)),
+                text(metadata.get(ChunkMetadata.KEY_TOKENIZER_ENCODING)),
+                text(metadata.get(ChunkMetadata.KEY_TOKENIZER_SELECTION_SOURCE)),
+                text(metadata.get(ChunkMetadata.KEY_TOKENIZER_CONFIDENCE)),
+                context.unit().value(),
+                effectiveSize(context.maxSize()),
+                effectiveOverlap(context.overlap()),
+                bool(metadata.get(ChunkMetadata.KEY_TOKENIZER_FALLBACK_USED)),
+                tokenizerWarnings(chunks));
+    }
+
+    private RagChunkingSimulationResponseDto.ChunkDto toChunkDto(Chunk chunk, Integer maxChunkSize) {
+        Map<String, Object> metadata = chunk.metadata().toMap();
+        int tokenCount = tokenCount(chunk);
+        List<String> warnings = new ArrayList<>();
+        if (maxChunkSize != null && maxChunkSize > 0 && tokenCount > maxChunkSize) {
+            warnings.add("chunkTokenCount exceeds maxChunkSize: " + tokenCount + " > " + maxChunkSize);
+        }
+        warnings.addAll(warnings(metadata.get(ChunkMetadata.KEY_TOKENIZER_WARNINGS)));
+        return new RagChunkingSimulationResponseDto.ChunkDto(
+                chunk.id(),
+                chunk.content(),
+                tokenCount,
+                chunk.content().length(),
+                text(metadata.get(ChunkMetadata.KEY_TOKENIZER_PROVIDER)),
+                text(metadata.get(ChunkMetadata.KEY_TOKENIZER_ENCODING)),
+                text(metadata.get(VectorRecord.KEY_EMBEDDING_MODEL)),
+                text(metadata.get(ChunkMetadata.KEY_CHUNK_TYPE)),
+                integer(metadata.get(ChunkMetadata.KEY_PAGE)),
+                text(firstPresent(metadata, ChunkMetadata.KEY_HEADING_PATH, ChunkMetadata.KEY_SECTION)),
+                warnings.stream().distinct().toList());
+    }
+
+    private RagChunkingSimulationResponseDto.TokenDistributionDto tokenDistribution(List<Chunk> chunks) {
+        if (chunks.isEmpty()) {
+            return new RagChunkingSimulationResponseDto.TokenDistributionDto(0, 0, 0.0d);
+        }
+        List<Integer> counts = chunks.stream().map(this::tokenCount).toList();
+        int min = counts.stream().mapToInt(Integer::intValue).min().orElse(0);
+        int max = counts.stream().mapToInt(Integer::intValue).max().orElse(0);
+        double average = counts.stream().mapToInt(Integer::intValue).average().orElse(0.0d);
+        return new RagChunkingSimulationResponseDto.TokenDistributionDto(min, max, average);
+    }
+
+    private List<String> maxChunkSizeWarnings(List<Chunk> chunks, Integer maxChunkSize) {
+        if (maxChunkSize == null || maxChunkSize <= 0) {
+            return List.of();
+        }
+        return chunks.stream()
+                .filter(chunk -> tokenCount(chunk) > maxChunkSize)
+                .map(chunk -> "Chunk " + chunk.id() + " exceeds maxChunkSize: "
+                        + tokenCount(chunk) + " > " + maxChunkSize)
+                .toList();
+    }
+
+    private List<String> tokenizerWarnings(List<Chunk> chunks) {
+        return chunks.stream()
+                .flatMap(chunk -> warnings(chunk.metadata().toMap().get(ChunkMetadata.KEY_TOKENIZER_WARNINGS)).stream())
+                .distinct()
+                .toList();
+    }
+
+    private Map<String, Object> mergedMetadata(List<Chunk> chunks) {
+        if (chunks.isEmpty()) {
+            return Map.of();
+        }
+        return chunks.get(0).metadata().toMap();
+    }
+
+    private int tokenCount(Chunk chunk) {
+        Map<String, Object> metadata = chunk.metadata().toMap();
+        Integer tokenCount = integer(firstPresent(metadata,
+                ChunkMetadata.KEY_CHUNK_TOKEN_COUNT,
+                ChunkMetadata.KEY_TOKEN_COUNT,
+                ChunkMetadata.KEY_TOKEN_ESTIMATE));
+        if (tokenCount != null) {
+            return tokenCount;
+        }
+        return Math.max(1, (int) Math.ceil(chunk.content().replaceAll("\\s+", " ").trim().length() / 4.0d));
+    }
+
+    private int effectiveSize(int value) {
+        return value == ChunkingContext.USE_CONFIGURED_MAX_SIZE ? ChunkingContext.DEFAULT_MAX_SIZE : value;
+    }
+
+    private int effectiveOverlap(int value) {
+        return value == ChunkingContext.USE_CONFIGURED_OVERLAP ? ChunkingContext.DEFAULT_OVERLAP : value;
+    }
+
+    private void put(Map<String, Object> metadata, String key, String value) {
+        String text = text(value);
+        if (text != null) {
+            metadata.put(key, text);
+        }
+    }
+
+    private Object firstPresent(Map<String, Object> metadata, String... keys) {
+        for (String key : keys) {
+            Object value = metadata.get(key);
+            if (value != null && (!(value instanceof String text) || !text.isBlank())) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private List<String> warnings(Object value) {
+        if (value instanceof Iterable<?> iterable) {
+            List<String> values = new ArrayList<>();
+            iterable.forEach(item -> {
+                String text = text(item);
+                if (text != null) {
+                    values.add(text);
+                }
+            });
+            return values;
+        }
+        String text = text(value);
+        return text == null ? List.of() : List.of(text);
+    }
+
+    private boolean bool(Object value) {
+        if (value instanceof Boolean bool) {
+            return bool;
+        }
+        return value != null && Boolean.parseBoolean(value.toString());
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private String text(Object value) {
+        if (value == null) {
+            return null;
+        }
+        String text = value.toString().trim();
+        return text.isBlank() ? null : text;
+    }
+
+    private Integer integer(Object value) {
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        if (value instanceof String text && !text.isBlank()) {
+            try {
+                return Integer.valueOf(text.trim());
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagChunkingSimulationController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagChunkingSimulationController.java
@@ -8,9 +8,9 @@ import java.util.Objects;
 
 import jakarta.validation.Valid;
 
+import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.core.env.Environment;
 import org.springframework.lang.Nullable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
@@ -134,7 +134,7 @@ public class RagChunkingSimulationController {
                 text(metadata.get(ChunkMetadata.KEY_TOKENIZER_ENCODING)),
                 text(metadata.get(ChunkMetadata.KEY_TOKENIZER_SELECTION_SOURCE)),
                 text(metadata.get(ChunkMetadata.KEY_TOKENIZER_CONFIDENCE)),
-                context.unit().value(),
+                effectiveUnit(request, context),
                 effectiveSize(context.maxSize()),
                 effectiveOverlap(context.overlap()),
                 bool(metadata.get(ChunkMetadata.KEY_TOKENIZER_FALLBACK_USED)),
@@ -221,6 +221,15 @@ public class RagChunkingSimulationController {
         return value == ChunkingContext.USE_CONFIGURED_OVERLAP
                 ? environment.getProperty(CHUNKING_PREFIX + ".overlap", Integer.class, ChunkingContext.DEFAULT_OVERLAP)
                 : value;
+    }
+
+    private String effectiveUnit(RagChunkingSimulationRequestDto request, ChunkingContext context) {
+        if (!hasText(request.chunkUnit())
+                && context.maxSize() == ChunkingContext.USE_CONFIGURED_MAX_SIZE
+                && context.overlap() == ChunkingContext.USE_CONFIGURED_OVERLAP) {
+            return environment.getProperty(CHUNKING_PREFIX + ".unit", context.unit().value());
+        }
+        return context.unit().value();
     }
 
     private void put(Map<String, Object> metadata, String key, String value) {

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/RagChunkingSimulationRequestDto.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/RagChunkingSimulationRequestDto.java
@@ -1,0 +1,17 @@
+package studio.one.platform.ai.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RagChunkingSimulationRequestDto(
+        @NotBlank String text,
+        String objectType,
+        String objectId,
+        String attachmentId,
+        String embeddingProvider,
+        String embeddingModel,
+        Boolean tokenizerAutoDetect,
+        String chunkUnit,
+        Integer chunkSize,
+        Integer chunkOverlap,
+        Integer maxChunkSize) {
+}

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/RagChunkingSimulationResponseDto.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/dto/RagChunkingSimulationResponseDto.java
@@ -1,0 +1,47 @@
+package studio.one.platform.ai.web.dto;
+
+import java.util.List;
+
+public record RagChunkingSimulationResponseDto(
+        TokenizerStatusDto tokenizer,
+        List<ChunkDto> chunks,
+        TokenDistributionDto tokenDistribution,
+        int totalChunks,
+        int totalChars,
+        int totalTokens,
+        List<String> warnings) {
+
+    public record TokenizerStatusDto(
+            String embeddingProvider,
+            String embeddingModel,
+            String tokenizerProvider,
+            String tokenizerEncoding,
+            String selectionSource,
+            String confidence,
+            String chunkUnit,
+            int chunkSize,
+            int chunkOverlap,
+            boolean fallbackUsed,
+            List<String> warnings) {
+    }
+
+    public record ChunkDto(
+            String chunkId,
+            String content,
+            int tokenCount,
+            int textLength,
+            String tokenizerProvider,
+            String tokenizerEncoding,
+            String embeddingModel,
+            String chunkType,
+            Integer page,
+            String section,
+            List<String> warnings) {
+    }
+
+    public record TokenDistributionDto(
+            int min,
+            int max,
+            double average) {
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/AiEndpointMappingTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/AiEndpointMappingTest.java
@@ -27,6 +27,8 @@ class AiEndpointMappingTest {
                 "${" + PropertyKeys.AI.Endpoints.MGMT_BASE_PATH + ":/api/mgmt/ai}/vectors");
         assertRequestMapping(RagController.class,
                 "${" + PropertyKeys.AI.Endpoints.MGMT_BASE_PATH + ":/api/mgmt/ai}/rag");
+        assertRequestMapping(RagChunkingSimulationController.class,
+                "${" + PropertyKeys.AI.Endpoints.MGMT_BASE_PATH + ":/api/mgmt/ai}/rag/simulations");
     }
 
     private void assertRequestMapping(Class<?> controllerType, String expectedPath) {

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagChunkingSimulationControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagChunkingSimulationControllerTest.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -30,7 +32,8 @@ class RagChunkingSimulationControllerTest {
         CapturingOrchestrator orchestrator = new CapturingOrchestrator(List.of(chunk("doc-0", "alpha beta", 0, 6)));
         RagChunkingSimulationController controller = new RagChunkingSimulationController(
                 orchestrator,
-                new AiWebRagProperties());
+                new AiWebRagProperties(),
+                environment());
 
         ResponseEntity<ApiResponse<RagChunkingSimulationResponseDto>> response = controller.simulateChunking(
                 new RagChunkingSimulationRequestDto(
@@ -82,7 +85,8 @@ class RagChunkingSimulationControllerTest {
                 .build());
         RagChunkingSimulationController controller = new RagChunkingSimulationController(
                 new CapturingOrchestrator(List.of(fallbackChunk)),
-                new AiWebRagProperties());
+                new AiWebRagProperties(),
+                environment());
 
         RagChunkingSimulationResponseDto body = controller.simulateChunking(new RagChunkingSimulationRequestDto(
                 "oversized",
@@ -104,16 +108,42 @@ class RagChunkingSimulationControllerTest {
     }
 
     @Test
+    void reportsConfiguredChunkDefaultsWhenRequestOmitsSizeAndOverlap() {
+        RagChunkingSimulationController controller = new RagChunkingSimulationController(
+                new CapturingOrchestrator(List.of(chunk("doc-0", "alpha", 0, 2))),
+                new AiWebRagProperties(),
+                environment());
+
+        RagChunkingSimulationResponseDto body = controller.simulateChunking(new RagChunkingSimulationRequestDto(
+                "alpha",
+                null,
+                null,
+                null,
+                "openai",
+                "text-embedding-3-small",
+                true,
+                "token",
+                null,
+                null,
+                null)).getBody().getData();
+
+        assertThat(body.tokenizer().chunkSize()).isEqualTo(120);
+        assertThat(body.tokenizer().chunkOverlap()).isEqualTo(12);
+    }
+
+    @Test
     void rejectsInvalidRequestsWithStatusCodes() {
         RagChunkingSimulationController missingOrchestrator = new RagChunkingSimulationController(
                 null,
-                new AiWebRagProperties());
+                new AiWebRagProperties(),
+                environment());
         assertStatus(() -> missingOrchestrator.simulateChunking(new RagChunkingSimulationRequestDto(
                 "alpha", null, null, null, null, null, null, null, null, null, null)), 503);
 
         RagChunkingSimulationController controller = new RagChunkingSimulationController(
                 new CapturingOrchestrator(List.of()),
-                new AiWebRagProperties());
+                new AiWebRagProperties(),
+                environment());
         assertStatus(() -> controller.simulateChunking(new RagChunkingSimulationRequestDto(
                 " ", null, null, null, null, null, null, null, null, null, null)), 400);
         assertStatus(() -> controller.simulateChunking(new RagChunkingSimulationRequestDto(
@@ -132,6 +162,14 @@ class RagChunkingSimulationControllerTest {
                         ChunkMetadata.KEY_TOKENIZER_CONFIDENCE, "high",
                         VectorRecord.KEY_EMBEDDING_MODEL, "text-embedding-3-small"))
                 .build());
+    }
+
+    private StandardEnvironment environment() {
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().addFirst(new MapPropertySource("test", Map.of(
+                "studio.chunking.max-size", "120",
+                "studio.chunking.overlap", "12")));
+        return environment;
     }
 
     private void assertStatus(Runnable action, int expectedStatus) {

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagChunkingSimulationControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagChunkingSimulationControllerTest.java
@@ -113,7 +113,10 @@ class RagChunkingSimulationControllerTest {
         RagChunkingSimulationController controller = new RagChunkingSimulationController(
                 new CapturingOrchestrator(List.of(chunk("doc-0", "alpha", 0, 2))),
                 new AiWebRagProperties(),
-                environment());
+                environment(Map.of(
+                        "studio.chunking.max-size", "120",
+                        "studio.chunking.overlap", "12",
+                        "studio.chunking.unit", "token")));
 
         RagChunkingSimulationResponseDto body = controller.simulateChunking(new RagChunkingSimulationRequestDto(
                 "alpha",
@@ -130,6 +133,7 @@ class RagChunkingSimulationControllerTest {
 
         assertThat(body.tokenizer().chunkSize()).isEqualTo(120);
         assertThat(body.tokenizer().chunkOverlap()).isEqualTo(12);
+        assertThat(body.tokenizer().chunkUnit()).isEqualTo("token");
     }
 
     @Test
@@ -166,10 +170,14 @@ class RagChunkingSimulationControllerTest {
     }
 
     private StandardEnvironment environment() {
-        StandardEnvironment environment = new StandardEnvironment();
-        environment.getPropertySources().addFirst(new MapPropertySource("test", Map.of(
+        return environment(Map.of(
                 "studio.chunking.max-size", "120",
-                "studio.chunking.overlap", "12")));
+                "studio.chunking.overlap", "12"));
+    }
+
+    private StandardEnvironment environment(Map<String, Object> properties) {
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().addFirst(new MapPropertySource("test", properties));
         return environment;
     }
 

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagChunkingSimulationControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagChunkingSimulationControllerTest.java
@@ -1,0 +1,158 @@
+package studio.one.platform.ai.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
+
+import studio.one.platform.ai.autoconfigure.AiWebRagProperties;
+import studio.one.platform.ai.core.vector.VectorRecord;
+import studio.one.platform.ai.web.dto.RagChunkingSimulationRequestDto;
+import studio.one.platform.ai.web.dto.RagChunkingSimulationResponseDto;
+import studio.one.platform.chunking.core.Chunk;
+import studio.one.platform.chunking.core.ChunkMetadata;
+import studio.one.platform.chunking.core.ChunkType;
+import studio.one.platform.chunking.core.ChunkUnit;
+import studio.one.platform.chunking.core.ChunkingContext;
+import studio.one.platform.chunking.core.ChunkingOrchestrator;
+import studio.one.platform.chunking.core.ChunkingStrategyType;
+import studio.one.platform.web.dto.ApiResponse;
+
+class RagChunkingSimulationControllerTest {
+
+    @Test
+    void simulatesTokenAwareChunkingWithTokenizerMetadata() {
+        CapturingOrchestrator orchestrator = new CapturingOrchestrator(List.of(chunk("doc-0", "alpha beta", 0, 6)));
+        RagChunkingSimulationController controller = new RagChunkingSimulationController(
+                orchestrator,
+                new AiWebRagProperties());
+
+        ResponseEntity<ApiResponse<RagChunkingSimulationResponseDto>> response = controller.simulateChunking(
+                new RagChunkingSimulationRequestDto(
+                        "alpha beta",
+                        "attachment",
+                        "42",
+                        "att-1",
+                        "openai",
+                        "text-embedding-3-small",
+                        true,
+                        "token",
+                        500,
+                        80,
+                        800));
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(orchestrator.context.unit()).isEqualTo(ChunkUnit.TOKEN);
+        assertThat(orchestrator.context.maxSize()).isEqualTo(500);
+        assertThat(orchestrator.context.overlap()).isEqualTo(80);
+        assertThat(orchestrator.context.metadata())
+                .containsEntry(VectorRecord.KEY_EMBEDDING_PROVIDER, "openai")
+                .containsEntry(VectorRecord.KEY_EMBEDDING_MODEL, "text-embedding-3-small")
+                .containsEntry("attachmentId", "att-1");
+
+        RagChunkingSimulationResponseDto body = response.getBody().getData();
+        assertThat(body.totalChunks()).isEqualTo(1);
+        assertThat(body.totalTokens()).isEqualTo(6);
+        assertThat(body.tokenizer().tokenizerProvider()).isEqualTo("tiktoken");
+        assertThat(body.tokenizer().tokenizerEncoding()).isEqualTo("cl100k_base");
+        assertThat(body.tokenizer().selectionSource()).isEqualTo("model-mapping");
+        assertThat(body.tokenizer().chunkUnit()).isEqualTo("token");
+        assertThat(body.chunks().get(0).tokenCount()).isEqualTo(6);
+        assertThat(body.chunks().get(0).embeddingModel()).isEqualTo("text-embedding-3-small");
+    }
+
+    @Test
+    void reportsFallbackAndMaxChunkSizeWarnings() {
+        Chunk fallbackChunk = Chunk.of("doc-0", "oversized", ChunkMetadata.builder(ChunkingStrategyType.RECURSIVE, 0)
+                .chunkType(ChunkType.CHILD)
+                .tokenCount(12)
+                .attributes(Map.of(
+                        ChunkMetadata.KEY_CHUNK_TOKEN_COUNT, 12,
+                        ChunkMetadata.KEY_TOKENIZER_PROVIDER, "approximate",
+                        ChunkMetadata.KEY_TOKENIZER_ENCODING, "approximate",
+                        ChunkMetadata.KEY_TOKENIZER_SELECTION_SOURCE, "fallback",
+                        ChunkMetadata.KEY_TOKENIZER_CONFIDENCE, "low",
+                        ChunkMetadata.KEY_TOKENIZER_FALLBACK_USED, true,
+                        ChunkMetadata.KEY_TOKENIZER_WARNINGS, List.of("No tokenizer mapping is available")))
+                .build());
+        RagChunkingSimulationController controller = new RagChunkingSimulationController(
+                new CapturingOrchestrator(List.of(fallbackChunk)),
+                new AiWebRagProperties());
+
+        RagChunkingSimulationResponseDto body = controller.simulateChunking(new RagChunkingSimulationRequestDto(
+                "oversized",
+                null,
+                null,
+                null,
+                "custom",
+                "custom-model",
+                true,
+                "token",
+                500,
+                80,
+                8)).getBody().getData();
+
+        assertThat(body.tokenizer().fallbackUsed()).isTrue();
+        assertThat(body.tokenizer().warnings()).contains("No tokenizer mapping is available");
+        assertThat(body.warnings()).anyMatch(warning -> warning.contains("exceeds maxChunkSize"));
+        assertThat(body.chunks().get(0).warnings()).anyMatch(warning -> warning.contains("maxChunkSize"));
+    }
+
+    @Test
+    void rejectsInvalidRequestsWithStatusCodes() {
+        RagChunkingSimulationController missingOrchestrator = new RagChunkingSimulationController(
+                null,
+                new AiWebRagProperties());
+        assertStatus(() -> missingOrchestrator.simulateChunking(new RagChunkingSimulationRequestDto(
+                "alpha", null, null, null, null, null, null, null, null, null, null)), 503);
+
+        RagChunkingSimulationController controller = new RagChunkingSimulationController(
+                new CapturingOrchestrator(List.of()),
+                new AiWebRagProperties());
+        assertStatus(() -> controller.simulateChunking(new RagChunkingSimulationRequestDto(
+                " ", null, null, null, null, null, null, null, null, null, null)), 400);
+        assertStatus(() -> controller.simulateChunking(new RagChunkingSimulationRequestDto(
+                "alpha", null, null, null, null, null, null, "bad-unit", null, null, null)), 400);
+    }
+
+    private Chunk chunk(String id, String content, int order, int tokenCount) {
+        return Chunk.of(id, content, ChunkMetadata.builder(ChunkingStrategyType.RECURSIVE, order)
+                .chunkType(ChunkType.CHILD)
+                .tokenCount(tokenCount)
+                .attributes(Map.of(
+                        ChunkMetadata.KEY_CHUNK_TOKEN_COUNT, tokenCount,
+                        ChunkMetadata.KEY_TOKENIZER_PROVIDER, "tiktoken",
+                        ChunkMetadata.KEY_TOKENIZER_ENCODING, "cl100k_base",
+                        ChunkMetadata.KEY_TOKENIZER_SELECTION_SOURCE, "model-mapping",
+                        ChunkMetadata.KEY_TOKENIZER_CONFIDENCE, "high",
+                        VectorRecord.KEY_EMBEDDING_MODEL, "text-embedding-3-small"))
+                .build());
+    }
+
+    private void assertStatus(Runnable action, int expectedStatus) {
+        assertThatThrownBy(action::run)
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode().value())
+                        .isEqualTo(expectedStatus));
+    }
+
+    private static final class CapturingOrchestrator implements ChunkingOrchestrator {
+        private final List<Chunk> chunks;
+        private ChunkingContext context;
+
+        private CapturingOrchestrator(List<Chunk> chunks) {
+            this.chunks = chunks;
+        }
+
+        @Override
+        public List<Chunk> chunk(ChunkingContext context) {
+            this.context = context;
+            return chunks;
+        }
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagChunkingSimulationControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagChunkingSimulationControllerTest.java
@@ -56,7 +56,8 @@ class RagChunkingSimulationControllerTest {
         assertThat(orchestrator.context.metadata())
                 .containsEntry(VectorRecord.KEY_EMBEDDING_PROVIDER, "openai")
                 .containsEntry(VectorRecord.KEY_EMBEDDING_MODEL, "text-embedding-3-small")
-                .containsEntry("attachmentId", "att-1");
+                .containsEntry("attachmentId", "att-1")
+                .containsEntry("tokenizerAutoDetect", true);
 
         RagChunkingSimulationResponseDto body = response.getBody().getData();
         assertThat(body.totalChunks()).isEqualTo(1);

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/DefaultTokenizerResolver.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/service/DefaultTokenizerResolver.java
@@ -17,6 +17,7 @@ public class DefaultTokenizerResolver implements TokenizerResolver {
 
     private static final String EMBEDDING_PROVIDER = "embeddingProvider";
     private static final String EMBEDDING_MODEL = "embeddingModel";
+    private static final String TOKENIZER_AUTO_DETECT = "tokenizerAutoDetect";
 
     private final ChunkingProperties.TokenizerProperties properties;
     private final Map<String, TokenizerPort> tokenizersByProvider;
@@ -45,11 +46,12 @@ public class DefaultTokenizerResolver implements TokenizerResolver {
         if (configured.isPresent()) {
             return configured.get();
         }
-        Optional<ResolvedTokenizer> modelMapping = modelMapping(model);
+        boolean autoDetect = autoDetectEnabled(values);
+        Optional<ResolvedTokenizer> modelMapping = modelMapping(model, autoDetect);
         if (modelMapping.isPresent()) {
             return modelMapping.get();
         }
-        Optional<ResolvedTokenizer> providerDefault = providerDefault(text(values.get(EMBEDDING_PROVIDER)));
+        Optional<ResolvedTokenizer> providerDefault = providerDefault(text(values.get(EMBEDDING_PROVIDER)), autoDetect);
         if (providerDefault.isPresent()) {
             return providerDefault.get();
         }
@@ -84,8 +86,8 @@ public class DefaultTokenizerResolver implements TokenizerResolver {
                 "explicit-config", "high"));
     }
 
-    private Optional<ResolvedTokenizer> modelMapping(String model) {
-        if (!properties.isAutoDetect() || model == null) {
+    private Optional<ResolvedTokenizer> modelMapping(String model, boolean autoDetect) {
+        if (!autoDetect || model == null) {
             return Optional.empty();
         }
         String normalized = model.toLowerCase(Locale.ROOT);
@@ -104,8 +106,8 @@ public class DefaultTokenizerResolver implements TokenizerResolver {
         return Optional.empty();
     }
 
-    private Optional<ResolvedTokenizer> providerDefault(String provider) {
-        if (!properties.isAutoDetect() || provider == null) {
+    private Optional<ResolvedTokenizer> providerDefault(String provider, boolean autoDetect) {
+        if (!autoDetect || provider == null) {
             return Optional.empty();
         }
         if (provider.equalsIgnoreCase("openai")) {
@@ -116,6 +118,17 @@ public class DefaultTokenizerResolver implements TokenizerResolver {
                     null, "provider-default"));
         }
         return Optional.empty();
+    }
+
+    private boolean autoDetectEnabled(Map<String, Object> metadata) {
+        Object value = metadata.get(TOKENIZER_AUTO_DETECT);
+        if (value instanceof Boolean bool) {
+            return properties.isAutoDetect() && bool;
+        }
+        if (value instanceof String text && !text.isBlank()) {
+            return properties.isAutoDetect() && Boolean.parseBoolean(text.trim());
+        }
+        return properties.isAutoDetect();
     }
 
     private ResolvedTokenizer resolve(

--- a/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/DefaultTokenizerResolverTest.java
+++ b/starter/studio-platform-starter-chunking/src/test/java/studio/one/platform/chunking/service/DefaultTokenizerResolverTest.java
@@ -48,6 +48,20 @@ class DefaultTokenizerResolverTest {
     }
 
     @Test
+    void metadataCanDisableAutoDetectForModelAndProviderMapping() {
+        DefaultTokenizerResolver resolver = resolver(new ChunkingProperties.TokenizerProperties());
+
+        var resolved = resolver.resolve(Map.of(
+                "embeddingProvider", "openai",
+                "embeddingModel", "text-embedding-3-small",
+                "tokenizerAutoDetect", false));
+
+        assertThat(resolved.provider()).isEqualTo("approximate");
+        assertThat(resolved.selectionSource()).isEqualTo("fallback");
+        assertThat(resolved.fallbackUsed()).isTrue();
+    }
+
+    @Test
     void unknownModelFallsBackToApproximateTokenizer() {
         DefaultTokenizerResolver resolver = resolver(new ChunkingProperties.TokenizerProperties());
 


### PR DESCRIPTION
## Why

RAG 관리 UI는 token-aware chunking simulation을 위해 `POST /api/mgmt/ai/rag/simulations/chunking`을 우선 호출하지만, 서버 2.x에는 기존 `rag/chunks/preview` endpoint만 있어 프론트가 fallback 안내를 표시하고 있었습니다.

## What

- `POST /api/mgmt/ai/rag/simulations/chunking` 관리 endpoint를 추가했습니다.
- 요청 DTO는 `text`, `objectType`, `objectId`, `attachmentId`, `embeddingProvider`, `embeddingModel`, `tokenizerAutoDetect`, `chunkUnit`, `chunkSize`, `chunkOverlap`, `maxChunkSize`를 받습니다.
- 응답 DTO는 tokenizer 상태, chunk별 token/text metadata, token distribution, totals, warnings를 반환합니다.
- `maxChunkSize` 초과와 fallback tokenizer warning을 응답에 포함합니다.
- `tokenizerAutoDetect=false` 요청 시 model/provider 자동 선택을 끄고 fallback 경로를 사용하도록 보정했습니다.
- 요청에서 chunk size/overlap/unit을 생략한 경우 응답에도 `studio.chunking.*` 설정 기본값이 반영되도록 보정했습니다.
- AutoConfiguration, exception handler, endpoint mapping test, controller unit test, README를 갱신했습니다.

## Validation

- [x] `./gradlew :starter:studio-platform-starter-chunking:test --tests studio.one.platform.chunking.service.DefaultTokenizerResolverTest`
- [x] `./gradlew :starter:studio-platform-starter-ai-web:test`
- [x] `git diff --check`
- [x] GitHub Actions `gitleaks`

## AI Usage

- AI-Assisted: Yes
- Usage type: 이슈 분석, 구현, 테스트, 문서 갱신, 검증 준비, 반복 리뷰 조치
- Subagent used: No
- Main author validation: chunking resolver test, ai-web module test, diff check, GitHub secret scan으로 검증

Closes #469