### PR TITLE
[ai-assisted] fix(skillgraph): candidate 검색 SQL null 조건 제거

### DIFF
--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/jdbc/JdbcSkillCandidateStore.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/jdbc/JdbcSkillCandidateStore.java
@@ -119,21 +119,35 @@ public class JdbcSkillCandidateStore implements SkillCandidateStore {
             int limit) {
         String query = q == null ? "" : q.trim().toLowerCase();
         int max = limit <= 0 ? 100 : limit;
-        return template.query("""
+        StringBuilder sql = new StringBuilder("""
                 SELECT * FROM tb_skill_candidate
-                WHERE (:status IS NULL OR status = :status)
-                  AND (:q = '' OR LOWER(term) LIKE :likeQ OR normalized_term LIKE :likeQ)
-                  AND (:sourceType IS NULL OR source_type = :sourceType)
-                  AND (:sourceId IS NULL OR source_id = :sourceId)
+                WHERE 1 = 1
+                """);
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        if (status != null) {
+            sql.append("  AND status = :status\n");
+            params.addValue("status", status.name());
+        }
+        if (!query.isBlank()) {
+            sql.append("  AND (LOWER(term) LIKE :likeQ OR normalized_term LIKE :likeQ)\n");
+            params.addValue("likeQ", "%" + query + "%");
+        }
+        String normalizedSourceType = normalize(sourceType);
+        if (normalizedSourceType != null) {
+            sql.append("  AND source_type = :sourceType\n");
+            params.addValue("sourceType", normalizedSourceType);
+        }
+        String normalizedSourceId = normalize(sourceId);
+        if (normalizedSourceId != null) {
+            sql.append("  AND source_id = :sourceId\n");
+            params.addValue("sourceId", normalizedSourceId);
+        }
+        sql.append("""
                 ORDER BY created_at DESC
                 LIMIT :limit
-                """, new MapSqlParameterSource()
-                .addValue("status", status == null ? null : status.name())
-                .addValue("q", query)
-                .addValue("likeQ", "%" + query + "%")
-                .addValue("sourceType", normalize(sourceType))
-                .addValue("sourceId", normalize(sourceId))
-                .addValue("limit", max), this::mapCandidate);
+                """);
+        params.addValue("limit", max);
+        return template.query(sql.toString(), params, this::mapCandidate);
     }
 
     private Optional<SkillCandidate> queryOne(String sql, Map<String, ?> params) {

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/jdbc/JdbcSkillGraphStore.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/jdbc/JdbcSkillGraphStore.java
@@ -51,14 +51,21 @@ public class JdbcSkillGraphStore implements SkillGraphStore {
     @Override
     public List<SkillRelation> findRelations(String skillId, SkillRelationType type) {
         String skill = normalize(skillId);
-        return template.query("""
+        StringBuilder sql = new StringBuilder("""
                 SELECT * FROM tb_skill_relation
-                WHERE (:skillId IS NULL OR source_skill_id = :skillId OR target_skill_id = :skillId)
-                  AND (:relationType IS NULL OR relation_type = :relationType)
-                ORDER BY created_at DESC
-                """, new MapSqlParameterSource()
-                .addValue("skillId", skill)
-                .addValue("relationType", type == null ? null : type.name()), this::map);
+                WHERE 1 = 1
+                """);
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        if (skill != null) {
+            sql.append("  AND (source_skill_id = :skillId OR target_skill_id = :skillId)\n");
+            params.addValue("skillId", skill);
+        }
+        if (type != null) {
+            sql.append("  AND relation_type = :relationType\n");
+            params.addValue("relationType", type.name());
+        }
+        sql.append("ORDER BY created_at DESC\n");
+        return template.query(sql.toString(), params, this::map);
     }
 
     private MapSqlParameterSource params(SkillRelation relation) {

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/jdbc/JdbcSkillMappingStore.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/jdbc/JdbcSkillMappingStore.java
@@ -57,20 +57,34 @@ public class JdbcSkillMappingStore implements SkillMappingStore {
 
     @Override
     public List<NcsSkillMapping> findNcsMappings(String ncsUnitId) {
+        String ncsUnit = normalize(ncsUnitId);
+        if (ncsUnit == null) {
+            return template.query("""
+                    SELECT * FROM tb_skill_ncs_mapping
+                    ORDER BY created_at DESC
+                    """, new MapSqlParameterSource(), this::mapNcs);
+        }
         return template.query("""
                 SELECT * FROM tb_skill_ncs_mapping
-                WHERE (:ncsUnitId IS NULL OR ncs_unit_id = :ncsUnitId)
+                WHERE ncs_unit_id = :ncsUnitId
                 ORDER BY created_at DESC
-                """, new MapSqlParameterSource("ncsUnitId", normalize(ncsUnitId)), this::mapNcs);
+                """, new MapSqlParameterSource("ncsUnitId", ncsUnit), this::mapNcs);
     }
 
     @Override
     public List<CourseSkillMapping> findCourseMappings(String courseId) {
+        String course = normalize(courseId);
+        if (course == null) {
+            return template.query("""
+                    SELECT * FROM tb_skill_course_mapping
+                    ORDER BY created_at DESC
+                    """, new MapSqlParameterSource(), this::mapCourse);
+        }
         return template.query("""
                 SELECT * FROM tb_skill_course_mapping
-                WHERE (:courseId IS NULL OR course_id = :courseId)
+                WHERE course_id = :courseId
                 ORDER BY created_at DESC
-                """, new MapSqlParameterSource("courseId", normalize(courseId)), this::mapCourse);
+                """, new MapSqlParameterSource("courseId", course), this::mapCourse);
     }
 
     @Override

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/jdbc/JdbcSkillProjectionStore.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/jdbc/JdbcSkillProjectionStore.java
@@ -42,18 +42,25 @@ public class JdbcSkillProjectionStore implements SkillProjectionStore {
     public List<SkillProjection> findProjectionPoints(String projectionId, String clusterId, int limit, int offset) {
         int max = limit <= 0 ? 100 : limit;
         int start = Math.max(0, offset);
-        return template.query("""
+        StringBuilder sql = new StringBuilder("""
                 SELECT *, ROW_NUMBER() OVER (ORDER BY created_at, skill_id) - 1 AS display_order
                 FROM tb_skill_projection
                 WHERE projection_id = :projectionId
-                  AND (:clusterId IS NULL OR cluster_id = :clusterId)
+                """);
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("projectionId", projectionId)
+                .addValue("limit", max)
+                .addValue("offset", start);
+        String cluster = normalize(clusterId);
+        if (cluster != null) {
+            sql.append("  AND cluster_id = :clusterId\n");
+            params.addValue("clusterId", cluster);
+        }
+        sql.append("""
                 ORDER BY display_order
                 LIMIT :limit OFFSET :offset
-                """, new MapSqlParameterSource()
-                .addValue("projectionId", projectionId)
-                .addValue("clusterId", normalize(clusterId))
-                .addValue("limit", max)
-                .addValue("offset", start), this::mapProjection);
+                """);
+        return template.query(sql.toString(), params, this::mapProjection);
     }
 
     @Override

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/jdbc/JdbcSkillTaxonomyStore.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/jdbc/JdbcSkillTaxonomyStore.java
@@ -45,12 +45,19 @@ public class JdbcSkillTaxonomyStore implements SkillTaxonomyStore {
 
     @Override
     public List<SkillCategory> findCategories(String parentCategoryId) {
+        String parent = normalize(parentCategoryId);
+        if (parent == null) {
+            return template.query("""
+                    SELECT * FROM tb_skill_category
+                    WHERE parent_category_id IS NULL
+                    ORDER BY display_order, name
+                    """, Map.of(), this::map);
+        }
         return template.query("""
                 SELECT * FROM tb_skill_category
-                WHERE (:parentCategoryId IS NULL AND parent_category_id IS NULL)
-                   OR parent_category_id = :parentCategoryId
+                WHERE parent_category_id = :parentCategoryId
                 ORDER BY display_order, name
-                """, new MapSqlParameterSource("parentCategoryId", normalize(parentCategoryId)), this::map);
+                """, new MapSqlParameterSource("parentCategoryId", parent), this::map);
     }
 
     private MapSqlParameterSource params(SkillCategory category) {

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/JdbcSkillGraphStoreTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/JdbcSkillGraphStoreTest.java
@@ -107,6 +107,22 @@ class JdbcSkillGraphStoreTest {
     }
 
     @Test
+    void candidateStoreSearchesWithOptionalFilters() {
+        Instant now = Instant.parse("2026-05-16T00:00:00Z");
+        candidateStore.saveSourceChunk(new SkillSourceChunk("source-1", "course", "course-1", "chunk-1", "Spring", now));
+        candidateStore.saveCandidate(new SkillCandidate("candidate-1", "source-1", "course", "course-1",
+                "Spring Boot", "spring boot", SkillCandidateStatus.PENDING, 0.9d, 1, null, null, now, now));
+
+        var all = candidateStore.searchCandidates(null, null, null, null, 10);
+        var filtered = candidateStore.searchCandidates(SkillCandidateStatus.PENDING, "spring", "course", "course-1", 10);
+        var missing = candidateStore.searchCandidates(SkillCandidateStatus.APPROVED, "spring", "course", "course-1", 10);
+
+        assertEquals(1, all.size());
+        assertEquals("candidate-1", filtered.get(0).candidateId());
+        assertTrue(missing.isEmpty());
+    }
+
+    @Test
     void dictionaryStorePersistsAndSearchesSkill() {
         Instant now = Instant.parse("2026-05-16T00:00:00Z");
         dictionaryStore.save(new SkillDictionary("skill-1", "Spring Boot", "spring boot", "backend", "ACTIVE", now, now));

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/JdbcSkillGraphStoreTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/JdbcSkillGraphStoreTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
+import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,19 +14,34 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 
+import studio.one.platform.skillgraph.domain.model.CourseSkillMapping;
 import studio.one.platform.skillgraph.domain.model.SkillCandidate;
 import studio.one.platform.skillgraph.domain.model.SkillCandidateStatus;
+import studio.one.platform.skillgraph.domain.model.SkillCategory;
+import studio.one.platform.skillgraph.domain.model.SkillCluster;
 import studio.one.platform.skillgraph.domain.model.SkillDictionary;
 import studio.one.platform.skillgraph.domain.model.SkillAlias;
+import studio.one.platform.skillgraph.domain.model.NcsSkillMapping;
+import studio.one.platform.skillgraph.domain.model.SkillProjection;
+import studio.one.platform.skillgraph.domain.model.SkillRelation;
+import studio.one.platform.skillgraph.domain.model.SkillRelationType;
 import studio.one.platform.skillgraph.domain.model.SkillSourceChunk;
 import studio.one.platform.skillgraph.infrastructure.persistence.jdbc.JdbcSkillCandidateStore;
 import studio.one.platform.skillgraph.infrastructure.persistence.jdbc.JdbcSkillDictionaryStore;
+import studio.one.platform.skillgraph.infrastructure.persistence.jdbc.JdbcSkillGraphStore;
+import studio.one.platform.skillgraph.infrastructure.persistence.jdbc.JdbcSkillMappingStore;
+import studio.one.platform.skillgraph.infrastructure.persistence.jdbc.JdbcSkillProjectionStore;
+import studio.one.platform.skillgraph.infrastructure.persistence.jdbc.JdbcSkillTaxonomyStore;
 
 class JdbcSkillGraphStoreTest {
 
     private EmbeddedDatabase database;
     private JdbcSkillCandidateStore candidateStore;
     private JdbcSkillDictionaryStore dictionaryStore;
+    private JdbcSkillTaxonomyStore taxonomyStore;
+    private JdbcSkillGraphStore graphStore;
+    private JdbcSkillMappingStore mappingStore;
+    private JdbcSkillProjectionStore projectionStore;
 
     @BeforeEach
     void setUp() {
@@ -80,8 +96,67 @@ class JdbcSkillGraphStoreTest {
                     created_at TIMESTAMP NOT NULL
                 )
                 """);
+        template.getJdbcTemplate().execute("""
+                CREATE TABLE tb_skill_category (
+                    category_id VARCHAR(100) PRIMARY KEY,
+                    parent_category_id VARCHAR(100),
+                    name VARCHAR(200) NOT NULL,
+                    display_order INT NOT NULL
+                )
+                """);
+        template.getJdbcTemplate().execute("""
+                CREATE TABLE tb_skill_relation (
+                    relation_id VARCHAR(100) PRIMARY KEY,
+                    source_skill_id VARCHAR(100) NOT NULL,
+                    target_skill_id VARCHAR(100) NOT NULL,
+                    relation_type VARCHAR(40) NOT NULL,
+                    created_at TIMESTAMP NOT NULL
+                )
+                """);
+        template.getJdbcTemplate().execute("""
+                CREATE TABLE tb_skill_ncs_mapping (
+                    mapping_id VARCHAR(100) PRIMARY KEY,
+                    ncs_unit_id VARCHAR(100) NOT NULL,
+                    skill_id VARCHAR(100) NOT NULL,
+                    weight DOUBLE NOT NULL,
+                    created_at TIMESTAMP NOT NULL
+                )
+                """);
+        template.getJdbcTemplate().execute("""
+                CREATE TABLE tb_skill_course_mapping (
+                    mapping_id VARCHAR(100) PRIMARY KEY,
+                    course_id VARCHAR(100) NOT NULL,
+                    skill_id VARCHAR(100) NOT NULL,
+                    weight DOUBLE NOT NULL,
+                    created_at TIMESTAMP NOT NULL
+                )
+                """);
+        template.getJdbcTemplate().execute("""
+                CREATE TABLE tb_skill_projection (
+                    projection_id VARCHAR(100) NOT NULL,
+                    skill_id VARCHAR(100) NOT NULL,
+                    x DOUBLE NOT NULL,
+                    y DOUBLE NOT NULL,
+                    cluster_id VARCHAR(100),
+                    created_at TIMESTAMP NOT NULL,
+                    PRIMARY KEY (projection_id, skill_id)
+                )
+                """);
+        template.getJdbcTemplate().execute("""
+                CREATE TABLE tb_skill_cluster (
+                    cluster_id VARCHAR(100) PRIMARY KEY,
+                    label VARCHAR(200),
+                    algorithm VARCHAR(100) NOT NULL,
+                    item_count INT NOT NULL,
+                    created_at TIMESTAMP NOT NULL
+                )
+                """);
         candidateStore = new JdbcSkillCandidateStore(template);
         dictionaryStore = new JdbcSkillDictionaryStore(template);
+        taxonomyStore = new JdbcSkillTaxonomyStore(template);
+        graphStore = new JdbcSkillGraphStore(template);
+        mappingStore = new JdbcSkillMappingStore(template);
+        projectionStore = new JdbcSkillProjectionStore(template);
     }
 
     @AfterEach
@@ -140,5 +215,69 @@ class JdbcSkillGraphStoreTest {
 
         var skill = dictionaryStore.findByNormalizedAlias("스프링부트").orElseThrow();
         assertEquals("skill-1", skill.skillId());
+    }
+
+    @Test
+    void taxonomyStoreSearchesRootAndChildCategories() {
+        taxonomyStore.saveCategory(new SkillCategory("backend", null, "Backend", 1));
+        taxonomyStore.saveCategory(new SkillCategory("java", "backend", "Java", 1));
+
+        var roots = taxonomyStore.findCategories(null);
+        var children = taxonomyStore.findCategories("backend");
+
+        assertEquals(1, roots.size());
+        assertEquals("backend", roots.get(0).categoryId());
+        assertEquals(1, children.size());
+        assertEquals("java", children.get(0).categoryId());
+    }
+
+    @Test
+    void graphStoreSearchesRelationsWithOptionalFilters() {
+        Instant now = Instant.parse("2026-05-16T00:00:00Z");
+        graphStore.saveRelation(new SkillRelation("relation-1", "spring", "java",
+                SkillRelationType.PREREQUISITE, now));
+
+        var all = graphStore.findRelations(null, null);
+        var bySkill = graphStore.findRelations("spring", null);
+        var byType = graphStore.findRelations(null, SkillRelationType.PREREQUISITE);
+        var missing = graphStore.findRelations("python", SkillRelationType.PREREQUISITE);
+
+        assertEquals(1, all.size());
+        assertEquals("relation-1", bySkill.get(0).relationId());
+        assertEquals("relation-1", byType.get(0).relationId());
+        assertTrue(missing.isEmpty());
+    }
+
+    @Test
+    void mappingStoreSearchesWithOptionalFilters() {
+        Instant now = Instant.parse("2026-05-16T00:00:00Z");
+        mappingStore.saveNcsMapping(new NcsSkillMapping("ncs-1", "unit-1", "spring", 0.8d, now));
+        mappingStore.saveCourseMapping(new CourseSkillMapping("course-1", "course-a", "spring", 0.7d, now));
+
+        var allNcs = mappingStore.findNcsMappings(null);
+        var ncsByUnit = mappingStore.findNcsMappings("unit-1");
+        var allCourses = mappingStore.findCourseMappings(null);
+        var coursesById = mappingStore.findCourseMappings("course-a");
+
+        assertEquals(1, allNcs.size());
+        assertEquals("ncs-1", ncsByUnit.get(0).mappingId());
+        assertEquals(1, allCourses.size());
+        assertEquals("course-1", coursesById.get(0).mappingId());
+    }
+
+    @Test
+    void projectionStoreSearchesWithOptionalClusterFilter() {
+        Instant now = Instant.parse("2026-05-16T00:00:00Z");
+        projectionStore.replaceProjection("default", List.of(
+                new SkillProjection("default", "spring", 1.0d, 2.0d, "cluster-a", 0, now),
+                new SkillProjection("default", "java", 3.0d, 4.0d, "cluster-b", 0, now)),
+                List.of(new SkillCluster("cluster-a", "Backend", "manual", 1, now)));
+
+        var all = projectionStore.findProjectionPoints("default", null, 10, 0);
+        var byCluster = projectionStore.findProjectionPoints("default", "cluster-a", 10, 0);
+
+        assertEquals(2, all.size());
+        assertEquals(1, byCluster.size());
+        assertEquals("spring", byCluster.get(0).skillId());
     }
 }


### PR DESCRIPTION
## Why

SkillGraph 조회 API에서 PostgreSQL이 `(:param IS NULL OR column = :param)` 형태의 null 바인딩 파라미터 타입을 추론하지 못해 `BadSqlGrammarException`이 발생했습니다. 최초 재현은 candidate 조회였고, 이슈 #475 확인 중 dashboard가 호출하는 category/relation 및 같은 JDBC 저장소 계열의 optional filter 쿼리에도 동일한 위험이 남아 있음을 확인했습니다.

## What

- `JdbcSkillCandidateStore.searchCandidates`에서 optional filter를 SQL 내부 null 조건으로 처리하지 않도록 변경했습니다.
- `JdbcSkillTaxonomyStore.findCategories`, `JdbcSkillGraphStore.findRelations`, `JdbcSkillMappingStore`, `JdbcSkillProjectionStore`의 optional filter 쿼리를 동적 SQL로 보정했습니다.
- null 필터, 복합 필터, category/relation/mapping/projection 조회 경로를 검증하는 focused JDBC test를 추가했습니다.

## Related Issues

- #472 follow-up
- Fixes #475

## Validation

- `./gradlew :studio-platform-skillgraph:test --tests studio.one.platform.skillgraph.JdbcSkillGraphStoreTest`
  - Result: `BUILD SUCCESSFUL`
- `./gradlew :studio-platform-skillgraph:test`
  - Result: `BUILD SUCCESSFUL`
- `git diff --check`
  - Result: 통과

## Risk / Rollback

쿼리 조건 구성 방식만 변경하므로 기능 위험은 낮습니다. rollback은 PR commit revert입니다.

## AI / Subagent Usage

AI-Assisted: Yes
Subagent 사용: 없음

## Checklist

- [x] commit message follows policy
- [x] issue template was used or exception was recorded
- [x] AI-Assisted value is correct
- [x] validation is recorded
- [x] subagent usage is recorded when used
- [x] CI or repository verification passed locally
- [x] human review is required before merge
- [x] unrelated changes are excluded
