### PR TITLE
[ai-assisted] feat(skillgraph): RAG chunk batch 추출 API 추가

### DIFF
--- a/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/RagPipelineSkillGraphRagChunkResolver.java
+++ b/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/RagPipelineSkillGraphRagChunkResolver.java
@@ -1,0 +1,51 @@
+package studio.one.platform.autoconfigure.skillgraph;
+
+import java.util.List;
+import java.util.Map;
+
+import lombok.RequiredArgsConstructor;
+import studio.one.platform.ai.core.rag.RagSearchResult;
+import studio.one.platform.ai.core.vector.VectorRecord;
+import studio.one.platform.ai.service.pipeline.RagPipelineService;
+import studio.one.platform.skillgraph.application.result.ResolvedRagChunk;
+import studio.one.platform.skillgraph.application.usecase.SkillGraphRagChunkResolver;
+
+@RequiredArgsConstructor
+class RagPipelineSkillGraphRagChunkResolver implements SkillGraphRagChunkResolver {
+
+    private final RagPipelineService ragPipelineService;
+
+    @Override
+    public List<ResolvedRagChunk> listByObject(String objectType, String objectId, int limit) {
+        return ragPipelineService.listByObject(objectType, objectId, limit).stream()
+                .map(this::toChunk)
+                .toList();
+    }
+
+    private ResolvedRagChunk toChunk(RagSearchResult result) {
+        Map<String, Object> metadata = result.metadata() == null ? Map.of() : result.metadata();
+        String documentId = text(firstPresent(metadata, VectorRecord.KEY_DOCUMENT_ID, "documentId", "sourceDocumentId"));
+        documentId = documentId == null ? result.documentId() : documentId;
+        String chunkId = text(firstPresent(metadata, VectorRecord.KEY_CHUNK_ID, "chunkId"));
+        chunkId = chunkId == null ? documentId : chunkId;
+        return new ResolvedRagChunk(chunkId, documentId, result.content());
+    }
+
+    private Object firstPresent(Map<String, Object> metadata, String... keys) {
+        for (String key : keys) {
+            Object value = metadata.get(key);
+            if (value != null && (!(value instanceof String text) || !text.isBlank())) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private String text(Object value) {
+        if (value == null) {
+            return null;
+        }
+        String text = String.valueOf(value).trim();
+        return text.isEmpty() ? null : text;
+    }
+}

--- a/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/SkillGraphWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/SkillGraphWebAutoConfiguration.java
@@ -2,10 +2,15 @@ package studio.one.platform.autoconfigure.skillgraph;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
+import studio.one.platform.ai.service.pipeline.RagPipelineService;
+import studio.one.platform.skillgraph.application.usecase.SkillGraphRagChunkResolver;
 import studio.one.platform.skillgraph.application.usecase.SkillCandidateReviewService;
 import studio.one.platform.skillgraph.application.usecase.SkillDictionaryService;
 import studio.one.platform.skillgraph.application.usecase.SkillExtractionService;
@@ -31,6 +36,18 @@ public class SkillGraphWebAutoConfiguration {
     @ConditionalOnBean(name = SkillExtractionService.SERVICE_NAME)
     @Import(SkillExtractionJobMgmtController.class)
     static class SkillExtractionWebConfig {
+    }
+
+    @Configuration
+    @ConditionalOnClass(name = "studio.one.platform.ai.service.pipeline.RagPipelineService")
+    static class SkillGraphRagExtractionConfig {
+
+        @Bean
+        @ConditionalOnBean(RagPipelineService.class)
+        @ConditionalOnMissingBean(SkillGraphRagChunkResolver.class)
+        SkillGraphRagChunkResolver skillGraphRagChunkResolver(RagPipelineService ragPipelineService) {
+            return new RagPipelineSkillGraphRagChunkResolver(ragPipelineService);
+        }
     }
 
     @Configuration

--- a/studio-platform-skillgraph/build.gradle.kts
+++ b/studio-platform-skillgraph/build.gradle.kts
@@ -28,6 +28,8 @@ dependencies {
 
     testImplementation(project(":studio-platform-ai"))
     testImplementation(project(":studio-platform-chunking"))
+    testImplementation("com.fasterxml.jackson.core:jackson-annotations")
+    testImplementation("org.springframework:spring-web")
     testImplementation("org.springframework:spring-jdbc")
     testRuntimeOnly("com.h2database:h2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/ResolvedRagChunk.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/ResolvedRagChunk.java
@@ -1,0 +1,7 @@
+package studio.one.platform.skillgraph.application.result;
+
+public record ResolvedRagChunk(
+        String chunkId,
+        String documentId,
+        String content) {
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/usecase/SkillGraphRagChunkResolver.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/usecase/SkillGraphRagChunkResolver.java
@@ -1,0 +1,10 @@
+package studio.one.platform.skillgraph.application.usecase;
+
+import java.util.List;
+
+import studio.one.platform.skillgraph.application.result.ResolvedRagChunk;
+
+public interface SkillGraphRagChunkResolver {
+
+    List<ResolvedRagChunk> listByObject(String objectType, String objectId, int limit);
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillExtractionJobMgmtController.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillExtractionJobMgmtController.java
@@ -1,7 +1,17 @@
 package studio.one.platform.skillgraph.web.controller;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
 import jakarta.validation.Valid;
 
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
@@ -9,21 +19,40 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
-import lombok.RequiredArgsConstructor;
 import studio.one.platform.skillgraph.application.command.SkillExtractionCommand;
+import studio.one.platform.skillgraph.application.result.ResolvedRagChunk;
+import studio.one.platform.skillgraph.application.result.SkillExtractionResult;
 import studio.one.platform.skillgraph.application.usecase.SkillExtractionService;
+import studio.one.platform.skillgraph.application.usecase.SkillGraphRagChunkResolver;
 import studio.one.platform.skillgraph.web.dto.request.SkillExtractionRequest;
+import studio.one.platform.skillgraph.web.dto.request.SkillRagChunkExtractionRequest;
+import studio.one.platform.skillgraph.web.dto.request.SkillRagDocumentExtractionRequest;
 import studio.one.platform.skillgraph.web.dto.response.SkillExtractionResponse;
+import studio.one.platform.skillgraph.web.dto.response.SkillRagBatchExtractionResponse;
+import studio.one.platform.skillgraph.web.dto.response.SkillRagChunkExtractionItemDto;
 import studio.one.platform.web.dto.ApiResponse;
 
 @RestController
 @RequestMapping("${studio.features.skillgraph.web.extraction-base-path:/api/mgmt/skillgraph/extraction-jobs}")
-@RequiredArgsConstructor
 @Validated
 public class SkillExtractionJobMgmtController {
 
+    private static final String RAG_CHUNK_SOURCE_TYPE = "RAG_CHUNK";
+    private static final int DEFAULT_RAG_CHUNK_LIMIT = 1000;
+    private static final int MAX_RAG_CHUNK_LIMIT = 5000;
+
     private final SkillExtractionService extractionService;
+    private final ObjectProvider<SkillGraphRagChunkResolver> ragChunkResolverProvider;
+
+    public SkillExtractionJobMgmtController(
+            SkillExtractionService extractionService,
+            ObjectProvider<SkillGraphRagChunkResolver> ragChunkResolverProvider) {
+        this.extractionService = Objects.requireNonNull(extractionService, "extractionService");
+        this.ragChunkResolverProvider = Objects.requireNonNull(ragChunkResolverProvider,
+                "ragChunkResolverProvider");
+    }
 
     @PostMapping
     @PreAuthorize("@endpointAuthz.can('features:skillgraph','manage') "
@@ -33,4 +62,193 @@ public class SkillExtractionJobMgmtController {
         return ResponseEntity.ok(ApiResponse.ok(SkillExtractionResponse.from(extractionService.extract(
                 new SkillExtractionCommand(request.sourceType(), request.sourceId(), request.chunkId(), request.text())))));
     }
+
+    @PostMapping("/rag-documents")
+    @PreAuthorize("@endpointAuthz.can('features:skillgraph','manage') "
+            + "and @endpointAuthz.can('services:ai_rag','read') "
+            + "and (@endpointAuthz.can('objects:' + #request.objectType().trim() + ':' + #request.objectId().trim(),'read') "
+            + "or @endpointAuthz.can('objects:' + #request.objectType().trim(),'read'))")
+    public ResponseEntity<ApiResponse<SkillRagBatchExtractionResponse>> extractRagDocument(
+            @Valid @RequestBody SkillRagDocumentExtractionRequest request) {
+        String mode = normalize(request.mode());
+        if (mode != null && !"ALL_CHUNKS".equals(mode.toUpperCase(Locale.ROOT))) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Only ALL_CHUNKS mode is supported");
+        }
+        String documentId = normalize(request.documentId());
+        List<ResolvedRagChunk> chunks = resolveChunks(request.objectType(), request.objectId(), boundedLimit(request.limit()))
+                .stream()
+                .filter(chunk -> documentId == null || documentId.equals(chunk.documentId()))
+                .toList();
+        if (chunks.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "RAG chunks not found");
+        }
+        return ResponseEntity.ok(ApiResponse.ok(extractChunks(
+                normalize(request.objectType()),
+                normalize(request.objectId()),
+                documentId,
+                chunks.size(),
+                chunks)));
+    }
+
+    @PostMapping("/rag-chunks")
+    @PreAuthorize("@endpointAuthz.can('features:skillgraph','manage') "
+            + "and @endpointAuthz.can('services:ai_rag','read') "
+            + "and (@endpointAuthz.can('objects:' + #request.objectType().trim() + ':' + #request.objectId().trim(),'read') "
+            + "or @endpointAuthz.can('objects:' + #request.objectType().trim(),'read'))")
+    public ResponseEntity<ApiResponse<SkillRagBatchExtractionResponse>> extractRagChunks(
+            @Valid @RequestBody SkillRagChunkExtractionRequest request) {
+        String documentId = normalize(request.documentId());
+        Map<String, String> requestedChunkIds = normalizedChunkIds(request.chunkIds());
+        List<ResolvedRagChunk> resolved = resolveChunks(request.objectType(), request.objectId(), MAX_RAG_CHUNK_LIMIT);
+        Map<String, ResolvedRagChunk> byChunkId = new LinkedHashMap<>();
+        for (ResolvedRagChunk chunk : resolved) {
+            if ((documentId == null || documentId.equals(chunk.documentId()))
+                    && requestedChunkIds.containsKey(chunk.chunkId())) {
+                byChunkId.putIfAbsent(chunk.chunkId(), chunk);
+            }
+        }
+        if (byChunkId.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "RAG chunks not found");
+        }
+        List<ResolvedRagChunk> chunks = new ArrayList<>(byChunkId.values());
+        SkillRagBatchExtractionResponse response = extractChunks(
+                normalize(request.objectType()),
+                normalize(request.objectId()),
+                documentId,
+                requestedChunkIds.size(),
+                chunks);
+        if (chunks.size() < requestedChunkIds.size()) {
+            response = withMissingChunks(response, requestedChunkIds, byChunkId);
+        }
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    private SkillRagBatchExtractionResponse extractChunks(
+            String objectType,
+            String objectId,
+            String requestedDocumentId,
+            int requestedChunks,
+            List<ResolvedRagChunk> chunks) {
+        List<SkillRagChunkExtractionItemDto> items = new ArrayList<>();
+        int extractedCount = 0;
+        int succeeded = 0;
+        int failed = 0;
+        for (ResolvedRagChunk chunk : chunks) {
+            String sourceId = Optional.ofNullable(chunk.documentId()).orElse(objectId);
+            try {
+                SkillExtractionResult result = extractionService.extract(new SkillExtractionCommand(
+                        RAG_CHUNK_SOURCE_TYPE,
+                        sourceId,
+                        chunk.chunkId(),
+                        chunk.content()));
+                extractedCount += result.extractedCount();
+                succeeded++;
+                items.add(new SkillRagChunkExtractionItemDto(
+                        chunk.chunkId(),
+                        chunk.documentId(),
+                        sourceId,
+                        result.sourceChunkId(),
+                        result.extractedCount(),
+                        "SUCCEEDED",
+                        null));
+            } catch (RuntimeException ex) {
+                failed++;
+                items.add(new SkillRagChunkExtractionItemDto(
+                        chunk.chunkId(),
+                        chunk.documentId(),
+                        sourceId,
+                        null,
+                        0,
+                        "FAILED",
+                        ex.getMessage()));
+            }
+        }
+        return new SkillRagBatchExtractionResponse(
+                objectType,
+                objectId,
+                requestedDocumentId,
+                requestedChunks,
+                chunks.size(),
+                succeeded,
+                failed,
+                extractedCount,
+                items);
+    }
+
+    private SkillRagBatchExtractionResponse withMissingChunks(
+            SkillRagBatchExtractionResponse response,
+            Map<String, String> requestedChunkIds,
+            Map<String, ResolvedRagChunk> resolvedByChunkId) {
+        List<SkillRagChunkExtractionItemDto> items = new ArrayList<>(response.items());
+        int missing = 0;
+        for (Map.Entry<String, String> entry : requestedChunkIds.entrySet()) {
+            if (resolvedByChunkId.containsKey(entry.getKey())) {
+                continue;
+            }
+            missing++;
+            items.add(new SkillRagChunkExtractionItemDto(
+                    entry.getValue(),
+                    response.documentId(),
+                    null,
+                    null,
+                    0,
+                    "NOT_FOUND",
+                    "RAG chunk not found"));
+        }
+        return new SkillRagBatchExtractionResponse(
+                response.objectType(),
+                response.objectId(),
+                response.documentId(),
+                response.requestedChunks(),
+                response.resolvedChunks(),
+                response.succeededChunks(),
+                response.failedChunks() + missing,
+                response.extractedCount(),
+                items);
+    }
+
+    private List<ResolvedRagChunk> resolveChunks(String objectType, String objectId, int limit) {
+        SkillGraphRagChunkResolver resolver = ragChunkResolverProvider.getIfAvailable();
+        if (resolver == null) {
+            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "RAG chunk resolver is not configured");
+        }
+        try {
+            return resolver.listByObject(normalizeRequired(objectType, "objectType"),
+                    normalizeRequired(objectId, "objectId"), limit)
+                    .stream()
+                    .filter(chunk -> chunk.content() != null && !chunk.content().isBlank())
+                    .toList();
+        } catch (UnsupportedOperationException ex) {
+            throw new ResponseStatusException(HttpStatus.NOT_IMPLEMENTED, "RAG chunk resolve is not supported", ex);
+        }
+    }
+
+    private Map<String, String> normalizedChunkIds(List<String> chunkIds) {
+        Map<String, String> normalized = new LinkedHashMap<>();
+        for (String chunkId : chunkIds) {
+            String value = normalizeRequired(chunkId, "chunkId");
+            normalized.putIfAbsent(value, value);
+        }
+        return normalized;
+    }
+
+    private int boundedLimit(Integer limit) {
+        if (limit == null || limit <= 0) {
+            return DEFAULT_RAG_CHUNK_LIMIT;
+        }
+        return Math.min(limit, MAX_RAG_CHUNK_LIMIT);
+    }
+
+    private String normalize(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+
+    private String normalizeRequired(String value, String field) {
+        String normalized = normalize(value);
+        if (normalized == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, field + " is required");
+        }
+        return normalized;
+    }
+
 }

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillExtractionJobMgmtController.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillExtractionJobMgmtController.java
@@ -160,7 +160,7 @@ public class SkillExtractionJobMgmtController {
                         null,
                         0,
                         "FAILED",
-                        ex.getMessage()));
+                        failureMessage(ex)));
             }
         }
         return new SkillRagBatchExtractionResponse(
@@ -249,6 +249,13 @@ public class SkillExtractionJobMgmtController {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, field + " is required");
         }
         return normalized;
+    }
+
+    private String failureMessage(RuntimeException ex) {
+        if (ex instanceof IllegalArgumentException && ex.getMessage() != null && !ex.getMessage().isBlank()) {
+            return ex.getMessage();
+        }
+        return "Skill extraction failed";
     }
 
 }

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/request/SkillRagChunkExtractionRequest.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/request/SkillRagChunkExtractionRequest.java
@@ -1,0 +1,19 @@
+package studio.one.platform.skillgraph.web.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+
+public record SkillRagChunkExtractionRequest(
+        @Size(max = 100)
+        @NotBlank String objectType,
+        @Size(max = 200)
+        @NotBlank String objectId,
+        @Size(max = 200)
+        String documentId,
+        @NotEmpty
+        @Size(max = 500)
+        List<@NotBlank @Size(max = 200) String> chunkIds) {
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/request/SkillRagDocumentExtractionRequest.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/request/SkillRagDocumentExtractionRequest.java
@@ -1,0 +1,19 @@
+package studio.one.platform.skillgraph.web.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SkillRagDocumentExtractionRequest(
+        @Size(max = 100)
+        @NotBlank String objectType,
+        @Size(max = 200)
+        @NotBlank String objectId,
+        @Size(max = 200)
+        String documentId,
+        String mode,
+        @Min(1)
+        @Max(5000)
+        Integer limit) {
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/response/SkillRagBatchExtractionResponse.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/response/SkillRagBatchExtractionResponse.java
@@ -1,0 +1,15 @@
+package studio.one.platform.skillgraph.web.dto.response;
+
+import java.util.List;
+
+public record SkillRagBatchExtractionResponse(
+        String objectType,
+        String objectId,
+        String documentId,
+        int requestedChunks,
+        int resolvedChunks,
+        int succeededChunks,
+        int failedChunks,
+        int extractedCount,
+        List<SkillRagChunkExtractionItemDto> items) {
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/response/SkillRagChunkExtractionItemDto.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/response/SkillRagChunkExtractionItemDto.java
@@ -1,0 +1,11 @@
+package studio.one.platform.skillgraph.web.dto.response;
+
+public record SkillRagChunkExtractionItemDto(
+        String chunkId,
+        String documentId,
+        String sourceId,
+        String sourceChunkId,
+        int extractedCount,
+        String status,
+        String error) {
+}

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/SkillExtractionJobMgmtControllerTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/SkillExtractionJobMgmtControllerTest.java
@@ -62,18 +62,39 @@ class SkillExtractionJobMgmtControllerTest {
                 new SkillRagDocumentExtractionRequest("attachment", "42", null, "ALL_CHUNKS", null)));
     }
 
+    @Test
+    void hidesUnexpectedExtractionFailureDetails() {
+        InMemorySkillCandidateStore store = new InMemorySkillCandidateStore();
+        SkillExtractionJobMgmtController controller = new SkillExtractionJobMgmtController(
+                command -> {
+                    throw new IllegalStateException("database password leaked");
+                },
+                resolverProvider(new FakeRagChunkResolver(List.of(ragChunk("doc-1", "chunk-1", "Spring Boot")))));
+
+        var response = controller.extractRagChunks(new SkillRagChunkExtractionRequest(
+                "attachment", "42", null, List.of("chunk-1"))).getBody().getData();
+
+        assertEquals(1, response.failedChunks());
+        assertEquals("Skill extraction failed", response.items().get(0).error());
+    }
+
     private SkillExtractionJobMgmtController controller(
             InMemorySkillCandidateStore store,
             SkillGraphRagChunkResolver resolver) {
         DefaultSkillExtractionService extractionService = new DefaultSkillExtractionService(store,
                 new PatternSkillCandidateExtractor());
+        return new SkillExtractionJobMgmtController(
+                extractionService,
+                resolverProvider(resolver));
+    }
+
+    private org.springframework.beans.factory.ObjectProvider<SkillGraphRagChunkResolver> resolverProvider(
+            SkillGraphRagChunkResolver resolver) {
         StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
         if (resolver != null) {
             beanFactory.addBean("skillGraphRagChunkResolver", resolver);
         }
-        return new SkillExtractionJobMgmtController(
-                extractionService,
-                beanFactory.getBeanProvider(SkillGraphRagChunkResolver.class));
+        return beanFactory.getBeanProvider(SkillGraphRagChunkResolver.class);
     }
 
     private static ResolvedRagChunk ragChunk(String documentId, String chunkId, String content) {

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/SkillExtractionJobMgmtControllerTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/SkillExtractionJobMgmtControllerTest.java
@@ -1,0 +1,97 @@
+package studio.one.platform.skillgraph;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.support.StaticListableBeanFactory;
+
+import studio.one.platform.skillgraph.application.result.ResolvedRagChunk;
+import studio.one.platform.skillgraph.application.service.DefaultSkillExtractionService;
+import studio.one.platform.skillgraph.application.usecase.SkillGraphRagChunkResolver;
+import studio.one.platform.skillgraph.infrastructure.extraction.PatternSkillCandidateExtractor;
+import studio.one.platform.skillgraph.infrastructure.persistence.memory.InMemorySkillCandidateStore;
+import studio.one.platform.skillgraph.web.controller.SkillExtractionJobMgmtController;
+import studio.one.platform.skillgraph.web.dto.request.SkillRagChunkExtractionRequest;
+import studio.one.platform.skillgraph.web.dto.request.SkillRagDocumentExtractionRequest;
+
+class SkillExtractionJobMgmtControllerTest {
+
+    @Test
+    void extractsRagDocumentChunksWithoutClientText() {
+        InMemorySkillCandidateStore store = new InMemorySkillCandidateStore();
+        SkillExtractionJobMgmtController controller = controller(store, new FakeRagChunkResolver(List.of(
+                ragChunk("doc-1", "chunk-1", "Spring Boot 기술"),
+                ragChunk("doc-2", "chunk-2", "Kubernetes 기술"))));
+
+        var response = controller.extractRagDocument(new SkillRagDocumentExtractionRequest(
+                "attachment", "42", "doc-1", "ALL_CHUNKS", null)).getBody().getData();
+
+        assertEquals(1, response.resolvedChunks());
+        assertEquals(1, response.succeededChunks());
+        assertEquals(0, response.failedChunks());
+        assertEquals("RAG_CHUNK", store.sourceChunks().get(0).sourceType());
+        assertEquals("doc-1", store.sourceChunks().get(0).sourceId());
+        assertEquals("chunk-1", store.sourceChunks().get(0).chunkId());
+    }
+
+    @Test
+    void extractsSelectedRagChunksAndReportsMissingChunks() {
+        InMemorySkillCandidateStore store = new InMemorySkillCandidateStore();
+        SkillExtractionJobMgmtController controller = controller(store, new FakeRagChunkResolver(List.of(
+                ragChunk("doc-1", "chunk-1", "Spring Boot 기술"))));
+
+        var response = controller.extractRagChunks(new SkillRagChunkExtractionRequest(
+                "attachment", "42", null, List.of("chunk-1", "missing"))).getBody().getData();
+
+        assertEquals(2, response.requestedChunks());
+        assertEquals(1, response.resolvedChunks());
+        assertEquals(1, response.succeededChunks());
+        assertEquals(1, response.failedChunks());
+        assertEquals("NOT_FOUND", response.items().get(1).status());
+    }
+
+    @Test
+    void rejectsRagExtractionWhenPipelineIsUnavailable() {
+        InMemorySkillCandidateStore store = new InMemorySkillCandidateStore();
+        SkillExtractionJobMgmtController controller = controller(store, null);
+
+        assertThrows(RuntimeException.class, () -> controller.extractRagDocument(
+                new SkillRagDocumentExtractionRequest("attachment", "42", null, "ALL_CHUNKS", null)));
+    }
+
+    private SkillExtractionJobMgmtController controller(
+            InMemorySkillCandidateStore store,
+            SkillGraphRagChunkResolver resolver) {
+        DefaultSkillExtractionService extractionService = new DefaultSkillExtractionService(store,
+                new PatternSkillCandidateExtractor());
+        StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
+        if (resolver != null) {
+            beanFactory.addBean("skillGraphRagChunkResolver", resolver);
+        }
+        return new SkillExtractionJobMgmtController(
+                extractionService,
+                beanFactory.getBeanProvider(SkillGraphRagChunkResolver.class));
+    }
+
+    private static ResolvedRagChunk ragChunk(String documentId, String chunkId, String content) {
+        return new ResolvedRagChunk(chunkId, documentId, content);
+    }
+
+    private static final class FakeRagChunkResolver implements SkillGraphRagChunkResolver {
+
+        private final List<ResolvedRagChunk> chunks;
+
+        private FakeRagChunkResolver(List<ResolvedRagChunk> chunks) {
+            this.chunks = chunks;
+        }
+
+        @Override
+        public List<ResolvedRagChunk> listByObject(String objectType, String objectId, int limit) {
+            int max = limit <= 0 ? chunks.size() : Math.min(limit, chunks.size());
+            return chunks.subList(0, max);
+        }
+    }
+}


### PR DESCRIPTION
## Why

SkillGraph extraction job은 기존에 `text` 필수 단건 요청만 지원했습니다. 이 때문에 SkillGraph Console이 RAG 문서 또는 선택 chunk에서 추출할 때 클라이언트가 chunk 원문을 직접 조회하고 chunk별로 반복 전송해야 했습니다.

## What

- `POST /api/mgmt/skillgraph/extraction-jobs/rag-documents` endpoint를 추가했습니다.
- `POST /api/mgmt/skillgraph/extraction-jobs/rag-chunks` endpoint를 추가했습니다.
- SkillGraph 내부에는 `SkillGraphRagChunkResolver` port와 `ResolvedRagChunk` 결과 계약을 추가했습니다.
- starter에는 `RagPipelineService` 기반 resolver adapter를 조건부 auto-configuration으로 연결했습니다.
- batch 응답에 requested/resolved/succeeded/failed chunk 수, extracted count, chunk별 결과를 포함했습니다.
- 추출 후보 provenance는 `sourceType=RAG_CHUNK`, `sourceId=documentId fallback objectId`, `chunkId`로 유지했습니다.
- 예상치 못한 chunk별 추출 실패는 내부 예외 메시지를 노출하지 않도록 일반 메시지로 마스킹했습니다.
- 기존 단건 `POST /extraction-jobs` 계약은 유지했습니다.

## Related Issues

- Fixes #477

## Validation

- `./gradlew :studio-platform-skillgraph:compileJava`
  - Result: `BUILD SUCCESSFUL`
- `./gradlew :studio-platform-skillgraph:test --tests studio.one.platform.skillgraph.SkillExtractionJobMgmtControllerTest`
  - Result: `BUILD SUCCESSFUL`
- `./gradlew :starter:studio-platform-starter-skillgraph:compileJava`
  - Result: `BUILD SUCCESSFUL`
- `./gradlew :studio-platform-skillgraph:test :starter:studio-platform-starter-skillgraph:test`
  - Result: `BUILD SUCCESSFUL`
- `git diff --check`
  - Result: 통과

## Risk / Rollback

주요 위험은 batch 요청이 서버에서 여러 chunk를 동기 처리하므로 대량 chunk에서 요청 시간이 길어질 수 있다는 점입니다. v1은 요청 크기 절감을 우선해 서버 resolve와 batch 결과 요약을 제공하고, 장기 실행 job persistence는 별도 확장으로 남깁니다.

Rollback은 PR commit revert입니다.

## AI / Subagent Usage

AI-Assisted: Yes
Subagent 사용: 없음

## Checklist

- [x] commit message follows policy
- [x] issue template was used or exception was recorded
- [x] AI-Assisted value is correct
- [x] validation is recorded
- [x] subagent usage is recorded when used
- [x] CI or repository verification passed locally
- [x] human review is required before merge
- [x] unrelated changes are excluded
