### PR TITLE
[ai-assisted] feat(skillgraph): extraction dry-run API 추가

### DIFF
--- a/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/SkillGraphWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/SkillGraphWebAutoConfiguration.java
@@ -23,6 +23,7 @@ import studio.one.platform.skillgraph.web.controller.SkillCandidateMgmtControlle
 import studio.one.platform.skillgraph.web.controller.SkillDictionaryMgmtController;
 import studio.one.platform.skillgraph.web.controller.SkillExtractionJobMgmtController;
 import studio.one.platform.skillgraph.web.controller.SkillGraphMgmtController;
+import studio.one.platform.skillgraph.web.controller.SkillGraphSimulationMgmtController;
 import studio.one.platform.skillgraph.web.controller.SkillMappingMgmtController;
 import studio.one.platform.skillgraph.web.controller.SkillRecommendationMgmtController;
 import studio.one.platform.skillgraph.web.controller.SkillTaxonomyMgmtController;
@@ -34,7 +35,7 @@ public class SkillGraphWebAutoConfiguration {
 
     @Configuration
     @ConditionalOnBean(name = SkillExtractionService.SERVICE_NAME)
-    @Import(SkillExtractionJobMgmtController.class)
+    @Import({SkillExtractionJobMgmtController.class, SkillGraphSimulationMgmtController.class})
     static class SkillExtractionWebConfig {
     }
 

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillExtractionService.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillExtractionService.java
@@ -49,6 +49,15 @@ public class DefaultSkillExtractionService implements SkillExtractionService {
 
     @Override
     public SkillExtractionResult extract(SkillExtractionCommand command) {
+        return extract(command, true);
+    }
+
+    @Override
+    public SkillExtractionResult dryRun(SkillExtractionCommand command) {
+        return extract(command, false);
+    }
+
+    private SkillExtractionResult extract(SkillExtractionCommand command, boolean persist) {
         if (command == null || command.text() == null || command.text().isBlank()) {
             throw new IllegalArgumentException("text must not be blank");
         }
@@ -57,26 +66,30 @@ public class DefaultSkillExtractionService implements SkillExtractionService {
         }
 
         Instant now = Instant.now();
-        String sourceChunkId = "sch_" + UUID.randomUUID();
-        store.saveSourceChunk(new SkillSourceChunk(
-                sourceChunkId,
-                command.sourceType(),
-                command.sourceId(),
-                command.chunkId(),
-                excerpt(command.text()),
-                now));
+        String sourceChunkId = persist ? "sch_" + UUID.randomUUID() : null;
+        if (persist) {
+            store.saveSourceChunk(new SkillSourceChunk(
+                    sourceChunkId,
+                    command.sourceType(),
+                    command.sourceId(),
+                    command.chunkId(),
+                    excerpt(command.text()),
+                    now));
+        }
 
         List<SkillCandidateView> candidates = new ArrayList<>();
         for (SkillCandidateExtractor.ExtractedSkillTerm term : extractor.extract(command.text())) {
             String normalized = SkillCandidate.normalizeSkillTerm(term.term());
-            SkillCandidate candidate = store.findCandidateBySourceAndNormalizedTerm(
-                    command.sourceType(),
-                    command.sourceId(),
-                    command.chunkId(),
-                    normalized)
-                    .map(existing -> existing.incrementOccurrence(now))
-                    .orElseGet(() -> newCandidate(command, sourceChunkId, term, normalized, now));
-            candidates.add(SkillCandidateView.from(store.saveCandidate(candidate)));
+            SkillCandidate candidate = persist
+                    ? store.findCandidateBySourceAndNormalizedTerm(
+                            command.sourceType(),
+                            command.sourceId(),
+                            command.chunkId(),
+                            normalized)
+                            .map(existing -> existing.incrementOccurrence(now))
+                            .orElseGet(() -> newCandidate(command, sourceChunkId, term, normalized, now))
+                    : newCandidate(command, sourceChunkId, term, normalized, now);
+            candidates.add(SkillCandidateView.from(persist ? store.saveCandidate(candidate) : candidate));
         }
         return new SkillExtractionResult(sourceChunkId, candidates.size(), candidates);
     }

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/usecase/SkillExtractionService.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/usecase/SkillExtractionService.java
@@ -8,4 +8,8 @@ public interface SkillExtractionService {
     String SERVICE_NAME = "skillExtractionService";
 
     SkillExtractionResult extract(SkillExtractionCommand command);
+
+    default SkillExtractionResult dryRun(SkillExtractionCommand command) {
+        throw new UnsupportedOperationException("Skill extraction dry-run is not supported");
+    }
 }

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillGraphSimulationMgmtController.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillGraphSimulationMgmtController.java
@@ -1,0 +1,35 @@
+package studio.one.platform.skillgraph.web.controller;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import studio.one.platform.skillgraph.application.command.SkillExtractionCommand;
+import studio.one.platform.skillgraph.application.usecase.SkillExtractionService;
+import studio.one.platform.skillgraph.web.dto.request.SkillExtractionSimulationRequest;
+import studio.one.platform.skillgraph.web.dto.response.SkillExtractionResponse;
+import studio.one.platform.web.dto.ApiResponse;
+
+@RestController
+@RequestMapping("${studio.features.skillgraph.web.simulation-base-path:/api/mgmt/skillgraph/simulations}")
+@RequiredArgsConstructor
+@Validated
+public class SkillGraphSimulationMgmtController {
+
+    private final SkillExtractionService extractionService;
+
+    @PostMapping("/extraction")
+    @PreAuthorize("@endpointAuthz.can('features:skillgraph','read')")
+    public ResponseEntity<ApiResponse<SkillExtractionResponse>> simulateExtraction(
+            @Valid @RequestBody SkillExtractionSimulationRequest request) {
+        return ResponseEntity.ok(ApiResponse.ok(SkillExtractionResponse.from(extractionService.dryRun(
+                new SkillExtractionCommand(request.sourceType(), request.sourceId(), request.chunkId(), request.text())))));
+    }
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/request/SkillExtractionSimulationRequest.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/request/SkillExtractionSimulationRequest.java
@@ -1,0 +1,15 @@
+package studio.one.platform.skillgraph.web.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SkillExtractionSimulationRequest(
+        @Size(max = 100)
+        String sourceType,
+        @Size(max = 200)
+        String sourceId,
+        @Size(max = 200)
+        String chunkId,
+        @Size(max = 200000)
+        @NotBlank String text) {
+}

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/DefaultSkillExtractionServiceTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/DefaultSkillExtractionServiceTest.java
@@ -36,6 +36,40 @@ class DefaultSkillExtractionServiceTest {
     }
 
     @Test
+    void dryRunExtractsCandidatesWithoutStoringSourceChunkOrCandidate() {
+        InMemorySkillCandidateStore store = new InMemorySkillCandidateStore();
+        DefaultSkillExtractionService service = new DefaultSkillExtractionService(store, new PatternSkillCandidateExtractor());
+
+        var result = service.dryRun(new SkillExtractionCommand("simulation", "sample", "chunk-1",
+                "Spring Security와 JPA 기술"));
+
+        assertFalse(result.candidates().isEmpty());
+        assertEquals(0, store.sourceChunks().size());
+        assertEquals(0, store.searchCandidates(null, null, 100).size());
+        assertEquals(null, result.sourceChunkId());
+        assertFalse(result.candidates().stream()
+                .filter(candidate -> candidate.normalizedTerm().contains("spring"))
+                .toList()
+                .isEmpty());
+    }
+
+    @Test
+    void dryRunAppliesDictionaryMatchWithoutStoringCandidate() {
+        InMemorySkillCandidateStore candidateStore = new InMemorySkillCandidateStore();
+        InMemorySkillDictionaryStore dictionaryStore = new InMemorySkillDictionaryStore();
+        dictionaryStore.save(new SkillDictionary("skill-1", "Spring Boot", "spring boot", null, "ACTIVE",
+                Instant.now(), Instant.now()));
+        DefaultSkillExtractionService service = new DefaultSkillExtractionService(candidateStore, dictionaryStore,
+                new PatternSkillCandidateExtractor(), text -> List.of(), SkillMatchPolicy.defaults());
+
+        var result = service.dryRun(new SkillExtractionCommand("simulation", "sample", null, "Spring Boot"));
+
+        assertEquals(SkillCandidateStatus.MATCHED, result.candidates().get(0).status());
+        assertEquals("skill-1", result.candidates().get(0).matchedSkillId());
+        assertEquals(0, candidateStore.searchCandidates(null, null, 100).size());
+    }
+
+    @Test
     void reviewUpdatesCandidateStatus() {
         InMemorySkillCandidateStore store = new InMemorySkillCandidateStore();
         DefaultSkillExtractionService extractionService = new DefaultSkillExtractionService(store,

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/SkillExtractionJobMgmtControllerTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/SkillExtractionJobMgmtControllerTest.java
@@ -8,8 +8,11 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.support.StaticListableBeanFactory;
 
+import studio.one.platform.skillgraph.application.command.SkillExtractionCommand;
 import studio.one.platform.skillgraph.application.result.ResolvedRagChunk;
+import studio.one.platform.skillgraph.application.result.SkillExtractionResult;
 import studio.one.platform.skillgraph.application.service.DefaultSkillExtractionService;
+import studio.one.platform.skillgraph.application.usecase.SkillExtractionService;
 import studio.one.platform.skillgraph.application.usecase.SkillGraphRagChunkResolver;
 import studio.one.platform.skillgraph.infrastructure.extraction.PatternSkillCandidateExtractor;
 import studio.one.platform.skillgraph.infrastructure.persistence.memory.InMemorySkillCandidateStore;
@@ -66,9 +69,7 @@ class SkillExtractionJobMgmtControllerTest {
     void hidesUnexpectedExtractionFailureDetails() {
         InMemorySkillCandidateStore store = new InMemorySkillCandidateStore();
         SkillExtractionJobMgmtController controller = new SkillExtractionJobMgmtController(
-                command -> {
-                    throw new IllegalStateException("database password leaked");
-                },
+                new FailingSkillExtractionService(),
                 resolverProvider(new FakeRagChunkResolver(List.of(ragChunk("doc-1", "chunk-1", "Spring Boot")))));
 
         var response = controller.extractRagChunks(new SkillRagChunkExtractionRequest(
@@ -113,6 +114,19 @@ class SkillExtractionJobMgmtControllerTest {
         public List<ResolvedRagChunk> listByObject(String objectType, String objectId, int limit) {
             int max = limit <= 0 ? chunks.size() : Math.min(limit, chunks.size());
             return chunks.subList(0, max);
+        }
+    }
+
+    private static final class FailingSkillExtractionService implements SkillExtractionService {
+
+        @Override
+        public SkillExtractionResult extract(SkillExtractionCommand command) {
+            throw new IllegalStateException("database password leaked");
+        }
+
+        @Override
+        public SkillExtractionResult dryRun(SkillExtractionCommand command) {
+            throw new IllegalStateException("database password leaked");
         }
     }
 }

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/SkillGraphSimulationMgmtControllerTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/SkillGraphSimulationMgmtControllerTest.java
@@ -1,0 +1,35 @@
+package studio.one.platform.skillgraph;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.skillgraph.application.service.DefaultSkillExtractionService;
+import studio.one.platform.skillgraph.infrastructure.extraction.PatternSkillCandidateExtractor;
+import studio.one.platform.skillgraph.infrastructure.persistence.memory.InMemorySkillCandidateStore;
+import studio.one.platform.skillgraph.web.controller.SkillGraphSimulationMgmtController;
+import studio.one.platform.skillgraph.web.dto.request.SkillExtractionSimulationRequest;
+
+class SkillGraphSimulationMgmtControllerTest {
+
+    @Test
+    void simulationExtractionDoesNotPersistCandidates() {
+        InMemorySkillCandidateStore store = new InMemorySkillCandidateStore();
+        SkillGraphSimulationMgmtController controller = new SkillGraphSimulationMgmtController(
+                new DefaultSkillExtractionService(store, new PatternSkillCandidateExtractor()));
+
+        var response = controller.simulateExtraction(new SkillExtractionSimulationRequest(
+                null,
+                null,
+                null,
+                "Spring Security를 사용해 인증과 권한 처리를 구현하고, JPA로 회원 데이터를 관리한다."))
+                .getBody()
+                .getData();
+
+        assertFalse(response.candidates().isEmpty());
+        assertEquals(0, store.sourceChunks().size());
+        assertEquals(0, store.searchCandidates(null, null, 100).size());
+        assertEquals(null, response.sourceChunkId());
+    }
+}


### PR DESCRIPTION
## Why

SkillGraph simulation 화면에서 저장 없이 extraction 결과를 확인해야 하지만 기존 `POST /api/mgmt/skillgraph/extraction-jobs` API는 실행 시 `sourceChunk`와 `candidate`를 저장했습니다.

## What

- `POST /api/mgmt/skillgraph/simulations/extraction` endpoint를 추가했습니다.
- `SkillExtractionService.dryRun(...)` 경로를 추가했습니다.
- `DefaultSkillExtractionService`에서 기존 추출/사전 매칭 로직을 재사용하되 dry-run 시 `sourceChunk`와 `candidate` 저장을 생략하도록 분리했습니다.
- dry-run 요청 DTO `SkillExtractionSimulationRequest`를 추가했습니다.
- SkillGraph web auto-configuration에 simulation controller를 등록했습니다.
- 기존 저장형 `POST /api/mgmt/skillgraph/extraction-jobs` 동작은 유지했습니다.

## Related Issues

- Fixes #476

## Validation

- `./gradlew :studio-platform-skillgraph:test --tests studio.one.platform.skillgraph.DefaultSkillExtractionServiceTest --tests studio.one.platform.skillgraph.SkillGraphSimulationMgmtControllerTest --tests studio.one.platform.skillgraph.SkillExtractionJobMgmtControllerTest`
  - Result: `BUILD SUCCESSFUL`
- `./gradlew :starter:studio-platform-starter-skillgraph:compileJava`
  - Result: `BUILD SUCCESSFUL`
- `./gradlew :studio-platform-skillgraph:test :starter:studio-platform-starter-skillgraph:test`
  - Result: `BUILD SUCCESSFUL`
- `git diff --check`
  - Result: 통과

## Risk / Rollback

주요 위험은 `SkillExtractionService` 계약 확장으로 인한 외부 구현체 영향입니다. 이를 줄이기 위해 `dryRun`은 default method로 추가했고, 기본 구현은 `UnsupportedOperationException`을 반환합니다. 실제 dry-run은 `DefaultSkillExtractionService`에서 제공합니다.

Rollback은 commit `0c890455` revert입니다.

## AI / Subagent Usage

AI-Assisted: Yes
Subagent 사용: 없음

## Checklist

- [x] commit message follows policy
- [x] issue template was used or exception was recorded
- [x] AI-Assisted value is correct
- [x] validation is recorded
- [x] subagent usage is recorded when used
- [x] CI or repository verification passed locally
- [x] human review is required before merge
- [x] unrelated changes are excluded
