### PR TITLE
[ai-assisted] feat(skillgraph): RAG chunk preview 추출 흐름 개선

### DIFF
--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/adapters/vector/PgVectorJdbcMapper.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/adapters/vector/PgVectorJdbcMapper.java
@@ -82,6 +82,22 @@ public final class PgVectorJdbcMapper implements PgVectorMapper {
              ORDER BY chunk_index
              LIMIT :limit OFFSET :offset
             """;
+    private static final String LIST_BY_OBJECT_PAGE_FILTERED_SQL = """
+            SELECT object_id, text, metadata
+              FROM tb_ai_document_chunk
+             WHERE object_type = :objectType AND object_id = :objectId
+               AND (:documentId IS NULL OR metadata->>'documentId' = :documentId)
+               AND (:query IS NULL OR (
+                    LOWER(text) LIKE :queryPattern
+                    OR LOWER(COALESCE(metadata->>'chunkId', '')) LIKE :queryPattern
+                    OR LOWER(COALESCE(metadata->>'documentId', '')) LIKE :queryPattern
+                    OR LOWER(COALESCE(metadata->>'sourceDocumentId', '')) LIKE :queryPattern
+                    OR LOWER(COALESCE(metadata->>'headingPath', '')) LIKE :queryPattern
+                    OR LOWER(COALESCE(metadata->>'section', '')) LIKE :queryPattern
+               ))
+             ORDER BY chunk_index
+             LIMIT :limit OFFSET :offset
+            """;
     private static final String METADATA_BY_OBJECT_SQL = """
             SELECT metadata
               FROM tb_ai_document_chunk
@@ -176,6 +192,22 @@ public final class PgVectorJdbcMapper implements PgVectorMapper {
     }
 
     @Override
+    public List<PgVectorSearchRow> listByObjectPageFiltered(
+            String objectType,
+            String objectId,
+            String documentId,
+            String query,
+            int offset,
+            int limit) {
+        return jdbcTemplate.query(LIST_BY_OBJECT_PAGE_FILTERED_SQL, objectParams(objectType, objectId)
+                .addValue("documentId", normalize(documentId))
+                .addValue("query", normalize(query))
+                .addValue("queryPattern", queryPattern(query))
+                .addValue("offset", offset)
+                .addValue("limit", limit), ROW_MAPPER);
+    }
+
+    @Override
     public String metadataByObject(String objectType, String objectId) {
         List<String> rows = jdbcTemplate.query(
                 METADATA_BY_OBJECT_SQL,
@@ -198,6 +230,15 @@ public final class PgVectorJdbcMapper implements PgVectorMapper {
         return new MapSqlParameterSource()
                 .addValue("objectType", objectType)
                 .addValue("objectId", objectId);
+    }
+
+    private static String queryPattern(String query) {
+        String normalized = normalize(query);
+        return normalized == null ? null : "%" + normalized.toLowerCase(java.util.Locale.ROOT) + "%";
+    }
+
+    private static String normalize(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
     }
 
     private static MapSqlParameterSource searchParams(PgVectorSearchParameter parameter) {

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/adapters/vector/PgVectorStoreAdapterV2.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/adapters/vector/PgVectorStoreAdapterV2.java
@@ -170,6 +170,28 @@ public class PgVectorStoreAdapterV2 implements VectorStorePort {
     }
 
     @Override
+    public List<VectorSearchResult> listByObject(
+            String objectType,
+            String objectId,
+            String documentId,
+            String query,
+            int offset,
+            int limit) {
+        int rowOffset = Math.max(0, offset);
+        int rowLimit = limit <= 0 ? 50 : limit;
+        return mapper.listByObjectPageFiltered(
+                        objectType,
+                        objectId,
+                        normalize(documentId),
+                        normalize(query),
+                        rowOffset,
+                        rowLimit)
+                .stream()
+                .map(PgVectorStoreAdapterV2::mapListRow)
+                .toList();
+    }
+
+    @Override
     public Map<String, Object> getMetadata(String objectType, String objectId) {
         String metadata = mapper.metadataByObject(objectType, objectId);
         if (metadata == null || metadata.isBlank()) {

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/adapters/vector/mybatis/PgVectorMapper.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/adapters/vector/mybatis/PgVectorMapper.java
@@ -35,6 +35,14 @@ public interface PgVectorMapper {
             @Param("offset") int offset,
             @Param("limit") int limit);
 
+    List<PgVectorSearchRow> listByObjectPageFiltered(
+            @Param("objectType") String objectType,
+            @Param("objectId") String objectId,
+            @Param("documentId") String documentId,
+            @Param("query") String query,
+            @Param("offset") int offset,
+            @Param("limit") int limit);
+
     String metadataByObject(
             @Param("objectType") String objectType,
             @Param("objectId") String objectId);

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagPipelineService.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagPipelineService.java
@@ -507,6 +507,31 @@ public class DefaultRagPipelineService implements RagPipelineService {
                 .toList();
     }
 
+    @Override
+    public List<RagSearchResult> listByObject(
+            String objectType,
+            String objectId,
+            String documentId,
+            String query,
+            int offset,
+            int limit) {
+        clearDiagnostics();
+        List<VectorSearchResult> results = vectorStorePort.listByObject(
+                objectType,
+                objectId,
+                normalize(documentId),
+                normalize(query),
+                Math.max(0, offset),
+                clampPagedListLimit(limit));
+        return results.stream()
+                .map(result -> new RagSearchResult(
+                        result.document().id(),
+                        result.document().content(),
+                        result.document().metadata(),
+                        result.score()))
+                .toList();
+    }
+
     private int clampPagedListLimit(int limit) {
         if (limit <= 0) {
             return options.defaultListLimit();
@@ -869,6 +894,10 @@ public class DefaultRagPipelineService implements RagPipelineService {
 
     private void clearDiagnostics() {
         latestDiagnostics.remove();
+    }
+
+    private String normalize(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
     }
 
     private void recordDiagnostics(

--- a/starter/studio-platform-starter-ai/src/main/resources/mybatis/ai/PgVectorMapper.xml
+++ b/starter/studio-platform-starter-ai/src/main/resources/mybatis/ai/PgVectorMapper.xml
@@ -40,6 +40,22 @@
     </where>
   </sql>
 
+  <sql id="listFilterConditions">
+    <if test="documentId != null">
+      AND (metadata -&gt;&gt; 'documentId') = #{documentId,jdbcType=VARCHAR}
+    </if>
+    <if test="query != null">
+      AND (
+        LOWER(text) LIKE CONCAT('%', LOWER(#{query,jdbcType=VARCHAR}), '%')
+        OR LOWER(COALESCE(metadata -&gt;&gt; 'chunkId', '')) LIKE CONCAT('%', LOWER(#{query,jdbcType=VARCHAR}), '%')
+        OR LOWER(COALESCE(metadata -&gt;&gt; 'documentId', '')) LIKE CONCAT('%', LOWER(#{query,jdbcType=VARCHAR}), '%')
+        OR LOWER(COALESCE(metadata -&gt;&gt; 'sourceDocumentId', '')) LIKE CONCAT('%', LOWER(#{query,jdbcType=VARCHAR}), '%')
+        OR LOWER(COALESCE(metadata -&gt;&gt; 'headingPath', '')) LIKE CONCAT('%', LOWER(#{query,jdbcType=VARCHAR}), '%')
+        OR LOWER(COALESCE(metadata -&gt;&gt; 'section', '')) LIKE CONCAT('%', LOWER(#{query,jdbcType=VARCHAR}), '%')
+      )
+    </if>
+  </sql>
+
   <insert id="upsertChunk" parameterType="studio.one.platform.ai.adapters.vector.mybatis.PgVectorChunkParameter">
     INSERT INTO tb_ai_document_chunk(object_type, object_id, chunk_index, text, metadata, embedding)
     VALUES (
@@ -134,6 +150,16 @@
     FROM tb_ai_document_chunk
     WHERE object_type = #{objectType,jdbcType=VARCHAR}
       AND object_id = #{objectId,jdbcType=VARCHAR}
+    ORDER BY chunk_index
+    LIMIT #{limit} OFFSET #{offset}
+  </select>
+
+  <select id="listByObjectPageFiltered" resultMap="PgVectorSearchRowMap">
+    SELECT object_id, text, metadata, NULL::double precision AS distance
+    FROM tb_ai_document_chunk
+    WHERE object_type = #{objectType,jdbcType=VARCHAR}
+      AND object_id = #{objectId,jdbcType=VARCHAR}
+      <include refid="listFilterConditions"/>
     ORDER BY chunk_index
     LIMIT #{limit} OFFSET #{offset}
   </select>

--- a/starter/studio-platform-starter-ai/src/main/resources/mybatis/ai/PgVectorMapper.xml
+++ b/starter/studio-platform-starter-ai/src/main/resources/mybatis/ai/PgVectorMapper.xml
@@ -121,7 +121,7 @@
   </select>
 
   <select id="listByObject" resultMap="PgVectorSearchRowMap">
-    SELECT object_id, text, metadata
+    SELECT object_id, text, metadata, NULL::double precision AS distance
     FROM tb_ai_document_chunk
     WHERE object_type = #{objectType,jdbcType=VARCHAR}
       AND object_id = #{objectId,jdbcType=VARCHAR}
@@ -130,7 +130,7 @@
   </select>
 
   <select id="listByObjectPage" resultMap="PgVectorSearchRowMap">
-    SELECT object_id, text, metadata
+    SELECT object_id, text, metadata, NULL::double precision AS distance
     FROM tb_ai_document_chunk
     WHERE object_type = #{objectType,jdbcType=VARCHAR}
       AND object_id = #{objectId,jdbcType=VARCHAR}

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/adapters/vector/PgVectorStoreAdapterV2Test.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/adapters/vector/PgVectorStoreAdapterV2Test.java
@@ -215,6 +215,25 @@ class PgVectorStoreAdapterV2Test {
     }
 
     @Test
+    void listByObjectWithFiltersDelegatesQueryAndPageToMapper() {
+        when(mapper.listByObjectPageFiltered(
+                eq("ARTICLE"), eq("article-1"), eq("doc-list"), eq("Spring"), eq(50), eq(51)))
+                .thenReturn(List.of(row(
+                        null,
+                        "article-1",
+                        "Spring content",
+                        "{\"documentId\":\"doc-list\",\"chunkId\":\"chunk-1\"}",
+                        null)));
+
+        List<VectorSearchResult> results = adapter.listByObject(
+                "ARTICLE", "article-1", "doc-list", "Spring", 50, 51);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).document().id()).isEqualTo("doc-list");
+        verify(mapper).listByObjectPageFiltered("ARTICLE", "article-1", "doc-list", "Spring", 50, 51);
+    }
+
+    @Test
     void getMetadataReturnsFirstRowAsImmutableMap() {
         when(mapper.metadataByObject("ARTICLE", "article-1"))
                 .thenReturn("{\"documentId\":\"doc-meta\",\"topic\":\"gamma\"}");

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/adapters/vector/mybatis/PgVectorMapperXmlContractTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/adapters/vector/mybatis/PgVectorMapperXmlContractTest.java
@@ -32,9 +32,22 @@ class PgVectorMapperXmlContractTest {
 
         assertThat(mapper)
                 .contains("<select id=\"listByObject\" resultMap=\"PgVectorSearchRowMap\">")
-                .contains("<select id=\"listByObjectPage\" resultMap=\"PgVectorSearchRowMap\">");
+                .contains("<select id=\"listByObjectPage\" resultMap=\"PgVectorSearchRowMap\">")
+                .contains("<select id=\"listByObjectPageFiltered\" resultMap=\"PgVectorSearchRowMap\">");
         assertThat(mapper.split(Pattern.quote("NULL::double precision AS distance"), -1))
-                .hasSize(3);
+                .hasSize(4);
+    }
+
+    @Test
+    void filteredListByObjectPushesPreviewFiltersIntoSql() throws Exception {
+        String mapper = mapperXml();
+
+        assertThat(mapper)
+                .contains("<sql id=\"listFilterConditions\">")
+                .contains("metadata -&gt;&gt; 'documentId'")
+                .contains("metadata -&gt;&gt; 'chunkId'")
+                .contains("metadata -&gt;&gt; 'headingPath'")
+                .contains("LIMIT #{limit} OFFSET #{offset}");
     }
 
     private String mapperXml() throws Exception {

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/adapters/vector/mybatis/PgVectorMapperXmlContractTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/adapters/vector/mybatis/PgVectorMapperXmlContractTest.java
@@ -11,11 +11,7 @@ class PgVectorMapperXmlContractTest {
 
     @Test
     void objectScopedSearchCastsNullableScopeParametersForPostgres() throws Exception {
-        String mapper = new String(
-                Objects.requireNonNull(getClass().getClassLoader()
-                                .getResourceAsStream("mybatis/ai/PgVectorMapper.xml"))
-                        .readAllBytes(),
-                StandardCharsets.UTF_8);
+        String mapper = mapperXml();
 
         assertThat(mapper)
                 .contains("<select id=\"searchByObject\"")
@@ -28,5 +24,24 @@ class PgVectorMapperXmlContractTest {
                 "CAST(#{objectId,jdbcType=VARCHAR} AS varchar) IS NULL OR object_id = CAST(#{objectId,jdbcType=VARCHAR} AS varchar)"),
                 -1))
                 .hasSize(3);
+    }
+
+    @Test
+    void listByObjectSelectsNullableDistanceForSharedResultMap() throws Exception {
+        String mapper = mapperXml();
+
+        assertThat(mapper)
+                .contains("<select id=\"listByObject\" resultMap=\"PgVectorSearchRowMap\">")
+                .contains("<select id=\"listByObjectPage\" resultMap=\"PgVectorSearchRowMap\">");
+        assertThat(mapper.split(Pattern.quote("NULL::double precision AS distance"), -1))
+                .hasSize(3);
+    }
+
+    private String mapperXml() throws Exception {
+        return new String(
+                Objects.requireNonNull(getClass().getClassLoader()
+                                .getResourceAsStream("mybatis/ai/PgVectorMapper.xml"))
+                        .readAllBytes(),
+                StandardCharsets.UTF_8);
     }
 }

--- a/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/RagPipelineSkillGraphRagChunkResolver.java
+++ b/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/RagPipelineSkillGraphRagChunkResolver.java
@@ -22,13 +22,32 @@ class RagPipelineSkillGraphRagChunkResolver implements SkillGraphRagChunkResolve
                 .toList();
     }
 
+    @Override
+    public List<ResolvedRagChunk> listByObject(String objectType, String objectId, int offset, int limit) {
+        return ragPipelineService.listByObject(objectType, objectId, offset, limit).stream()
+                .map(this::toChunk)
+                .toList();
+    }
+
     private ResolvedRagChunk toChunk(RagSearchResult result) {
         Map<String, Object> metadata = result.metadata() == null ? Map.of() : result.metadata();
         String documentId = text(firstPresent(metadata, VectorRecord.KEY_DOCUMENT_ID, "documentId", "sourceDocumentId"));
         documentId = documentId == null ? result.documentId() : documentId;
         String chunkId = text(firstPresent(metadata, VectorRecord.KEY_CHUNK_ID, "chunkId"));
         chunkId = chunkId == null ? documentId : chunkId;
-        return new ResolvedRagChunk(chunkId, documentId, result.content());
+        Integer tokenCount = integer(firstPresent(metadata, VectorRecord.KEY_CHUNK_TOKEN_COUNT, "tokenCount"));
+        String warningStatus = firstPresent(metadata, VectorRecord.KEY_TOKENIZER_WARNINGS, "warnings") == null
+                ? null
+                : "WARNING";
+        return new ResolvedRagChunk(
+                chunkId,
+                documentId,
+                result.content(),
+                integer(firstPresent(metadata, VectorRecord.KEY_CHUNK_INDEX, "chunkOrder")),
+                integer(firstPresent(metadata, VectorRecord.KEY_PAGE, "page")),
+                text(firstPresent(metadata, VectorRecord.KEY_HEADING_PATH, "headingPath", "section")),
+                tokenCount,
+                warningStatus);
     }
 
     private Object firstPresent(Map<String, Object> metadata, String... keys) {
@@ -47,5 +66,20 @@ class RagPipelineSkillGraphRagChunkResolver implements SkillGraphRagChunkResolve
         }
         String text = String.valueOf(value).trim();
         return text.isEmpty() ? null : text;
+    }
+
+    private Integer integer(Object value) {
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        String text = text(value);
+        if (text == null) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(text);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
     }
 }

--- a/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/RagPipelineSkillGraphRagChunkResolver.java
+++ b/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/RagPipelineSkillGraphRagChunkResolver.java
@@ -29,6 +29,19 @@ class RagPipelineSkillGraphRagChunkResolver implements SkillGraphRagChunkResolve
                 .toList();
     }
 
+    @Override
+    public List<ResolvedRagChunk> listByObject(
+            String objectType,
+            String objectId,
+            String documentId,
+            String query,
+            int offset,
+            int limit) {
+        return ragPipelineService.listByObject(objectType, objectId, documentId, query, offset, limit).stream()
+                .map(this::toChunk)
+                .toList();
+    }
+
     private ResolvedRagChunk toChunk(RagSearchResult result) {
         Map<String, Object> metadata = result.metadata() == null ? Map.of() : result.metadata();
         String documentId = text(firstPresent(metadata, VectorRecord.KEY_DOCUMENT_ID, "documentId", "sourceDocumentId"));

--- a/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/SkillGraphAutoConfiguration.java
+++ b/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/SkillGraphAutoConfiguration.java
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 import studio.one.platform.skillgraph.application.service.SkillMatchPolicy;
 import studio.one.platform.skillgraph.application.service.DefaultSkillCandidateReviewService;
 import studio.one.platform.skillgraph.application.service.DefaultSkillDictionaryService;
-import studio.one.platform.skillgraph.application.service.DefaultSkillExtractionService;
+import studio.one.platform.skillgraph.application.service.RegexSkillCandidateExtractor;
 import studio.one.platform.skillgraph.application.service.DefaultSkillGraphService;
 import studio.one.platform.skillgraph.application.service.DefaultSkillMappingService;
 import studio.one.platform.skillgraph.application.service.DefaultSkillRecommendationService;
@@ -92,7 +92,7 @@ public class SkillGraphAutoConfiguration {
             SkillCandidateExtractor extractor,
             SkillEmbeddingPort embeddingPort,
             SkillMatchPolicy matchPolicy) {
-        return new DefaultSkillExtractionService(candidateStore, dictionaryStore, extractor, embeddingPort, matchPolicy);
+        return new RegexSkillCandidateExtractor(candidateStore, dictionaryStore, extractor, embeddingPort, matchPolicy);
     }
 
     @Bean(name = SkillCandidateReviewService.SERVICE_NAME)

--- a/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/SkillGraphWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/SkillGraphWebAutoConfiguration.java
@@ -22,6 +22,7 @@ import studio.one.platform.skillgraph.application.usecase.SkillVisualizationServ
 import studio.one.platform.skillgraph.web.controller.SkillCandidateMgmtController;
 import studio.one.platform.skillgraph.web.controller.SkillDictionaryMgmtController;
 import studio.one.platform.skillgraph.web.controller.SkillExtractionJobMgmtController;
+import studio.one.platform.skillgraph.web.controller.SkillGraphExtractionSourceMgmtController;
 import studio.one.platform.skillgraph.web.controller.SkillGraphMgmtController;
 import studio.one.platform.skillgraph.web.controller.SkillGraphSimulationMgmtController;
 import studio.one.platform.skillgraph.web.controller.SkillMappingMgmtController;
@@ -35,7 +36,11 @@ public class SkillGraphWebAutoConfiguration {
 
     @Configuration
     @ConditionalOnBean(name = SkillExtractionService.SERVICE_NAME)
-    @Import({SkillExtractionJobMgmtController.class, SkillGraphSimulationMgmtController.class})
+    @Import({
+            SkillExtractionJobMgmtController.class,
+            SkillGraphExtractionSourceMgmtController.class,
+            SkillGraphSimulationMgmtController.class
+    })
     static class SkillExtractionWebConfig {
     }
 

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorStorePort.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/core/vector/VectorStorePort.java
@@ -191,6 +191,16 @@ public interface VectorStorePort {
                 .toList();
     }
 
+    default List<VectorSearchResult> listByObject(
+            String objectType,
+            String objectId,
+            String documentId,
+            String query,
+            int offset,
+            int limit) {
+        return listByObject(objectType, objectId, offset, limit);
+    }
+
     /**
      * objectType/objectId에 대한 메타데이터를 조회한다.
      * 구현체는 필요한 경우 chunk_index 순으로 첫 번째 레코드를 사용하거나 통합 메타를 반환한다.

--- a/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineService.java
+++ b/studio-platform-ai/src/main/java/studio/one/platform/ai/service/pipeline/RagPipelineService.java
@@ -42,6 +42,16 @@ public interface RagPipelineService {
                 .toList();
     }
 
+    default List<RagSearchResult> listByObject(
+            String objectType,
+            String objectId,
+            String documentId,
+            String query,
+            int offset,
+            int limit) {
+        return listByObject(objectType, objectId, offset, limit);
+    }
+
     /**
      * Returns diagnostics for the most recent retrieval in the current thread.
      * Calling from a different thread than the one that executed search returns empty.

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/ResolvedRagChunk.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/ResolvedRagChunk.java
@@ -3,5 +3,14 @@ package studio.one.platform.skillgraph.application.result;
 public record ResolvedRagChunk(
         String chunkId,
         String documentId,
-        String content) {
+        String content,
+        Integer chunkOrder,
+        Integer page,
+        String section,
+        Integer tokenCount,
+        String warningStatus) {
+
+    public ResolvedRagChunk(String chunkId, String documentId, String content) {
+        this(chunkId, documentId, content, null, null, null, null, null);
+    }
 }

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillCandidateReviewService.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillCandidateReviewService.java
@@ -16,6 +16,37 @@ import studio.one.platform.skillgraph.domain.model.SkillDictionary;
 import studio.one.platform.skillgraph.domain.port.SkillCandidateStore;
 import studio.one.platform.skillgraph.domain.port.SkillDictionaryStore;
 
+/**
+ * * 스킬 후보 검토 유스케이스 구현체.
+ *
+ * 주요 역할:
+ * - 추출된 SkillCandidate 조회
+ * - 후보 승인/거절 처리
+ * - 기존 Skill의 alias 등록
+ * - Skill Dictionary 품질 관리
+ *
+ * 핵심 처리 흐름:
+ * 1. 검토 대상 SkillCandidate 조회
+ * 2. 승인 시:
+ * - 신규 Skill 생성 또는
+ * - 기존 Skill alias 연결
+ * 3. 검토 상태(APPROVED/REJECTED) 저장
+ * 4. Skill Dictionary 반영
+ *
+ * 이 서비스는 자동 추출 결과를 사람이 검증하는 과정에서 사용되며, Skill Graph의 품질을 높이는 데 중요한 역할을 한다.
+ *
+ * @author donghyuck, son
+ * @since 2026-05-17
+ *
+ *        <pre>
+ *
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *   수정일        수정자           수정내용
+ *  ---------    --------    ---------------------------
+ * 2026-05-17  donghyuck, son: 최초 생성.
+ *        </pre>
+ */
+
 @RequiredArgsConstructor
 public class DefaultSkillCandidateReviewService implements SkillCandidateReviewService {
 
@@ -32,8 +63,12 @@ public class DefaultSkillCandidateReviewService implements SkillCandidateReviewS
     }
 
     @Override
-    public List<SkillCandidateView> search(SkillCandidateStatus status, String q, String sourceType, String sourceId, int limit) {
-        return store.searchCandidates(status, normalizeQuery(q), normalizeSource(sourceType), normalizeSource(sourceId), normalizeLimit(limit)).stream()
+    public List<SkillCandidateView> search(SkillCandidateStatus status, String q, String sourceType, String sourceId,
+            int limit) {
+        return store
+                .searchCandidates(status, normalizeQuery(q), normalizeSource(sourceType), normalizeSource(sourceId),
+                        normalizeLimit(limit))
+                .stream()
                 .map(SkillCandidateView::from)
                 .toList();
     }
@@ -53,7 +88,8 @@ public class DefaultSkillCandidateReviewService implements SkillCandidateReviewS
                 .withStatus(command.status(), command.matchedSkillId(), command.reviewerNote(), Instant.now());
         String matchedSkillId = reflectReview(candidate);
         if (matchedSkillId != null && !matchedSkillId.equals(candidate.matchedSkillId())) {
-            candidate = candidate.withStatus(candidate.status(), matchedSkillId, candidate.reviewerNote(), Instant.now());
+            candidate = candidate.withStatus(candidate.status(), matchedSkillId, candidate.reviewerNote(),
+                    Instant.now());
         }
         return SkillCandidateView.from(store.saveCandidate(candidate));
     }

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillDictionaryService.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillDictionaryService.java
@@ -8,6 +8,36 @@ import studio.one.platform.skillgraph.application.usecase.SkillDictionaryService
 import studio.one.platform.skillgraph.domain.constants.SkillGraphLimits;
 import studio.one.platform.skillgraph.domain.port.SkillDictionaryStore;
 
+/**
+ * 스킬 사전 조회 유스케이스 구현체.
+ *
+ * 주요 역할:
+ * - Skill Dictionary 검색
+ * - Skill 상세 조회
+ * - alias 포함 검색 지원
+ * - category/taxonomy 기반 조회
+ *
+ * 핵심 처리 흐름:
+ * 1. 검색어 normalize
+ * 2. exact/alias 기준 검색
+ * 3. category/taxonomy 조건 적용
+ * 4. 결과 정렬 및 반환
+ *
+ * Skill Extraction, Recommendation, Mapping 기능의
+ * 기준 데이터 조회 계층으로 사용된다.
+ *
+ * @author donghyuck, son
+ * @since 2026-05-17
+ *
+ *        <pre>
+ *
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *   수정일        수정자           수정내용
+ *  ---------    --------    ---------------------------
+ * 2026-05-17  donghyuck, son: 최초 생성.
+ *        </pre>
+ */
+
 @RequiredArgsConstructor
 public class DefaultSkillDictionaryService implements SkillDictionaryService {
 

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillGraphService.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillGraphService.java
@@ -11,6 +11,34 @@ import studio.one.platform.skillgraph.domain.model.SkillRelation;
 import studio.one.platform.skillgraph.domain.model.SkillRelationType;
 import studio.one.platform.skillgraph.domain.port.SkillGraphStore;
 
+/**
+ * 스킬 그래프 관리 유스케이스 구현체.
+ *
+ * 주요 역할:
+ * - 스킬 간 관계 저장
+ * - 스킬 관계 조회
+ * - 그래프 탐색 지원 (향후)
+ *
+ * 핵심 처리 흐름:
+ * 1. 관계 저장 시 유효성 검증 (예: 존재하는 스킬인지)
+ * 2. 관계 유형에 따른 저장 로직 분기 (예: prerequisite, related)
+ * 3. 관계 조회 시 필터링 및 정렬 적용
+ * 4. 그래프 탐색 시 BFS/DFS 알고리즘 활용 (향후)
+ *
+ * 현재 구조는 단일 레벨의 스킬 관계 관리에 초점을 맞추고 있으며, 향후 다중 레벨 그래프 탐색 및 분석 기능이 추가될 수 있다.
+ *
+ * @author donghyuck, son
+ * @since 2026-05-17
+ *
+ *        <pre>
+ *
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *   수정일        수정자           수정내용
+ *  ---------    --------    ---------------------------
+ * 2026-05-17  donghyuck, son: 최초 생성.
+ *        </pre>
+ */
+
 @RequiredArgsConstructor
 public class DefaultSkillGraphService implements SkillGraphService {
 

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillMappingService.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillMappingService.java
@@ -13,6 +13,22 @@ import studio.one.platform.skillgraph.domain.model.CourseSkillMapping;
 import studio.one.platform.skillgraph.domain.model.NcsSkillMapping;
 import studio.one.platform.skillgraph.domain.port.SkillMappingStore;
 
+/**
+ * 스킬 매핑 관리 유스케이스 구현체.
+ *
+ * 주요 역할:
+ * - NCS 스킬 매핑 저장
+ * - 코스 스킬 매핑 저장
+ * - 스킬 매핑 조회
+ *
+ * 핵심 처리 흐름:
+ * 1. 입력 데이터 유효성 검증
+ * 2. 매핑 정보 저장
+ * 3. 저장된 매핑 정보 조회
+ *
+ * @author donghyuck, son
+ * @since 2026-05-17
+ */
 @RequiredArgsConstructor
 public class DefaultSkillMappingService implements SkillMappingService {
     private final SkillMappingStore store;

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillRecommendationService.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillRecommendationService.java
@@ -14,12 +14,30 @@ import studio.one.platform.skillgraph.domain.model.CourseRecommendation;
 import studio.one.platform.skillgraph.domain.model.CourseSkillMapping;
 import studio.one.platform.skillgraph.domain.port.SkillMappingStore;
 
+/**
+ * 스킬 기반 코스 추천 유스케이스 구현체.
+ *
+ * 주요 역할:
+ * - 사용자의 보유 스킬과 목표 스킬을 기반으로 코스 추천
+ * - 추천 결과는 매칭된 스킬과 누락된 스킬, 그리고 추천 점수로 구성
+ *
+ * 핵심 처리 흐름:
+ * 1. 입력된 목표 스킬과 보유 스킬을 정규화하여 집합으로 변환
+ * 2. 목표 스킬에서 보유한 스킬을 제외하여 누락된 스킬 집합 생성
+ * 3. 누락된 스킬을 포함하는 코스 매핑 정보를 조회하여 코스별 매칭된 스킬과 가중치 계산
+ * 4. 매칭된 스킬의 가중치 합산을 통해 코스별 추천 점수 계산
+ * 5. 추천 점수를 기준으로 코스 목록 정렬 및 제한된 수 만큼 반환
+ *
+ * @author donghyuck, son
+ * @since 2026-05-17
+ */
 @RequiredArgsConstructor
 public class DefaultSkillRecommendationService implements SkillRecommendationService {
     private final SkillMappingStore store;
 
     @Override
-    public List<CourseRecommendationView> recommendCourses(List<String> targetSkillIds, List<String> ownedSkillIds, int limit) {
+    public List<CourseRecommendationView> recommendCourses(List<String> targetSkillIds, List<String> ownedSkillIds,
+            int limit) {
         Set<String> targets = normalize(targetSkillIds);
         Set<String> owned = normalize(ownedSkillIds);
         Set<String> missing = new HashSet<>(targets);

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillTaxonomyService.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillTaxonomyService.java
@@ -9,6 +9,31 @@ import studio.one.platform.skillgraph.application.usecase.SkillTaxonomyService;
 import studio.one.platform.skillgraph.domain.model.SkillCategory;
 import studio.one.platform.skillgraph.domain.port.SkillTaxonomyStore;
 
+/**
+ * 스킬 분류 관리 유스케이스 구현체.
+ *
+ * 주요 역할:
+ * - 스킬 카테고리 저장
+ * - 스킬 카테고리 조회
+ *
+ * 핵심 처리 흐름:
+ * 1. 카테고리 저장 시 유효성 검증 (예: 이름 중복, 부모 카테고리 존재 여부)
+ * 2. 계층적 카테고리 구조 지원 (parentCategoryId 활용)
+ * 3. 카테고리 조회 시 부모-자식 관계 반영
+ *
+ * 현재 구조는 단일 레벨의 카테고리 관리에 초점을 맞추고 있으며, 향후 다중 레벨 계층 구조 및 트리 탐색 기능이 추가될 수 있다.
+ *
+ * @author donghyuck, son
+ * @since 2026-05-17
+ *
+ *        <pre>
+ *
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *   수정일        수정자           수정내용
+ *  ---------    --------    ---------------------------
+ * 2026-05-17  donghyuck, son: 최초 생성.
+ *        </pre>
+ */
 @RequiredArgsConstructor
 public class DefaultSkillTaxonomyService implements SkillTaxonomyService {
 

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillVisualizationService.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillVisualizationService.java
@@ -20,6 +20,33 @@ import studio.one.platform.skillgraph.domain.port.SkillClusterer;
 import studio.one.platform.skillgraph.domain.port.SkillDictionaryStore;
 import studio.one.platform.skillgraph.domain.port.SkillProjectionStore;
 
+/**
+ * 스킬 시각화 유스케이스 구현체.
+ *
+ * 주요 역할:
+ * - 스킬 벡터 데이터를 2D 공간에 투영
+ * - 투영된 데이터 클러스터링
+ * - 시각화 결과 제공
+ *
+ * 핵심 처리 흐름:
+ * 1. Skill Dictionary에서 벡터 아이템 조회
+ * 2. UMAP 기반 2D 투영 생성
+ * 3. 투영 결과 클러스터링
+ * 4. Projection/Cluster 저장 및 반환
+ *
+ * 현재 구조는 단일 projectionId에 대해 전체 스킬을 투영하는 방식이지만, 향후 사용자별 맞춤 투영, 실시간 업데이트, 다양한 projection 알고리즘 지원 등으로 확장 가능하다.
+ *
+ * @author donghyuck, son
+ * @since 2026-05-17
+ *
+ *        <pre>
+ *
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *   수정일        수정자           수정내용
+ *  ---------    --------    ---------------------------
+ * 2026-05-17  donghyuck, son: 최초 생성.
+ *        </pre>
+ */
 @RequiredArgsConstructor
 public class DefaultSkillVisualizationService implements SkillVisualizationService {
 

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/RegexSkillCandidateExtractor.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/RegexSkillCandidateExtractor.java
@@ -22,7 +22,56 @@ import studio.one.platform.skillgraph.domain.port.SkillDictionaryStore;
 import studio.one.platform.skillgraph.domain.port.SkillEmbeddingPort;
 import studio.one.platform.skillgraph.domain.port.NoOpSkillEmbeddingPort;
 
-public class DefaultSkillExtractionService implements SkillExtractionService {
+/**
+ * 텍스트 기반 스킬 추출 유스케이스 구현체.
+ *
+ *
+ *
+ * 주요 역할:
+ *
+ * - 입력 텍스트에서 스킬 후보 추출
+ *
+ * - Skill Dictionary 매칭
+ *
+ * - embedding 기반 유사 스킬 탐색
+ *
+ * - SkillCandidate 저장
+ *
+ *
+ *
+ * 핵심 처리 흐름:
+ *
+ * 1. 입력 텍스트 검증
+ * 2. source chunk 저장
+ * 3. SkillCandidateExtractor 실행
+ * 4. 용어 normalize
+ * 5. exact/alias 매칭 시도
+ * 6. 실패 시 embedding 유사도 검색
+ * 7. SkillCandidate 생성 또는 기존 후보 갱신
+
+ *
+ * 현재 구조는 패턴 기반 후보 추출에 의존하므로 단순 기술 키워드 수준 결과가 발생할 수 있다.
+ *
+ * 향후 개선 방향:
+ * - Token-aware chunking
+ * - semantic chunking
+ * - LLM structured extraction
+ * - canonical skill generation
+ * - evidence 기반 confidence scoring
+ *
+ * @author donghyuck, son
+ * @since 2026-05-17
+ *
+ *        <pre>
+ *
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *   수정일        수정자           수정내용
+ *  ---------    --------    ---------------------------
+ * 2026-05-17  donghyuck, son: 최초 생성.
+ *        </pre>
+ */
+
+public class RegexSkillCandidateExtractor implements SkillExtractionService {
 
     private final SkillCandidateStore store;
     private final SkillDictionaryStore dictionaryStore;
@@ -30,11 +79,11 @@ public class DefaultSkillExtractionService implements SkillExtractionService {
     private final SkillEmbeddingPort embeddingPort;
     private final SkillMatchPolicy matchPolicy;
 
-    public DefaultSkillExtractionService(SkillCandidateStore store, SkillCandidateExtractor extractor) {
+    public RegexSkillCandidateExtractor(SkillCandidateStore store, SkillCandidateExtractor extractor) {
         this(store, null, extractor, new NoOpSkillEmbeddingPort(), SkillMatchPolicy.defaults());
     }
 
-    public DefaultSkillExtractionService(
+    public RegexSkillCandidateExtractor(
             SkillCandidateStore store,
             SkillDictionaryStore dictionaryStore,
             SkillCandidateExtractor extractor,

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/SkillMatchPolicy.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/SkillMatchPolicy.java
@@ -1,5 +1,8 @@
 package studio.one.platform.skillgraph.application.service;
 
+/**
+ * 스킬 매칭 정책을 정의하는 레코드.
+ */
 public record SkillMatchPolicy(
         double matchThreshold,
         double aliasThreshold) {

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/usecase/SkillGraphRagChunkResolver.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/usecase/SkillGraphRagChunkResolver.java
@@ -1,6 +1,7 @@
 package studio.one.platform.skillgraph.application.usecase;
 
 import java.util.List;
+import java.util.Locale;
 
 import studio.one.platform.skillgraph.application.result.ResolvedRagChunk;
 
@@ -17,5 +18,32 @@ public interface SkillGraphRagChunkResolver {
                 .skip(safeOffset)
                 .limit(safeLimit)
                 .toList();
+    }
+
+    default List<ResolvedRagChunk> listByObject(
+            String objectType,
+            String objectId,
+            String documentId,
+            String query,
+            int offset,
+            int limit) {
+        int safeOffset = Math.max(0, offset);
+        int safeLimit = limit <= 0 ? 50 : limit;
+        return listByObject(objectType, objectId, safeOffset, safeLimit).stream()
+                .filter(chunk -> documentId == null || documentId.equals(chunk.documentId()))
+                .filter(chunk -> matchesQuery(chunk, query))
+                .toList();
+    }
+
+    private static boolean matchesQuery(ResolvedRagChunk chunk, String query) {
+        if (query == null || query.isBlank()) {
+            return true;
+        }
+        String normalizedQuery = query.toLowerCase(Locale.ROOT);
+        String haystack = (String.valueOf(chunk.chunkId()) + " "
+                + String.valueOf(chunk.documentId()) + " "
+                + String.valueOf(chunk.section()) + " "
+                + String.valueOf(chunk.content())).toLowerCase(Locale.ROOT);
+        return haystack.contains(normalizedQuery);
     }
 }

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/usecase/SkillGraphRagChunkResolver.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/usecase/SkillGraphRagChunkResolver.java
@@ -7,4 +7,15 @@ import studio.one.platform.skillgraph.application.result.ResolvedRagChunk;
 public interface SkillGraphRagChunkResolver {
 
     List<ResolvedRagChunk> listByObject(String objectType, String objectId, int limit);
+
+    default List<ResolvedRagChunk> listByObject(String objectType, String objectId, int offset, int limit) {
+        int safeOffset = Math.max(0, offset);
+        int safeLimit = limit <= 0 ? 50 : limit;
+        long requested = (long) safeOffset + safeLimit;
+        int fetchLimit = requested > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) requested;
+        return listByObject(objectType, objectId, fetchLimit).stream()
+                .skip(safeOffset)
+                .limit(safeLimit)
+                .toList();
+    }
 }

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillExtractionJobMgmtController.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillExtractionJobMgmtController.java
@@ -27,6 +27,7 @@ import studio.one.platform.skillgraph.application.result.SkillExtractionResult;
 import studio.one.platform.skillgraph.application.usecase.SkillExtractionService;
 import studio.one.platform.skillgraph.application.usecase.SkillGraphRagChunkResolver;
 import studio.one.platform.skillgraph.web.dto.request.SkillExtractionRequest;
+import studio.one.platform.skillgraph.web.dto.request.SkillRagExtractionRequest;
 import studio.one.platform.skillgraph.web.dto.request.SkillRagChunkExtractionRequest;
 import studio.one.platform.skillgraph.web.dto.request.SkillRagDocumentExtractionRequest;
 import studio.one.platform.skillgraph.web.dto.response.SkillExtractionResponse;
@@ -121,6 +122,35 @@ public class SkillExtractionJobMgmtController {
             response = withMissingChunks(response, requestedChunkIds, byChunkId);
         }
         return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @PostMapping("/rag")
+    @PreAuthorize("@endpointAuthz.can('features:skillgraph','manage') "
+            + "and @endpointAuthz.can('services:ai_rag','read') "
+            + "and (@endpointAuthz.can('objects:' + #request.objectType().trim() + ':' + #request.objectId().trim(),'read') "
+            + "or @endpointAuthz.can('objects:' + #request.objectType().trim(),'read'))")
+    public ResponseEntity<ApiResponse<SkillRagBatchExtractionResponse>> extractRag(
+            @Valid @RequestBody SkillRagExtractionRequest request) {
+        String mode = normalize(request.mode());
+        if (mode == null || "ALL_CHUNKS".equalsIgnoreCase(mode)) {
+            return extractRagDocument(new SkillRagDocumentExtractionRequest(
+                    request.objectType(),
+                    request.objectId(),
+                    request.documentId(),
+                    "ALL_CHUNKS",
+                    request.limit()));
+        }
+        if ("SELECTED_CHUNKS".equalsIgnoreCase(mode)) {
+            if (request.chunkIds() == null || request.chunkIds().isEmpty()) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "chunkIds are required for SELECTED_CHUNKS");
+            }
+            return extractRagChunks(new SkillRagChunkExtractionRequest(
+                    request.objectType(),
+                    request.objectId(),
+                    request.documentId(),
+                    request.chunkIds()));
+        }
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unsupported RAG extraction mode");
     }
 
     private SkillRagBatchExtractionResponse extractChunks(

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillGraphExtractionSourceMgmtController.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillGraphExtractionSourceMgmtController.java
@@ -1,7 +1,6 @@
 package studio.one.platform.skillgraph.web.controller;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 
 import org.springframework.beans.factory.ObjectProvider;
@@ -28,7 +27,6 @@ public class SkillGraphExtractionSourceMgmtController {
 
     private static final int DEFAULT_LIMIT = 50;
     private static final int MAX_LIMIT = 200;
-    private static final int MAX_FILTER_FETCH_LIMIT = 5000;
     private static final int PREVIEW_LENGTH = 240;
 
     private final ObjectProvider<SkillGraphRagChunkResolver> ragChunkResolverProvider;
@@ -62,17 +60,17 @@ public class SkillGraphExtractionSourceMgmtController {
         Integer total = null;
         boolean hasMore;
         if (query != null || normalizedDocumentId != null) {
-            filtered = resolver.listByObject(normalizedObjectType, normalizedObjectId, MAX_FILTER_FETCH_LIMIT).stream()
-                    .filter(chunk -> matchesDocument(chunk, normalizedDocumentId))
-                    .filter(chunk -> matchesQuery(chunk, query))
+            List<ResolvedRagChunk> fetched = resolver.listByObject(
+                    normalizedObjectType,
+                    normalizedObjectId,
+                    normalizedDocumentId,
+                    query,
+                    boundedOffset,
+                    boundedLimit + 1).stream()
                     .sorted((left, right) -> compare(left, right, sort))
                     .toList();
-            total = filtered.size();
-            hasMore = boundedOffset + boundedLimit < filtered.size();
-            filtered = filtered.stream()
-                    .skip(boundedOffset)
-                    .limit(boundedLimit)
-                    .toList();
+            hasMore = fetched.size() > boundedLimit;
+            filtered = hasMore ? fetched.subList(0, boundedLimit) : fetched;
         } else {
             List<ResolvedRagChunk> fetched = resolver.listByObject(
                     normalizedObjectType,
@@ -119,21 +117,6 @@ public class SkillGraphExtractionSourceMgmtController {
                 chunk.tokenCount(),
                 content.length(),
                 chunk.warningStatus());
-    }
-
-    private boolean matchesDocument(ResolvedRagChunk chunk, String documentId) {
-        return documentId == null || documentId.equals(chunk.documentId());
-    }
-
-    private boolean matchesQuery(ResolvedRagChunk chunk, String q) {
-        if (q == null) {
-            return true;
-        }
-        String haystack = (String.valueOf(chunk.chunkId()) + " "
-                + String.valueOf(chunk.documentId()) + " "
-                + String.valueOf(chunk.section()) + " "
-                + String.valueOf(chunk.content())).toLowerCase(Locale.ROOT);
-        return haystack.contains(q.toLowerCase(Locale.ROOT));
     }
 
     private int compare(ResolvedRagChunk left, ResolvedRagChunk right, String sort) {

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillGraphExtractionSourceMgmtController.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillGraphExtractionSourceMgmtController.java
@@ -1,0 +1,171 @@
+package studio.one.platform.skillgraph.web.controller;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import studio.one.platform.skillgraph.application.result.ResolvedRagChunk;
+import studio.one.platform.skillgraph.application.usecase.SkillGraphRagChunkResolver;
+import studio.one.platform.skillgraph.web.dto.response.SkillRagChunkPageResponse;
+import studio.one.platform.skillgraph.web.dto.response.SkillRagChunkPreviewDto;
+import studio.one.platform.web.dto.ApiResponse;
+
+@RestController
+@RequestMapping("${studio.features.skillgraph.web.extraction-source-base-path:/api/mgmt/skillgraph/extraction-sources}")
+@Validated
+public class SkillGraphExtractionSourceMgmtController {
+
+    private static final int DEFAULT_LIMIT = 50;
+    private static final int MAX_LIMIT = 200;
+    private static final int MAX_FILTER_FETCH_LIMIT = 5000;
+    private static final int PREVIEW_LENGTH = 240;
+
+    private final ObjectProvider<SkillGraphRagChunkResolver> ragChunkResolverProvider;
+
+    public SkillGraphExtractionSourceMgmtController(
+            ObjectProvider<SkillGraphRagChunkResolver> ragChunkResolverProvider) {
+        this.ragChunkResolverProvider = Objects.requireNonNull(ragChunkResolverProvider, "ragChunkResolverProvider");
+    }
+
+    @GetMapping("/rag/chunks")
+    @PreAuthorize("@endpointAuthz.can('features:skillgraph','read') "
+            + "and @endpointAuthz.can('services:ai_rag','read') "
+            + "and (@endpointAuthz.can('objects:' + #objectType.trim() + ':' + #objectId.trim(),'read') "
+            + "or @endpointAuthz.can('objects:' + #objectType.trim(),'read'))")
+    public ResponseEntity<ApiResponse<SkillRagChunkPageResponse>> ragChunks(
+            @RequestParam("objectType") String objectType,
+            @RequestParam("objectId") String objectId,
+            @RequestParam(name = "documentId", required = false) String documentId,
+            @RequestParam(name = "q", required = false) String q,
+            @RequestParam(name = "offset", required = false, defaultValue = "0") int offset,
+            @RequestParam(name = "limit", required = false, defaultValue = "50") int limit,
+            @RequestParam(name = "sort", required = false) String sort) {
+        SkillGraphRagChunkResolver resolver = requireResolver();
+        String normalizedObjectType = required(objectType, "objectType");
+        String normalizedObjectId = required(objectId, "objectId");
+        String normalizedDocumentId = normalize(documentId);
+        String query = normalize(q);
+        int boundedOffset = Math.max(0, offset);
+        int boundedLimit = boundedLimit(limit);
+        List<ResolvedRagChunk> filtered;
+        Integer total = null;
+        boolean hasMore;
+        if (query != null || normalizedDocumentId != null) {
+            filtered = resolver.listByObject(normalizedObjectType, normalizedObjectId, MAX_FILTER_FETCH_LIMIT).stream()
+                    .filter(chunk -> matchesDocument(chunk, normalizedDocumentId))
+                    .filter(chunk -> matchesQuery(chunk, query))
+                    .sorted((left, right) -> compare(left, right, sort))
+                    .toList();
+            total = filtered.size();
+            hasMore = boundedOffset + boundedLimit < filtered.size();
+            filtered = filtered.stream()
+                    .skip(boundedOffset)
+                    .limit(boundedLimit)
+                    .toList();
+        } else {
+            List<ResolvedRagChunk> fetched = resolver.listByObject(
+                    normalizedObjectType,
+                    normalizedObjectId,
+                    boundedOffset,
+                    boundedLimit + 1).stream()
+                    .sorted((left, right) -> compare(left, right, sort))
+                    .toList();
+            hasMore = fetched.size() > boundedLimit;
+            filtered = hasMore ? fetched.subList(0, boundedLimit) : fetched;
+        }
+        if (boundedOffset == 0 && filtered.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "RAG chunks not found");
+        }
+        List<SkillRagChunkPreviewDto> items = filtered.stream()
+                .map(this::toPreview)
+                .toList();
+        return ResponseEntity.ok(ApiResponse.ok(new SkillRagChunkPageResponse(
+                items,
+                boundedOffset,
+                boundedLimit,
+                items.size(),
+                total,
+                hasMore)));
+    }
+
+    private SkillGraphRagChunkResolver requireResolver() {
+        SkillGraphRagChunkResolver resolver = ragChunkResolverProvider.getIfAvailable();
+        if (resolver == null) {
+            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "RAG chunk resolver is not configured");
+        }
+        return resolver;
+    }
+
+    private SkillRagChunkPreviewDto toPreview(ResolvedRagChunk chunk) {
+        String content = chunk.content() == null ? "" : chunk.content();
+        return new SkillRagChunkPreviewDto(
+                chunk.chunkId(),
+                chunk.documentId(),
+                chunk.chunkOrder(),
+                chunk.page(),
+                chunk.section(),
+                preview(content),
+                chunk.tokenCount(),
+                content.length(),
+                chunk.warningStatus());
+    }
+
+    private boolean matchesDocument(ResolvedRagChunk chunk, String documentId) {
+        return documentId == null || documentId.equals(chunk.documentId());
+    }
+
+    private boolean matchesQuery(ResolvedRagChunk chunk, String q) {
+        if (q == null) {
+            return true;
+        }
+        String haystack = (String.valueOf(chunk.chunkId()) + " "
+                + String.valueOf(chunk.documentId()) + " "
+                + String.valueOf(chunk.section()) + " "
+                + String.valueOf(chunk.content())).toLowerCase(Locale.ROOT);
+        return haystack.contains(q.toLowerCase(Locale.ROOT));
+    }
+
+    private int compare(ResolvedRagChunk left, ResolvedRagChunk right, String sort) {
+        if ("chunkOrderDesc".equalsIgnoreCase(sort)) {
+            return Integer.compare(order(right), order(left));
+        }
+        return Integer.compare(order(left), order(right));
+    }
+
+    private int order(ResolvedRagChunk chunk) {
+        return chunk.chunkOrder() == null ? Integer.MAX_VALUE : chunk.chunkOrder();
+    }
+
+    private int boundedLimit(int limit) {
+        int requested = limit <= 0 ? DEFAULT_LIMIT : limit;
+        return Math.min(requested, MAX_LIMIT);
+    }
+
+    private String preview(String content) {
+        String normalized = content.replaceAll("\\s+", " ").trim();
+        return normalized.length() <= PREVIEW_LENGTH ? normalized : normalized.substring(0, PREVIEW_LENGTH);
+    }
+
+    private String required(String value, String field) {
+        String normalized = normalize(value);
+        if (normalized == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, field + " is required");
+        }
+        return normalized;
+    }
+
+    private String normalize(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/request/SkillRagExtractionRequest.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/request/SkillRagExtractionRequest.java
@@ -1,0 +1,19 @@
+package studio.one.platform.skillgraph.web.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SkillRagExtractionRequest(
+        @Size(max = 100)
+        @NotBlank String objectType,
+        @Size(max = 200)
+        @NotBlank String objectId,
+        @Size(max = 200)
+        String documentId,
+        String mode,
+        @Size(max = 500)
+        List<@NotBlank @Size(max = 200) String> chunkIds,
+        Integer limit) {
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/response/SkillRagChunkPageResponse.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/response/SkillRagChunkPageResponse.java
@@ -1,0 +1,12 @@
+package studio.one.platform.skillgraph.web.dto.response;
+
+import java.util.List;
+
+public record SkillRagChunkPageResponse(
+        List<SkillRagChunkPreviewDto> items,
+        int offset,
+        int limit,
+        int returned,
+        Integer total,
+        boolean hasMore) {
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/response/SkillRagChunkPreviewDto.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/response/SkillRagChunkPreviewDto.java
@@ -1,0 +1,13 @@
+package studio.one.platform.skillgraph.web.dto.response;
+
+public record SkillRagChunkPreviewDto(
+        String chunkId,
+        String documentId,
+        Integer chunkOrder,
+        Integer page,
+        String section,
+        String textPreview,
+        Integer tokenCount,
+        int textLength,
+        String warningStatus) {
+}

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/DefaultSkillExtractionServiceTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/DefaultSkillExtractionServiceTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import studio.one.platform.skillgraph.application.command.SkillCandidateReviewCommand;
 import studio.one.platform.skillgraph.application.command.SkillExtractionCommand;
 import studio.one.platform.skillgraph.application.service.DefaultSkillCandidateReviewService;
-import studio.one.platform.skillgraph.application.service.DefaultSkillExtractionService;
+import studio.one.platform.skillgraph.application.service.RegexSkillCandidateExtractor;
 import studio.one.platform.skillgraph.application.service.SkillMatchPolicy;
 import studio.one.platform.skillgraph.domain.model.SkillAlias;
 import studio.one.platform.skillgraph.domain.model.SkillCandidateStatus;
@@ -26,7 +26,7 @@ class DefaultSkillExtractionServiceTest {
     @Test
     void extractsAndStoresCandidatesFromText() {
         InMemorySkillCandidateStore store = new InMemorySkillCandidateStore();
-        DefaultSkillExtractionService service = new DefaultSkillExtractionService(store, new PatternSkillCandidateExtractor());
+        RegexSkillCandidateExtractor service = new RegexSkillCandidateExtractor(store, new PatternSkillCandidateExtractor());
 
         var result = service.extract(new SkillExtractionCommand("course", "course-1", "chunk-1",
                 "Spring Boot와 OAuth2 인증 기술"));
@@ -38,7 +38,7 @@ class DefaultSkillExtractionServiceTest {
     @Test
     void dryRunExtractsCandidatesWithoutStoringSourceChunkOrCandidate() {
         InMemorySkillCandidateStore store = new InMemorySkillCandidateStore();
-        DefaultSkillExtractionService service = new DefaultSkillExtractionService(store, new PatternSkillCandidateExtractor());
+        RegexSkillCandidateExtractor service = new RegexSkillCandidateExtractor(store, new PatternSkillCandidateExtractor());
 
         var result = service.dryRun(new SkillExtractionCommand("simulation", "sample", "chunk-1",
                 "Spring Security와 JPA 기술"));
@@ -59,7 +59,7 @@ class DefaultSkillExtractionServiceTest {
         InMemorySkillDictionaryStore dictionaryStore = new InMemorySkillDictionaryStore();
         dictionaryStore.save(new SkillDictionary("skill-1", "Spring Boot", "spring boot", null, "ACTIVE",
                 Instant.now(), Instant.now()));
-        DefaultSkillExtractionService service = new DefaultSkillExtractionService(candidateStore, dictionaryStore,
+        RegexSkillCandidateExtractor service = new RegexSkillCandidateExtractor(candidateStore, dictionaryStore,
                 new PatternSkillCandidateExtractor(), text -> List.of(), SkillMatchPolicy.defaults());
 
         var result = service.dryRun(new SkillExtractionCommand("simulation", "sample", null, "Spring Boot"));
@@ -72,7 +72,7 @@ class DefaultSkillExtractionServiceTest {
     @Test
     void reviewUpdatesCandidateStatus() {
         InMemorySkillCandidateStore store = new InMemorySkillCandidateStore();
-        DefaultSkillExtractionService extractionService = new DefaultSkillExtractionService(store,
+        RegexSkillCandidateExtractor extractionService = new RegexSkillCandidateExtractor(store,
                 new PatternSkillCandidateExtractor());
         DefaultSkillCandidateReviewService reviewService = new DefaultSkillCandidateReviewService(store);
         var result = extractionService.extract(new SkillExtractionCommand("course", "course-1", "chunk-1", "JWT 기술"));
@@ -88,7 +88,7 @@ class DefaultSkillExtractionServiceTest {
     @Test
     void duplicateNormalizedTermIncrementsOccurrenceWithinSameSourceChunk() {
         InMemorySkillCandidateStore store = new InMemorySkillCandidateStore();
-        DefaultSkillExtractionService service = new DefaultSkillExtractionService(store, new PatternSkillCandidateExtractor());
+        RegexSkillCandidateExtractor service = new RegexSkillCandidateExtractor(store, new PatternSkillCandidateExtractor());
 
         service.extract(new SkillExtractionCommand("course", "course-1", "chunk-1", "Spring Boot"));
         service.extract(new SkillExtractionCommand("course", "course-1", "chunk-2", "Spring Boot"));
@@ -102,7 +102,7 @@ class DefaultSkillExtractionServiceTest {
     @Test
     void duplicateNormalizedTermIncrementsOccurrenceWithinSameChunk() {
         InMemorySkillCandidateStore store = new InMemorySkillCandidateStore();
-        DefaultSkillExtractionService service = new DefaultSkillExtractionService(store, new PatternSkillCandidateExtractor());
+        RegexSkillCandidateExtractor service = new RegexSkillCandidateExtractor(store, new PatternSkillCandidateExtractor());
 
         service.extract(new SkillExtractionCommand("course", "course-1", "chunk-1", "Kubernetes"));
         service.extract(new SkillExtractionCommand("course", "course-1", "chunk-1", "Kubernetes"));
@@ -115,7 +115,7 @@ class DefaultSkillExtractionServiceTest {
     @Test
     void rejectsOversizedExtractionText() {
         InMemorySkillCandidateStore store = new InMemorySkillCandidateStore();
-        DefaultSkillExtractionService service = new DefaultSkillExtractionService(store, new PatternSkillCandidateExtractor());
+        RegexSkillCandidateExtractor service = new RegexSkillCandidateExtractor(store, new PatternSkillCandidateExtractor());
 
         assertThrows(IllegalArgumentException.class,
                 () -> service.extract(new SkillExtractionCommand("course", "course-1", "chunk-1", "x".repeat(200_001))));
@@ -127,7 +127,7 @@ class DefaultSkillExtractionServiceTest {
         InMemorySkillDictionaryStore dictionaryStore = new InMemorySkillDictionaryStore();
         dictionaryStore.save(new SkillDictionary("skill-1", "Spring Boot", "spring boot", null, "ACTIVE",
                 Instant.now(), Instant.now()));
-        DefaultSkillExtractionService service = new DefaultSkillExtractionService(candidateStore, dictionaryStore,
+        RegexSkillCandidateExtractor service = new RegexSkillCandidateExtractor(candidateStore, dictionaryStore,
                 new PatternSkillCandidateExtractor(), text -> List.of(), SkillMatchPolicy.defaults());
 
         var result = service.extract(new SkillExtractionCommand("course", "course-1", "chunk-1", "Spring Boot"));
@@ -143,7 +143,7 @@ class DefaultSkillExtractionServiceTest {
         dictionaryStore.save(new SkillDictionary("skill-1", "Spring Boot", "spring boot", null, "ACTIVE",
                 Instant.now(), Instant.now()));
         dictionaryStore.saveAlias(new SkillAlias("alias-1", "skill-1", "스프링부트", "스프링부트"));
-        DefaultSkillExtractionService service = new DefaultSkillExtractionService(candidateStore, dictionaryStore,
+        RegexSkillCandidateExtractor service = new RegexSkillCandidateExtractor(candidateStore, dictionaryStore,
                 new PatternSkillCandidateExtractor(), text -> List.of(), SkillMatchPolicy.defaults());
 
         var result = service.extract(new SkillExtractionCommand("course", "course-1", "chunk-1", "스프링부트 기술"));
@@ -158,7 +158,7 @@ class DefaultSkillExtractionServiceTest {
         InMemorySkillDictionaryStore dictionaryStore = new InMemorySkillDictionaryStore();
         dictionaryStore.save(new SkillDictionary("skill-1", "Spring Boot", "spring boot", null, "ACTIVE",
                 Instant.now(), Instant.now()), List.of(1.0d, 0.0d));
-        DefaultSkillExtractionService service = new DefaultSkillExtractionService(candidateStore, dictionaryStore,
+        RegexSkillCandidateExtractor service = new RegexSkillCandidateExtractor(candidateStore, dictionaryStore,
                 new PatternSkillCandidateExtractor(), text -> List.of(0.9d, 0.4d),
                 new SkillMatchPolicy(0.98d, 0.80d));
 
@@ -172,7 +172,7 @@ class DefaultSkillExtractionServiceTest {
     void approvingNewCandidateAddsDictionaryEntry() {
         InMemorySkillCandidateStore candidateStore = new InMemorySkillCandidateStore();
         InMemorySkillDictionaryStore dictionaryStore = new InMemorySkillDictionaryStore();
-        DefaultSkillExtractionService extractionService = new DefaultSkillExtractionService(candidateStore,
+        RegexSkillCandidateExtractor extractionService = new RegexSkillCandidateExtractor(candidateStore,
                 dictionaryStore, new PatternSkillCandidateExtractor(), text -> List.of(), SkillMatchPolicy.defaults());
         DefaultSkillCandidateReviewService reviewService = new DefaultSkillCandidateReviewService(candidateStore,
                 dictionaryStore);
@@ -191,7 +191,7 @@ class DefaultSkillExtractionServiceTest {
         InMemorySkillDictionaryStore dictionaryStore = new InMemorySkillDictionaryStore();
         dictionaryStore.save(new SkillDictionary("skill-1", "Spring Boot", "spring boot", null, "ACTIVE",
                 Instant.now(), Instant.now()));
-        DefaultSkillExtractionService extractionService = new DefaultSkillExtractionService(candidateStore,
+        RegexSkillCandidateExtractor extractionService = new RegexSkillCandidateExtractor(candidateStore,
                 dictionaryStore, new PatternSkillCandidateExtractor(), text -> List.of(), SkillMatchPolicy.defaults());
         DefaultSkillCandidateReviewService reviewService = new DefaultSkillCandidateReviewService(candidateStore,
                 dictionaryStore);

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/SkillExtractionJobMgmtControllerTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/SkillExtractionJobMgmtControllerTest.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.support.StaticListableBeanFactory;
 import studio.one.platform.skillgraph.application.command.SkillExtractionCommand;
 import studio.one.platform.skillgraph.application.result.ResolvedRagChunk;
 import studio.one.platform.skillgraph.application.result.SkillExtractionResult;
-import studio.one.platform.skillgraph.application.service.DefaultSkillExtractionService;
+import studio.one.platform.skillgraph.application.service.RegexSkillCandidateExtractor;
 import studio.one.platform.skillgraph.application.usecase.SkillExtractionService;
 import studio.one.platform.skillgraph.application.usecase.SkillGraphRagChunkResolver;
 import studio.one.platform.skillgraph.infrastructure.extraction.PatternSkillCandidateExtractor;
@@ -116,7 +116,7 @@ class SkillExtractionJobMgmtControllerTest {
     private SkillExtractionJobMgmtController controller(
             InMemorySkillCandidateStore store,
             SkillGraphRagChunkResolver resolver) {
-        DefaultSkillExtractionService extractionService = new DefaultSkillExtractionService(store,
+        RegexSkillCandidateExtractor extractionService = new RegexSkillCandidateExtractor(store,
                 new PatternSkillCandidateExtractor());
         return new SkillExtractionJobMgmtController(
                 extractionService,

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/SkillExtractionJobMgmtControllerTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/SkillExtractionJobMgmtControllerTest.java
@@ -17,6 +17,7 @@ import studio.one.platform.skillgraph.application.usecase.SkillGraphRagChunkReso
 import studio.one.platform.skillgraph.infrastructure.extraction.PatternSkillCandidateExtractor;
 import studio.one.platform.skillgraph.infrastructure.persistence.memory.InMemorySkillCandidateStore;
 import studio.one.platform.skillgraph.web.controller.SkillExtractionJobMgmtController;
+import studio.one.platform.skillgraph.web.dto.request.SkillRagExtractionRequest;
 import studio.one.platform.skillgraph.web.dto.request.SkillRagChunkExtractionRequest;
 import studio.one.platform.skillgraph.web.dto.request.SkillRagDocumentExtractionRequest;
 
@@ -54,6 +55,39 @@ class SkillExtractionJobMgmtControllerTest {
         assertEquals(1, response.succeededChunks());
         assertEquals(1, response.failedChunks());
         assertEquals("NOT_FOUND", response.items().get(1).status());
+    }
+
+    @Test
+    void extractsSelectedRagChunksThroughUnifiedRagEndpoint() {
+        InMemorySkillCandidateStore store = new InMemorySkillCandidateStore();
+        SkillExtractionJobMgmtController controller = controller(store, new FakeRagChunkResolver(List.of(
+                ragChunk("doc-1", "chunk-1", "Spring Boot 기술"))));
+
+        var response = controller.extractRag(new SkillRagExtractionRequest(
+                "attachment",
+                "42",
+                "doc-1",
+                "SELECTED_CHUNKS",
+                List.of("chunk-1"),
+                null)).getBody().getData();
+
+        assertEquals(1, response.succeededChunks());
+        assertEquals("chunk-1", store.sourceChunks().get(0).chunkId());
+    }
+
+    @Test
+    void rejectsUnifiedRagEndpointWithoutSelectedChunkIds() {
+        InMemorySkillCandidateStore store = new InMemorySkillCandidateStore();
+        SkillExtractionJobMgmtController controller = controller(store, new FakeRagChunkResolver(List.of(
+                ragChunk("doc-1", "chunk-1", "Spring Boot 기술"))));
+
+        assertThrows(RuntimeException.class, () -> controller.extractRag(new SkillRagExtractionRequest(
+                "attachment",
+                "42",
+                "doc-1",
+                "SELECTED_CHUNKS",
+                null,
+                null)));
     }
 
     @Test

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/SkillGraphExtractionSourceMgmtControllerTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/SkillGraphExtractionSourceMgmtControllerTest.java
@@ -1,0 +1,107 @@
+package studio.one.platform.skillgraph;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.support.StaticListableBeanFactory;
+
+import studio.one.platform.skillgraph.application.result.ResolvedRagChunk;
+import studio.one.platform.skillgraph.application.usecase.SkillGraphRagChunkResolver;
+import studio.one.platform.skillgraph.web.controller.SkillGraphExtractionSourceMgmtController;
+
+class SkillGraphExtractionSourceMgmtControllerTest {
+
+    @Test
+    void pagesRagChunksForSkillGraphPreview() {
+        String longContent = "Spring Boot ".repeat(40);
+        SkillGraphExtractionSourceMgmtController controller = controller(List.of(
+                chunk("doc-1", "chunk-1", longContent, 0),
+                chunk("doc-1", "chunk-2", "JPA content", 1),
+                chunk("doc-1", "chunk-3", "Security content", 2)));
+
+        var page = controller.ragChunks("attachment", "42", null, null, 1, 1, null)
+                .getBody()
+                .getData();
+
+        assertEquals(1, page.offset());
+        assertEquals(1, page.limit());
+        assertEquals(1, page.returned());
+        assertTrue(page.hasMore());
+        assertEquals(null, page.total());
+        assertEquals("chunk-2", page.items().get(0).chunkId());
+        assertEquals("JPA content", page.items().get(0).textPreview());
+
+        var firstPage = controller.ragChunks("attachment", "42", null, null, 0, 1, null)
+                .getBody()
+                .getData();
+
+        assertTrue(firstPage.items().get(0).textPreview().length() < longContent.length());
+        assertEquals(longContent.length(), firstPage.items().get(0).textLength());
+    }
+
+    @Test
+    void filtersRagChunkPreviewByQueryAndDocument() {
+        SkillGraphExtractionSourceMgmtController controller = controller(List.of(
+                chunk("doc-1", "chunk-1", "Spring Boot content", 0),
+                chunk("doc-2", "chunk-2", "JPA content", 1),
+                chunk("doc-2", "chunk-3", "Security content", 2)));
+
+        var page = controller.ragChunks("attachment", "42", "doc-2", "security", 0, 10, null)
+                .getBody()
+                .getData();
+
+        assertEquals(1, page.total());
+        assertFalse(page.hasMore());
+        assertEquals("chunk-3", page.items().get(0).chunkId());
+        assertEquals("WARNING", page.items().get(0).warningStatus());
+    }
+
+    @Test
+    void rejectsRagChunkPreviewWhenResolverIsUnavailable() {
+        StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
+        SkillGraphExtractionSourceMgmtController controller = new SkillGraphExtractionSourceMgmtController(
+                beanFactory.getBeanProvider(SkillGraphRagChunkResolver.class));
+
+        assertThrows(RuntimeException.class, () -> controller.ragChunks(
+                "attachment", "42", null, null, 0, 10, null));
+    }
+
+    private SkillGraphExtractionSourceMgmtController controller(List<ResolvedRagChunk> chunks) {
+        StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
+        beanFactory.addBean("skillGraphRagChunkResolver", new FakeRagChunkResolver(chunks));
+        return new SkillGraphExtractionSourceMgmtController(
+                beanFactory.getBeanProvider(SkillGraphRagChunkResolver.class));
+    }
+
+    private static ResolvedRagChunk chunk(String documentId, String chunkId, String content, int order) {
+        String warningStatus = "chunk-3".equals(chunkId) ? "WARNING" : null;
+        return new ResolvedRagChunk(chunkId, documentId, content, order, order + 1, "Section", 10, warningStatus);
+    }
+
+    private static final class FakeRagChunkResolver implements SkillGraphRagChunkResolver {
+
+        private final List<ResolvedRagChunk> chunks;
+
+        private FakeRagChunkResolver(List<ResolvedRagChunk> chunks) {
+            this.chunks = chunks;
+        }
+
+        @Override
+        public List<ResolvedRagChunk> listByObject(String objectType, String objectId, int limit) {
+            int max = limit <= 0 ? chunks.size() : Math.min(limit, chunks.size());
+            return chunks.subList(0, max);
+        }
+
+        @Override
+        public List<ResolvedRagChunk> listByObject(String objectType, String objectId, int offset, int limit) {
+            int start = Math.max(0, offset);
+            int end = Math.min(chunks.size(), start + Math.max(0, limit));
+            return start >= end ? List.of() : chunks.subList(start, end);
+        }
+    }
+}

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/SkillGraphExtractionSourceMgmtControllerTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/SkillGraphExtractionSourceMgmtControllerTest.java
@@ -46,19 +46,24 @@ class SkillGraphExtractionSourceMgmtControllerTest {
 
     @Test
     void filtersRagChunkPreviewByQueryAndDocument() {
-        SkillGraphExtractionSourceMgmtController controller = controller(List.of(
+        FakeRagChunkResolver resolver = new FakeRagChunkResolver(List.of(
                 chunk("doc-1", "chunk-1", "Spring Boot content", 0),
                 chunk("doc-2", "chunk-2", "JPA content", 1),
                 chunk("doc-2", "chunk-3", "Security content", 2)));
+        SkillGraphExtractionSourceMgmtController controller = controller(resolver);
 
         var page = controller.ragChunks("attachment", "42", "doc-2", "security", 0, 10, null)
                 .getBody()
                 .getData();
 
-        assertEquals(1, page.total());
+        assertEquals(null, page.total());
         assertFalse(page.hasMore());
         assertEquals("chunk-3", page.items().get(0).chunkId());
         assertEquals("WARNING", page.items().get(0).warningStatus());
+        assertEquals("doc-2", resolver.documentId);
+        assertEquals("security", resolver.query);
+        assertEquals(0, resolver.offset);
+        assertEquals(11, resolver.limit);
     }
 
     @Test
@@ -72,8 +77,12 @@ class SkillGraphExtractionSourceMgmtControllerTest {
     }
 
     private SkillGraphExtractionSourceMgmtController controller(List<ResolvedRagChunk> chunks) {
+        return controller(new FakeRagChunkResolver(chunks));
+    }
+
+    private SkillGraphExtractionSourceMgmtController controller(FakeRagChunkResolver resolver) {
         StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
-        beanFactory.addBean("skillGraphRagChunkResolver", new FakeRagChunkResolver(chunks));
+        beanFactory.addBean("skillGraphRagChunkResolver", resolver);
         return new SkillGraphExtractionSourceMgmtController(
                 beanFactory.getBeanProvider(SkillGraphRagChunkResolver.class));
     }
@@ -86,6 +95,10 @@ class SkillGraphExtractionSourceMgmtControllerTest {
     private static final class FakeRagChunkResolver implements SkillGraphRagChunkResolver {
 
         private final List<ResolvedRagChunk> chunks;
+        private String documentId;
+        private String query;
+        private int offset;
+        private int limit;
 
         private FakeRagChunkResolver(List<ResolvedRagChunk> chunks) {
             this.chunks = chunks;
@@ -102,6 +115,27 @@ class SkillGraphExtractionSourceMgmtControllerTest {
             int start = Math.max(0, offset);
             int end = Math.min(chunks.size(), start + Math.max(0, limit));
             return start >= end ? List.of() : chunks.subList(start, end);
+        }
+
+        @Override
+        public List<ResolvedRagChunk> listByObject(
+                String objectType,
+                String objectId,
+                String documentId,
+                String query,
+                int offset,
+                int limit) {
+            this.documentId = documentId;
+            this.query = query;
+            this.offset = offset;
+            this.limit = limit;
+            int start = Math.max(0, offset);
+            List<ResolvedRagChunk> filtered = chunks.stream()
+                    .filter(chunk -> documentId == null || documentId.equals(chunk.documentId()))
+                    .filter(chunk -> query == null || chunk.content().toLowerCase().contains(query.toLowerCase()))
+                    .toList();
+            int end = Math.min(filtered.size(), start + Math.max(0, limit));
+            return start >= end ? List.of() : filtered.subList(start, end);
         }
     }
 }

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/SkillGraphSimulationMgmtControllerTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/SkillGraphSimulationMgmtControllerTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.junit.jupiter.api.Test;
 
-import studio.one.platform.skillgraph.application.service.DefaultSkillExtractionService;
+import studio.one.platform.skillgraph.application.service.RegexSkillCandidateExtractor;
 import studio.one.platform.skillgraph.infrastructure.extraction.PatternSkillCandidateExtractor;
 import studio.one.platform.skillgraph.infrastructure.persistence.memory.InMemorySkillCandidateStore;
 import studio.one.platform.skillgraph.web.controller.SkillGraphSimulationMgmtController;
@@ -17,7 +17,7 @@ class SkillGraphSimulationMgmtControllerTest {
     void simulationExtractionDoesNotPersistCandidates() {
         InMemorySkillCandidateStore store = new InMemorySkillCandidateStore();
         SkillGraphSimulationMgmtController controller = new SkillGraphSimulationMgmtController(
-                new DefaultSkillExtractionService(store, new PatternSkillCandidateExtractor()));
+                new RegexSkillCandidateExtractor(store, new PatternSkillCandidateExtractor()));
 
         var response = controller.simulateExtraction(new SkillExtractionSimulationRequest(
                 null,


### PR DESCRIPTION
# Summary

SkillGraph의 RAG 기반 추출 흐름을 서버 API 중심으로 정리하고, chunk 조회/검색 경로의 안정성과 조회 비용을 개선했습니다.

# Changes

- SkillGraph 전용 RAG chunk preview paging API를 추가했습니다.
- `POST /api/mgmt/skillgraph/extraction-jobs/rag` 통합 추출 endpoint를 추가해 `ALL_CHUNKS`와 `SELECTED_CHUNKS`를 지원합니다.
- RAG chunk list 조회에서 MyBatis `distance` 컬럼 누락 오류를 수정했습니다.
- `q`/`documentId` 검색 조건을 DB 조회 조건으로 전달해 최대 5000건 선조회 후 메모리 필터링하던 경로를 줄였습니다.
- `DefaultSkillExtractionService`를 `RegexSkillCandidateExtractor`로 변경하고 관련 auto-configuration/test 참조를 갱신했습니다.
- SkillGraph application service 구현체들에 역할과 처리 흐름 설명을 추가했습니다.

# Root Cause

- SkillGraph UI가 RAG 내부 chunk 응답과 반복 추출 호출에 의존하고 있었습니다.
- RAG list 조회 SQL이 공통 resultMap의 `distance` 매핑과 맞지 않았습니다.
- 검색어가 있는 preview 조회가 page size와 무관하게 최대 5000건을 fetch해 ResultSet 로그와 row mapping 비용이 커졌습니다.

# Validation

- `./gradlew :studio-platform-skillgraph:test --tests studio.one.platform.skillgraph.SkillGraphExtractionSourceMgmtControllerTest --tests studio.one.platform.skillgraph.SkillExtractionJobMgmtControllerTest`
- `./gradlew :studio-platform-skillgraph:test :starter:studio-platform-starter-skillgraph:test`
- `./gradlew :starter:studio-platform-starter-ai:test --tests studio.one.platform.ai.adapters.vector.mybatis.PgVectorMapperXmlContractTest --tests studio.one.platform.ai.adapters.vector.PgVectorStoreAdapterV2Test`
- `./gradlew :studio-platform-ai:test :starter:studio-platform-starter-ai:test :studio-platform-skillgraph:test :starter:studio-platform-starter-skillgraph:test`
- `git diff --check`
- `git diff --cached --check`

# AI-Assisted

- AI-Assisted: Yes
- Usage type: 구현, 검증, 리뷰, PR 본문 작성
- Subagent used: No

Closes #480
Closes #481
Closes #482
