### PR TITLE
[ai-assisted] fix(rag): JDBC chunk 목록 distance 컬럼 반환

### DIFF
--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/adapters/vector/PgVectorJdbcMapper.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/adapters/vector/PgVectorJdbcMapper.java
@@ -69,21 +69,21 @@ public final class PgVectorJdbcMapper implements PgVectorMapper {
              WHERE object_type = :objectType AND object_id = :objectId
             """;
     private static final String LIST_BY_OBJECT_SQL = """
-            SELECT object_id, text, metadata
+            SELECT object_id, text, metadata, NULL::double precision AS distance
               FROM tb_ai_document_chunk
              WHERE object_type = :objectType AND object_id = :objectId
              ORDER BY chunk_index
              LIMIT :limit
             """;
     private static final String LIST_BY_OBJECT_PAGE_SQL = """
-            SELECT object_id, text, metadata
+            SELECT object_id, text, metadata, NULL::double precision AS distance
               FROM tb_ai_document_chunk
              WHERE object_type = :objectType AND object_id = :objectId
              ORDER BY chunk_index
              LIMIT :limit OFFSET :offset
             """;
     private static final String LIST_BY_OBJECT_PAGE_FILTERED_SQL = """
-            SELECT object_id, text, metadata
+            SELECT object_id, text, metadata, NULL::double precision AS distance
               FROM tb_ai_document_chunk
              WHERE object_type = :objectType AND object_id = :objectId
                AND (:documentId IS NULL OR metadata->>'documentId' = :documentId)

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/adapters/vector/PgVectorJdbcMapperSqlContractTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/adapters/vector/PgVectorJdbcMapperSqlContractTest.java
@@ -1,0 +1,25 @@
+package studio.one.platform.ai.adapters.vector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+
+class PgVectorJdbcMapperSqlContractTest {
+
+    @Test
+    void listQueriesSelectNullableDistanceForSharedRowMapper() throws Exception {
+        assertThat(sql("LIST_BY_OBJECT_SQL"))
+                .contains("NULL::double precision AS distance");
+        assertThat(sql("LIST_BY_OBJECT_PAGE_SQL"))
+                .contains("NULL::double precision AS distance");
+        assertThat(sql("LIST_BY_OBJECT_PAGE_FILTERED_SQL"))
+                .contains("NULL::double precision AS distance");
+    }
+
+    private static String sql(String fieldName) throws Exception {
+        Field field = PgVectorJdbcMapper.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return (String) field.get(null);
+    }
+}


### PR DESCRIPTION
## Why

- #481에서 MyBatis 경로 수정 이후에도 JDBC mapper 경로에서 `ResultSet.getDouble(distance)` 오류가 재발했습니다.
- `PgVectorJdbcMapper`의 list 계열 SQL은 공용 RowMapper를 사용하지만 `distance` 컬럼을 반환하지 않아, log4jdbc/PostgreSQL 환경에서 chunk 목록 조회와 전체 문서 추출 등록 경로가 실패할 수 있습니다.

## What

- `PgVectorJdbcMapper`의 `listByObject`, `listByObjectPage`, `listByObjectPageFiltered` SQL에 `NULL::double precision AS distance`를 추가했습니다.
- JDBC mapper list SQL이 공용 RowMapper의 `distance` 컬럼 계약을 만족하는지 검증하는 계약 테스트를 추가했습니다.

## Related Issues

- Closes #481

## Validation

- Command: `./gradlew :starter:studio-platform-starter-ai:test --tests studio.one.platform.ai.adapters.vector.PgVectorJdbcMapperSqlContractTest --tests studio.one.platform.ai.adapters.vector.mybatis.PgVectorMapperXmlContractTest --tests studio.one.platform.ai.adapters.vector.PgVectorStoreAdapterV2Test`
- Result: PASS
- Command: `git diff --check`
- Result: PASS

## Risk / Rollback

- Risk: list 조회 결과에 nullable `distance` alias만 추가하는 변경이라 검색/저장 로직 영향은 낮습니다.
- Rollback: 해당 SQL alias 추가와 계약 테스트를 되돌리면 됩니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: 없음
- Main author validation: #481 댓글의 JDBC 재현 경로를 기준으로 `PgVectorJdbcMapper` list 계열 SQL과 공용 RowMapper 계약을 대조하고, 관련 단위 테스트를 실행했습니다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
