### PR TITLE
[ai-assisted] feat(skillgraph): RAG 전체 문서 추출 job 처리 추가

### DIFF
--- a/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/SkillGraphAutoConfiguration.java
+++ b/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/SkillGraphAutoConfiguration.java
@@ -12,6 +12,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import studio.one.platform.ai.core.chat.ChatPort;
 import studio.one.platform.ai.service.prompt.PromptRenderer;
@@ -39,6 +43,7 @@ import studio.one.platform.skillgraph.domain.port.SkillCandidateStore;
 import studio.one.platform.skillgraph.domain.port.SkillDictionaryStore;
 import studio.one.platform.skillgraph.domain.port.SkillEmbeddingPort;
 import studio.one.platform.skillgraph.domain.port.SkillGraphStore;
+import studio.one.platform.skillgraph.domain.port.SkillRagExtractionJobStore;
 import studio.one.platform.skillgraph.domain.port.SkillMappingStore;
 import studio.one.platform.skillgraph.domain.port.NoOpSkillEmbeddingPort;
 import studio.one.platform.skillgraph.domain.port.SkillProjectionStore;
@@ -50,12 +55,14 @@ import studio.one.platform.skillgraph.infrastructure.persistence.jdbc.JdbcSkillD
 import studio.one.platform.skillgraph.infrastructure.persistence.jdbc.JdbcSkillGraphStore;
 import studio.one.platform.skillgraph.infrastructure.persistence.jdbc.JdbcSkillMappingStore;
 import studio.one.platform.skillgraph.infrastructure.persistence.jdbc.JdbcSkillProjectionStore;
+import studio.one.platform.skillgraph.infrastructure.persistence.jdbc.JdbcSkillRagExtractionJobStore;
 import studio.one.platform.skillgraph.infrastructure.persistence.jdbc.JdbcSkillTaxonomyStore;
 import studio.one.platform.skillgraph.infrastructure.persistence.memory.InMemorySkillCandidateStore;
 import studio.one.platform.skillgraph.infrastructure.persistence.memory.InMemorySkillDictionaryStore;
 import studio.one.platform.skillgraph.infrastructure.persistence.memory.InMemorySkillGraphStore;
 import studio.one.platform.skillgraph.infrastructure.persistence.memory.InMemorySkillMappingStore;
 import studio.one.platform.skillgraph.infrastructure.persistence.memory.InMemorySkillProjectionStore;
+import studio.one.platform.skillgraph.infrastructure.persistence.memory.InMemorySkillRagExtractionJobStore;
 import studio.one.platform.skillgraph.infrastructure.persistence.memory.InMemorySkillTaxonomyStore;
 
 @AutoConfiguration
@@ -147,6 +154,25 @@ public class SkillGraphAutoConfiguration {
     @ConditionalOnMissingBean
     public SkillRecommendationService skillRecommendationService(SkillMappingStore mappingStore) {
         return new DefaultSkillRecommendationService(mappingStore);
+    }
+
+    @Bean(destroyMethod = "shutdown")
+    @ConditionalOnMissingBean(name = "skillRagExtractionJobExecutor")
+    public ThreadPoolExecutor skillRagExtractionJobExecutor(SkillGraphProperties properties) {
+        SkillGraphProperties.RagJob ragJob = properties.getExtraction().getRagJob();
+        int workers = Math.max(1, ragJob.getWorkerCount());
+        return new ThreadPoolExecutor(
+                workers,
+                workers,
+                0L,
+                TimeUnit.MILLISECONDS,
+                new ArrayBlockingQueue<>(Math.max(1, ragJob.getQueueCapacity())),
+                runnable -> {
+                    Thread thread = new Thread(runnable, "skill-rag-extraction-worker");
+                    thread.setDaemon(true);
+                    return thread;
+                },
+                new ThreadPoolExecutor.AbortPolicy());
     }
 
     @Configuration
@@ -241,6 +267,12 @@ public class SkillGraphAutoConfiguration {
             return new InMemorySkillMappingStore();
         }
 
+        @Bean(name = SkillRagExtractionJobStore.SERVICE_NAME)
+        @ConditionalOnMissingBean
+        public SkillRagExtractionJobStore skillRagExtractionJobStore() {
+            return new InMemorySkillRagExtractionJobStore();
+        }
+
     }
 
     @Configuration
@@ -284,6 +316,12 @@ public class SkillGraphAutoConfiguration {
         @ConditionalOnMissingBean
         public SkillMappingStore skillMappingStore(NamedParameterJdbcTemplate template) {
             return new JdbcSkillMappingStore(template);
+        }
+
+        @Bean(name = SkillRagExtractionJobStore.SERVICE_NAME)
+        @ConditionalOnMissingBean
+        public SkillRagExtractionJobStore skillRagExtractionJobStore(NamedParameterJdbcTemplate template) {
+            return new JdbcSkillRagExtractionJobStore(template);
         }
     }
 }

--- a/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/SkillGraphProperties.java
+++ b/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/SkillGraphProperties.java
@@ -26,6 +26,7 @@ public class SkillGraphProperties {
         private int maxTerms = 50;
         private Mode mode = Mode.regex;
         private Llm llm = new Llm();
+        private RagJob ragJob = new RagJob();
     }
 
     public enum Mode {
@@ -40,6 +41,16 @@ public class SkillGraphProperties {
         private int maxInputChars = 4000;
         private Integer maxOutputTokens = 1024;
         private Double temperature = 0.0d;
+    }
+
+    @Getter
+    @Setter
+    public static class RagJob {
+        private int batchSize = 20;
+        private int workerCount = 2;
+        private int queueCapacity = 100;
+        private int maxChunks = 5000;
+        private int maxTextBytesPerBatch = 1_000_000;
     }
 
     @Getter

--- a/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/SkillGraphWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/SkillGraphWebAutoConfiguration.java
@@ -9,7 +9,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
+import java.util.concurrent.Executor;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
+import studio.one.platform.skillgraph.application.service.DefaultSkillRagExtractionJobService;
+import studio.one.platform.skillgraph.application.service.SkillRagExtractionJobSettings;
 import studio.one.platform.skillgraph.application.usecase.SkillGraphRagChunkResolver;
 import studio.one.platform.skillgraph.application.usecase.SkillCandidateReviewService;
 import studio.one.platform.skillgraph.application.usecase.SkillDictionaryService;
@@ -17,8 +20,10 @@ import studio.one.platform.skillgraph.application.usecase.SkillExtractionService
 import studio.one.platform.skillgraph.application.usecase.SkillGraphService;
 import studio.one.platform.skillgraph.application.usecase.SkillMappingService;
 import studio.one.platform.skillgraph.application.usecase.SkillRecommendationService;
+import studio.one.platform.skillgraph.application.usecase.SkillRagExtractionJobService;
 import studio.one.platform.skillgraph.application.usecase.SkillTaxonomyService;
 import studio.one.platform.skillgraph.application.usecase.SkillVisualizationService;
+import studio.one.platform.skillgraph.domain.port.SkillRagExtractionJobStore;
 import studio.one.platform.skillgraph.web.controller.SkillCandidateMgmtController;
 import studio.one.platform.skillgraph.web.controller.SkillDictionaryMgmtController;
 import studio.one.platform.skillgraph.web.controller.SkillExtractionJobMgmtController;
@@ -53,6 +58,31 @@ public class SkillGraphWebAutoConfiguration {
         @ConditionalOnMissingBean(SkillGraphRagChunkResolver.class)
         SkillGraphRagChunkResolver skillGraphRagChunkResolver(RagPipelineService ragPipelineService) {
             return new RagPipelineSkillGraphRagChunkResolver(ragPipelineService);
+        }
+
+        @Bean(name = SkillRagExtractionJobService.SERVICE_NAME)
+        @ConditionalOnBean({
+                SkillExtractionService.class,
+                SkillGraphRagChunkResolver.class,
+                SkillRagExtractionJobStore.class
+        })
+        @ConditionalOnMissingBean
+        SkillRagExtractionJobService skillRagExtractionJobService(
+                SkillExtractionService extractionService,
+                SkillGraphRagChunkResolver ragChunkResolver,
+                SkillRagExtractionJobStore jobStore,
+                Executor skillRagExtractionJobExecutor,
+                SkillGraphProperties properties) {
+            SkillGraphProperties.RagJob ragJob = properties.getExtraction().getRagJob();
+            return new DefaultSkillRagExtractionJobService(
+                    extractionService,
+                    ragChunkResolver,
+                    jobStore,
+                    skillRagExtractionJobExecutor,
+                    new SkillRagExtractionJobSettings(
+                            ragJob.getBatchSize(),
+                            ragJob.getMaxChunks(),
+                            ragJob.getMaxTextBytesPerBatch()));
         }
     }
 

--- a/starter/studio-platform-starter-skillgraph/src/test/java/studio/one/platform/autoconfigure/skillgraph/SkillGraphAutoConfigurationTest.java
+++ b/starter/studio-platform-starter-skillgraph/src/test/java/studio/one/platform/autoconfigure/skillgraph/SkillGraphAutoConfigurationTest.java
@@ -9,7 +9,12 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import studio.one.platform.ai.core.chat.ChatMessage;
 import studio.one.platform.ai.core.chat.ChatPort;
 import studio.one.platform.ai.core.chat.ChatResponse;
+import studio.one.platform.ai.core.rag.RagIndexRequest;
+import studio.one.platform.ai.core.rag.RagRetrievalDiagnostics;
+import studio.one.platform.ai.core.rag.RagSearchRequest;
+import studio.one.platform.ai.core.rag.RagSearchResult;
 import studio.one.platform.ai.service.prompt.PromptRenderer;
+import studio.one.platform.ai.service.pipeline.RagPipelineService;
 import studio.one.platform.skillgraph.application.service.LlmSkillCandidateExtractor;
 import studio.one.platform.skillgraph.application.service.RegexSkillCandidateExtractor;
 import studio.one.platform.skillgraph.application.usecase.SkillCandidateReviewService;
@@ -18,16 +23,19 @@ import studio.one.platform.skillgraph.application.usecase.SkillExtractionService
 import studio.one.platform.skillgraph.application.usecase.SkillGraphService;
 import studio.one.platform.skillgraph.application.usecase.SkillMappingService;
 import studio.one.platform.skillgraph.application.usecase.SkillRecommendationService;
+import studio.one.platform.skillgraph.application.usecase.SkillRagExtractionJobService;
 import studio.one.platform.skillgraph.application.usecase.SkillTaxonomyService;
 import studio.one.platform.skillgraph.domain.port.SkillCandidateExtractor;
 import studio.one.platform.skillgraph.domain.port.SkillCandidateStore;
 import studio.one.platform.skillgraph.domain.port.SkillDictionaryStore;
 import studio.one.platform.skillgraph.domain.port.SkillGraphStore;
 import studio.one.platform.skillgraph.domain.port.SkillMappingStore;
+import studio.one.platform.skillgraph.domain.port.SkillRagExtractionJobStore;
 import studio.one.platform.skillgraph.domain.port.SkillTaxonomyStore;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 class SkillGraphAutoConfigurationTest {
 
@@ -46,6 +54,7 @@ class SkillGraphAutoConfigurationTest {
             assertThat(context).hasSingleBean(SkillTaxonomyStore.class);
             assertThat(context).hasSingleBean(SkillGraphStore.class);
             assertThat(context).hasSingleBean(SkillMappingStore.class);
+            assertThat(context).hasSingleBean(SkillRagExtractionJobStore.class);
             assertThat(context).hasSingleBean(SkillTaxonomyService.class);
             assertThat(context).hasSingleBean(SkillGraphService.class);
             assertThat(context).hasSingleBean(SkillMappingService.class);
@@ -53,6 +62,23 @@ class SkillGraphAutoConfigurationTest {
             assertThat(context).getBean(SkillExtractionService.class)
                     .isInstanceOf(RegexSkillCandidateExtractor.class);
         });
+    }
+
+    @Test
+    void createsRagExtractionJobServiceAfterWebRagResolverIsAvailable() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        SkillGraphAutoConfiguration.class,
+                        SkillGraphWebAutoConfiguration.SkillGraphRagExtractionConfig.class))
+                .withBean(RagPipelineService.class, FakeRagPipelineService::new)
+                .withPropertyValues(
+                        "studio.features.skillgraph.web.enabled=true",
+                        "studio.skillgraph.extraction.rag-job.batch-size=10",
+                        "studio.skillgraph.extraction.rag-job.worker-count=1",
+                        "studio.skillgraph.extraction.rag-job.queue-capacity=2",
+                        "studio.skillgraph.extraction.rag-job.max-chunks=100",
+                        "studio.skillgraph.extraction.rag-job.max-text-bytes-per-batch=20000")
+                .run(context -> assertThat(context).hasSingleBean(SkillRagExtractionJobService.class));
     }
 
     @Test
@@ -92,6 +118,33 @@ class SkillGraphAutoConfigurationTest {
         @Override
         public String getRawPrompt(String name) {
             return "prompt";
+        }
+    }
+
+    private static final class FakeRagPipelineService implements RagPipelineService {
+
+        @Override
+        public void index(RagIndexRequest request) {
+        }
+
+        @Override
+        public List<RagSearchResult> search(RagSearchRequest request) {
+            return List.of();
+        }
+
+        @Override
+        public List<RagSearchResult> searchByObject(RagSearchRequest request, String objectType, String objectId) {
+            return List.of();
+        }
+
+        @Override
+        public List<RagSearchResult> listByObject(String objectType, String objectId, Integer limit) {
+            return List.of(new RagSearchResult("doc-1", "Spring Boot", Map.of("chunkId", "chunk-1"), 1.0d));
+        }
+
+        @Override
+        public Optional<RagRetrievalDiagnostics> latestDiagnostics() {
+            return Optional.empty();
         }
     }
 }

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/SkillRagExtractionItemStatus.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/SkillRagExtractionItemStatus.java
@@ -1,0 +1,9 @@
+package studio.one.platform.skillgraph.application.result;
+
+public enum SkillRagExtractionItemStatus {
+    READY,
+    RUNNING,
+    SUCCEEDED,
+    FAILED,
+    NOT_FOUND
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/SkillRagExtractionJob.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/SkillRagExtractionJob.java
@@ -1,0 +1,38 @@
+package studio.one.platform.skillgraph.application.result;
+
+import java.time.Instant;
+
+public record SkillRagExtractionJob(
+        String jobId,
+        String objectType,
+        String objectId,
+        String documentId,
+        SkillRagExtractionJobStatus status,
+        int requestedChunks,
+        int totalChunks,
+        int processedChunks,
+        int succeededChunks,
+        int failedChunks,
+        int extractedCount,
+        String error,
+        Instant createdAt,
+        Instant updatedAt) {
+
+    public SkillRagExtractionJob withStatus(SkillRagExtractionJobStatus status, String error, Instant now) {
+        return new SkillRagExtractionJob(jobId, objectType, objectId, documentId, status, requestedChunks,
+                totalChunks, processedChunks, succeededChunks, failedChunks, extractedCount, error, createdAt, now);
+    }
+
+    public SkillRagExtractionJob withProgress(
+            SkillRagExtractionJobStatus status,
+            int totalChunks,
+            int processedChunks,
+            int succeededChunks,
+            int failedChunks,
+            int extractedCount,
+            String error,
+            Instant now) {
+        return new SkillRagExtractionJob(jobId, objectType, objectId, documentId, status, requestedChunks,
+                totalChunks, processedChunks, succeededChunks, failedChunks, extractedCount, error, createdAt, now);
+    }
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/SkillRagExtractionJobItem.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/SkillRagExtractionJobItem.java
@@ -1,0 +1,16 @@
+package studio.one.platform.skillgraph.application.result;
+
+import java.time.Instant;
+
+public record SkillRagExtractionJobItem(
+        String jobId,
+        String chunkId,
+        String documentId,
+        String sourceId,
+        String sourceChunkId,
+        int extractedCount,
+        SkillRagExtractionItemStatus status,
+        String error,
+        Instant createdAt,
+        Instant updatedAt) {
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/SkillRagExtractionJobStatus.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/SkillRagExtractionJobStatus.java
@@ -1,0 +1,10 @@
+package studio.one.platform.skillgraph.application.result;
+
+public enum SkillRagExtractionJobStatus {
+    READY,
+    RUNNING,
+    COMPLETED,
+    PARTIAL,
+    FAILED,
+    CANCELLED
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillRagExtractionJobService.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillRagExtractionJobService.java
@@ -1,0 +1,278 @@
+package studio.one.platform.skillgraph.application.service;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+
+import lombok.extern.slf4j.Slf4j;
+import studio.one.platform.skillgraph.application.command.SkillExtractionCommand;
+import studio.one.platform.skillgraph.application.result.ResolvedRagChunk;
+import studio.one.platform.skillgraph.application.result.SkillExtractionResult;
+import studio.one.platform.skillgraph.application.result.SkillRagExtractionItemStatus;
+import studio.one.platform.skillgraph.application.result.SkillRagExtractionJob;
+import studio.one.platform.skillgraph.application.result.SkillRagExtractionJobItem;
+import studio.one.platform.skillgraph.application.result.SkillRagExtractionJobStatus;
+import studio.one.platform.skillgraph.application.usecase.SkillExtractionService;
+import studio.one.platform.skillgraph.application.usecase.SkillGraphRagChunkResolver;
+import studio.one.platform.skillgraph.application.usecase.SkillRagExtractionJobService;
+import studio.one.platform.skillgraph.domain.port.SkillRagExtractionJobStore;
+
+@Slf4j
+public class DefaultSkillRagExtractionJobService implements SkillRagExtractionJobService {
+
+    private static final String RAG_CHUNK_SOURCE_TYPE = "RAG_CHUNK";
+    private static final int DEFAULT_ITEM_LIMIT = 100;
+    private static final int MAX_ITEM_LIMIT = 500;
+
+    private final SkillExtractionService extractionService;
+    private final SkillGraphRagChunkResolver ragChunkResolver;
+    private final SkillRagExtractionJobStore store;
+    private final Executor executor;
+    private final SkillRagExtractionJobSettings settings;
+    private final Clock clock;
+
+    public DefaultSkillRagExtractionJobService(
+            SkillExtractionService extractionService,
+            SkillGraphRagChunkResolver ragChunkResolver,
+            SkillRagExtractionJobStore store,
+            Executor executor,
+            SkillRagExtractionJobSettings settings) {
+        this(extractionService, ragChunkResolver, store, executor, settings, Clock.systemUTC());
+    }
+
+    public DefaultSkillRagExtractionJobService(
+            SkillExtractionService extractionService,
+            SkillGraphRagChunkResolver ragChunkResolver,
+            SkillRagExtractionJobStore store,
+            Executor executor,
+            SkillRagExtractionJobSettings settings,
+            Clock clock) {
+        this.extractionService = Objects.requireNonNull(extractionService, "extractionService");
+        this.ragChunkResolver = Objects.requireNonNull(ragChunkResolver, "ragChunkResolver");
+        this.store = Objects.requireNonNull(store, "store");
+        this.executor = Objects.requireNonNull(executor, "executor");
+        this.settings = Objects.requireNonNull(settings, "settings");
+        this.clock = Objects.requireNonNull(clock, "clock");
+    }
+
+    @Override
+    public SkillRagExtractionJob submitAllChunks(String objectType, String objectId, String documentId, Integer limit) {
+        int requestedChunks = boundedLimit(limit);
+        Instant now = clock.instant();
+        SkillRagExtractionJob job = new SkillRagExtractionJob(
+                "srj_" + UUID.randomUUID().toString().replace("-", ""),
+                required(objectType, "objectType"),
+                required(objectId, "objectId"),
+                normalize(documentId),
+                SkillRagExtractionJobStatus.RUNNING,
+                requestedChunks,
+                0,
+                0,
+                0,
+                0,
+                0,
+                null,
+                now,
+                now);
+        store.saveJob(job);
+        try {
+            executor.execute(() -> processAllChunks(job.jobId(), Set.of()));
+            return job;
+        } catch (RejectedExecutionException ex) {
+            return store.saveJob(job.withStatus(SkillRagExtractionJobStatus.FAILED,
+                    "RAG extraction job queue is full", clock.instant()));
+        }
+    }
+
+    @Override
+    public SkillRagExtractionJob getJob(String jobId) {
+        return store.findJob(required(jobId, "jobId"))
+                .orElseThrow(() -> new IllegalArgumentException("RAG extraction job not found: " + jobId));
+    }
+
+    @Override
+    public List<SkillRagExtractionJobItem> listItems(String jobId, int offset, int limit) {
+        getJob(jobId);
+        return store.listItems(required(jobId, "jobId"), Math.max(0, offset), boundedItemLimit(limit));
+    }
+
+    @Override
+    public SkillRagExtractionJob retryFailed(String jobId) {
+        SkillRagExtractionJob job = getJob(jobId);
+        if (job.status() == SkillRagExtractionJobStatus.RUNNING || job.status() == SkillRagExtractionJobStatus.READY) {
+            throw new IllegalStateException("RAG extraction job is still active: " + jobId);
+        }
+        List<SkillRagExtractionJobItem> failedItems = store.listItemsByStatus(
+                job.jobId(), SkillRagExtractionItemStatus.FAILED, settings.maxChunks());
+        if (failedItems.isEmpty()) {
+            return job;
+        }
+        Set<String> chunkIds = new HashSet<>();
+        for (SkillRagExtractionJobItem item : failedItems) {
+            chunkIds.add(item.chunkId());
+        }
+        SkillRagExtractionJob running = store.saveJob(job.withStatus(SkillRagExtractionJobStatus.RUNNING, null,
+                clock.instant()));
+        try {
+            executor.execute(() -> processAllChunks(job.jobId(), chunkIds));
+            return running;
+        } catch (RejectedExecutionException ex) {
+            return store.saveJob(running.withStatus(SkillRagExtractionJobStatus.FAILED,
+                    "RAG extraction job queue is full", clock.instant()));
+        }
+    }
+
+    private void processAllChunks(String jobId, Set<String> retryChunkIds) {
+        SkillRagExtractionJob job = getJob(jobId);
+        int offset = 0;
+        int total = retryChunkIds.isEmpty() ? 0 : job.totalChunks();
+        int processed = retryChunkIds.isEmpty() ? 0 : job.processedChunks() - retryChunkIds.size();
+        int succeeded = retryChunkIds.isEmpty() ? 0 : job.succeededChunks();
+        int failed = retryChunkIds.isEmpty() ? 0 : Math.max(0, job.failedChunks() - retryChunkIds.size());
+        int extracted = retryChunkIds.isEmpty() ? 0 : job.extractedCount();
+        try {
+            while (processed < job.requestedChunks()) {
+                List<ResolvedRagChunk> fetched = ragChunkResolver.listByObject(
+                        job.objectType(), job.objectId(), offset, settings.batchSize());
+                if (fetched.isEmpty()) {
+                    break;
+                }
+                offset += fetched.size();
+                List<ResolvedRagChunk> batch = eligibleBatch(job, fetched, retryChunkIds);
+                if (batch.isEmpty() && fetched.size() < settings.batchSize()) {
+                    break;
+                }
+                for (ResolvedRagChunk chunk : batch) {
+                    if (processed >= job.requestedChunks()) {
+                        break;
+                    }
+                    total = retryChunkIds.isEmpty() ? total + 1 : total;
+                    SkillRagExtractionJobItem item = extract(job, chunk);
+                    processed++;
+                    if (item.status() == SkillRagExtractionItemStatus.SUCCEEDED) {
+                        succeeded++;
+                        extracted += item.extractedCount();
+                    } else {
+                        failed++;
+                    }
+                    store.saveJob(job.withProgress(
+                            SkillRagExtractionJobStatus.RUNNING,
+                            total,
+                            processed,
+                            succeeded,
+                            failed,
+                            extracted,
+                            null,
+                            clock.instant()));
+                }
+                if (fetched.size() < settings.batchSize()) {
+                    break;
+                }
+            }
+            SkillRagExtractionJobStatus status = finalStatus(processed, succeeded, failed);
+            store.saveJob(job.withProgress(status, total, processed, succeeded, failed, extracted, null, clock.instant()));
+        } catch (RuntimeException ex) {
+            log.warn("SkillGraph RAG extraction job failed: {}", jobId, ex);
+            store.saveJob(job.withProgress(SkillRagExtractionJobStatus.FAILED, total, processed, succeeded, failed,
+                    extracted, "RAG extraction job failed", clock.instant()));
+        }
+    }
+
+    private List<ResolvedRagChunk> eligibleBatch(
+            SkillRagExtractionJob job,
+            List<ResolvedRagChunk> fetched,
+            Set<String> retryChunkIds) {
+        List<ResolvedRagChunk> batch = new ArrayList<>();
+        for (ResolvedRagChunk chunk : fetched) {
+            if (chunk.content() == null || chunk.content().isBlank()) {
+                continue;
+            }
+            if (job.documentId() != null && !job.documentId().equals(chunk.documentId())) {
+                continue;
+            }
+            if (!retryChunkIds.isEmpty() && !retryChunkIds.contains(chunk.chunkId())) {
+                continue;
+            }
+            batch.add(chunk);
+        }
+        return batch;
+    }
+
+    private SkillRagExtractionJobItem extract(SkillRagExtractionJob job, ResolvedRagChunk chunk) {
+        Instant now = clock.instant();
+        String sourceId = Optional.ofNullable(chunk.documentId()).orElse(job.objectId());
+        if (chunk.content().getBytes(StandardCharsets.UTF_8).length > settings.maxTextBytesPerBatch()) {
+            return store.saveItem(new SkillRagExtractionJobItem(job.jobId(), chunk.chunkId(), chunk.documentId(),
+                    sourceId, null, 0, SkillRagExtractionItemStatus.FAILED,
+                    "RAG chunk text exceeds maxTextBytesPerBatch", now, now));
+        }
+        try {
+            SkillExtractionResult result = extractionService.extract(new SkillExtractionCommand(
+                    RAG_CHUNK_SOURCE_TYPE,
+                    sourceId,
+                    chunk.chunkId(),
+                    chunk.content()));
+            return store.saveItem(new SkillRagExtractionJobItem(job.jobId(), chunk.chunkId(), chunk.documentId(),
+                    sourceId, result.sourceChunkId(), result.extractedCount(), SkillRagExtractionItemStatus.SUCCEEDED,
+                    null, now, now));
+        } catch (RuntimeException ex) {
+            return store.saveItem(new SkillRagExtractionJobItem(job.jobId(), chunk.chunkId(), chunk.documentId(),
+                    sourceId, null, 0, SkillRagExtractionItemStatus.FAILED, failureMessage(ex), now, now));
+        }
+    }
+
+    private SkillRagExtractionJobStatus finalStatus(int processed, int succeeded, int failed) {
+        if (processed == 0) {
+            return SkillRagExtractionJobStatus.FAILED;
+        }
+        if (failed > 0 && succeeded > 0) {
+            return SkillRagExtractionJobStatus.PARTIAL;
+        }
+        if (failed > 0) {
+            return SkillRagExtractionJobStatus.FAILED;
+        }
+        return SkillRagExtractionJobStatus.COMPLETED;
+    }
+
+    private int boundedLimit(Integer limit) {
+        if (limit == null || limit <= 0) {
+            return settings.maxChunks();
+        }
+        return Math.min(limit, settings.maxChunks());
+    }
+
+    private int boundedItemLimit(int limit) {
+        if (limit <= 0) {
+            return DEFAULT_ITEM_LIMIT;
+        }
+        return Math.min(limit, MAX_ITEM_LIMIT);
+    }
+
+    private String failureMessage(RuntimeException ex) {
+        if (ex instanceof IllegalArgumentException && ex.getMessage() != null && !ex.getMessage().isBlank()) {
+            return ex.getMessage();
+        }
+        return "Skill extraction failed";
+    }
+
+    private String required(String value, String field) {
+        String normalized = normalize(value);
+        if (normalized == null) {
+            throw new IllegalArgumentException(field + " is required");
+        }
+        return normalized;
+    }
+
+    private String normalize(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/SkillRagExtractionJobSettings.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/SkillRagExtractionJobSettings.java
@@ -1,0 +1,13 @@
+package studio.one.platform.skillgraph.application.service;
+
+public record SkillRagExtractionJobSettings(
+        int batchSize,
+        int maxChunks,
+        int maxTextBytesPerBatch) {
+
+    public SkillRagExtractionJobSettings {
+        batchSize = batchSize <= 0 ? 20 : batchSize;
+        maxChunks = maxChunks <= 0 ? 5000 : maxChunks;
+        maxTextBytesPerBatch = maxTextBytesPerBatch <= 0 ? 1_000_000 : maxTextBytesPerBatch;
+    }
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/usecase/SkillRagExtractionJobService.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/usecase/SkillRagExtractionJobService.java
@@ -1,0 +1,19 @@
+package studio.one.platform.skillgraph.application.usecase;
+
+import java.util.List;
+
+import studio.one.platform.skillgraph.application.result.SkillRagExtractionJob;
+import studio.one.platform.skillgraph.application.result.SkillRagExtractionJobItem;
+
+public interface SkillRagExtractionJobService {
+
+    String SERVICE_NAME = "skillRagExtractionJobService";
+
+    SkillRagExtractionJob submitAllChunks(String objectType, String objectId, String documentId, Integer limit);
+
+    SkillRagExtractionJob getJob(String jobId);
+
+    List<SkillRagExtractionJobItem> listItems(String jobId, int offset, int limit);
+
+    SkillRagExtractionJob retryFailed(String jobId);
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/domain/port/SkillRagExtractionJobStore.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/domain/port/SkillRagExtractionJobStore.java
@@ -1,0 +1,26 @@
+package studio.one.platform.skillgraph.domain.port;
+
+import java.util.List;
+import java.util.Optional;
+
+import studio.one.platform.skillgraph.application.result.SkillRagExtractionItemStatus;
+import studio.one.platform.skillgraph.application.result.SkillRagExtractionJob;
+import studio.one.platform.skillgraph.application.result.SkillRagExtractionJobItem;
+
+public interface SkillRagExtractionJobStore {
+
+    String SERVICE_NAME = "skillRagExtractionJobStore";
+
+    SkillRagExtractionJob saveJob(SkillRagExtractionJob job);
+
+    Optional<SkillRagExtractionJob> findJob(String jobId);
+
+    SkillRagExtractionJobItem saveItem(SkillRagExtractionJobItem item);
+
+    List<SkillRagExtractionJobItem> listItems(String jobId, int offset, int limit);
+
+    List<SkillRagExtractionJobItem> listItemsByStatus(
+            String jobId,
+            SkillRagExtractionItemStatus status,
+            int limit);
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/jdbc/JdbcSkillRagExtractionJobStore.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/jdbc/JdbcSkillRagExtractionJobStore.java
@@ -1,0 +1,185 @@
+package studio.one.platform.skillgraph.infrastructure.persistence.jdbc;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import lombok.RequiredArgsConstructor;
+import studio.one.platform.skillgraph.application.result.SkillRagExtractionItemStatus;
+import studio.one.platform.skillgraph.application.result.SkillRagExtractionJob;
+import studio.one.platform.skillgraph.application.result.SkillRagExtractionJobItem;
+import studio.one.platform.skillgraph.application.result.SkillRagExtractionJobStatus;
+import studio.one.platform.skillgraph.domain.port.SkillRagExtractionJobStore;
+
+@RequiredArgsConstructor
+public class JdbcSkillRagExtractionJobStore implements SkillRagExtractionJobStore {
+
+    private final NamedParameterJdbcTemplate template;
+
+    @Override
+    public SkillRagExtractionJob saveJob(SkillRagExtractionJob job) {
+        int updated = template.update("""
+                UPDATE tb_skill_rag_extraction_job
+                SET status = :status,
+                    requested_chunks = :requestedChunks,
+                    total_chunks = :totalChunks,
+                    processed_chunks = :processedChunks,
+                    succeeded_chunks = :succeededChunks,
+                    failed_chunks = :failedChunks,
+                    extracted_count = :extractedCount,
+                    error_message = :error,
+                    updated_at = :updatedAt
+                WHERE job_id = :jobId
+                """, jobParams(job));
+        if (updated == 0) {
+            template.update("""
+                    INSERT INTO tb_skill_rag_extraction_job
+                        (job_id, object_type, object_id, document_id, status, requested_chunks, total_chunks,
+                         processed_chunks, succeeded_chunks, failed_chunks, extracted_count, error_message,
+                         created_at, updated_at)
+                    VALUES
+                        (:jobId, :objectType, :objectId, :documentId, :status, :requestedChunks, :totalChunks,
+                         :processedChunks, :succeededChunks, :failedChunks, :extractedCount, :error,
+                         :createdAt, :updatedAt)
+                    """, jobParams(job));
+        }
+        return job;
+    }
+
+    @Override
+    public Optional<SkillRagExtractionJob> findJob(String jobId) {
+        List<SkillRagExtractionJob> rows = template.query("""
+                SELECT * FROM tb_skill_rag_extraction_job WHERE job_id = :jobId
+                """, new MapSqlParameterSource("jobId", jobId), this::mapJob);
+        return rows.stream().findFirst();
+    }
+
+    @Override
+    public SkillRagExtractionJobItem saveItem(SkillRagExtractionJobItem item) {
+        int updated = template.update("""
+                UPDATE tb_skill_rag_extraction_job_item
+                SET document_id = :documentId,
+                    source_id = :sourceId,
+                    source_chunk_id = :sourceChunkId,
+                    extracted_count = :extractedCount,
+                    status = :status,
+                    error_message = :error,
+                    updated_at = :updatedAt
+                WHERE job_id = :jobId AND chunk_id = :chunkId
+                """, itemParams(item));
+        if (updated == 0) {
+            template.update("""
+                    INSERT INTO tb_skill_rag_extraction_job_item
+                        (job_id, chunk_id, document_id, source_id, source_chunk_id, extracted_count, status,
+                         error_message, created_at, updated_at)
+                    VALUES
+                        (:jobId, :chunkId, :documentId, :sourceId, :sourceChunkId, :extractedCount, :status,
+                         :error, :createdAt, :updatedAt)
+                    """, itemParams(item));
+        }
+        return item;
+    }
+
+    @Override
+    public List<SkillRagExtractionJobItem> listItems(String jobId, int offset, int limit) {
+        return template.query("""
+                SELECT * FROM tb_skill_rag_extraction_job_item
+                WHERE job_id = :jobId
+                ORDER BY created_at, chunk_id
+                LIMIT :limit OFFSET :offset
+                """, new MapSqlParameterSource()
+                .addValue("jobId", jobId)
+                .addValue("offset", Math.max(0, offset))
+                .addValue("limit", limit <= 0 ? 100 : limit), this::mapItem);
+    }
+
+    @Override
+    public List<SkillRagExtractionJobItem> listItemsByStatus(
+            String jobId,
+            SkillRagExtractionItemStatus status,
+            int limit) {
+        return template.query("""
+                SELECT * FROM tb_skill_rag_extraction_job_item
+                WHERE job_id = :jobId AND status = :status
+                ORDER BY created_at, chunk_id
+                LIMIT :limit
+                """, new MapSqlParameterSource()
+                .addValue("jobId", jobId)
+                .addValue("status", status.name())
+                .addValue("limit", limit <= 0 ? 100 : limit), this::mapItem);
+    }
+
+    private MapSqlParameterSource jobParams(SkillRagExtractionJob job) {
+        return new MapSqlParameterSource()
+                .addValue("jobId", job.jobId())
+                .addValue("objectType", job.objectType())
+                .addValue("objectId", job.objectId())
+                .addValue("documentId", job.documentId())
+                .addValue("status", job.status().name())
+                .addValue("requestedChunks", job.requestedChunks())
+                .addValue("totalChunks", job.totalChunks())
+                .addValue("processedChunks", job.processedChunks())
+                .addValue("succeededChunks", job.succeededChunks())
+                .addValue("failedChunks", job.failedChunks())
+                .addValue("extractedCount", job.extractedCount())
+                .addValue("error", job.error())
+                .addValue("createdAt", Timestamp.from(job.createdAt()))
+                .addValue("updatedAt", Timestamp.from(job.updatedAt()));
+    }
+
+    private MapSqlParameterSource itemParams(SkillRagExtractionJobItem item) {
+        return new MapSqlParameterSource()
+                .addValue("jobId", item.jobId())
+                .addValue("chunkId", item.chunkId())
+                .addValue("documentId", item.documentId())
+                .addValue("sourceId", item.sourceId())
+                .addValue("sourceChunkId", item.sourceChunkId())
+                .addValue("extractedCount", item.extractedCount())
+                .addValue("status", item.status().name())
+                .addValue("error", item.error())
+                .addValue("createdAt", Timestamp.from(item.createdAt()))
+                .addValue("updatedAt", Timestamp.from(item.updatedAt()));
+    }
+
+    private SkillRagExtractionJob mapJob(ResultSet rs, int rowNum) throws SQLException {
+        return new SkillRagExtractionJob(
+                rs.getString("job_id"),
+                rs.getString("object_type"),
+                rs.getString("object_id"),
+                rs.getString("document_id"),
+                SkillRagExtractionJobStatus.valueOf(rs.getString("status")),
+                rs.getInt("requested_chunks"),
+                rs.getInt("total_chunks"),
+                rs.getInt("processed_chunks"),
+                rs.getInt("succeeded_chunks"),
+                rs.getInt("failed_chunks"),
+                rs.getInt("extracted_count"),
+                rs.getString("error_message"),
+                instant(rs.getTimestamp("created_at")),
+                instant(rs.getTimestamp("updated_at")));
+    }
+
+    private SkillRagExtractionJobItem mapItem(ResultSet rs, int rowNum) throws SQLException {
+        return new SkillRagExtractionJobItem(
+                rs.getString("job_id"),
+                rs.getString("chunk_id"),
+                rs.getString("document_id"),
+                rs.getString("source_id"),
+                rs.getString("source_chunk_id"),
+                rs.getInt("extracted_count"),
+                SkillRagExtractionItemStatus.valueOf(rs.getString("status")),
+                rs.getString("error_message"),
+                instant(rs.getTimestamp("created_at")),
+                instant(rs.getTimestamp("updated_at")));
+    }
+
+    private Instant instant(Timestamp timestamp) {
+        return timestamp == null ? null : timestamp.toInstant();
+    }
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/memory/InMemorySkillRagExtractionJobStore.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/memory/InMemorySkillRagExtractionJobStore.java
@@ -1,0 +1,58 @@
+package studio.one.platform.skillgraph.infrastructure.persistence.memory;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import studio.one.platform.skillgraph.application.result.SkillRagExtractionItemStatus;
+import studio.one.platform.skillgraph.application.result.SkillRagExtractionJob;
+import studio.one.platform.skillgraph.application.result.SkillRagExtractionJobItem;
+import studio.one.platform.skillgraph.domain.port.SkillRagExtractionJobStore;
+
+public class InMemorySkillRagExtractionJobStore implements SkillRagExtractionJobStore {
+
+    private final Map<String, SkillRagExtractionJob> jobs = new ConcurrentHashMap<>();
+    private final Map<String, SkillRagExtractionJobItem> items = new ConcurrentHashMap<>();
+
+    @Override
+    public SkillRagExtractionJob saveJob(SkillRagExtractionJob job) {
+        jobs.put(job.jobId(), job);
+        return job;
+    }
+
+    @Override
+    public Optional<SkillRagExtractionJob> findJob(String jobId) {
+        return Optional.ofNullable(jobs.get(jobId));
+    }
+
+    @Override
+    public SkillRagExtractionJobItem saveItem(SkillRagExtractionJobItem item) {
+        items.put(item.jobId() + "|" + item.chunkId(), item);
+        return item;
+    }
+
+    @Override
+    public List<SkillRagExtractionJobItem> listItems(String jobId, int offset, int limit) {
+        return items.values().stream()
+                .filter(item -> item.jobId().equals(jobId))
+                .sorted(Comparator.comparing(SkillRagExtractionJobItem::createdAt))
+                .skip(Math.max(0, offset))
+                .limit(limit <= 0 ? 100 : limit)
+                .toList();
+    }
+
+    @Override
+    public List<SkillRagExtractionJobItem> listItemsByStatus(
+            String jobId,
+            SkillRagExtractionItemStatus status,
+            int limit) {
+        return items.values().stream()
+                .filter(item -> item.jobId().equals(jobId))
+                .filter(item -> item.status() == status)
+                .sorted(Comparator.comparing(SkillRagExtractionJobItem::createdAt))
+                .limit(limit <= 0 ? 100 : limit)
+                .toList();
+    }
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillExtractionJobMgmtController.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillExtractionJobMgmtController.java
@@ -15,7 +15,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,6 +29,7 @@ import studio.one.platform.skillgraph.application.result.ResolvedRagChunk;
 import studio.one.platform.skillgraph.application.result.SkillExtractionResult;
 import studio.one.platform.skillgraph.application.usecase.SkillExtractionService;
 import studio.one.platform.skillgraph.application.usecase.SkillGraphRagChunkResolver;
+import studio.one.platform.skillgraph.application.usecase.SkillRagExtractionJobService;
 import studio.one.platform.skillgraph.web.dto.request.SkillExtractionRequest;
 import studio.one.platform.skillgraph.web.dto.request.SkillRagExtractionRequest;
 import studio.one.platform.skillgraph.web.dto.request.SkillRagChunkExtractionRequest;
@@ -33,6 +37,8 @@ import studio.one.platform.skillgraph.web.dto.request.SkillRagDocumentExtraction
 import studio.one.platform.skillgraph.web.dto.response.SkillExtractionResponse;
 import studio.one.platform.skillgraph.web.dto.response.SkillRagBatchExtractionResponse;
 import studio.one.platform.skillgraph.web.dto.response.SkillRagChunkExtractionItemDto;
+import studio.one.platform.skillgraph.web.dto.response.SkillRagExtractionJobItemPageResponse;
+import studio.one.platform.skillgraph.web.dto.response.SkillRagExtractionJobResponse;
 import studio.one.platform.web.dto.ApiResponse;
 
 @RestController
@@ -46,13 +52,17 @@ public class SkillExtractionJobMgmtController {
 
     private final SkillExtractionService extractionService;
     private final ObjectProvider<SkillGraphRagChunkResolver> ragChunkResolverProvider;
+    private final ObjectProvider<SkillRagExtractionJobService> ragExtractionJobServiceProvider;
 
     public SkillExtractionJobMgmtController(
             SkillExtractionService extractionService,
-            ObjectProvider<SkillGraphRagChunkResolver> ragChunkResolverProvider) {
+            ObjectProvider<SkillGraphRagChunkResolver> ragChunkResolverProvider,
+            ObjectProvider<SkillRagExtractionJobService> ragExtractionJobServiceProvider) {
         this.extractionService = Objects.requireNonNull(extractionService, "extractionService");
         this.ragChunkResolverProvider = Objects.requireNonNull(ragChunkResolverProvider,
                 "ragChunkResolverProvider");
+        this.ragExtractionJobServiceProvider = Objects.requireNonNull(ragExtractionJobServiceProvider,
+                "ragExtractionJobServiceProvider");
     }
 
     @PostMapping
@@ -69,26 +79,19 @@ public class SkillExtractionJobMgmtController {
             + "and @endpointAuthz.can('services:ai_rag','read') "
             + "and (@endpointAuthz.can('objects:' + #request.objectType().trim() + ':' + #request.objectId().trim(),'read') "
             + "or @endpointAuthz.can('objects:' + #request.objectType().trim(),'read'))")
-    public ResponseEntity<ApiResponse<SkillRagBatchExtractionResponse>> extractRagDocument(
+    public ResponseEntity<ApiResponse<SkillRagExtractionJobResponse>> extractRagDocument(
             @Valid @RequestBody SkillRagDocumentExtractionRequest request) {
         String mode = normalize(request.mode());
         if (mode != null && !"ALL_CHUNKS".equals(mode.toUpperCase(Locale.ROOT))) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Only ALL_CHUNKS mode is supported");
         }
-        String documentId = normalize(request.documentId());
-        List<ResolvedRagChunk> chunks = resolveChunks(request.objectType(), request.objectId(), boundedLimit(request.limit()))
-                .stream()
-                .filter(chunk -> documentId == null || documentId.equals(chunk.documentId()))
-                .toList();
-        if (chunks.isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "RAG chunks not found");
-        }
-        return ResponseEntity.ok(ApiResponse.ok(extractChunks(
-                normalize(request.objectType()),
-                normalize(request.objectId()),
-                documentId,
-                chunks.size(),
-                chunks)));
+        SkillRagExtractionJobService jobService = ragExtractionJobService();
+        return ResponseEntity.status(HttpStatus.ACCEPTED)
+                .body(ApiResponse.ok(SkillRagExtractionJobResponse.from(jobService.submitAllChunks(
+                        request.objectType(),
+                        request.objectId(),
+                        request.documentId(),
+                        request.limit()))));
     }
 
     @PostMapping("/rag-chunks")
@@ -129,7 +132,7 @@ public class SkillExtractionJobMgmtController {
             + "and @endpointAuthz.can('services:ai_rag','read') "
             + "and (@endpointAuthz.can('objects:' + #request.objectType().trim() + ':' + #request.objectId().trim(),'read') "
             + "or @endpointAuthz.can('objects:' + #request.objectType().trim(),'read'))")
-    public ResponseEntity<ApiResponse<SkillRagBatchExtractionResponse>> extractRag(
+    public ResponseEntity<?> extractRag(
             @Valid @RequestBody SkillRagExtractionRequest request) {
         String mode = normalize(request.mode());
         if (mode == null || "ALL_CHUNKS".equalsIgnoreCase(mode)) {
@@ -151,6 +154,38 @@ public class SkillExtractionJobMgmtController {
                     request.chunkIds()));
         }
         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unsupported RAG extraction mode");
+    }
+
+    @GetMapping("/{jobId}")
+    @PreAuthorize("@endpointAuthz.can('features:skillgraph','manage')")
+    public ResponseEntity<ApiResponse<SkillRagExtractionJobResponse>> getRagExtractionJob(
+            @PathVariable String jobId) {
+        return ResponseEntity.ok(ApiResponse.ok(SkillRagExtractionJobResponse.from(
+                ragExtractionJobService().getJob(jobId))));
+    }
+
+    @GetMapping("/{jobId}/items")
+    @PreAuthorize("@endpointAuthz.can('features:skillgraph','manage')")
+    public ResponseEntity<ApiResponse<SkillRagExtractionJobItemPageResponse>> getRagExtractionJobItems(
+            @PathVariable String jobId,
+            @RequestParam(defaultValue = "0") int offset,
+            @RequestParam(defaultValue = "100") int limit) {
+        int safeOffset = Math.max(0, offset);
+        int safeLimit = limit <= 0 ? 100 : Math.min(limit, 500);
+        return ResponseEntity.ok(ApiResponse.ok(SkillRagExtractionJobItemPageResponse.from(
+                jobId,
+                safeOffset,
+                safeLimit,
+                ragExtractionJobService().listItems(jobId, safeOffset, safeLimit + 1))));
+    }
+
+    @PostMapping("/{jobId}/retry-failed")
+    @PreAuthorize("@endpointAuthz.can('features:skillgraph','manage')")
+    public ResponseEntity<ApiResponse<SkillRagExtractionJobResponse>> retryFailedRagExtractionJob(
+            @PathVariable String jobId) {
+        return ResponseEntity.status(HttpStatus.ACCEPTED)
+                .body(ApiResponse.ok(SkillRagExtractionJobResponse.from(
+                        ragExtractionJobService().retryFailed(jobId))));
     }
 
     private SkillRagBatchExtractionResponse extractChunks(
@@ -251,6 +286,15 @@ public class SkillExtractionJobMgmtController {
         } catch (UnsupportedOperationException ex) {
             throw new ResponseStatusException(HttpStatus.NOT_IMPLEMENTED, "RAG chunk resolve is not supported", ex);
         }
+    }
+
+    private SkillRagExtractionJobService ragExtractionJobService() {
+        SkillRagExtractionJobService service = ragExtractionJobServiceProvider.getIfAvailable();
+        if (service == null) {
+            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
+                    "RAG extraction job service is not configured");
+        }
+        return service;
     }
 
     private Map<String, String> normalizedChunkIds(List<String> chunkIds) {

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/response/SkillRagExtractionJobItemPageResponse.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/response/SkillRagExtractionJobItemPageResponse.java
@@ -1,0 +1,32 @@
+package studio.one.platform.skillgraph.web.dto.response;
+
+import java.util.List;
+
+import studio.one.platform.skillgraph.application.result.SkillRagExtractionJobItem;
+
+public record SkillRagExtractionJobItemPageResponse(
+        String jobId,
+        int offset,
+        int limit,
+        int returned,
+        boolean hasMore,
+        List<SkillRagExtractionJobItemResponse> items) {
+
+    public static SkillRagExtractionJobItemPageResponse from(
+            String jobId,
+            int offset,
+            int limit,
+            List<SkillRagExtractionJobItem> items) {
+        List<SkillRagExtractionJobItemResponse> mapped = items.stream()
+                .limit(limit)
+                .map(SkillRagExtractionJobItemResponse::from)
+                .toList();
+        return new SkillRagExtractionJobItemPageResponse(
+                jobId,
+                offset,
+                limit,
+                mapped.size(),
+                items.size() > limit,
+                mapped);
+    }
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/response/SkillRagExtractionJobItemResponse.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/response/SkillRagExtractionJobItemResponse.java
@@ -1,0 +1,32 @@
+package studio.one.platform.skillgraph.web.dto.response;
+
+import java.time.Instant;
+
+import studio.one.platform.skillgraph.application.result.SkillRagExtractionJobItem;
+
+public record SkillRagExtractionJobItemResponse(
+        String jobId,
+        String chunkId,
+        String documentId,
+        String sourceId,
+        String sourceChunkId,
+        int extractedCount,
+        String status,
+        String error,
+        Instant createdAt,
+        Instant updatedAt) {
+
+    public static SkillRagExtractionJobItemResponse from(SkillRagExtractionJobItem item) {
+        return new SkillRagExtractionJobItemResponse(
+                item.jobId(),
+                item.chunkId(),
+                item.documentId(),
+                item.sourceId(),
+                item.sourceChunkId(),
+                item.extractedCount(),
+                item.status().name(),
+                item.error(),
+                item.createdAt(),
+                item.updatedAt());
+    }
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/response/SkillRagExtractionJobResponse.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/response/SkillRagExtractionJobResponse.java
@@ -1,0 +1,40 @@
+package studio.one.platform.skillgraph.web.dto.response;
+
+import java.time.Instant;
+
+import studio.one.platform.skillgraph.application.result.SkillRagExtractionJob;
+
+public record SkillRagExtractionJobResponse(
+        String jobId,
+        String objectType,
+        String objectId,
+        String documentId,
+        String status,
+        int requestedChunks,
+        int totalChunks,
+        int processedChunks,
+        int succeededChunks,
+        int failedChunks,
+        int extractedCount,
+        String error,
+        Instant createdAt,
+        Instant updatedAt) {
+
+    public static SkillRagExtractionJobResponse from(SkillRagExtractionJob job) {
+        return new SkillRagExtractionJobResponse(
+                job.jobId(),
+                job.objectType(),
+                job.objectId(),
+                job.documentId(),
+                job.status().name(),
+                job.requestedChunks(),
+                job.totalChunks(),
+                job.processedChunks(),
+                job.succeededChunks(),
+                job.failedChunks(),
+                job.extractedCount(),
+                job.error(),
+                job.createdAt(),
+                job.updatedAt());
+    }
+}

--- a/studio-platform-skillgraph/src/main/resources/schema/skillgraph/mariadb/V1501__create_skill_rag_extraction_job_tables.sql
+++ b/studio-platform-skillgraph/src/main/resources/schema/skillgraph/mariadb/V1501__create_skill_rag_extraction_job_tables.sql
@@ -1,0 +1,39 @@
+CREATE TABLE IF NOT EXISTS tb_skill_rag_extraction_job (
+    job_id VARCHAR(100) PRIMARY KEY,
+    object_type VARCHAR(100) NOT NULL,
+    object_id VARCHAR(200) NOT NULL,
+    document_id VARCHAR(200),
+    status VARCHAR(40) NOT NULL,
+    requested_chunks INT NOT NULL DEFAULT 0,
+    total_chunks INT NOT NULL DEFAULT 0,
+    processed_chunks INT NOT NULL DEFAULT 0,
+    succeeded_chunks INT NOT NULL DEFAULT 0,
+    failed_chunks INT NOT NULL DEFAULT 0,
+    extracted_count INT NOT NULL DEFAULT 0,
+    error_message TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_skill_rag_extraction_job_status
+    ON tb_skill_rag_extraction_job(status, updated_at);
+
+CREATE INDEX idx_skill_rag_extraction_job_object
+    ON tb_skill_rag_extraction_job(object_type, object_id, updated_at);
+
+CREATE TABLE IF NOT EXISTS tb_skill_rag_extraction_job_item (
+    job_id VARCHAR(100) NOT NULL,
+    chunk_id VARCHAR(200) NOT NULL,
+    document_id VARCHAR(200),
+    source_id VARCHAR(200),
+    source_chunk_id VARCHAR(100),
+    extracted_count INT NOT NULL DEFAULT 0,
+    status VARCHAR(40) NOT NULL,
+    error_message TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (job_id, chunk_id)
+);
+
+CREATE INDEX idx_skill_rag_extraction_job_item_status
+    ON tb_skill_rag_extraction_job_item(job_id, status, created_at);

--- a/studio-platform-skillgraph/src/main/resources/schema/skillgraph/mysql/V1501__create_skill_rag_extraction_job_tables.sql
+++ b/studio-platform-skillgraph/src/main/resources/schema/skillgraph/mysql/V1501__create_skill_rag_extraction_job_tables.sql
@@ -1,0 +1,39 @@
+CREATE TABLE IF NOT EXISTS tb_skill_rag_extraction_job (
+    job_id VARCHAR(100) PRIMARY KEY,
+    object_type VARCHAR(100) NOT NULL,
+    object_id VARCHAR(200) NOT NULL,
+    document_id VARCHAR(200),
+    status VARCHAR(40) NOT NULL,
+    requested_chunks INT NOT NULL DEFAULT 0,
+    total_chunks INT NOT NULL DEFAULT 0,
+    processed_chunks INT NOT NULL DEFAULT 0,
+    succeeded_chunks INT NOT NULL DEFAULT 0,
+    failed_chunks INT NOT NULL DEFAULT 0,
+    extracted_count INT NOT NULL DEFAULT 0,
+    error_message TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_skill_rag_extraction_job_status
+    ON tb_skill_rag_extraction_job(status, updated_at);
+
+CREATE INDEX idx_skill_rag_extraction_job_object
+    ON tb_skill_rag_extraction_job(object_type, object_id, updated_at);
+
+CREATE TABLE IF NOT EXISTS tb_skill_rag_extraction_job_item (
+    job_id VARCHAR(100) NOT NULL,
+    chunk_id VARCHAR(200) NOT NULL,
+    document_id VARCHAR(200),
+    source_id VARCHAR(200),
+    source_chunk_id VARCHAR(100),
+    extracted_count INT NOT NULL DEFAULT 0,
+    status VARCHAR(40) NOT NULL,
+    error_message TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (job_id, chunk_id)
+);
+
+CREATE INDEX idx_skill_rag_extraction_job_item_status
+    ON tb_skill_rag_extraction_job_item(job_id, status, created_at);

--- a/studio-platform-skillgraph/src/main/resources/schema/skillgraph/postgres/V1501__create_skill_rag_extraction_job_tables.sql
+++ b/studio-platform-skillgraph/src/main/resources/schema/skillgraph/postgres/V1501__create_skill_rag_extraction_job_tables.sql
@@ -1,0 +1,39 @@
+CREATE TABLE IF NOT EXISTS tb_skill_rag_extraction_job (
+    job_id VARCHAR(100) PRIMARY KEY,
+    object_type VARCHAR(100) NOT NULL,
+    object_id VARCHAR(200) NOT NULL,
+    document_id VARCHAR(200),
+    status VARCHAR(40) NOT NULL,
+    requested_chunks INT NOT NULL DEFAULT 0,
+    total_chunks INT NOT NULL DEFAULT 0,
+    processed_chunks INT NOT NULL DEFAULT 0,
+    succeeded_chunks INT NOT NULL DEFAULT 0,
+    failed_chunks INT NOT NULL DEFAULT 0,
+    extracted_count INT NOT NULL DEFAULT 0,
+    error_message TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_skill_rag_extraction_job_status
+    ON tb_skill_rag_extraction_job(status, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_skill_rag_extraction_job_object
+    ON tb_skill_rag_extraction_job(object_type, object_id, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS tb_skill_rag_extraction_job_item (
+    job_id VARCHAR(100) NOT NULL,
+    chunk_id VARCHAR(200) NOT NULL,
+    document_id VARCHAR(200),
+    source_id VARCHAR(200),
+    source_chunk_id VARCHAR(100),
+    extracted_count INT NOT NULL DEFAULT 0,
+    status VARCHAR(40) NOT NULL,
+    error_message TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP NOT NULL DEFAULT now(),
+    PRIMARY KEY (job_id, chunk_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_skill_rag_extraction_job_item_status
+    ON tb_skill_rag_extraction_job_item(job_id, status, created_at);

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/DefaultSkillRagExtractionJobServiceTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/DefaultSkillRagExtractionJobServiceTest.java
@@ -1,0 +1,124 @@
+package studio.one.platform.skillgraph;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.skillgraph.application.command.SkillExtractionCommand;
+import studio.one.platform.skillgraph.application.result.ResolvedRagChunk;
+import studio.one.platform.skillgraph.application.result.SkillExtractionResult;
+import studio.one.platform.skillgraph.application.result.SkillRagExtractionJobStatus;
+import studio.one.platform.skillgraph.application.service.DefaultSkillRagExtractionJobService;
+import studio.one.platform.skillgraph.application.service.SkillRagExtractionJobSettings;
+import studio.one.platform.skillgraph.application.usecase.SkillExtractionService;
+import studio.one.platform.skillgraph.application.usecase.SkillGraphRagChunkResolver;
+import studio.one.platform.skillgraph.infrastructure.persistence.memory.InMemorySkillRagExtractionJobStore;
+
+class DefaultSkillRagExtractionJobServiceTest {
+
+    @Test
+    void processesAllChunksByPageWithoutLoadingWholeDocument() {
+        InMemorySkillRagExtractionJobStore store = new InMemorySkillRagExtractionJobStore();
+        PagingResolver resolver = new PagingResolver(List.of(
+                chunk("doc-1", "chunk-1", "Spring Boot"),
+                chunk("doc-1", "chunk-2", "Kubernetes"),
+                chunk("doc-1", "chunk-3", "PostgreSQL")));
+        DefaultSkillRagExtractionJobService service = new DefaultSkillRagExtractionJobService(
+                new CountingExtractionService(),
+                resolver,
+                store,
+                Runnable::run,
+                new SkillRagExtractionJobSettings(2, 10, 1_000_000));
+
+        var submitted = service.submitAllChunks("attachment", "42", "doc-1", null);
+        var job = service.getJob(submitted.jobId());
+
+        assertEquals(SkillRagExtractionJobStatus.COMPLETED, job.status());
+        assertEquals(3, job.totalChunks());
+        assertEquals(3, job.processedChunks());
+        assertEquals(3, job.succeededChunks());
+        assertEquals(List.of(0, 2), resolver.offsets);
+    }
+
+    @Test
+    void recordsPartialJobWhenChunkFails() {
+        InMemorySkillRagExtractionJobStore store = new InMemorySkillRagExtractionJobStore();
+        DefaultSkillRagExtractionJobService service = new DefaultSkillRagExtractionJobService(
+                command -> {
+                    if ("chunk-2".equals(command.chunkId())) {
+                        throw new IllegalArgumentException("bad chunk");
+                    }
+                    return new SkillExtractionResult("source-" + command.chunkId(), 1, List.of());
+                },
+                new PagingResolver(List.of(
+                        chunk("doc-1", "chunk-1", "Spring Boot"),
+                        chunk("doc-1", "chunk-2", "Kubernetes"))),
+                store,
+                Runnable::run,
+                new SkillRagExtractionJobSettings(20, 10, 1_000_000));
+
+        var submitted = service.submitAllChunks("attachment", "42", "doc-1", null);
+        var job = service.getJob(submitted.jobId());
+
+        assertEquals(SkillRagExtractionJobStatus.PARTIAL, job.status());
+        assertEquals(1, job.succeededChunks());
+        assertEquals(1, job.failedChunks());
+        assertEquals("bad chunk", service.listItems(job.jobId(), 0, 10).get(1).error());
+    }
+
+    @Test
+    void skipsChunkThatExceedsTextByteLimit() {
+        InMemorySkillRagExtractionJobStore store = new InMemorySkillRagExtractionJobStore();
+        DefaultSkillRagExtractionJobService service = new DefaultSkillRagExtractionJobService(
+                new CountingExtractionService(),
+                new PagingResolver(List.of(chunk("doc-1", "chunk-1", "Spring Boot"))),
+                store,
+                Runnable::run,
+                new SkillRagExtractionJobSettings(20, 10, 4));
+
+        var submitted = service.submitAllChunks("attachment", "42", "doc-1", null);
+        var job = service.getJob(submitted.jobId());
+
+        assertEquals(SkillRagExtractionJobStatus.FAILED, job.status());
+        assertEquals("RAG chunk text exceeds maxTextBytesPerBatch",
+                service.listItems(job.jobId(), 0, 10).get(0).error());
+    }
+
+    private static ResolvedRagChunk chunk(String documentId, String chunkId, String content) {
+        return new ResolvedRagChunk(chunkId, documentId, content);
+    }
+
+    private static final class PagingResolver implements SkillGraphRagChunkResolver {
+
+        private final List<ResolvedRagChunk> chunks;
+        private final List<Integer> offsets = new ArrayList<>();
+
+        private PagingResolver(List<ResolvedRagChunk> chunks) {
+            this.chunks = chunks;
+        }
+
+        @Override
+        public List<ResolvedRagChunk> listByObject(String objectType, String objectId, int limit) {
+            return listByObject(objectType, objectId, 0, limit);
+        }
+
+        @Override
+        public List<ResolvedRagChunk> listByObject(String objectType, String objectId, int offset, int limit) {
+            offsets.add(offset);
+            int from = Math.min(offset, chunks.size());
+            int to = Math.min(from + limit, chunks.size());
+            return chunks.subList(from, to);
+        }
+    }
+
+    private static final class CountingExtractionService implements SkillExtractionService {
+
+        @Override
+        public SkillExtractionResult extract(SkillExtractionCommand command) {
+            return new SkillExtractionResult("source-" + command.chunkId(), 1, List.of());
+        }
+    }
+}

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/SkillExtractionJobMgmtControllerTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/SkillExtractionJobMgmtControllerTest.java
@@ -11,15 +11,21 @@ import org.springframework.beans.factory.support.StaticListableBeanFactory;
 import studio.one.platform.skillgraph.application.command.SkillExtractionCommand;
 import studio.one.platform.skillgraph.application.result.ResolvedRagChunk;
 import studio.one.platform.skillgraph.application.result.SkillExtractionResult;
+import studio.one.platform.skillgraph.application.service.DefaultSkillRagExtractionJobService;
+import studio.one.platform.skillgraph.application.service.SkillRagExtractionJobSettings;
 import studio.one.platform.skillgraph.application.service.RegexSkillCandidateExtractor;
 import studio.one.platform.skillgraph.application.usecase.SkillExtractionService;
 import studio.one.platform.skillgraph.application.usecase.SkillGraphRagChunkResolver;
+import studio.one.platform.skillgraph.application.usecase.SkillRagExtractionJobService;
 import studio.one.platform.skillgraph.infrastructure.extraction.PatternSkillCandidateExtractor;
 import studio.one.platform.skillgraph.infrastructure.persistence.memory.InMemorySkillCandidateStore;
+import studio.one.platform.skillgraph.infrastructure.persistence.memory.InMemorySkillRagExtractionJobStore;
 import studio.one.platform.skillgraph.web.controller.SkillExtractionJobMgmtController;
 import studio.one.platform.skillgraph.web.dto.request.SkillRagExtractionRequest;
 import studio.one.platform.skillgraph.web.dto.request.SkillRagChunkExtractionRequest;
 import studio.one.platform.skillgraph.web.dto.request.SkillRagDocumentExtractionRequest;
+import studio.one.platform.skillgraph.web.dto.response.SkillRagBatchExtractionResponse;
+import studio.one.platform.web.dto.ApiResponse;
 
 class SkillExtractionJobMgmtControllerTest {
 
@@ -33,9 +39,8 @@ class SkillExtractionJobMgmtControllerTest {
         var response = controller.extractRagDocument(new SkillRagDocumentExtractionRequest(
                 "attachment", "42", "doc-1", "ALL_CHUNKS", null)).getBody().getData();
 
-        assertEquals(1, response.resolvedChunks());
-        assertEquals(1, response.succeededChunks());
-        assertEquals(0, response.failedChunks());
+        assertEquals("RUNNING", response.status());
+        assertEquals(1000, response.requestedChunks());
         assertEquals("RAG_CHUNK", store.sourceChunks().get(0).sourceType());
         assertEquals("doc-1", store.sourceChunks().get(0).sourceId());
         assertEquals("chunk-1", store.sourceChunks().get(0).chunkId());
@@ -63,13 +68,14 @@ class SkillExtractionJobMgmtControllerTest {
         SkillExtractionJobMgmtController controller = controller(store, new FakeRagChunkResolver(List.of(
                 ragChunk("doc-1", "chunk-1", "Spring Boot 기술"))));
 
-        var response = controller.extractRag(new SkillRagExtractionRequest(
+        var body = (ApiResponse<?>) controller.extractRag(new SkillRagExtractionRequest(
                 "attachment",
                 "42",
                 "doc-1",
                 "SELECTED_CHUNKS",
                 List.of("chunk-1"),
-                null)).getBody().getData();
+                null)).getBody();
+        var response = (SkillRagBatchExtractionResponse) body.getData();
 
         assertEquals(1, response.succeededChunks());
         assertEquals("chunk-1", store.sourceChunks().get(0).chunkId());
@@ -104,7 +110,8 @@ class SkillExtractionJobMgmtControllerTest {
         InMemorySkillCandidateStore store = new InMemorySkillCandidateStore();
         SkillExtractionJobMgmtController controller = new SkillExtractionJobMgmtController(
                 new FailingSkillExtractionService(),
-                resolverProvider(new FakeRagChunkResolver(List.of(ragChunk("doc-1", "chunk-1", "Spring Boot")))));
+                resolverProvider(new FakeRagChunkResolver(List.of(ragChunk("doc-1", "chunk-1", "Spring Boot")))),
+                jobServiceProvider(null));
 
         var response = controller.extractRagChunks(new SkillRagChunkExtractionRequest(
                 "attachment", "42", null, List.of("chunk-1"))).getBody().getData();
@@ -120,7 +127,13 @@ class SkillExtractionJobMgmtControllerTest {
                 new PatternSkillCandidateExtractor());
         return new SkillExtractionJobMgmtController(
                 extractionService,
-                resolverProvider(resolver));
+                resolverProvider(resolver),
+                jobServiceProvider(resolver == null ? null : new DefaultSkillRagExtractionJobService(
+                        extractionService,
+                        resolver,
+                        new InMemorySkillRagExtractionJobStore(),
+                        Runnable::run,
+                        new SkillRagExtractionJobSettings(20, 1000, 1_000_000))));
     }
 
     private org.springframework.beans.factory.ObjectProvider<SkillGraphRagChunkResolver> resolverProvider(
@@ -130,6 +143,15 @@ class SkillExtractionJobMgmtControllerTest {
             beanFactory.addBean("skillGraphRagChunkResolver", resolver);
         }
         return beanFactory.getBeanProvider(SkillGraphRagChunkResolver.class);
+    }
+
+    private org.springframework.beans.factory.ObjectProvider<SkillRagExtractionJobService> jobServiceProvider(
+            SkillRagExtractionJobService service) {
+        StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
+        if (service != null) {
+            beanFactory.addBean("skillRagExtractionJobService", service);
+        }
+        return beanFactory.getBeanProvider(SkillRagExtractionJobService.class);
     }
 
     private static ResolvedRagChunk ragChunk(String documentId, String chunkId, String content) {


### PR DESCRIPTION
## Why

- #485에서 정리한 대량 RAG chunk 전체 문서 추출 경로는 HTTP 요청 안에서 모든 chunk를 동기 처리해 OOM, timeout, partial failure 복구 문제가 발생할 수 있습니다.
- `ALL_CHUNKS` 요청은 background job으로 등록하고, 서버 worker가 page/batch 단위로 bounded 처리하도록 전환해야 합니다.
- dev 서버 확인 중 `RAG extraction job service is not configured`가 발생할 수 있어, RAG resolver 생성 이후 job service가 생성되도록 auto-configuration 순서도 함께 수정했습니다.

## What

- `POST /api/mgmt/skillgraph/extraction-jobs/rag` 및 `/rag-documents`의 `ALL_CHUNKS` 경로를 `202 Accepted` + `jobId/status` 응답으로 전환했습니다.
- job 조회, job item page 조회, 실패 item 재시도 API를 추가했습니다.
- `SkillRagExtractionJobService`, job/item model, memory/JDBC job store, V1501 schema를 추가했습니다.
- worker 설정을 `studio.skillgraph.extraction.rag-job.*`로 추가했습니다.
- `SkillRagExtractionJobService` 생성 위치를 RAG resolver가 생성되는 web auto-configuration 쪽으로 옮겼습니다.
- `SELECTED_CHUNKS` 경로는 기존 동기 batch 응답을 유지했습니다.

## Related Issues

- Closes #485

## Validation

- Command: `./gradlew :studio-platform-skillgraph:test :starter:studio-platform-starter-skillgraph:test`
- Result: PASS
- Command: `ruby -e 'require "yaml"; YAML.load_file("/Users/donghyuck.son/git/studio-one/studio-one-api-server/src/main/resources/config/application-dev.yml"); puts "yaml ok"'`
- Result: PASS (`yaml ok`)
- Command: `git diff --check`
- Result: PASS

## Risk / Rollback

- Risk: `ALL_CHUNKS` API 응답이 기존 동기 batch 결과에서 async job 응답으로 바뀌므로 클라이언트는 job 상태 조회 흐름을 사용해야 합니다.
- Rollback: job service/controller/schema 추가분과 `ALL_CHUNKS` async 전환을 되돌리면 기존 동기 처리로 복구됩니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: 없음
- Main author validation: #485 acceptance criteria와 dev 서버 auto-configuration 재현 가능성을 기준으로 구현, 테스트, YAML 파싱 검증을 수행했습니다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
