### PR TITLE
[ai-assisted] feat(skillgraph): dictionary 생성 API와 job 상태 보정 추가

### DIFF
--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/command/CreateSkillDictionaryCommand.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/command/CreateSkillDictionaryCommand.java
@@ -1,0 +1,9 @@
+package studio.one.platform.skillgraph.application.command;
+
+public record CreateSkillDictionaryCommand(
+        String name,
+        String normalizedName,
+        String categoryId,
+        String status,
+        String description) {
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillDictionaryService.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillDictionaryService.java
@@ -50,7 +50,12 @@ public class DefaultSkillDictionaryService implements SkillDictionaryService {
 
     @Override
     public List<SkillDictionaryView> search(String q, int limit) {
-        return store.search(normalizeQuery(q), normalizeLimit(limit)).stream()
+        return search(q, 0, limit);
+    }
+
+    @Override
+    public List<SkillDictionaryView> search(String q, int offset, int limit) {
+        return store.search(normalizeQuery(q), Math.max(0, offset), normalizeLimit(limit)).stream()
                 .map(SkillDictionaryView::from)
                 .toList();
     }

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillDictionaryService.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillDictionaryService.java
@@ -1,11 +1,16 @@
 package studio.one.platform.skillgraph.application.service;
 
+import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 
 import lombok.RequiredArgsConstructor;
+import studio.one.platform.skillgraph.application.command.CreateSkillDictionaryCommand;
 import studio.one.platform.skillgraph.application.result.SkillDictionaryView;
 import studio.one.platform.skillgraph.application.usecase.SkillDictionaryService;
 import studio.one.platform.skillgraph.domain.constants.SkillGraphLimits;
+import studio.one.platform.skillgraph.domain.model.SkillCandidate;
+import studio.one.platform.skillgraph.domain.model.SkillDictionary;
 import studio.one.platform.skillgraph.domain.port.SkillDictionaryStore;
 
 /**
@@ -51,6 +56,32 @@ public class DefaultSkillDictionaryService implements SkillDictionaryService {
     }
 
     @Override
+    public SkillDictionaryView create(CreateSkillDictionaryCommand command) {
+        if (command == null) {
+            throw new IllegalArgumentException("request must not be null");
+        }
+        String name = requireText(command.name(), "name");
+        String normalizedName = SkillCandidate.normalizeSkillTerm(
+                command.normalizedName() == null || command.normalizedName().isBlank()
+                        ? name
+                        : command.normalizedName());
+        store.findByNormalizedName(normalizedName)
+                .ifPresent(existing -> {
+                    throw new DuplicateSkillDictionaryException(normalizedName);
+                });
+        Instant now = Instant.now();
+        SkillDictionary skill = new SkillDictionary(
+                "skill_" + UUID.randomUUID(),
+                name,
+                normalizedName,
+                normalize(command.categoryId()),
+                normalize(command.status()),
+                now,
+                now);
+        return SkillDictionaryView.from(store.save(skill));
+    }
+
+    @Override
     public SkillDictionaryView get(String skillId) {
         return store.findById(skillId)
                 .map(SkillDictionaryView::from)
@@ -72,5 +103,19 @@ public class DefaultSkillDictionaryService implements SkillDictionaryService {
         return trimmed.length() <= SkillGraphLimits.MAX_QUERY_LENGTH
                 ? trimmed
                 : trimmed.substring(0, SkillGraphLimits.MAX_QUERY_LENGTH);
+    }
+
+    private String normalize(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.trim();
+    }
+
+    private String requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return value.trim();
     }
 }

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillRagExtractionJobService.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillRagExtractionJobService.java
@@ -98,6 +98,7 @@ public class DefaultSkillRagExtractionJobService implements SkillRagExtractionJo
     @Override
     public SkillRagExtractionJob getJob(String jobId) {
         return store.findJob(required(jobId, "jobId"))
+                .map(this::reconcileCompletedActiveJob)
                 .orElseThrow(() -> new IllegalArgumentException("RAG extraction job not found: " + jobId));
     }
 
@@ -109,8 +110,12 @@ public class DefaultSkillRagExtractionJobService implements SkillRagExtractionJo
             String documentId,
             int offset,
             int limit) {
-        return store.listJobs(parseStatus(status), normalize(objectType), normalize(objectId), normalize(documentId),
-                Math.max(0, offset), boundedJobLimit(limit));
+        SkillRagExtractionJobStatus parsedStatus = parseStatus(status);
+        return store.listJobs(null, normalize(objectType), normalize(objectId), normalize(documentId),
+                Math.max(0, offset), boundedJobLimit(limit)).stream()
+                .map(this::reconcileCompletedActiveJob)
+                .filter(job -> parsedStatus == null || job.status() == parsedStatus)
+                .toList();
     }
 
     @Override
@@ -255,6 +260,23 @@ public class DefaultSkillRagExtractionJobService implements SkillRagExtractionJo
             return SkillRagExtractionJobStatus.FAILED;
         }
         return SkillRagExtractionJobStatus.COMPLETED;
+    }
+
+    private SkillRagExtractionJob reconcileCompletedActiveJob(SkillRagExtractionJob job) {
+        if (job.status() != SkillRagExtractionJobStatus.RUNNING && job.status() != SkillRagExtractionJobStatus.READY) {
+            return job;
+        }
+        if (job.totalChunks() <= 0 || job.processedChunks() < job.totalChunks()) {
+            return job;
+        }
+        SkillRagExtractionJobStatus status = finalStatus(
+                job.processedChunks(),
+                job.succeededChunks(),
+                job.failedChunks());
+        if (status == job.status()) {
+            return job;
+        }
+        return store.saveJob(job.withStatus(status, null, clock.instant()));
     }
 
     private int boundedLimit(Integer limit) {

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DuplicateSkillDictionaryException.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DuplicateSkillDictionaryException.java
@@ -1,0 +1,8 @@
+package studio.one.platform.skillgraph.application.service;
+
+public class DuplicateSkillDictionaryException extends RuntimeException {
+
+    public DuplicateSkillDictionaryException(String normalizedName) {
+        super("Skill dictionary already exists: " + normalizedName);
+    }
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/usecase/SkillDictionaryService.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/usecase/SkillDictionaryService.java
@@ -2,6 +2,7 @@ package studio.one.platform.skillgraph.application.usecase;
 
 import java.util.List;
 
+import studio.one.platform.skillgraph.application.command.CreateSkillDictionaryCommand;
 import studio.one.platform.skillgraph.application.result.SkillDictionaryView;
 
 public interface SkillDictionaryService {
@@ -9,6 +10,8 @@ public interface SkillDictionaryService {
     String SERVICE_NAME = "skillDictionaryService";
 
     List<SkillDictionaryView> search(String q, int limit);
+
+    SkillDictionaryView create(CreateSkillDictionaryCommand command);
 
     SkillDictionaryView get(String skillId);
 }

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/usecase/SkillDictionaryService.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/usecase/SkillDictionaryService.java
@@ -11,6 +11,8 @@ public interface SkillDictionaryService {
 
     List<SkillDictionaryView> search(String q, int limit);
 
+    List<SkillDictionaryView> search(String q, int offset, int limit);
+
     SkillDictionaryView create(CreateSkillDictionaryCommand command);
 
     SkillDictionaryView get(String skillId);

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/domain/port/SkillDictionaryStore.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/domain/port/SkillDictionaryStore.java
@@ -45,4 +45,13 @@ public interface SkillDictionaryStore {
     }
 
     List<SkillDictionary> search(String q, int limit);
+
+    default List<SkillDictionary> search(String q, int offset, int limit) {
+        int safeOffset = Math.max(0, offset);
+        int safeLimit = limit <= 0 ? 100 : limit;
+        return search(q, safeOffset + safeLimit).stream()
+                .skip(safeOffset)
+                .limit(safeLimit)
+                .toList();
+    }
 }

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/jdbc/JdbcSkillDictionaryStore.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/jdbc/JdbcSkillDictionaryStore.java
@@ -88,14 +88,23 @@ public class JdbcSkillDictionaryStore implements SkillDictionaryStore {
 
     @Override
     public List<SkillDictionary> search(String q, int limit) {
+        return search(q, 0, limit);
+    }
+
+    @Override
+    public List<SkillDictionary> search(String q, int offset, int limit) {
         String query = q == null ? "" : q.trim().toLowerCase();
         int max = limit <= 0 ? 100 : limit;
         return template.query("""
                 SELECT * FROM tb_skill_dictionary
                 WHERE (:q = '' OR LOWER(name) LIKE :likeQ OR normalized_name LIKE :likeQ)
                 ORDER BY name
-                LIMIT :limit
-                """, Map.of("q", query, "likeQ", "%" + query + "%", "limit", max), this::mapSkill);
+                LIMIT :limit OFFSET :offset
+                """, Map.of(
+                "q", query,
+                "likeQ", "%" + query + "%",
+                "limit", max,
+                "offset", Math.max(0, offset)), this::mapSkill);
     }
 
     private Optional<SkillDictionary> queryOne(String sql, Map<String, ?> params) {

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/memory/InMemorySkillDictionaryStore.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/memory/InMemorySkillDictionaryStore.java
@@ -75,6 +75,11 @@ public class InMemorySkillDictionaryStore implements SkillDictionaryStore {
 
     @Override
     public List<SkillDictionary> search(String q, int limit) {
+        return search(q, 0, limit);
+    }
+
+    @Override
+    public List<SkillDictionary> search(String q, int offset, int limit) {
         String query = q == null ? "" : q.trim().toLowerCase(Locale.ROOT);
         int max = limit <= 0 ? 100 : limit;
         return skills.values().stream()
@@ -82,6 +87,7 @@ public class InMemorySkillDictionaryStore implements SkillDictionaryStore {
                         || skill.normalizedName().contains(query)
                         || skill.name().toLowerCase(Locale.ROOT).contains(query))
                 .sorted(Comparator.comparing(SkillDictionary::name))
+                .skip(Math.max(0, offset))
                 .limit(max)
                 .toList();
     }

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillDictionaryMgmtController.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillDictionaryMgmtController.java
@@ -1,7 +1,5 @@
 package studio.one.platform.skillgraph.web.controller;
 
-import java.util.List;
-
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -25,6 +23,7 @@ import studio.one.platform.skillgraph.application.service.DuplicateSkillDictiona
 import studio.one.platform.skillgraph.application.usecase.SkillDictionaryService;
 import studio.one.platform.skillgraph.web.dto.request.CreateSkillDictionaryRequest;
 import studio.one.platform.skillgraph.web.dto.response.SkillDictionaryDto;
+import studio.one.platform.skillgraph.web.dto.response.SkillDictionaryPageResponse;
 import studio.one.platform.web.dto.ApiResponse;
 
 @RestController
@@ -37,12 +36,14 @@ public class SkillDictionaryMgmtController {
 
     @GetMapping
     @PreAuthorize("@endpointAuthz.can('features:skillgraph','read')")
-    public ResponseEntity<ApiResponse<List<SkillDictionaryDto>>> search(
+    public ResponseEntity<ApiResponse<SkillDictionaryPageResponse>> search(
             @RequestParam(value = "q", required = false) @Size(max = 200) String q,
+            @RequestParam(value = "offset", required = false, defaultValue = "0") @Min(0) int offset,
             @RequestParam(value = "limit", required = false, defaultValue = "100") @Min(1) @Max(500) int limit) {
-        return ResponseEntity.ok(ApiResponse.ok(dictionaryService.search(q, limit).stream()
-                .map(SkillDictionaryDto::from)
-                .toList()));
+        return ResponseEntity.ok(ApiResponse.ok(SkillDictionaryPageResponse.from(
+                offset,
+                limit,
+                dictionaryService.search(q, offset, limit + 1))));
     }
 
     @PostMapping

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillDictionaryMgmtController.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillDictionaryMgmtController.java
@@ -2,21 +2,28 @@ package studio.one.platform.skillgraph.web.controller;
 
 import java.util.List;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import lombok.RequiredArgsConstructor;
+import studio.one.platform.skillgraph.application.service.DuplicateSkillDictionaryException;
 import studio.one.platform.skillgraph.application.usecase.SkillDictionaryService;
+import studio.one.platform.skillgraph.web.dto.request.CreateSkillDictionaryRequest;
 import studio.one.platform.skillgraph.web.dto.response.SkillDictionaryDto;
 import studio.one.platform.web.dto.ApiResponse;
 
@@ -36,6 +43,20 @@ public class SkillDictionaryMgmtController {
         return ResponseEntity.ok(ApiResponse.ok(dictionaryService.search(q, limit).stream()
                 .map(SkillDictionaryDto::from)
                 .toList()));
+    }
+
+    @PostMapping
+    @PreAuthorize("@endpointAuthz.can('features:skillgraph','manage')")
+    public ResponseEntity<ApiResponse<SkillDictionaryDto>> create(
+            @Valid @RequestBody CreateSkillDictionaryRequest request) {
+        try {
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .body(ApiResponse.ok(SkillDictionaryDto.from(dictionaryService.create(request.toCommand()))));
+        } catch (DuplicateSkillDictionaryException ex) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ex.getMessage(), ex);
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+        }
     }
 
     @GetMapping("/{skillId}")

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/request/CreateSkillDictionaryRequest.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/request/CreateSkillDictionaryRequest.java
@@ -1,0 +1,16 @@
+package studio.one.platform.skillgraph.web.dto.request;
+
+import jakarta.validation.constraints.Size;
+import studio.one.platform.skillgraph.application.command.CreateSkillDictionaryCommand;
+
+public record CreateSkillDictionaryRequest(
+        @Size(max = 200) String name,
+        @Size(max = 200) String normalizedName,
+        @Size(max = 100) String categoryId,
+        @Size(max = 50) String status,
+        @Size(max = 2000) String description) {
+
+    public CreateSkillDictionaryCommand toCommand() {
+        return new CreateSkillDictionaryCommand(name, normalizedName, categoryId, status, description);
+    }
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/response/SkillDictionaryPageResponse.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/response/SkillDictionaryPageResponse.java
@@ -1,0 +1,26 @@
+package studio.one.platform.skillgraph.web.dto.response;
+
+import java.util.List;
+
+import studio.one.platform.skillgraph.application.result.SkillDictionaryView;
+
+public record SkillDictionaryPageResponse(
+        int offset,
+        int limit,
+        int returned,
+        boolean hasMore,
+        List<SkillDictionaryDto> items) {
+
+    public static SkillDictionaryPageResponse from(int offset, int limit, List<SkillDictionaryView> skills) {
+        List<SkillDictionaryDto> mapped = skills.stream()
+                .limit(limit)
+                .map(SkillDictionaryDto::from)
+                .toList();
+        return new SkillDictionaryPageResponse(
+                offset,
+                limit,
+                mapped.size(),
+                skills.size() > limit,
+                mapped);
+    }
+}

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/DefaultSkillDictionaryServiceTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/DefaultSkillDictionaryServiceTest.java
@@ -1,0 +1,60 @@
+package studio.one.platform.skillgraph;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.skillgraph.application.command.CreateSkillDictionaryCommand;
+import studio.one.platform.skillgraph.application.service.DefaultSkillDictionaryService;
+import studio.one.platform.skillgraph.application.service.DuplicateSkillDictionaryException;
+import studio.one.platform.skillgraph.infrastructure.persistence.memory.InMemorySkillDictionaryStore;
+
+class DefaultSkillDictionaryServiceTest {
+
+    @Test
+    void createsDictionarySkillAndSearchesIt() {
+        DefaultSkillDictionaryService service = new DefaultSkillDictionaryService(new InMemorySkillDictionaryStore());
+
+        var created = service.create(new CreateSkillDictionaryCommand(
+                "Spring Boot",
+                null,
+                "backend",
+                null,
+                null));
+        var searched = service.search("spring", 10);
+
+        assertFalse(created.skillId().isBlank());
+        assertEquals("Spring Boot", created.name());
+        assertEquals("spring boot", created.normalizedName());
+        assertEquals("backend", created.categoryId());
+        assertEquals("ACTIVE", created.status());
+        assertEquals(1, searched.size());
+        assertEquals(created.skillId(), searched.get(0).skillId());
+    }
+
+    @Test
+    void rejectsDuplicateNormalizedName() {
+        DefaultSkillDictionaryService service = new DefaultSkillDictionaryService(new InMemorySkillDictionaryStore());
+        service.create(new CreateSkillDictionaryCommand("Spring Boot", null, null, null, null));
+
+        assertThrows(DuplicateSkillDictionaryException.class,
+                () -> service.create(new CreateSkillDictionaryCommand("SpringBoot", "spring boot", null, null, null)));
+    }
+
+    @Test
+    void usesExplicitNormalizedName() {
+        DefaultSkillDictionaryService service = new DefaultSkillDictionaryService(new InMemorySkillDictionaryStore());
+
+        var created = service.create(new CreateSkillDictionaryCommand(
+                "SpringBoot",
+                "Spring Boot",
+                null,
+                "DRAFT",
+                null));
+
+        assertEquals("spring boot", created.normalizedName());
+        assertEquals("DRAFT", created.status());
+    }
+}

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/DefaultSkillDictionaryServiceTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/DefaultSkillDictionaryServiceTest.java
@@ -57,4 +57,18 @@ class DefaultSkillDictionaryServiceTest {
         assertEquals("spring boot", created.normalizedName());
         assertEquals("DRAFT", created.status());
     }
+
+    @Test
+    void searchesWithOffsetAndLimit() {
+        DefaultSkillDictionaryService service = new DefaultSkillDictionaryService(new InMemorySkillDictionaryStore());
+        service.create(new CreateSkillDictionaryCommand("Backend REST API 설계", null, null, null, null));
+        service.create(new CreateSkillDictionaryCommand("Frontend Vue 컴포넌트 개발", null, null, null, null));
+        service.create(new CreateSkillDictionaryCommand("Spring Security JWT 인증 구성", null, null, null, null));
+
+        var page = service.search(null, 1, 2);
+
+        assertEquals(2, page.size());
+        assertEquals("Frontend Vue 컴포넌트 개발", page.get(0).name());
+        assertEquals("Spring Security JWT 인증 구성", page.get(1).name());
+    }
 }

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/DefaultSkillRagExtractionJobServiceTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/DefaultSkillRagExtractionJobServiceTest.java
@@ -2,6 +2,7 @@ package studio.one.platform.skillgraph;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import studio.one.platform.skillgraph.application.command.SkillExtractionCommand;
 import studio.one.platform.skillgraph.application.result.ResolvedRagChunk;
 import studio.one.platform.skillgraph.application.result.SkillExtractionResult;
+import studio.one.platform.skillgraph.application.result.SkillRagExtractionJob;
 import studio.one.platform.skillgraph.application.result.SkillRagExtractionJobStatus;
 import studio.one.platform.skillgraph.application.service.DefaultSkillRagExtractionJobService;
 import studio.one.platform.skillgraph.application.service.SkillRagExtractionJobSettings;
@@ -105,6 +107,71 @@ class DefaultSkillRagExtractionJobServiceTest {
         assertEquals(1, jobs.size());
         assertEquals("42", jobs.get(0).objectId());
         assertEquals("doc-1", jobs.get(0).documentId());
+    }
+
+    @Test
+    void getJobReconcilesCompletedRunningJob() {
+        InMemorySkillRagExtractionJobStore store = new InMemorySkillRagExtractionJobStore();
+        DefaultSkillRagExtractionJobService service = new DefaultSkillRagExtractionJobService(
+                new CountingExtractionService(),
+                new PagingResolver(List.of()),
+                store,
+                Runnable::run,
+                new SkillRagExtractionJobSettings(20, 10, 1_000_000));
+        Instant now = Instant.now();
+        store.saveJob(new SkillRagExtractionJob(
+                "job-1",
+                "attachment",
+                "42",
+                "doc-1",
+                SkillRagExtractionJobStatus.RUNNING,
+                10,
+                2,
+                2,
+                2,
+                0,
+                2,
+                null,
+                now,
+                now));
+
+        var job = service.getJob("job-1");
+
+        assertEquals(SkillRagExtractionJobStatus.COMPLETED, job.status());
+        assertEquals(SkillRagExtractionJobStatus.COMPLETED, store.findJob("job-1").orElseThrow().status());
+    }
+
+    @Test
+    void listJobsReconcilesPartialRunningJobBeforeFiltering() {
+        InMemorySkillRagExtractionJobStore store = new InMemorySkillRagExtractionJobStore();
+        DefaultSkillRagExtractionJobService service = new DefaultSkillRagExtractionJobService(
+                new CountingExtractionService(),
+                new PagingResolver(List.of()),
+                store,
+                Runnable::run,
+                new SkillRagExtractionJobSettings(20, 10, 1_000_000));
+        Instant now = Instant.now();
+        store.saveJob(new SkillRagExtractionJob(
+                "job-1",
+                "attachment",
+                "42",
+                "doc-1",
+                SkillRagExtractionJobStatus.RUNNING,
+                10,
+                2,
+                2,
+                1,
+                1,
+                1,
+                null,
+                now,
+                now));
+
+        var jobs = service.listJobs("PARTIAL", "attachment", "42", "doc-1", 0, 10);
+
+        assertEquals(1, jobs.size());
+        assertEquals(SkillRagExtractionJobStatus.PARTIAL, jobs.get(0).status());
+        assertEquals(SkillRagExtractionJobStatus.PARTIAL, store.findJob("job-1").orElseThrow().status());
     }
 
     private static ResolvedRagChunk chunk(String documentId, String chunkId, String content) {

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/SkillDictionaryMgmtControllerTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/SkillDictionaryMgmtControllerTest.java
@@ -1,0 +1,51 @@
+package studio.one.platform.skillgraph;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
+
+import studio.one.platform.skillgraph.application.service.DefaultSkillDictionaryService;
+import studio.one.platform.skillgraph.infrastructure.persistence.memory.InMemorySkillDictionaryStore;
+import studio.one.platform.skillgraph.web.controller.SkillDictionaryMgmtController;
+import studio.one.platform.skillgraph.web.dto.request.CreateSkillDictionaryRequest;
+
+class SkillDictionaryMgmtControllerTest {
+
+    @Test
+    void createsDictionarySkill() {
+        SkillDictionaryMgmtController controller = controller();
+
+        var response = controller.create(new CreateSkillDictionaryRequest(
+                "Spring Boot",
+                null,
+                "backend",
+                null,
+                "server framework")).getBody().getData();
+        var list = controller.search("spring", 10).getBody().getData();
+
+        assertEquals("Spring Boot", response.name());
+        assertEquals("spring boot", response.normalizedName());
+        assertEquals("backend", response.categoryId());
+        assertEquals("ACTIVE", response.status());
+        assertEquals(1, list.size());
+        assertEquals(response.skillId(), list.get(0).skillId());
+    }
+
+    @Test
+    void duplicateNormalizedNameReturnsConflict() {
+        SkillDictionaryMgmtController controller = controller();
+        controller.create(new CreateSkillDictionaryRequest("Spring Boot", null, null, null, null));
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+                () -> controller.create(new CreateSkillDictionaryRequest("SpringBoot", "spring boot", null, null, null)));
+
+        assertEquals(409, exception.getStatusCode().value());
+    }
+
+    private SkillDictionaryMgmtController controller() {
+        return new SkillDictionaryMgmtController(
+                new DefaultSkillDictionaryService(new InMemorySkillDictionaryStore()));
+    }
+}

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/SkillDictionaryMgmtControllerTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/SkillDictionaryMgmtControllerTest.java
@@ -23,14 +23,34 @@ class SkillDictionaryMgmtControllerTest {
                 "backend",
                 null,
                 "server framework")).getBody().getData();
-        var list = controller.search("spring", 10).getBody().getData();
+        var page = controller.search("spring", 0, 10).getBody().getData();
 
         assertEquals("Spring Boot", response.name());
         assertEquals("spring boot", response.normalizedName());
         assertEquals("backend", response.categoryId());
         assertEquals("ACTIVE", response.status());
-        assertEquals(1, list.size());
-        assertEquals(response.skillId(), list.get(0).skillId());
+        assertEquals(0, page.offset());
+        assertEquals(10, page.limit());
+        assertEquals(1, page.returned());
+        assertEquals(false, page.hasMore());
+        assertEquals(response.skillId(), page.items().get(0).skillId());
+    }
+
+    @Test
+    void searchesDictionarySkillsWithPaging() {
+        SkillDictionaryMgmtController controller = controller();
+        controller.create(new CreateSkillDictionaryRequest("Backend REST API 설계", null, null, null, null));
+        controller.create(new CreateSkillDictionaryRequest("Frontend Vue 컴포넌트 개발", null, null, null, null));
+        controller.create(new CreateSkillDictionaryRequest("Spring Security JWT 인증 구성", null, null, null, null));
+
+        var firstPage = controller.search(null, 0, 2).getBody().getData();
+        var secondPage = controller.search(null, 2, 2).getBody().getData();
+
+        assertEquals(2, firstPage.returned());
+        assertEquals(true, firstPage.hasMore());
+        assertEquals(1, secondPage.returned());
+        assertEquals(false, secondPage.hasMore());
+        assertEquals(2, secondPage.offset());
     }
 
     @Test


### PR DESCRIPTION
## Why

- SkillGraph Console에서 Dictionary 수동 추가 다이얼로그가 서버 저장 API 없이 동작할 수 없는 상태였습니다.
- RAG extraction job item 처리가 끝난 뒤에도 job 상태가 `RUNNING`으로 남는 stale 상태를 서버 조회 계층에서 방어해야 합니다.

## What

- `POST /api/mgmt/skillgraph/dictionary` 생성 API를 추가했습니다.
- `name`, `normalizedName`, `categoryId`, `status`, `description` 요청 DTO와 생성 command를 추가했습니다.
- `normalizedName` 생략 시 서버가 `name` 기준으로 정규화합니다.
- 동일 `normalizedName`이 이미 있으면 `409 Conflict`를 반환합니다.
- 생성 성공 시 `201 Created`와 `SkillDictionaryDto`를 반환하고, 기존 dictionary 검색 API에서 조회됩니다.
- RAG extraction job 조회/list 시 `RUNNING`/`READY` job이 이미 전체 처리 완료 상태이면 `COMPLETED`/`PARTIAL`/`FAILED`로 보정해 저장 후 반환합니다.
- Dictionary 생성과 RAG job stale 상태 보정 회귀 테스트를 추가했습니다.

## Related Issues

- Closes #491
- Closes #492

## Validation

- Command: `./gradlew :studio-platform-skillgraph:test :starter:studio-platform-starter-skillgraph:test`
- Result: `BUILD SUCCESSFUL`
- Command: `git diff --check`
- Result: passed

## Risk / Rollback

- Risk: Dictionary 생성 API는 `description`을 요청으로 받지만 현재 dictionary schema/model에 저장 필드가 없어 v1에서는 저장하지 않습니다.
- Risk: job list는 stale active 상태 보정을 위해 조회 시 저장을 수행할 수 있습니다. 대상은 `processedChunks >= totalChunks`인 active job으로 제한했습니다.
- Rollback: 이 PR 커밋을 revert하면 생성 API와 조회 시 상태 보정 로직이 제거됩니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope:
- Main author validation: 관련 모듈 테스트와 diff whitespace 검증 완료

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
