### PR TITLE
[ai-assisted] feat(skillgraph): 카테고리 자동 생성 워크플로우 추가

### DIFF
--- a/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/SkillGraphAutoConfiguration.java
+++ b/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/SkillGraphAutoConfiguration.java
@@ -21,6 +21,7 @@ import studio.one.platform.ai.core.chat.ChatPort;
 import studio.one.platform.ai.service.prompt.PromptRenderer;
 import studio.one.platform.skillgraph.application.service.SkillMatchPolicy;
 import studio.one.platform.skillgraph.application.service.DefaultSkillCandidateReviewService;
+import studio.one.platform.skillgraph.application.service.DefaultSkillCategoryDraftService;
 import studio.one.platform.skillgraph.application.service.DefaultSkillDictionaryService;
 import studio.one.platform.skillgraph.application.service.DefaultSkillExtractionService;
 import studio.one.platform.skillgraph.application.service.DefaultSkillGraphService;
@@ -29,6 +30,7 @@ import studio.one.platform.skillgraph.application.service.DefaultSkillRecommenda
 import studio.one.platform.skillgraph.application.service.DefaultSkillTaxonomyService;
 import studio.one.platform.skillgraph.application.service.DefaultSkillVisualizationService;
 import studio.one.platform.skillgraph.application.usecase.SkillCandidateReviewService;
+import studio.one.platform.skillgraph.application.usecase.SkillCategoryDraftService;
 import studio.one.platform.skillgraph.application.usecase.SkillDictionaryService;
 import studio.one.platform.skillgraph.application.usecase.SkillExtractionService;
 import studio.one.platform.skillgraph.application.usecase.SkillGraphService;
@@ -118,8 +120,10 @@ public class SkillGraphAutoConfiguration {
 
     @Bean(name = SkillDictionaryService.SERVICE_NAME)
     @ConditionalOnMissingBean
-    public SkillDictionaryService skillDictionaryService(SkillDictionaryStore dictionaryStore) {
-        return new DefaultSkillDictionaryService(dictionaryStore);
+    public SkillDictionaryService skillDictionaryService(
+            SkillDictionaryStore dictionaryStore,
+            SkillEmbeddingPort embeddingPort) {
+        return new DefaultSkillDictionaryService(dictionaryStore, embeddingPort);
     }
 
     @Bean(name = SkillVisualizationService.SERVICE_NAME)
@@ -136,6 +140,15 @@ public class SkillGraphAutoConfiguration {
     @ConditionalOnMissingBean
     public SkillTaxonomyService skillTaxonomyService(SkillTaxonomyStore taxonomyStore) {
         return new DefaultSkillTaxonomyService(taxonomyStore);
+    }
+
+    @Bean(name = SkillCategoryDraftService.SERVICE_NAME)
+    @ConditionalOnMissingBean
+    public SkillCategoryDraftService skillCategoryDraftService(
+            SkillProjectionStore projectionStore,
+            SkillDictionaryStore dictionaryStore,
+            SkillTaxonomyStore taxonomyStore) {
+        return new DefaultSkillCategoryDraftService(projectionStore, dictionaryStore, taxonomyStore);
     }
 
     @Bean(name = SkillGraphService.SERVICE_NAME)

--- a/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/SkillGraphWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/SkillGraphWebAutoConfiguration.java
@@ -15,6 +15,7 @@ import studio.one.platform.skillgraph.application.service.DefaultSkillRagExtract
 import studio.one.platform.skillgraph.application.service.SkillRagExtractionJobSettings;
 import studio.one.platform.skillgraph.application.usecase.SkillGraphRagChunkResolver;
 import studio.one.platform.skillgraph.application.usecase.SkillCandidateReviewService;
+import studio.one.platform.skillgraph.application.usecase.SkillCategoryDraftService;
 import studio.one.platform.skillgraph.application.usecase.SkillDictionaryService;
 import studio.one.platform.skillgraph.application.usecase.SkillExtractionService;
 import studio.one.platform.skillgraph.application.usecase.SkillGraphService;
@@ -25,6 +26,7 @@ import studio.one.platform.skillgraph.application.usecase.SkillTaxonomyService;
 import studio.one.platform.skillgraph.application.usecase.SkillVisualizationService;
 import studio.one.platform.skillgraph.domain.port.SkillRagExtractionJobStore;
 import studio.one.platform.skillgraph.web.controller.SkillCandidateMgmtController;
+import studio.one.platform.skillgraph.web.controller.SkillCategoryDraftMgmtController;
 import studio.one.platform.skillgraph.web.controller.SkillDictionaryMgmtController;
 import studio.one.platform.skillgraph.web.controller.SkillExtractionJobMgmtController;
 import studio.one.platform.skillgraph.web.controller.SkillGraphExtractionSourceMgmtController;
@@ -108,6 +110,12 @@ public class SkillGraphWebAutoConfiguration {
     @ConditionalOnBean(name = SkillTaxonomyService.SERVICE_NAME)
     @Import(SkillTaxonomyMgmtController.class)
     static class SkillTaxonomyWebConfig {
+    }
+
+    @Configuration
+    @ConditionalOnBean(name = SkillCategoryDraftService.SERVICE_NAME)
+    @Import(SkillCategoryDraftMgmtController.class)
+    static class SkillCategoryDraftWebConfig {
     }
 
     @Configuration

--- a/starter/studio-platform-starter-skillgraph/src/test/java/studio/one/platform/autoconfigure/skillgraph/SkillGraphAutoConfigurationTest.java
+++ b/starter/studio-platform-starter-skillgraph/src/test/java/studio/one/platform/autoconfigure/skillgraph/SkillGraphAutoConfigurationTest.java
@@ -17,6 +17,7 @@ import studio.one.platform.ai.service.prompt.PromptRenderer;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
 import studio.one.platform.skillgraph.application.service.DefaultSkillExtractionService;
 import studio.one.platform.skillgraph.application.usecase.SkillCandidateReviewService;
+import studio.one.platform.skillgraph.application.usecase.SkillCategoryDraftService;
 import studio.one.platform.skillgraph.application.usecase.SkillDictionaryService;
 import studio.one.platform.skillgraph.application.usecase.SkillExtractionService;
 import studio.one.platform.skillgraph.application.usecase.SkillGraphService;
@@ -50,6 +51,7 @@ class SkillGraphAutoConfigurationTest {
             assertThat(context).hasSingleBean(SkillExtractionService.class);
             assertThat(context).hasSingleBean(SkillCandidateReviewService.class);
             assertThat(context).hasSingleBean(SkillDictionaryService.class);
+            assertThat(context).hasSingleBean(SkillCategoryDraftService.class);
             assertThat(context).hasSingleBean(SkillTaxonomyStore.class);
             assertThat(context).hasSingleBean(SkillGraphStore.class);
             assertThat(context).hasSingleBean(SkillMappingStore.class);

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/command/SaveSkillCategoryDraftCommand.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/command/SaveSkillCategoryDraftCommand.java
@@ -1,0 +1,14 @@
+package studio.one.platform.skillgraph.application.command;
+
+import java.util.List;
+
+public record SaveSkillCategoryDraftCommand(
+        List<SaveSkillCategoryItem> categories) {
+
+    public record SaveSkillCategoryItem(
+            String categoryId,
+            String parentCategoryId,
+            String name,
+            Integer displayOrder) {
+    }
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/SkillCategoryDraftResult.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/SkillCategoryDraftResult.java
@@ -1,0 +1,10 @@
+package studio.one.platform.skillgraph.application.result;
+
+import java.util.List;
+
+public record SkillCategoryDraftResult(
+        String projectionId,
+        int draftCount,
+        int noiseCount,
+        List<SkillCategoryDraftView> drafts) {
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/SkillCategoryDraftView.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/SkillCategoryDraftView.java
@@ -1,0 +1,14 @@
+package studio.one.platform.skillgraph.application.result;
+
+import java.util.List;
+
+public record SkillCategoryDraftView(
+        String draftId,
+        String clusterId,
+        String proposedName,
+        double confidence,
+        boolean noise,
+        int itemCount,
+        List<String> representativeSkillIds,
+        List<String> representativeSkillNames) {
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/SkillDictionaryEmbeddingResult.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/SkillDictionaryEmbeddingResult.java
@@ -1,0 +1,9 @@
+package studio.one.platform.skillgraph.application.result;
+
+public record SkillDictionaryEmbeddingResult(
+        int requestedCount,
+        int processedCount,
+        int skippedCount,
+        int failedCount,
+        String jobId) {
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/SkillDictionaryEmbeddingResult.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/SkillDictionaryEmbeddingResult.java
@@ -1,6 +1,7 @@
 package studio.one.platform.skillgraph.application.result;
 
 public record SkillDictionaryEmbeddingResult(
+        int totalMissingCount,
         int requestedCount,
         int processedCount,
         int skippedCount,

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillCategoryDraftService.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillCategoryDraftService.java
@@ -1,0 +1,122 @@
+package studio.one.platform.skillgraph.application.service;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+
+import lombok.RequiredArgsConstructor;
+import studio.one.platform.skillgraph.application.command.SaveSkillCategoryDraftCommand;
+import studio.one.platform.skillgraph.application.result.SkillCategoryDraftResult;
+import studio.one.platform.skillgraph.application.result.SkillCategoryDraftView;
+import studio.one.platform.skillgraph.application.result.SkillCategoryView;
+import studio.one.platform.skillgraph.application.usecase.SkillCategoryDraftService;
+import studio.one.platform.skillgraph.domain.model.SkillCategory;
+import studio.one.platform.skillgraph.domain.model.SkillCluster;
+import studio.one.platform.skillgraph.domain.model.SkillDictionary;
+import studio.one.platform.skillgraph.domain.model.SkillProjection;
+import studio.one.platform.skillgraph.domain.port.SkillDictionaryStore;
+import studio.one.platform.skillgraph.domain.port.SkillProjectionStore;
+import studio.one.platform.skillgraph.domain.port.SkillTaxonomyStore;
+
+@RequiredArgsConstructor
+public class DefaultSkillCategoryDraftService implements SkillCategoryDraftService {
+
+    private static final String NOISE_CLUSTER_ID = "noise";
+
+    private final SkillProjectionStore projectionStore;
+    private final SkillDictionaryStore dictionaryStore;
+    private final SkillTaxonomyStore taxonomyStore;
+
+    @Override
+    public SkillCategoryDraftResult generateDrafts(String projectionId, int representativeLimit) {
+        String resolvedProjectionId = required(projectionId, "projectionId");
+        int maxRepresentatives = representativeLimit <= 0 ? 5 : Math.min(representativeLimit, 20);
+        List<SkillCluster> clusters = projectionStore.findClusters(resolvedProjectionId);
+        List<SkillCategoryDraftView> drafts = clusters.stream()
+                .sorted(Comparator.comparing(SkillCluster::clusterId))
+                .map(cluster -> draft(resolvedProjectionId, cluster, maxRepresentatives))
+                .toList();
+        int noiseCount = (int) drafts.stream().filter(SkillCategoryDraftView::noise).count();
+        return new SkillCategoryDraftResult(resolvedProjectionId, drafts.size(), noiseCount, drafts);
+    }
+
+    @Override
+    public List<SkillCategoryView> saveDrafts(SaveSkillCategoryDraftCommand command) {
+        if (command == null || command.categories() == null || command.categories().isEmpty()) {
+            throw new IllegalArgumentException("categories must not be empty");
+        }
+        return command.categories().stream()
+                .map(item -> new SkillCategory(
+                        normalize(item.categoryId()) == null ? "cat_" + UUID.randomUUID().toString().replace("-", "") : item.categoryId(),
+                        normalize(item.parentCategoryId()),
+                        required(item.name(), "name"),
+                        item.displayOrder() == null ? 0 : item.displayOrder()))
+                .map(taxonomyStore::saveCategory)
+                .map(SkillCategoryView::from)
+                .toList();
+    }
+
+    private SkillCategoryDraftView draft(String projectionId, SkillCluster cluster, int representativeLimit) {
+        List<SkillProjection> points = projectionStore.findProjectionPoints(
+                projectionId,
+                cluster.clusterId(),
+                representativeLimit,
+                0);
+        List<String> skillIds = points.stream().map(SkillProjection::skillId).toList();
+        List<String> names = skillIds.stream()
+                .map(skillId -> dictionaryStore.findById(skillId).map(SkillDictionary::name).orElse(skillId))
+                .toList();
+        boolean noise = isNoise(cluster);
+        return new SkillCategoryDraftView(
+                "draft_" + cluster.clusterId(),
+                cluster.clusterId(),
+                noise ? "미분류 스킬" : proposeName(names, cluster),
+                noise ? 0.2d : confidence(cluster.itemCount()),
+                noise,
+                cluster.itemCount(),
+                skillIds,
+                names);
+    }
+
+    private String proposeName(List<String> names, SkillCluster cluster) {
+        String joined = String.join(" ", names).toLowerCase(Locale.ROOT);
+        if (joined.contains("security") || joined.contains("인증") || joined.contains("인가") || joined.contains("oauth")) {
+            return "인증·인가 보안";
+        }
+        if (joined.contains("vue") || joined.contains("react") || joined.contains("frontend") || joined.contains("컴포넌트")) {
+            return "프론트엔드 UI 개발";
+        }
+        if (joined.contains("postgresql") || joined.contains("데이터") || joined.contains("jpa") || joined.contains("hibernate")) {
+            return "데이터 처리 및 저장";
+        }
+        if (joined.contains("docker") || joined.contains("kubernetes") || joined.contains("배포") || joined.contains("운영")) {
+            return "배포 및 운영 자동화";
+        }
+        if (joined.contains("api") || joined.contains("spring") || joined.contains("backend")) {
+            return "백엔드 API 개발";
+        }
+        return cluster.label() == null ? "스킬 카테고리 " + cluster.clusterId() : cluster.label();
+    }
+
+    private boolean isNoise(SkillCluster cluster) {
+        return NOISE_CLUSTER_ID.equalsIgnoreCase(cluster.clusterId())
+                || cluster.clusterId().toLowerCase(Locale.ROOT).contains("noise");
+    }
+
+    private double confidence(int itemCount) {
+        return Math.min(0.95d, 0.55d + Math.min(itemCount, 40) / 100.0d);
+    }
+
+    private String required(String value, String field) {
+        String normalized = normalize(value);
+        if (normalized == null) {
+            throw new IllegalArgumentException(field + " is required");
+        }
+        return normalized;
+    }
+
+    private String normalize(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillDictionaryService.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillDictionaryService.java
@@ -4,14 +4,16 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
-import lombok.RequiredArgsConstructor;
 import studio.one.platform.skillgraph.application.command.CreateSkillDictionaryCommand;
+import studio.one.platform.skillgraph.application.result.SkillDictionaryEmbeddingResult;
 import studio.one.platform.skillgraph.application.result.SkillDictionaryView;
 import studio.one.platform.skillgraph.application.usecase.SkillDictionaryService;
 import studio.one.platform.skillgraph.domain.constants.SkillGraphLimits;
 import studio.one.platform.skillgraph.domain.model.SkillCandidate;
 import studio.one.platform.skillgraph.domain.model.SkillDictionary;
+import studio.one.platform.skillgraph.domain.port.NoOpSkillEmbeddingPort;
 import studio.one.platform.skillgraph.domain.port.SkillDictionaryStore;
+import studio.one.platform.skillgraph.domain.port.SkillEmbeddingPort;
 
 /**
  * 스킬 사전 조회 유스케이스 구현체.
@@ -43,10 +45,19 @@ import studio.one.platform.skillgraph.domain.port.SkillDictionaryStore;
  *        </pre>
  */
 
-@RequiredArgsConstructor
 public class DefaultSkillDictionaryService implements SkillDictionaryService {
 
     private final SkillDictionaryStore store;
+    private final SkillEmbeddingPort embeddingPort;
+
+    public DefaultSkillDictionaryService(SkillDictionaryStore store) {
+        this(store, new NoOpSkillEmbeddingPort());
+    }
+
+    public DefaultSkillDictionaryService(SkillDictionaryStore store, SkillEmbeddingPort embeddingPort) {
+        this.store = store;
+        this.embeddingPort = embeddingPort == null ? new NoOpSkillEmbeddingPort() : embeddingPort;
+    }
 
     @Override
     public List<SkillDictionaryView> search(String q, int limit) {
@@ -91,6 +102,29 @@ public class DefaultSkillDictionaryService implements SkillDictionaryService {
         return store.findById(skillId)
                 .map(SkillDictionaryView::from)
                 .orElseThrow(() -> new IllegalArgumentException("Unknown skill: " + skillId));
+    }
+
+    @Override
+    public SkillDictionaryEmbeddingResult embedMissing(int limit) {
+        int max = normalizeLimit(limit);
+        List<SkillDictionary> missing = store.findMissingEmbeddingSkills(max);
+        int processed = 0;
+        int failed = 0;
+        for (SkillDictionary skill : missing) {
+            List<Double> embedding = embeddingPort.embedSkill(skill.name());
+            if (embedding == null || embedding.isEmpty()) {
+                failed++;
+                continue;
+            }
+            store.saveEmbedding(skill.skillId(), embedding, null);
+            processed++;
+        }
+        return new SkillDictionaryEmbeddingResult(
+                missing.size(),
+                processed,
+                Math.max(0, max - missing.size()),
+                failed,
+                null);
     }
 
     private int normalizeLimit(int limit) {

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillDictionaryService.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillDictionaryService.java
@@ -107,6 +107,7 @@ public class DefaultSkillDictionaryService implements SkillDictionaryService {
     @Override
     public SkillDictionaryEmbeddingResult embedMissing(int limit) {
         int max = normalizeLimit(limit);
+        int totalMissing = store.countMissingEmbeddingSkills();
         List<SkillDictionary> missing = store.findMissingEmbeddingSkills(max);
         int processed = 0;
         int failed = 0;
@@ -120,9 +121,10 @@ public class DefaultSkillDictionaryService implements SkillDictionaryService {
             processed++;
         }
         return new SkillDictionaryEmbeddingResult(
+                totalMissing,
                 missing.size(),
                 processed,
-                Math.max(0, max - missing.size()),
+                Math.max(0, totalMissing - missing.size()),
                 failed,
                 null);
     }

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/usecase/SkillCategoryDraftService.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/usecase/SkillCategoryDraftService.java
@@ -1,0 +1,16 @@
+package studio.one.platform.skillgraph.application.usecase;
+
+import java.util.List;
+
+import studio.one.platform.skillgraph.application.command.SaveSkillCategoryDraftCommand;
+import studio.one.platform.skillgraph.application.result.SkillCategoryDraftResult;
+import studio.one.platform.skillgraph.application.result.SkillCategoryView;
+
+public interface SkillCategoryDraftService {
+
+    String SERVICE_NAME = "skillCategoryDraftService";
+
+    SkillCategoryDraftResult generateDrafts(String projectionId, int representativeLimit);
+
+    List<SkillCategoryView> saveDrafts(SaveSkillCategoryDraftCommand command);
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/usecase/SkillDictionaryService.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/usecase/SkillDictionaryService.java
@@ -3,6 +3,7 @@ package studio.one.platform.skillgraph.application.usecase;
 import java.util.List;
 
 import studio.one.platform.skillgraph.application.command.CreateSkillDictionaryCommand;
+import studio.one.platform.skillgraph.application.result.SkillDictionaryEmbeddingResult;
 import studio.one.platform.skillgraph.application.result.SkillDictionaryView;
 
 public interface SkillDictionaryService {
@@ -14,6 +15,8 @@ public interface SkillDictionaryService {
     List<SkillDictionaryView> search(String q, int offset, int limit);
 
     SkillDictionaryView create(CreateSkillDictionaryCommand command);
+
+    SkillDictionaryEmbeddingResult embedMissing(int limit);
 
     SkillDictionaryView get(String skillId);
 }

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/domain/port/SkillDictionaryStore.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/domain/port/SkillDictionaryStore.java
@@ -44,6 +44,14 @@ public interface SkillDictionaryStore {
         return List.of();
     }
 
+    default List<SkillDictionary> findMissingEmbeddingSkills(int limit) {
+        return List.of();
+    }
+
+    default SkillDictionary saveEmbedding(String skillId, List<Double> embedding, String embeddingModel) {
+        throw new UnsupportedOperationException("Skill embedding persistence is not implemented");
+    }
+
     List<SkillDictionary> search(String q, int limit);
 
     default List<SkillDictionary> search(String q, int offset, int limit) {

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/domain/port/SkillDictionaryStore.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/domain/port/SkillDictionaryStore.java
@@ -48,6 +48,10 @@ public interface SkillDictionaryStore {
         return List.of();
     }
 
+    default int countMissingEmbeddingSkills() {
+        return findMissingEmbeddingSkills(Integer.MAX_VALUE).size();
+    }
+
     default SkillDictionary saveEmbedding(String skillId, List<Double> embedding, String embeddingModel) {
         throw new UnsupportedOperationException("Skill embedding persistence is not implemented");
     }

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/jdbc/JdbcSkillDictionaryStore.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/jdbc/JdbcSkillDictionaryStore.java
@@ -4,6 +4,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -14,6 +15,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import lombok.RequiredArgsConstructor;
 import studio.one.platform.skillgraph.domain.model.SkillAlias;
 import studio.one.platform.skillgraph.domain.model.SkillDictionary;
+import studio.one.platform.skillgraph.domain.model.SkillVectorItem;
 import studio.one.platform.skillgraph.domain.port.SkillDictionaryStore;
 
 @RequiredArgsConstructor
@@ -66,6 +68,25 @@ public class JdbcSkillDictionaryStore implements SkillDictionaryStore {
     }
 
     @Override
+    public SkillDictionary saveEmbedding(String skillId, List<Double> embedding, String embeddingModel) {
+        SkillDictionary skill = findById(skillId)
+                .orElseThrow(() -> new IllegalArgumentException("Unknown skill: " + skillId));
+        if (embedding == null || embedding.isEmpty()) {
+            return skill;
+        }
+        template.update("""
+                UPDATE tb_skill_dictionary
+                SET embedding = CAST(:embedding AS vector),
+                    updated_at = :updatedAt
+                WHERE skill_id = :skillId
+                """, new MapSqlParameterSource()
+                .addValue("skillId", skillId)
+                .addValue("embedding", vectorLiteral(embedding))
+                .addValue("updatedAt", Timestamp.from(Instant.now())));
+        return findById(skillId).orElse(skill);
+    }
+
+    @Override
     public SkillAlias saveAlias(SkillAlias alias) {
         int updated = template.update("""
                 UPDATE tb_skill_alias
@@ -107,6 +128,34 @@ public class JdbcSkillDictionaryStore implements SkillDictionaryStore {
                 "offset", Math.max(0, offset)), this::mapSkill);
     }
 
+    @Override
+    public List<SkillVectorItem> findVectorItems(int limit) {
+        int max = limit <= 0 ? 1000 : limit;
+        return template.query("""
+                SELECT skill_id, name, embedding::text AS embedding_text, created_at
+                FROM tb_skill_dictionary
+                WHERE status = 'ACTIVE' AND embedding IS NOT NULL
+                ORDER BY name
+                LIMIT :limit
+                """, Map.of("limit", max), (rs, rowNum) -> new SkillVectorItem(
+                rs.getString("skill_id"),
+                rs.getString("name"),
+                parseVector(rs.getString("embedding_text")),
+                null,
+                instant(rs.getTimestamp("created_at"))));
+    }
+
+    @Override
+    public List<SkillDictionary> findMissingEmbeddingSkills(int limit) {
+        int max = limit <= 0 ? 100 : limit;
+        return template.query("""
+                SELECT * FROM tb_skill_dictionary
+                WHERE status = 'ACTIVE' AND embedding IS NULL
+                ORDER BY name
+                LIMIT :limit
+                """, Map.of("limit", max), this::mapSkill);
+    }
+
     private Optional<SkillDictionary> queryOne(String sql, Map<String, ?> params) {
         return template.query(sql, params, this::mapSkill).stream().findFirst();
     }
@@ -140,6 +189,28 @@ public class JdbcSkillDictionaryStore implements SkillDictionaryStore {
                 rs.getString("status"),
                 instant(rs.getTimestamp("created_at")),
                 instant(rs.getTimestamp("updated_at")));
+    }
+
+    private String vectorLiteral(List<Double> embedding) {
+        return embedding.toString();
+    }
+
+    private List<Double> parseVector(String value) {
+        if (value == null || value.isBlank()) {
+            return List.of();
+        }
+        String stripped = value.trim()
+                .replace("[", "")
+                .replace("]", "");
+        if (stripped.isBlank()) {
+            return List.of();
+        }
+        String[] parts = stripped.split(",");
+        List<Double> vector = new ArrayList<>(parts.length);
+        for (String part : parts) {
+            vector.add(Double.parseDouble(part.trim()));
+        }
+        return vector;
     }
 
     private Instant instant(Timestamp timestamp) {

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/jdbc/JdbcSkillDictionaryStore.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/jdbc/JdbcSkillDictionaryStore.java
@@ -156,6 +156,16 @@ public class JdbcSkillDictionaryStore implements SkillDictionaryStore {
                 """, Map.of("limit", max), this::mapSkill);
     }
 
+    @Override
+    public int countMissingEmbeddingSkills() {
+        Integer count = template.queryForObject("""
+                SELECT COUNT(*)
+                FROM tb_skill_dictionary
+                WHERE status = 'ACTIVE' AND embedding IS NULL
+                """, Map.of(), Integer.class);
+        return count == null ? 0 : count;
+    }
+
     private Optional<SkillDictionary> queryOne(String sql, Map<String, ?> params) {
         return template.query(sql, params, this::mapSkill).stream().findFirst();
     }

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/memory/InMemorySkillDictionaryStore.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/memory/InMemorySkillDictionaryStore.java
@@ -38,6 +38,16 @@ public class InMemorySkillDictionaryStore implements SkillDictionaryStore {
     }
 
     @Override
+    public SkillDictionary saveEmbedding(String skillId, List<Double> embedding, String embeddingModel) {
+        SkillDictionary skill = findById(skillId)
+                .orElseThrow(() -> new IllegalArgumentException("Unknown skill: " + skillId));
+        if (embedding != null && !embedding.isEmpty()) {
+            embeddingsBySkillId.put(skill.skillId(), List.copyOf(embedding));
+        }
+        return skill;
+    }
+
+    @Override
     public Optional<SkillDictionary> findById(String skillId) {
         return Optional.ofNullable(skills.get(skillId));
     }
@@ -105,6 +115,17 @@ public class InMemorySkillDictionaryStore implements SkillDictionaryStore {
                         embeddingsBySkillId.get(skill.skillId()),
                         null,
                         skill.createdAt()))
+                .toList();
+    }
+
+    @Override
+    public List<SkillDictionary> findMissingEmbeddingSkills(int limit) {
+        int max = limit <= 0 ? 100 : limit;
+        return skills.values().stream()
+                .filter(skill -> "ACTIVE".equalsIgnoreCase(skill.status()))
+                .filter(skill -> !embeddingsBySkillId.containsKey(skill.skillId()))
+                .sorted(Comparator.comparing(SkillDictionary::name))
+                .limit(max)
                 .toList();
     }
 

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/memory/InMemorySkillDictionaryStore.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/memory/InMemorySkillDictionaryStore.java
@@ -129,6 +129,14 @@ public class InMemorySkillDictionaryStore implements SkillDictionaryStore {
                 .toList();
     }
 
+    @Override
+    public int countMissingEmbeddingSkills() {
+        return (int) skills.values().stream()
+                .filter(skill -> "ACTIVE".equalsIgnoreCase(skill.status()))
+                .filter(skill -> !embeddingsBySkillId.containsKey(skill.skillId()))
+                .count();
+    }
+
     private double cosine(List<Double> left, List<Double> right) {
         int size = Math.min(left.size(), right.size());
         if (size == 0) {

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillCategoryDraftMgmtController.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillCategoryDraftMgmtController.java
@@ -1,0 +1,49 @@
+package studio.one.platform.skillgraph.web.controller;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import studio.one.platform.skillgraph.application.command.SaveSkillCategoryDraftCommand;
+import studio.one.platform.skillgraph.application.result.SkillCategoryDraftResult;
+import studio.one.platform.skillgraph.application.result.SkillCategoryView;
+import studio.one.platform.skillgraph.application.usecase.SkillCategoryDraftService;
+import studio.one.platform.web.dto.ApiResponse;
+
+@RestController
+@RequestMapping("${studio.features.skillgraph.web.category-draft-base-path:/api/mgmt/skillgraph/category-drafts}")
+@RequiredArgsConstructor
+@Validated
+public class SkillCategoryDraftMgmtController {
+
+    private final SkillCategoryDraftService service;
+
+    @GetMapping
+    @PreAuthorize("@endpointAuthz.can('features:skillgraph','read')")
+    public ResponseEntity<ApiResponse<SkillCategoryDraftResult>> generate(
+            @RequestParam(value = "projectionId", defaultValue = "default") @Size(max = 100) String projectionId,
+            @RequestParam(value = "representativeLimit", defaultValue = "5") @Min(1) @Max(20) int representativeLimit) {
+        return ResponseEntity.ok(ApiResponse.ok(service.generateDrafts(projectionId, representativeLimit)));
+    }
+
+    @PostMapping("/save")
+    @PreAuthorize("@endpointAuthz.can('features:skillgraph','manage')")
+    public ResponseEntity<ApiResponse<List<SkillCategoryView>>> save(
+            @Valid @RequestBody SaveSkillCategoryDraftCommand command) {
+        return ResponseEntity.ok(ApiResponse.ok(service.saveDrafts(command)));
+    }
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillDictionaryMgmtController.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillDictionaryMgmtController.java
@@ -22,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import studio.one.platform.skillgraph.application.service.DuplicateSkillDictionaryException;
 import studio.one.platform.skillgraph.application.usecase.SkillDictionaryService;
 import studio.one.platform.skillgraph.web.dto.request.CreateSkillDictionaryRequest;
+import studio.one.platform.skillgraph.web.dto.request.SkillDictionaryEmbeddingRequest;
 import studio.one.platform.skillgraph.web.dto.response.SkillDictionaryDto;
 import studio.one.platform.skillgraph.web.dto.response.SkillDictionaryPageResponse;
 import studio.one.platform.web.dto.ApiResponse;
@@ -58,6 +59,14 @@ public class SkillDictionaryMgmtController {
         } catch (IllegalArgumentException ex) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
         }
+    }
+
+    @PostMapping("/embeddings/missing")
+    @PreAuthorize("@endpointAuthz.can('features:skillgraph','manage')")
+    public ResponseEntity<ApiResponse<?>> embedMissing(
+            @Valid @RequestBody(required = false) SkillDictionaryEmbeddingRequest request) {
+        int limit = request == null || request.limit() == null ? 500 : request.limit();
+        return ResponseEntity.ok(ApiResponse.ok(dictionaryService.embedMissing(limit)));
     }
 
     @GetMapping("/{skillId}")

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/request/SkillDictionaryEmbeddingRequest.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/request/SkillDictionaryEmbeddingRequest.java
@@ -1,0 +1,8 @@
+package studio.one.platform.skillgraph.web.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public record SkillDictionaryEmbeddingRequest(
+        @Min(1) @Max(2000) Integer limit) {
+}

--- a/studio-platform-skillgraph/src/main/resources/schema/skillgraph/postgres/V1500__create_skillgraph_tables.sql
+++ b/studio-platform-skillgraph/src/main/resources/schema/skillgraph/postgres/V1500__create_skillgraph_tables.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS tb_skill_dictionary (
     normalized_name VARCHAR(300) NOT NULL,
     category_id VARCHAR(100),
     status VARCHAR(30) NOT NULL DEFAULT 'ACTIVE',
-    embedding VECTOR(1536),
+    embedding VECTOR,
     created_at TIMESTAMP NOT NULL DEFAULT now(),
     updated_at TIMESTAMP NOT NULL DEFAULT now(),
     CONSTRAINT uk_skill_dictionary_normalized_name UNIQUE (normalized_name)
@@ -26,9 +26,6 @@ CREATE TABLE IF NOT EXISTS tb_skill_dictionary (
 
 CREATE INDEX IF NOT EXISTS idx_skill_dictionary_status
     ON tb_skill_dictionary(status, name);
-
-CREATE INDEX IF NOT EXISTS idx_skill_dictionary_embedding
-    ON tb_skill_dictionary USING hnsw (embedding vector_cosine_ops);
 
 CREATE TABLE IF NOT EXISTS tb_skill_candidate (
     candidate_id VARCHAR(100) PRIMARY KEY,
@@ -42,7 +39,7 @@ CREATE TABLE IF NOT EXISTS tb_skill_candidate (
     occurrence_count INT NOT NULL DEFAULT 1,
     matched_skill_id VARCHAR(100),
     reviewer_note TEXT,
-    embedding VECTOR(1536),
+    embedding VECTOR,
     created_at TIMESTAMP NOT NULL DEFAULT now(),
     updated_at TIMESTAMP NOT NULL DEFAULT now()
 );
@@ -52,9 +49,6 @@ CREATE INDEX IF NOT EXISTS idx_skill_candidate_status
 
 CREATE INDEX IF NOT EXISTS idx_skill_candidate_normalized
     ON tb_skill_candidate(normalized_term);
-
-CREATE INDEX IF NOT EXISTS idx_skill_candidate_embedding
-    ON tb_skill_candidate USING hnsw (embedding vector_cosine_ops);
 
 CREATE TABLE IF NOT EXISTS tb_skill_alias (
     alias_id VARCHAR(100) PRIMARY KEY,

--- a/studio-platform-skillgraph/src/main/resources/schema/skillgraph/postgres/V1502__allow_variable_dimension_skill_embeddings.sql
+++ b/studio-platform-skillgraph/src/main/resources/schema/skillgraph/postgres/V1502__allow_variable_dimension_skill_embeddings.sql
@@ -1,0 +1,8 @@
+DROP INDEX IF EXISTS idx_skill_dictionary_embedding;
+DROP INDEX IF EXISTS idx_skill_candidate_embedding;
+
+ALTER TABLE tb_skill_dictionary
+    ALTER COLUMN embedding TYPE VECTOR;
+
+ALTER TABLE tb_skill_candidate
+    ALTER COLUMN embedding TYPE VECTOR;

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/DefaultSkillCategoryDraftServiceTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/DefaultSkillCategoryDraftServiceTest.java
@@ -1,0 +1,53 @@
+package studio.one.platform.skillgraph;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.skillgraph.application.command.SaveSkillCategoryDraftCommand;
+import studio.one.platform.skillgraph.application.service.DefaultSkillCategoryDraftService;
+import studio.one.platform.skillgraph.domain.model.SkillCluster;
+import studio.one.platform.skillgraph.domain.model.SkillDictionary;
+import studio.one.platform.skillgraph.domain.model.SkillProjection;
+import studio.one.platform.skillgraph.infrastructure.persistence.memory.InMemorySkillDictionaryStore;
+import studio.one.platform.skillgraph.infrastructure.persistence.memory.InMemorySkillProjectionStore;
+import studio.one.platform.skillgraph.infrastructure.persistence.memory.InMemorySkillTaxonomyStore;
+
+class DefaultSkillCategoryDraftServiceTest {
+
+    @Test
+    void generatesDraftsFromProjectionClustersAndSavesCategories() {
+        InMemorySkillDictionaryStore dictionaryStore = new InMemorySkillDictionaryStore();
+        InMemorySkillProjectionStore projectionStore = new InMemorySkillProjectionStore();
+        InMemorySkillTaxonomyStore taxonomyStore = new InMemorySkillTaxonomyStore();
+        Instant now = Instant.now();
+        dictionaryStore.save(new SkillDictionary("skill-1", "Spring Security JWT 인증 구성", null, null, "ACTIVE", now, now));
+        dictionaryStore.save(new SkillDictionary("skill-2", "OAuth2 로그인 연동", null, null, "ACTIVE", now, now));
+        projectionStore.replaceProjection("default", List.of(
+                new SkillProjection("default", "skill-1", 0.1d, 0.2d, "cluster-1", 0, now),
+                new SkillProjection("default", "skill-2", 0.2d, 0.3d, "cluster-1", 1, now)),
+                List.of(new SkillCluster("cluster-1", null, "distance-threshold", 2, now)));
+        DefaultSkillCategoryDraftService service = new DefaultSkillCategoryDraftService(
+                projectionStore,
+                dictionaryStore,
+                taxonomyStore);
+
+        var drafts = service.generateDrafts("default", 5);
+        var saved = service.saveDrafts(new SaveSkillCategoryDraftCommand(List.of(
+                new SaveSkillCategoryDraftCommand.SaveSkillCategoryItem(
+                        "auth-security",
+                        null,
+                        drafts.drafts().get(0).proposedName(),
+                        0))));
+
+        assertEquals(1, drafts.draftCount());
+        assertEquals("인증·인가 보안", drafts.drafts().get(0).proposedName());
+        assertEquals(List.of("Spring Security JWT 인증 구성", "OAuth2 로그인 연동"),
+                drafts.drafts().get(0).representativeSkillNames());
+        assertEquals("auth-security", saved.get(0).categoryId());
+        assertEquals(1, taxonomyStore.findCategories(null).size());
+    }
+}

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/DefaultSkillDictionaryServiceTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/DefaultSkillDictionaryServiceTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import studio.one.platform.skillgraph.application.command.CreateSkillDictionaryCommand;
@@ -70,5 +72,25 @@ class DefaultSkillDictionaryServiceTest {
         assertEquals(2, page.size());
         assertEquals("Frontend Vue 컴포넌트 개발", page.get(0).name());
         assertEquals("Spring Security JWT 인증 구성", page.get(1).name());
+    }
+
+    @Test
+    void embedsMissingDictionarySkillsOnly() {
+        InMemorySkillDictionaryStore store = new InMemorySkillDictionaryStore();
+        DefaultSkillDictionaryService service = new DefaultSkillDictionaryService(
+                store,
+                text -> List.of(1.0d, 0.0d, 0.5d));
+        service.create(new CreateSkillDictionaryCommand("Spring Security JWT 인증 구성", null, null, null, null));
+        service.create(new CreateSkillDictionaryCommand("Vue 컴포넌트 개발", null, null, null, null));
+
+        var first = service.embedMissing(10);
+        var second = service.embedMissing(10);
+
+        assertEquals(2, first.requestedCount());
+        assertEquals(2, first.processedCount());
+        assertEquals(0, first.failedCount());
+        assertEquals(2, store.findVectorItems(10).size());
+        assertEquals(0, second.requestedCount());
+        assertEquals(0, second.processedCount());
     }
 }

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/DefaultSkillDictionaryServiceTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/DefaultSkillDictionaryServiceTest.java
@@ -86,11 +86,32 @@ class DefaultSkillDictionaryServiceTest {
         var first = service.embedMissing(10);
         var second = service.embedMissing(10);
 
+        assertEquals(2, first.totalMissingCount());
         assertEquals(2, first.requestedCount());
         assertEquals(2, first.processedCount());
+        assertEquals(0, first.skippedCount());
         assertEquals(0, first.failedCount());
         assertEquals(2, store.findVectorItems(10).size());
+        assertEquals(0, second.totalMissingCount());
         assertEquals(0, second.requestedCount());
         assertEquals(0, second.processedCount());
+    }
+
+    @Test
+    void embeddingResultSeparatesTotalMissingFromBatchSize() {
+        InMemorySkillDictionaryStore store = new InMemorySkillDictionaryStore();
+        DefaultSkillDictionaryService service = new DefaultSkillDictionaryService(
+                store,
+                text -> List.of(1.0d, 0.0d, 0.5d));
+        service.create(new CreateSkillDictionaryCommand("Spring Security JWT 인증 구성", null, null, null, null));
+        service.create(new CreateSkillDictionaryCommand("Vue 컴포넌트 개발", null, null, null, null));
+        service.create(new CreateSkillDictionaryCommand("PostgreSQL 벡터 검색 구현", null, null, null, null));
+
+        var result = service.embedMissing(1);
+
+        assertEquals(3, result.totalMissingCount());
+        assertEquals(1, result.requestedCount());
+        assertEquals(1, result.processedCount());
+        assertEquals(2, result.skippedCount());
     }
 }


### PR DESCRIPTION
## Why

- SkillGraph category 자동 생성은 Dictionary skill embedding, projection 대상 vector 조회, cluster 기반 category draft API가 함께 준비되어야 화면에서 동작합니다.
- 기존 JDBC Dictionary store는 `findVectorItems`를 구현하지 않아 projection 결과가 `items 0`, `clusters 0`으로 반환될 수 있었습니다.
- Dictionary에 대량 skill이 있어도 embedding이 없으면 projection/category draft 생성이 불가능했습니다.

## What

- `POST /api/mgmt/skillgraph/dictionary/embeddings/missing` API를 추가했습니다.
- `SkillDictionaryService.embedMissing()`을 추가해 embedding이 없는 active skill만 처리합니다.
- `JdbcSkillDictionaryStore.findVectorItems(int limit)`를 구현해 `tb_skill_dictionary.embedding` vector 데이터를 projection 대상으로 조회합니다.
- `JdbcSkillDictionaryStore.saveEmbedding()`과 memory store embedding 저장/조회 흐름을 추가했습니다.
- projection cluster 기반 category draft 생성 API를 추가했습니다.
  - `GET /api/mgmt/skillgraph/category-drafts?projectionId=default`
  - draft에는 cluster id, proposed name, confidence, noise 여부, 대표 skill ids/names가 포함됩니다.
- 검토 완료 draft를 taxonomy로 저장하는 API를 추가했습니다.
  - `POST /api/mgmt/skillgraph/category-drafts/save`
- auto-configuration과 web auto-configuration에 draft service/controller를 등록했습니다.
- embedding 생성과 category draft 생성/저장 회귀 테스트를 추가했습니다.

## Related Issues

- Closes #493
- Closes #495
- Closes #496

## Validation

- Command: `./gradlew :studio-platform-skillgraph:clean :studio-platform-skillgraph:test :starter:studio-platform-starter-skillgraph:clean :starter:studio-platform-starter-skillgraph:test`
- Result: `BUILD SUCCESSFUL`
- Command: `git diff --check`
- Result: passed

## Risk / Rollback

- Risk: embedding 생성 API는 동기 처리 v1입니다. 많은 건수를 한 번에 처리할 경우 호출 시간이 길어질 수 있으므로 `limit`으로 나눠 호출해야 합니다.
- Risk: 실제 embedding 생성은 `SkillEmbeddingPort` bean이 필요합니다. 기본 NoOp 환경에서는 처리 실패 수가 반환됩니다.
- Risk: category draft name proposal은 v1 휴리스틱입니다. LLM category naming은 후속 개선으로 분리 가능합니다.
- Rollback: 이 PR 커밋을 revert하면 embedding batch API, JDBC vector item 조회, category draft API가 제거됩니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope:
- Main author validation: 관련 모듈 clean test와 diff whitespace 검증 완료

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
