### PR TITLE
[ai-assisted] feat(skillgraph): Dictionary embedding job 진행 상태 조회

### DIFF
--- a/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/SkillGraphAutoConfiguration.java
+++ b/starter/studio-platform-starter-skillgraph/src/main/java/studio/one/platform/autoconfigure/skillgraph/SkillGraphAutoConfiguration.java
@@ -1,5 +1,11 @@
 package studio.one.platform.autoconfigure.skillgraph;
 
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -12,10 +18,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import studio.one.platform.ai.core.chat.ChatPort;
 import studio.one.platform.ai.service.prompt.PromptRenderer;
@@ -122,8 +124,9 @@ public class SkillGraphAutoConfiguration {
     @ConditionalOnMissingBean
     public SkillDictionaryService skillDictionaryService(
             SkillDictionaryStore dictionaryStore,
-            SkillEmbeddingPort embeddingPort) {
-        return new DefaultSkillDictionaryService(dictionaryStore, embeddingPort);
+            SkillEmbeddingPort embeddingPort,
+            @Qualifier("skillRagExtractionJobExecutor") Executor embeddingJobExecutor) {
+        return new DefaultSkillDictionaryService(dictionaryStore, embeddingPort, embeddingJobExecutor);
     }
 
     @Bean(name = SkillVisualizationService.SERVICE_NAME)

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/SkillDictionaryEmbeddingJob.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/SkillDictionaryEmbeddingJob.java
@@ -1,0 +1,57 @@
+package studio.one.platform.skillgraph.application.result;
+
+import java.time.Instant;
+
+public record SkillDictionaryEmbeddingJob(
+        String jobId,
+        SkillDictionaryEmbeddingJobStatus status,
+        int totalCount,
+        int requestedCount,
+        int processedCount,
+        int failedCount,
+        int skippedCount,
+        Instant startedAt,
+        Instant updatedAt,
+        Instant completedAt,
+        String message) {
+
+    public SkillDictionaryEmbeddingJob withStatus(
+            SkillDictionaryEmbeddingJobStatus status,
+            String message,
+            Instant updatedAt) {
+        return new SkillDictionaryEmbeddingJob(
+                jobId,
+                status,
+                totalCount,
+                requestedCount,
+                processedCount,
+                failedCount,
+                skippedCount,
+                startedAt,
+                updatedAt,
+                completedAt,
+                message);
+    }
+
+    public SkillDictionaryEmbeddingJob withProgress(
+            SkillDictionaryEmbeddingJobStatus status,
+            int processedCount,
+            int failedCount,
+            int skippedCount,
+            Instant updatedAt,
+            Instant completedAt,
+            String message) {
+        return new SkillDictionaryEmbeddingJob(
+                jobId,
+                status,
+                totalCount,
+                requestedCount,
+                processedCount,
+                failedCount,
+                skippedCount,
+                startedAt,
+                updatedAt,
+                completedAt,
+                message);
+    }
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/SkillDictionaryEmbeddingJobStatus.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/SkillDictionaryEmbeddingJobStatus.java
@@ -1,0 +1,9 @@
+package studio.one.platform.skillgraph.application.result;
+
+public enum SkillDictionaryEmbeddingJobStatus {
+    READY,
+    RUNNING,
+    COMPLETED,
+    PARTIAL,
+    FAILED
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/SkillDictionaryEmbeddingResult.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/SkillDictionaryEmbeddingResult.java
@@ -6,5 +6,7 @@ public record SkillDictionaryEmbeddingResult(
         int processedCount,
         int skippedCount,
         int failedCount,
-        String jobId) {
+        String jobId,
+        SkillDictionaryEmbeddingJobStatus status,
+        String message) {
 }

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillDictionaryService.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillDictionaryService.java
@@ -2,9 +2,16 @@ package studio.one.platform.skillgraph.application.service;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 
 import studio.one.platform.skillgraph.application.command.CreateSkillDictionaryCommand;
+import studio.one.platform.skillgraph.application.result.SkillDictionaryEmbeddingJob;
+import studio.one.platform.skillgraph.application.result.SkillDictionaryEmbeddingJobStatus;
 import studio.one.platform.skillgraph.application.result.SkillDictionaryEmbeddingResult;
 import studio.one.platform.skillgraph.application.result.SkillDictionaryView;
 import studio.one.platform.skillgraph.application.usecase.SkillDictionaryService;
@@ -49,14 +56,24 @@ public class DefaultSkillDictionaryService implements SkillDictionaryService {
 
     private final SkillDictionaryStore store;
     private final SkillEmbeddingPort embeddingPort;
+    private final Executor embeddingJobExecutor;
+    private final Map<String, SkillDictionaryEmbeddingJob> embeddingJobs = new ConcurrentHashMap<>();
 
     public DefaultSkillDictionaryService(SkillDictionaryStore store) {
         this(store, new NoOpSkillEmbeddingPort());
     }
 
     public DefaultSkillDictionaryService(SkillDictionaryStore store, SkillEmbeddingPort embeddingPort) {
+        this(store, embeddingPort, Runnable::run);
+    }
+
+    public DefaultSkillDictionaryService(
+            SkillDictionaryStore store,
+            SkillEmbeddingPort embeddingPort,
+            Executor embeddingJobExecutor) {
         this.store = store;
         this.embeddingPort = embeddingPort == null ? new NoOpSkillEmbeddingPort() : embeddingPort;
+        this.embeddingJobExecutor = embeddingJobExecutor == null ? Runnable::run : embeddingJobExecutor;
     }
 
     @Override
@@ -109,24 +126,116 @@ public class DefaultSkillDictionaryService implements SkillDictionaryService {
         int max = normalizeLimit(limit);
         int totalMissing = store.countMissingEmbeddingSkills();
         List<SkillDictionary> missing = store.findMissingEmbeddingSkills(max);
-        int processed = 0;
-        int failed = 0;
-        for (SkillDictionary skill : missing) {
-            List<Double> embedding = embeddingPort.embedSkill(skill.name());
-            if (embedding == null || embedding.isEmpty()) {
-                failed++;
-                continue;
-            }
-            store.saveEmbedding(skill.skillId(), embedding, null);
-            processed++;
-        }
-        return new SkillDictionaryEmbeddingResult(
+        String jobId = "skill_dictionary_embedding_" + UUID.randomUUID();
+        Instant now = Instant.now();
+        SkillDictionaryEmbeddingJob job = new SkillDictionaryEmbeddingJob(
+                jobId,
+                SkillDictionaryEmbeddingJobStatus.READY,
                 totalMissing,
                 missing.size(),
-                processed,
+                0,
+                0,
                 Math.max(0, totalMissing - missing.size()),
-                failed,
-                null);
+                now,
+                now,
+                null,
+                "Embedding job is queued");
+        embeddingJobs.put(jobId, job);
+        try {
+            embeddingJobExecutor.execute(() -> runEmbeddingJob(jobId, missing, totalMissing));
+        } catch (RejectedExecutionException ex) {
+            Instant failedAt = Instant.now();
+            SkillDictionaryEmbeddingJob failedJob = job.withProgress(
+                    SkillDictionaryEmbeddingJobStatus.FAILED,
+                    0,
+                    missing.size(),
+                    Math.max(0, totalMissing - missing.size()),
+                    failedAt,
+                    failedAt,
+                    "Embedding job queue is full");
+            embeddingJobs.put(jobId, failedJob);
+            return resultFrom(failedJob);
+        }
+        return resultFrom(currentJob(jobId).orElse(job));
+    }
+
+    @Override
+    public SkillDictionaryEmbeddingJob getEmbeddingJob(String jobId) {
+        String normalizedJobId = requireText(jobId, "jobId");
+        return currentJob(normalizedJobId)
+                .orElseThrow(() -> new IllegalArgumentException("Unknown embedding job: " + normalizedJobId));
+    }
+
+    private void runEmbeddingJob(String jobId, List<SkillDictionary> missing, int totalMissing) {
+        Instant startedAt = Instant.now();
+        embeddingJobs.computeIfPresent(jobId,
+                (ignored, job) -> job.withStatus(SkillDictionaryEmbeddingJobStatus.RUNNING,
+                        "Embedding job is running", startedAt));
+        int processed = 0;
+        int failed = 0;
+        int skipped = Math.max(0, totalMissing - missing.size());
+        String lastFailureMessage = null;
+        for (SkillDictionary skill : missing) {
+            try {
+                List<Double> embedding = embeddingPort.embedSkill(skill.name());
+                if (embedding == null || embedding.isEmpty()) {
+                    failed++;
+                    lastFailureMessage = "Embedding provider returned an empty vector";
+                    updateEmbeddingJob(jobId, missing, totalMissing, processed, failed, lastFailureMessage);
+                    continue;
+                }
+                store.saveEmbedding(skill.skillId(), embedding, null);
+                processed++;
+                updateEmbeddingJob(jobId, missing, totalMissing, processed, failed, null);
+            } catch (RuntimeException ex) {
+                failed++;
+                lastFailureMessage = ex.getMessage();
+                updateEmbeddingJob(jobId, missing, totalMissing, processed, failed, lastFailureMessage);
+            }
+        }
+        SkillDictionaryEmbeddingJobStatus status = failed == 0
+                ? SkillDictionaryEmbeddingJobStatus.COMPLETED
+                : processed > 0 ? SkillDictionaryEmbeddingJobStatus.PARTIAL : SkillDictionaryEmbeddingJobStatus.FAILED;
+        Instant completedAt = Instant.now();
+        String message = failed == 0 ? "Embedding job completed"
+                : "Embedding job completed with failures"
+                        + (lastFailureMessage == null || lastFailureMessage.isBlank() ? "" : ": " + lastFailureMessage);
+        int finalProcessed = processed;
+        int finalFailed = failed;
+        embeddingJobs.computeIfPresent(jobId,
+                (ignored, job) -> job.withProgress(status, finalProcessed, finalFailed, skipped, completedAt,
+                        completedAt, message));
+    }
+
+    private void updateEmbeddingJob(
+            String jobId,
+            List<SkillDictionary> missing,
+            int totalMissing,
+            int processed,
+            int failed,
+            String message) {
+        Instant now = Instant.now();
+        int skipped = Math.max(0, totalMissing - missing.size());
+        embeddingJobs.computeIfPresent(jobId,
+                (ignored, job) -> job.withProgress(SkillDictionaryEmbeddingJobStatus.RUNNING, processed, failed,
+                        skipped, now, null,
+                        message == null || message.isBlank() ? "Embedding job is running" : message));
+    }
+
+    private Optional<SkillDictionaryEmbeddingJob> currentJob(String jobId) {
+        return Optional.ofNullable(embeddingJobs.get(jobId));
+    }
+
+    private SkillDictionaryEmbeddingResult resultFrom(SkillDictionaryEmbeddingJob job) {
+        return new SkillDictionaryEmbeddingResult(
+                job.totalCount(),
+                job.requestedCount(),
+                job.processedCount(),
+                job.skippedCount(),
+                job.failedCount(),
+                job.jobId(),
+                job.status(),
+                job.message());
     }
 
     private int normalizeLimit(int limit) {

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/usecase/SkillDictionaryService.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/usecase/SkillDictionaryService.java
@@ -3,6 +3,7 @@ package studio.one.platform.skillgraph.application.usecase;
 import java.util.List;
 
 import studio.one.platform.skillgraph.application.command.CreateSkillDictionaryCommand;
+import studio.one.platform.skillgraph.application.result.SkillDictionaryEmbeddingJob;
 import studio.one.platform.skillgraph.application.result.SkillDictionaryEmbeddingResult;
 import studio.one.platform.skillgraph.application.result.SkillDictionaryView;
 
@@ -17,6 +18,8 @@ public interface SkillDictionaryService {
     SkillDictionaryView create(CreateSkillDictionaryCommand command);
 
     SkillDictionaryEmbeddingResult embedMissing(int limit);
+
+    SkillDictionaryEmbeddingJob getEmbeddingJob(String jobId);
 
     SkillDictionaryView get(String skillId);
 }

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillDictionaryMgmtController.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillDictionaryMgmtController.java
@@ -69,6 +69,16 @@ public class SkillDictionaryMgmtController {
         return ResponseEntity.ok(ApiResponse.ok(dictionaryService.embedMissing(limit)));
     }
 
+    @GetMapping("/embeddings/jobs/{jobId}")
+    @PreAuthorize("@endpointAuthz.can('features:skillgraph','read')")
+    public ResponseEntity<ApiResponse<?>> getEmbeddingJob(@PathVariable @Size(max = 120) String jobId) {
+        try {
+            return ResponseEntity.ok(ApiResponse.ok(dictionaryService.getEmbeddingJob(jobId)));
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage(), ex);
+        }
+    }
+
     @GetMapping("/{skillId}")
     @PreAuthorize("@endpointAuthz.can('features:skillgraph','read')")
     public ResponseEntity<ApiResponse<SkillDictionaryDto>> get(@PathVariable @Size(max = 100) String skillId) {

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/DefaultSkillDictionaryServiceTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/DefaultSkillDictionaryServiceTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import studio.one.platform.skillgraph.application.command.CreateSkillDictionaryCommand;
+import studio.one.platform.skillgraph.application.result.SkillDictionaryEmbeddingJobStatus;
 import studio.one.platform.skillgraph.application.service.DefaultSkillDictionaryService;
 import studio.one.platform.skillgraph.application.service.DuplicateSkillDictionaryException;
 import studio.one.platform.skillgraph.infrastructure.persistence.memory.InMemorySkillDictionaryStore;
@@ -91,6 +92,8 @@ class DefaultSkillDictionaryServiceTest {
         assertEquals(2, first.processedCount());
         assertEquals(0, first.skippedCount());
         assertEquals(0, first.failedCount());
+        assertEquals(SkillDictionaryEmbeddingJobStatus.COMPLETED, first.status());
+        assertFalse(first.jobId().isBlank());
         assertEquals(2, store.findVectorItems(10).size());
         assertEquals(0, second.totalMissingCount());
         assertEquals(0, second.requestedCount());
@@ -113,5 +116,43 @@ class DefaultSkillDictionaryServiceTest {
         assertEquals(1, result.requestedCount());
         assertEquals(1, result.processedCount());
         assertEquals(2, result.skippedCount());
+    }
+
+    @Test
+    void embeddingJobCanBeQueriedByJobId() {
+        InMemorySkillDictionaryStore store = new InMemorySkillDictionaryStore();
+        DefaultSkillDictionaryService service = new DefaultSkillDictionaryService(
+                store,
+                text -> List.of(1.0d, 0.0d, 0.5d));
+        service.create(new CreateSkillDictionaryCommand("Spring Security JWT 인증 구성", null, null, null, null));
+
+        var result = service.embedMissing(10);
+        var job = service.getEmbeddingJob(result.jobId());
+
+        assertEquals(result.jobId(), job.jobId());
+        assertEquals(SkillDictionaryEmbeddingJobStatus.COMPLETED, job.status());
+        assertEquals(1, job.totalCount());
+        assertEquals(1, job.requestedCount());
+        assertEquals(1, job.processedCount());
+        assertEquals(0, job.failedCount());
+        assertEquals(0, job.skippedCount());
+    }
+
+    @Test
+    void embeddingJobReportsProviderFailureMessage() {
+        InMemorySkillDictionaryStore store = new InMemorySkillDictionaryStore();
+        DefaultSkillDictionaryService service = new DefaultSkillDictionaryService(
+                store,
+                text -> List.of());
+        service.create(new CreateSkillDictionaryCommand("Spring Security JWT 인증 구성", null, null, null, null));
+
+        var result = service.embedMissing(10);
+        var job = service.getEmbeddingJob(result.jobId());
+
+        assertEquals(SkillDictionaryEmbeddingJobStatus.FAILED, result.status());
+        assertEquals(SkillDictionaryEmbeddingJobStatus.FAILED, job.status());
+        assertEquals(0, job.processedCount());
+        assertEquals(1, job.failedCount());
+        assertEquals("Embedding job completed with failures: Embedding provider returned an empty vector", job.message());
     }
 }


### PR DESCRIPTION
## Why

- SkillGraph Dictionary embedding 생성 작업이 오래 걸릴 때 클라이언트가 진행 상태를 조회할 수 있는 서버 계약이 필요합니다.
- 기존 응답의 `jobId`가 실제 상태 조회와 연결되지 않아 화면 새로고침 또는 polling 기반 진행률 표시가 불가능했습니다.

## What

- `POST /api/mgmt/skillgraph/dictionary/embeddings/missing` 응답의 `jobId`를 실제 in-memory job 상태와 연결했습니다.
- `GET /api/mgmt/skillgraph/dictionary/embeddings/jobs/{jobId}` 상태 조회 API를 추가했습니다.
- job 상태에 `READY`, `RUNNING`, `COMPLETED`, `PARTIAL`, `FAILED`와 처리/실패/스킵 수량, 시작/수정/완료 시각, 메시지를 포함했습니다.
- auto-configuration에서 기존 bounded worker executor를 dictionary embedding job에도 주입했습니다.
- provider 빈 벡터/예외 발생 시 실패 수량과 UI 전달용 메시지를 남기도록 테스트를 추가했습니다.

## Related Issues

- Closes #498

## Validation

- Command: `./gradlew :studio-platform-skillgraph:test :starter:studio-platform-starter-skillgraph:test`
- Result: Passed
- Command: `git diff --check`
- Result: Passed

## Risk / Rollback

- Risk: job 상태는 현재 서버 프로세스 메모리에 보관되므로 서버 재시작 후에는 이전 jobId 조회가 불가능합니다. 화면 새로고침과 polling에는 충분하지만 장기 이력 보관은 별도 영속화가 필요합니다.
- Rollback: 신규 endpoint와 `DefaultSkillDictionaryService`의 executor/job 상태 확장을 되돌리면 기존 동기형 embedding 생성 동작으로 복귀할 수 있습니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope:
- Main author validation: 서버 단위 테스트와 starter auto-configuration 테스트 실행으로 검증했습니다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
