### PR TITLE
[ai-assisted] feat(skillgraph): projection 목록 조회 API 추가

### DIFF
--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/SkillProjectionSummaryView.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/result/SkillProjectionSummaryView.java
@@ -1,0 +1,24 @@
+package studio.one.platform.skillgraph.application.result;
+
+import java.time.Instant;
+
+import studio.one.platform.skillgraph.domain.model.SkillProjectionSummary;
+
+public record SkillProjectionSummaryView(
+        String projectionId,
+        int itemCount,
+        int clusterCount,
+        String algorithm,
+        Instant createdAt,
+        Instant updatedAt) {
+
+    public static SkillProjectionSummaryView from(SkillProjectionSummary summary) {
+        return new SkillProjectionSummaryView(
+                summary.projectionId(),
+                summary.itemCount(),
+                summary.clusterCount(),
+                summary.algorithm(),
+                summary.createdAt(),
+                summary.updatedAt());
+    }
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillVisualizationService.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/service/DefaultSkillVisualizationService.java
@@ -12,6 +12,7 @@ import studio.one.platform.ai.core.vector.visualization.VectorProjectionPoint;
 import studio.one.platform.skillgraph.application.result.SkillClusterView;
 import studio.one.platform.skillgraph.application.result.SkillProjectionPointView;
 import studio.one.platform.skillgraph.application.result.SkillProjectionResult;
+import studio.one.platform.skillgraph.application.result.SkillProjectionSummaryView;
 import studio.one.platform.skillgraph.application.usecase.SkillVisualizationService;
 import studio.one.platform.skillgraph.domain.constants.SkillGraphLimits;
 import studio.one.platform.skillgraph.domain.model.SkillProjection;
@@ -92,6 +93,13 @@ public class DefaultSkillVisualizationService implements SkillVisualizationServi
                 clustered.clusters().size(),
                 clustered.projections().stream().map(SkillProjectionPointView::from).toList(),
                 clustered.clusters().stream().map(SkillClusterView::from).toList());
+    }
+
+    @Override
+    public List<SkillProjectionSummaryView> listProjections(int limit, int offset) {
+        return projectionStore.listProjections(normalizeLimit(limit, 100), Math.max(0, offset)).stream()
+                .map(SkillProjectionSummaryView::from)
+                .toList();
     }
 
     @Override

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/usecase/SkillVisualizationService.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/application/usecase/SkillVisualizationService.java
@@ -5,12 +5,15 @@ import java.util.List;
 import studio.one.platform.skillgraph.application.result.SkillClusterView;
 import studio.one.platform.skillgraph.application.result.SkillProjectionPointView;
 import studio.one.platform.skillgraph.application.result.SkillProjectionResult;
+import studio.one.platform.skillgraph.application.result.SkillProjectionSummaryView;
 
 public interface SkillVisualizationService {
 
     String SERVICE_NAME = "skillVisualizationService";
 
     SkillProjectionResult generateProjection(String projectionId, int limit);
+
+    List<SkillProjectionSummaryView> listProjections(int limit, int offset);
 
     List<SkillProjectionPointView> findProjectionPoints(String projectionId, String clusterId, int limit, int offset);
 

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/domain/model/SkillProjectionSummary.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/domain/model/SkillProjectionSummary.java
@@ -1,0 +1,32 @@
+package studio.one.platform.skillgraph.domain.model;
+
+import java.time.Instant;
+
+public record SkillProjectionSummary(
+        String projectionId,
+        int itemCount,
+        int clusterCount,
+        String algorithm,
+        Instant createdAt,
+        Instant updatedAt) {
+
+    public SkillProjectionSummary {
+        projectionId = requireText(projectionId, "projectionId");
+        itemCount = Math.max(0, itemCount);
+        clusterCount = Math.max(0, clusterCount);
+        algorithm = normalize(algorithm);
+        createdAt = createdAt == null ? Instant.now() : createdAt;
+        updatedAt = updatedAt == null ? createdAt : updatedAt;
+    }
+
+    private static String normalize(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+
+    private static String requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return value.trim();
+    }
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/domain/port/SkillProjectionStore.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/domain/port/SkillProjectionStore.java
@@ -5,12 +5,15 @@ import java.util.Optional;
 
 import studio.one.platform.skillgraph.domain.model.SkillCluster;
 import studio.one.platform.skillgraph.domain.model.SkillProjection;
+import studio.one.platform.skillgraph.domain.model.SkillProjectionSummary;
 
 public interface SkillProjectionStore {
 
     String SERVICE_NAME = "skillProjectionStore";
 
     void replaceProjection(String projectionId, List<SkillProjection> projections, List<SkillCluster> clusters);
+
+    List<SkillProjectionSummary> listProjections(int limit, int offset);
 
     List<SkillProjection> findProjectionPoints(String projectionId, String clusterId, int limit, int offset);
 

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/jdbc/JdbcSkillProjectionStore.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/jdbc/JdbcSkillProjectionStore.java
@@ -14,6 +14,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import lombok.RequiredArgsConstructor;
 import studio.one.platform.skillgraph.domain.model.SkillCluster;
 import studio.one.platform.skillgraph.domain.model.SkillProjection;
+import studio.one.platform.skillgraph.domain.model.SkillProjectionSummary;
 import studio.one.platform.skillgraph.domain.port.SkillProjectionStore;
 
 @RequiredArgsConstructor
@@ -36,6 +37,25 @@ public class JdbcSkillProjectionStore implements SkillProjectionStore {
                 saveCluster(cluster);
             }
         }
+    }
+
+    @Override
+    public List<SkillProjectionSummary> listProjections(int limit, int offset) {
+        int max = limit <= 0 ? 100 : limit;
+        int start = Math.max(0, offset);
+        return template.query("""
+                SELECT p.projection_id,
+                       COUNT(*) AS item_count,
+                       COUNT(DISTINCT p.cluster_id) AS cluster_count,
+                       MIN(c.algorithm) AS algorithm,
+                       MIN(p.created_at) AS created_at,
+                       MAX(p.created_at) AS updated_at
+                FROM tb_skill_projection p
+                LEFT JOIN tb_skill_cluster c ON c.cluster_id = p.cluster_id
+                GROUP BY p.projection_id
+                ORDER BY MAX(p.created_at) DESC, p.projection_id
+                LIMIT :limit OFFSET :offset
+                """, Map.of("limit", max, "offset", start), this::mapProjectionSummary);
     }
 
     @Override
@@ -140,6 +160,16 @@ public class JdbcSkillProjectionStore implements SkillProjectionStore {
                 rs.getString("algorithm"),
                 rs.getInt("item_count"),
                 instant(rs.getTimestamp("created_at")));
+    }
+
+    private SkillProjectionSummary mapProjectionSummary(ResultSet rs, int rowNum) throws SQLException {
+        return new SkillProjectionSummary(
+                rs.getString("projection_id"),
+                rs.getInt("item_count"),
+                rs.getInt("cluster_count"),
+                rs.getString("algorithm"),
+                instant(rs.getTimestamp("created_at")),
+                instant(rs.getTimestamp("updated_at")));
     }
 
     private Instant instant(Timestamp timestamp) {

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/memory/InMemorySkillProjectionStore.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/infrastructure/persistence/memory/InMemorySkillProjectionStore.java
@@ -8,6 +8,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import studio.one.platform.skillgraph.domain.model.SkillCluster;
 import studio.one.platform.skillgraph.domain.model.SkillProjection;
+import studio.one.platform.skillgraph.domain.model.SkillProjectionSummary;
 import studio.one.platform.skillgraph.domain.port.SkillProjectionStore;
 
 public class InMemorySkillProjectionStore implements SkillProjectionStore {
@@ -17,12 +18,30 @@ public class InMemorySkillProjectionStore implements SkillProjectionStore {
 
     @Override
     public void replaceProjection(String projectionId, List<SkillProjection> projections, List<SkillCluster> clusters) {
+        if (projections == null || projections.isEmpty()) {
+            projectionsByProjectionId.remove(projectionId);
+            clustersByProjectionId.remove(projectionId);
+            return;
+        }
         Map<String, SkillProjection> points = new ConcurrentHashMap<>();
         for (SkillProjection projection : projections) {
             points.put(projection.skillId(), projection);
         }
         projectionsByProjectionId.put(projectionId, points);
         clustersByProjectionId.put(projectionId, clusters == null ? List.of() : List.copyOf(clusters));
+    }
+
+    @Override
+    public List<SkillProjectionSummary> listProjections(int limit, int offset) {
+        int max = limit <= 0 ? 100 : limit;
+        int start = Math.max(0, offset);
+        return projectionsByProjectionId.entrySet().stream()
+                .map(entry -> summary(entry.getKey(), entry.getValue().values().stream().toList()))
+                .sorted(Comparator.comparing(SkillProjectionSummary::updatedAt).reversed()
+                        .thenComparing(SkillProjectionSummary::projectionId))
+                .skip(start)
+                .limit(max)
+                .toList();
     }
 
     @Override
@@ -45,5 +64,30 @@ public class InMemorySkillProjectionStore implements SkillProjectionStore {
     @Override
     public Optional<SkillProjection> findProjectionPoint(String projectionId, String skillId) {
         return Optional.ofNullable(projectionsByProjectionId.getOrDefault(projectionId, Map.of()).get(skillId));
+    }
+
+    private SkillProjectionSummary summary(String projectionId, List<SkillProjection> projections) {
+        List<SkillCluster> clusters = clustersByProjectionId.getOrDefault(projectionId, List.of());
+        return new SkillProjectionSummary(
+                projectionId,
+                projections.size(),
+                (int) projections.stream()
+                        .map(SkillProjection::clusterId)
+                        .filter(clusterId -> clusterId != null && !clusterId.isBlank())
+                        .distinct()
+                        .count(),
+                clusters.stream()
+                        .map(SkillCluster::algorithm)
+                        .filter(algorithm -> algorithm != null && !algorithm.isBlank())
+                        .findFirst()
+                        .orElse(null),
+                projections.stream()
+                        .map(SkillProjection::createdAt)
+                        .min(Comparator.naturalOrder())
+                        .orElse(null),
+                projections.stream()
+                        .map(SkillProjection::createdAt)
+                        .max(Comparator.naturalOrder())
+                        .orElse(null));
     }
 }

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillVisualizationMgmtController.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/controller/SkillVisualizationMgmtController.java
@@ -22,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import studio.one.platform.skillgraph.application.usecase.SkillVisualizationService;
 import studio.one.platform.skillgraph.web.dto.request.SkillProjectionRequest;
 import studio.one.platform.skillgraph.web.dto.response.SkillClusterDto;
+import studio.one.platform.skillgraph.web.dto.response.SkillProjectionPageResponse;
 import studio.one.platform.skillgraph.web.dto.response.SkillProjectionPointDto;
 import studio.one.platform.skillgraph.web.dto.response.SkillProjectionResponse;
 import studio.one.platform.web.dto.ApiResponse;
@@ -40,6 +41,17 @@ public class SkillVisualizationMgmtController {
         int limit = request.limit() == null ? 1000 : request.limit();
         return ResponseEntity.ok(ApiResponse.ok(SkillProjectionResponse.from(
                 visualizationService.generateProjection(request.projectionId(), limit))));
+    }
+
+    @GetMapping("/projections")
+    @PreAuthorize("@endpointAuthz.can('features:skillgraph','read')")
+    public ResponseEntity<ApiResponse<SkillProjectionPageResponse>> projections(
+            @RequestParam(value = "limit", required = false, defaultValue = "100") @Min(1) @Max(500) int limit,
+            @RequestParam(value = "offset", required = false, defaultValue = "0") @Min(0) int offset) {
+        return ResponseEntity.ok(ApiResponse.ok(SkillProjectionPageResponse.from(
+                offset,
+                limit,
+                visualizationService.listProjections(limit + 1, offset))));
     }
 
     @GetMapping("/projections/{projectionId}/points")

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/response/SkillProjectionPageResponse.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/response/SkillProjectionPageResponse.java
@@ -1,0 +1,29 @@
+package studio.one.platform.skillgraph.web.dto.response;
+
+import java.util.List;
+
+import studio.one.platform.skillgraph.application.result.SkillProjectionSummaryView;
+
+public record SkillProjectionPageResponse(
+        int offset,
+        int limit,
+        int returned,
+        boolean hasMore,
+        List<SkillProjectionSummaryDto> items) {
+
+    public static SkillProjectionPageResponse from(
+            int offset,
+            int limit,
+            List<SkillProjectionSummaryView> projections) {
+        List<SkillProjectionSummaryDto> mapped = projections.stream()
+                .limit(limit)
+                .map(SkillProjectionSummaryDto::from)
+                .toList();
+        return new SkillProjectionPageResponse(
+                offset,
+                limit,
+                mapped.size(),
+                projections.size() > limit,
+                mapped);
+    }
+}

--- a/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/response/SkillProjectionSummaryDto.java
+++ b/studio-platform-skillgraph/src/main/java/studio/one/platform/skillgraph/web/dto/response/SkillProjectionSummaryDto.java
@@ -1,0 +1,28 @@
+package studio.one.platform.skillgraph.web.dto.response;
+
+import java.time.Instant;
+
+import studio.one.platform.skillgraph.application.result.SkillProjectionSummaryView;
+
+public record SkillProjectionSummaryDto(
+        String projectionId,
+        String name,
+        String status,
+        String algorithm,
+        int itemCount,
+        int clusterCount,
+        Instant createdAt,
+        Instant updatedAt) {
+
+    public static SkillProjectionSummaryDto from(SkillProjectionSummaryView view) {
+        return new SkillProjectionSummaryDto(
+                view.projectionId(),
+                view.projectionId(),
+                "READY",
+                view.algorithm(),
+                view.itemCount(),
+                view.clusterCount(),
+                view.createdAt(),
+                view.updatedAt());
+    }
+}

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/DefaultSkillVisualizationServiceTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/DefaultSkillVisualizationServiceTest.java
@@ -38,6 +38,11 @@ class DefaultSkillVisualizationServiceTest {
         assertFalse(result.points().isEmpty());
         assertFalse(result.clusters().isEmpty());
         assertEquals(3, service.findProjectionPoints("projection-1", null, 100, 0).size());
+        var projections = service.listProjections(10, 0);
+        assertEquals(1, projections.size());
+        assertEquals("projection-1", projections.get(0).projectionId());
+        assertEquals(3, projections.get(0).itemCount());
+        assertEquals(result.clusterCount(), projections.get(0).clusterCount());
     }
 
     @Test
@@ -54,5 +59,6 @@ class DefaultSkillVisualizationServiceTest {
 
         assertEquals(0, result.itemCount());
         assertEquals(0, result.clusterCount());
+        assertEquals(0, service.listProjections(10, 0).size());
     }
 }

--- a/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/JdbcSkillGraphStoreTest.java
+++ b/studio-platform-skillgraph/src/test/java/studio/one/platform/skillgraph/JdbcSkillGraphStoreTest.java
@@ -275,9 +275,15 @@ class JdbcSkillGraphStoreTest {
 
         var all = projectionStore.findProjectionPoints("default", null, 10, 0);
         var byCluster = projectionStore.findProjectionPoints("default", "cluster-a", 10, 0);
+        var summaries = projectionStore.listProjections(10, 0);
 
         assertEquals(2, all.size());
         assertEquals(1, byCluster.size());
         assertEquals("spring", byCluster.get(0).skillId());
+        assertEquals(1, summaries.size());
+        assertEquals("default", summaries.get(0).projectionId());
+        assertEquals(2, summaries.get(0).itemCount());
+        assertEquals(2, summaries.get(0).clusterCount());
+        assertEquals("manual", summaries.get(0).algorithm());
     }
 }


### PR DESCRIPTION
## Why

- SkillGraph Category 화면이 기존 projection 목록을 조회하고 선택할 수 있는 서버 API가 필요합니다.
- 기존 API는 projection 생성, point 조회, cluster 조회만 제공하여 화면 진입 시 생성된 projection 목록을 구성할 수 없었습니다.

## What

- `GET /api/mgmt/skillgraph/visualization/projections` 목록 조회 API를 추가했습니다.
- 응답에 `projectionId`, `name`, `status`, `algorithm`, `itemCount`, `clusterCount`, `createdAt`, `updatedAt`을 포함했습니다.
- `limit`, `offset` 기반 paging 응답과 `hasMore`를 제공합니다.
- JDBC store에서 `tb_skill_projection` 기준 projection별 요약을 집계합니다.
- memory store도 JDBC와 동일하게 빈 projection은 목록에 노출하지 않도록 정렬했습니다.

## Related Issues

- Closes #500

## Validation

- Command: `./gradlew :studio-platform-skillgraph:test :starter:studio-platform-starter-skillgraph:test`
- Result: Passed
- Command: `git diff --check`
- Result: Passed

## Risk / Rollback

- Risk: projection metadata 테이블이 따로 없어서 `name`은 현재 `projectionId`, `status`는 `READY`로 반환합니다. 별도 projection metadata 저장소가 생기면 해당 필드의 출처를 바꿔야 합니다.
- Rollback: 신규 목록 endpoint와 `SkillProjectionStore.listProjections` 확장을 되돌리면 기존 생성/point/cluster 조회 동작으로 복귀합니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope:
- Main author validation: JDBC/memory store 집계 테스트와 visualization service 테스트로 검증했습니다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [x] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included
