### PR TITLE
[ai-assisted] fix(markdown): improve pipeline recovery and RAG indexing

### DIFF
--- a/starter/studio-platform-starter-ai/README.md
+++ b/starter/studio-platform-starter-ai/README.md
@@ -236,6 +236,7 @@ studio:
         embedding:
           enabled: true
           model: nlpai-lab/KURE-v1
+          request-timeout: 5m
     rag:
       default-embedding-profile: retrieval-ko-kure
       embedding-profiles:

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/adapter/TeiEmbeddingAdapter.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/adapter/TeiEmbeddingAdapter.java
@@ -2,9 +2,11 @@ package studio.one.platform.ai.autoconfigure.adapter;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.http.HttpConnectTimeoutException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,21 +34,29 @@ public class TeiEmbeddingAdapter implements EmbeddingPort {
     private final ObjectMapper objectMapper;
     private final URI embedUri;
     private final String configuredModel;
+    private final Duration requestTimeout;
 
     public TeiEmbeddingAdapter(String baseUrl, String configuredModel) {
+        this(baseUrl, configuredModel, Duration.ofMinutes(2));
+    }
+
+    public TeiEmbeddingAdapter(String baseUrl, String configuredModel, Duration requestTimeout) {
         this(HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
                 .build(),
                 new ObjectMapper(),
                 baseUrl,
-                configuredModel);
+                configuredModel,
+                requestTimeout);
     }
 
-    TeiEmbeddingAdapter(HttpClient httpClient, ObjectMapper objectMapper, String baseUrl, String configuredModel) {
+    TeiEmbeddingAdapter(HttpClient httpClient, ObjectMapper objectMapper, String baseUrl, String configuredModel,
+            Duration requestTimeout) {
         this.httpClient = Objects.requireNonNull(httpClient, "httpClient");
         this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
         this.embedUri = URI.create(normalizeBaseUrl(baseUrl) + "/embed");
         this.configuredModel = normalize(configuredModel);
+        this.requestTimeout = sanitizeTimeout(requestTimeout);
     }
 
     @Override
@@ -75,7 +85,7 @@ public class TeiEmbeddingAdapter implements EmbeddingPort {
         try {
             String body = objectMapper.writeValueAsString(new TeiEmbeddingRequest(texts));
             HttpRequest httpRequest = HttpRequest.newBuilder(embedUri)
-                    .timeout(Duration.ofMinutes(2))
+                    .timeout(requestTimeout)
                     .header("Content-Type", "application/json")
                     .POST(HttpRequest.BodyPublishers.ofString(body))
                     .build();
@@ -85,6 +95,12 @@ public class TeiEmbeddingAdapter implements EmbeddingPort {
                         + response.statusCode() + ": " + abbreviate(response.body()));
             }
             return objectMapper.readValue(response.body(), EMBEDDING_LIST_TYPE);
+        } catch (HttpConnectTimeoutException e) {
+            throw new IllegalStateException("Timed out connecting to TEI embedding server after "
+                    + requestTimeout, e);
+        } catch (HttpTimeoutException e) {
+            throw new IllegalStateException("Timed out waiting for TEI embedding server after "
+                    + requestTimeout, e);
         } catch (IOException e) {
             throw new IllegalStateException("Failed to call TEI embedding server", e);
         } catch (InterruptedException e) {
@@ -106,6 +122,13 @@ public class TeiEmbeddingAdapter implements EmbeddingPort {
 
     private static String normalize(String value) {
         return value == null || value.isBlank() ? null : value.trim();
+    }
+
+    private static Duration sanitizeTimeout(Duration timeout) {
+        if (timeout == null || timeout.isZero() || timeout.isNegative()) {
+            return Duration.ofMinutes(2);
+        }
+        return timeout;
     }
 
     private static String abbreviate(String body) {

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/AiAdapterProperties.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/AiAdapterProperties.java
@@ -1,5 +1,6 @@
 package studio.one.platform.ai.autoconfigure.config;
 
+import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -64,6 +65,7 @@ public class AiAdapterProperties {
         private boolean enabled = false;
         private String model;
         private Integer dimension;
+        private Duration requestTimeout;
     }
 
     @Getter

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/TeiPortFactoryConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/TeiPortFactoryConfiguration.java
@@ -43,7 +43,7 @@ public class TeiPortFactoryConfiguration {
             baseUrl = requireText(baseUrl, "studio.ai.providers." + providerId
                     + ".base-url must be configured for TEI embedding provider");
             String model = provider.getEmbedding().getModel();
-            return new TeiEmbeddingAdapter(baseUrl, model);
+            return new TeiEmbeddingAdapter(baseUrl, model, provider.getEmbedding().getRequestTimeout());
         }
 
         private static String requireText(String value, String message) {

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagPipelineService.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/DefaultRagPipelineService.java
@@ -299,11 +299,20 @@ public class DefaultRagPipelineService implements RagPipelineService {
         if (objectType != null && objectId != null) {
             progress.onInfo(
                     RagIndexJobStep.INDEXING,
-                    "RAG index will resume with object-scoped upserts",
+                    "RAG index will replace object-scoped vectors with batched upserts",
                     "objectType=%s, objectId=%s, chunkCount=%d, upsertBatchSize=%d"
                             .formatted(objectType, objectId, chunks.size(), indexUpsertBatchSize));
+            vectorStorePort.deleteByObject(objectType, objectId);
         }
-        int indexed = embedAndUpsertInBatches(request, chunks, baseMetadata, progress);
+        int indexed;
+        try {
+            indexed = embedAndUpsertInBatches(request, chunks, baseMetadata, progress);
+        } catch (RuntimeException ex) {
+            if (objectType != null && objectId != null) {
+                vectorStorePort.deleteByObject(objectType, objectId);
+            }
+            throw ex;
+        }
         if (objectType != null && objectId != null) {
             chunkStageStore.deleteByObject(objectType, objectId, request.documentId());
         }

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/JdbcRagChunkStageStore.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/service/pipeline/JdbcRagChunkStageStore.java
@@ -17,6 +17,7 @@ public class JdbcRagChunkStageStore implements RagChunkStageStore {
 
     private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {
     };
+    private static final int INSERT_BATCH_SIZE = 200;
 
     private final NamedParameterJdbcTemplate template;
     private final ObjectMapper objectMapper;
@@ -32,15 +33,19 @@ public class JdbcRagChunkStageStore implements RagChunkStageStore {
         if (chunks == null || chunks.isEmpty()) {
             return;
         }
-        MapSqlParameterSource[] batch = chunks.stream()
-                .map(chunk -> params(objectType, objectId, documentId, chunk))
-                .toArray(MapSqlParameterSource[]::new);
-        template.batchUpdate("""
-                INSERT INTO tb_ai_rag_chunk_stage(
-                    object_type, object_id, document_id, chunk_index, chunk_id, text, metadata, created_at)
-                VALUES (
-                    :objectType, :objectId, :documentId, :chunkIndex, :chunkId, :text, :metadata, :createdAt)
-                """, batch);
+        for (int offset = 0; offset < chunks.size(); offset += INSERT_BATCH_SIZE) {
+            List<RagChunkStage> slice = chunks.subList(offset, Math.min(offset + INSERT_BATCH_SIZE, chunks.size()));
+            MapSqlParameterSource[] batch = new MapSqlParameterSource[slice.size()];
+            for (int index = 0; index < slice.size(); index++) {
+                batch[index] = params(objectType, objectId, documentId, slice.get(index));
+            }
+            template.batchUpdate("""
+                    INSERT INTO tb_ai_rag_chunk_stage(
+                        object_type, object_id, document_id, chunk_index, chunk_id, text, metadata, created_at)
+                    VALUES (
+                        :objectType, :objectId, :documentId, :chunkIndex, :chunkId, :text, :metadata, :createdAt)
+                    """, batch);
+        }
     }
 
     @Override

--- a/starter/studio-platform-starter-ai/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/starter/studio-platform-starter-ai/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -73,6 +73,12 @@
       "description": "Embedding vector dimension metadata exposed through AI embedding option discovery."
     },
     {
+      "name": "studio.ai.providers.*.embedding.request-timeout",
+      "type": "java.time.Duration",
+      "defaultValue": "2m",
+      "description": "HTTP request timeout for non-Spring AI embedding providers such as TEI."
+    },
+    {
       "name": "studio.ai.providers.*.google-embedding.task-type",
       "type": "java.lang.String",
       "defaultValue": "RETRIEVAL_DOCUMENT",

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/service/pipeline/RagPipelineServiceTest.java
@@ -58,6 +58,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doThrow;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("deprecation")
@@ -644,13 +645,36 @@ class RagPipelineServiceTest {
 
         ragPipelineService.index(request);
 
-        verify(vectorStorePort, never()).deleteByObject("attachment", "99");
+        verify(vectorStorePort).deleteByObject("attachment", "99");
         verify(vectorStorePort, never()).replaceRecordsByObject(anyString(), anyString(), any());
         verify(embeddingPort, times(7)).embed(any(EmbeddingRequest.class));
         verify(vectorStorePort, times(7)).upsertAll(recordsCaptor.capture());
         assertThat(recordsCaptor.getAllValues()).hasSize(7);
         assertThat(recordsCaptor.getAllValues().subList(0, 6)).allSatisfy(batch -> assertThat(batch).hasSize(10));
         assertThat(recordsCaptor.getAllValues().get(6)).hasSize(5);
+    }
+
+    @Test
+    void shouldDeletePartialObjectScopedVectorsWhenLargeBatchedIndexFails() {
+        RagIndexRequest request = new RagIndexRequest("doc-large-fail", "large text", Map.of(
+                "objectType", "attachment",
+                "objectId", "101"));
+        List<TextChunk> chunks = new ArrayList<>();
+        for (int i = 0; i < 65; i++) {
+            chunks.add(new TextChunk("doc-large-fail-" + i, "chunk-" + i));
+        }
+        when(textChunker.chunk("doc-large-fail", "large text")).thenReturn(chunks);
+        when(embeddingPort.embed(any(EmbeddingRequest.class)))
+                .thenReturn(new EmbeddingResponse(embeddingVectors(10)));
+        doThrow(new IllegalStateException("vector store unavailable"))
+                .when(vectorStorePort)
+                .upsertAll(any());
+
+        assertThatThrownBy(() -> ragPipelineService.index(request))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("vector store unavailable");
+
+        verify(vectorStorePort, times(2)).deleteByObject("attachment", "101");
     }
 
     @Test

--- a/starter/studio-platform-starter-markdown/README.md
+++ b/starter/studio-platform-starter-markdown/README.md
@@ -6,7 +6,7 @@
 studio:
   markdown:
     enabled: true
-    max-source-bytes: 26214400
+    max-source-bytes: 67108864
     pandoc-version: pandoc-3
     textract-version: native-1
   document-convert:

--- a/starter/studio-platform-starter-markdown/src/main/java/studio/one/platform/markdown/autoconfigure/AttachmentMarkdownSourceAdapter.java
+++ b/starter/studio-platform-starter-markdown/src/main/java/studio/one/platform/markdown/autoconfigure/AttachmentMarkdownSourceAdapter.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 
 import studio.one.application.attachment.application.usecase.AttachmentService;
 import studio.one.application.attachment.domain.model.Attachment;
+import studio.one.platform.markdown.application.MarkdownSourceTooLargeException;
 import studio.one.platform.markdown.application.port.MarkdownSourcePort;
 
 public class AttachmentMarkdownSourceAdapter implements MarkdownSourcePort {
@@ -17,15 +18,23 @@ public class AttachmentMarkdownSourceAdapter implements MarkdownSourcePort {
     }
 
     @Override
+    public MarkdownSourceDescriptor describe(long attachmentId) {
+        Attachment attachment = attachmentService.getAttachmentById(attachmentId);
+        return new MarkdownSourceDescriptor(attachment.getAttachmentId(), attachment.getName(),
+                attachment.getContentType(), String.valueOf(attachment.getObjectType()),
+                String.valueOf(attachment.getObjectId()), attachment.getSize());
+    }
+
+    @Override
     public MarkdownSource load(long attachmentId) {
         Attachment attachment = attachmentService.getAttachmentById(attachmentId);
         if (attachment.getSize() > maxSourceBytes) {
-            throw new IllegalArgumentException("Attachment exceeds markdown source size limit");
+            throw new MarkdownSourceTooLargeException(attachment.getSize(), maxSourceBytes);
         }
         try (InputStream input = attachmentService.getInputStream(attachment)) {
             byte[] content = input.readNBytes(maxSourceBytes + 1);
             if (content.length > maxSourceBytes) {
-                throw new IllegalArgumentException("Attachment exceeds markdown source size limit");
+                throw new MarkdownSourceTooLargeException(content.length, maxSourceBytes);
             }
             return new MarkdownSource(attachment.getAttachmentId(), attachment.getName(),
                     attachment.getContentType(), String.valueOf(attachment.getObjectType()),

--- a/starter/studio-platform-starter-markdown/src/main/java/studio/one/platform/markdown/autoconfigure/MarkdownDownstreamPipelineAdapter.java
+++ b/starter/studio-platform-starter-markdown/src/main/java/studio/one/platform/markdown/autoconfigure/MarkdownDownstreamPipelineAdapter.java
@@ -3,6 +3,7 @@ package studio.one.platform.markdown.autoconfigure;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -11,7 +12,10 @@ import org.springframework.beans.factory.ObjectProvider;
 
 import studio.one.platform.ai.core.rag.RagIndexJob;
 import studio.one.platform.ai.core.rag.RagIndexJobCreateRequest;
+import studio.one.platform.ai.core.rag.RagIndexJobFilter;
 import studio.one.platform.ai.core.rag.RagIndexJobStatus;
+import studio.one.platform.ai.core.rag.RagIndexJobPageRequest;
+import studio.one.platform.ai.core.rag.RagIndexJobSort;
 import studio.one.platform.ai.core.rag.RagIndexRequest;
 import studio.one.platform.ai.service.pipeline.RagChunkStage;
 import studio.one.platform.ai.service.pipeline.RagChunkStageStore;
@@ -26,6 +30,7 @@ import studio.one.platform.chunking.core.NormalizedBlock;
 import studio.one.platform.chunking.core.NormalizedBlockType;
 import studio.one.platform.chunking.core.NormalizedDocument;
 import studio.one.platform.markdown.application.MarkdownPipelineOptions;
+import studio.one.platform.markdown.application.MarkdownPipelineProgress;
 import studio.one.platform.markdown.application.port.MarkdownPipelinePort;
 import studio.one.platform.markdown.application.port.MarkdownRepository;
 import studio.one.platform.markdown.domain.MarkdownLocator;
@@ -117,6 +122,54 @@ public class MarkdownDownstreamPipelineAdapter implements MarkdownPipelinePort {
         }
     }
 
+    @Override
+    public int estimateChunkCount(MarkdownRevision revision, MarkdownPipelineOptions options) {
+        ChunkingOrchestrator chunking = chunkingProvider.getIfAvailable();
+        if (chunking == null || revision == null || revision.markdownText() == null || revision.markdownText().isBlank()) {
+            return MarkdownPipelinePort.super.estimateChunkCount(revision, options);
+        }
+        String objectType = "attachment";
+        String objectId = Long.toString(revision.sourceAttachmentId());
+        Map<String, Object> metadata = metadata(revision, objectType, objectId);
+        addPipelineMetadata(metadata, options);
+        NormalizedDocument document = NormalizedDocument.builder(revision.documentId())
+                .plainText(revision.markdownText())
+                .sourceFormat("markdown")
+                .filename(revision.sourceFileName())
+                .blocks(blocks(revision))
+                .metadata(metadata)
+                .build();
+        return chunking.chunk(document, chunkingContext(document, options).build()).size();
+    }
+
+    @Override
+    public MarkdownPipelineProgress.RagProgress latestRagProgress(MarkdownRevision revision) {
+        RagIndexJobService ragJobService = ragJobServiceProvider.getIfAvailable();
+        if (ragJobService == null || revision == null) {
+            return null;
+        }
+        RagIndexJobFilter filter = new RagIndexJobFilter(
+                null,
+                "attachment",
+                Long.toString(revision.sourceAttachmentId()),
+                revision.documentId());
+        var page = ragJobService.listJobs(filter, new RagIndexJobPageRequest(0, 1),
+                new RagIndexJobSort(RagIndexJobSort.Field.CREATED_AT, RagIndexJobSort.Direction.DESC));
+        if (page == null || page.jobs().isEmpty()) {
+            return null;
+        }
+        RagIndexJob job = page.jobs().get(0);
+        return new MarkdownPipelineProgress.RagProgress(
+                job.jobId(),
+                job.status() == null ? null : job.status().name(),
+                job.currentStep() == null ? null : job.currentStep().name(),
+                job.chunkCount(),
+                job.embeddedCount(),
+                job.indexedCount(),
+                job.warningCount(),
+                job.errorMessage());
+    }
+
     private void stageChunks(MarkdownRevision revision, String objectType, String objectId,
             Map<String, Object> metadata, MarkdownPipelineOptions options) {
         ChunkingOrchestrator chunking = chunkingProvider.getIfAvailable();
@@ -132,6 +185,26 @@ public class MarkdownDownstreamPipelineAdapter implements MarkdownPipelinePort {
                 .metadata(metadata)
                 .build();
         ChunkingContext.Builder context = document.toContextBuilder();
+        applyChunkingOptions(context, options);
+        List<Chunk> chunks = chunking.chunk(document, context.build());
+        List<RagChunkStage> stages = new ArrayList<>(chunks.size());
+        for (int index = 0; index < chunks.size(); index++) {
+            Chunk chunk = chunks.get(index);
+            Map<String, Object> chunkMetadata = new HashMap<>(metadata);
+            chunkMetadata.putAll(stageMetadata(chunk.metadata().toMap()));
+            stages.add(new RagChunkStage(objectType, objectId, revision.documentId(), index,
+                    chunk.id(), chunk.content(), chunkMetadata, null));
+        }
+        stageStore.replace(objectType, objectId, revision.documentId(), stages);
+    }
+
+    private ChunkingContext.Builder chunkingContext(NormalizedDocument document, MarkdownPipelineOptions options) {
+        ChunkingContext.Builder context = document.toContextBuilder();
+        applyChunkingOptions(context, options);
+        return context;
+    }
+
+    private void applyChunkingOptions(ChunkingContext.Builder context, MarkdownPipelineOptions options) {
         if (options.chunkingStrategy() == null) {
             context.useConfiguredStrategy();
         } else {
@@ -150,16 +223,15 @@ public class MarkdownDownstreamPipelineAdapter implements MarkdownPipelinePort {
         if (options.chunkUnit() != null) {
             context.unit(ChunkUnit.valueOf(options.chunkUnit()));
         }
-        List<Chunk> chunks = chunking.chunk(document, context.build());
-        List<RagChunkStage> stages = new ArrayList<>(chunks.size());
-        for (int index = 0; index < chunks.size(); index++) {
-            Chunk chunk = chunks.get(index);
-            Map<String, Object> chunkMetadata = new HashMap<>(metadata);
-            chunkMetadata.putAll(chunk.metadata().toMap());
-            stages.add(new RagChunkStage(objectType, objectId, revision.documentId(), index,
-                    chunk.id(), chunk.content(), chunkMetadata, null));
+    }
+
+    private Map<String, Object> stageMetadata(Map<String, Object> metadata) {
+        if (metadata == null || metadata.isEmpty()) {
+            return Map.of();
         }
-        stageStore.replace(objectType, objectId, revision.documentId(), stages);
+        Map<String, Object> sanitized = new LinkedHashMap<>(metadata);
+        sanitized.remove(ChunkMetadata.KEY_PARENT_CHUNK_CONTENT);
+        return sanitized;
     }
 
     private void addPipelineMetadata(Map<String, Object> metadata, MarkdownPipelineOptions options) {

--- a/starter/studio-platform-starter-markdown/src/main/java/studio/one/platform/markdown/autoconfigure/MarkdownProperties.java
+++ b/starter/studio-platform-starter-markdown/src/main/java/studio/one/platform/markdown/autoconfigure/MarkdownProperties.java
@@ -5,7 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("studio.markdown")
 public class MarkdownProperties {
     private boolean enabled;
-    private int maxSourceBytes = 25 * 1024 * 1024;
+    private int maxSourceBytes = 64 * 1024 * 1024;
     private String pandocVersion = "pandoc";
     private String textractVersion = "native";
     private final Web web = new Web();

--- a/starter/studio-platform-starter-markdown/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/starter/studio-platform-starter-markdown/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -9,7 +9,7 @@
     {
       "name": "studio.markdown.max-source-bytes",
       "type": "java.lang.Integer",
-      "defaultValue": 26214400,
+      "defaultValue": 67108864,
       "description": "Maximum source or converted Markdown attachment size loaded by the orchestrator."
     },
     {

--- a/studio-platform-markdown/src/main/java/studio/one/platform/markdown/application/MarkdownDocumentService.java
+++ b/studio-platform-markdown/src/main/java/studio/one/platform/markdown/application/MarkdownDocumentService.java
@@ -50,6 +50,9 @@ public class MarkdownDocumentService {
     private final Clock clock;
     private final String pandocVersion;
     private final Set<String> activeTasks = ConcurrentHashMap.newKeySet();
+    private static final int ESTIMATE_TARGET_CHUNKS = 1000;
+    private static final int ESTIMATE_DEFAULT_EMBEDDING_BATCH_SIZE = 4;
+    private static final int STALE_PIPELINE_RECOVERY_MINUTES = 30;
 
     public MarkdownDocumentService(MarkdownRepository repository, MarkdownSourcePort sourcePort,
             MarkdownNativeExtractorPort nativeExtractor, MarkdownConversionPort conversionPort,
@@ -74,6 +77,7 @@ public class MarkdownDocumentService {
         this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
         this.clock = Objects.requireNonNull(clock, "clock");
         this.pandocVersion = normalize(pandocVersion, "pandoc");
+        recoverStalePipelineExecutions();
     }
 
     public MarkdownExtractionResult create(MarkdownExtractionRequest request) {
@@ -195,6 +199,78 @@ public class MarkdownDocumentService {
         MarkdownRevision revision = latestRevision(documentId);
         return repository.findPipelineExecution(revision.revisionId())
                 .orElseGet(() -> legacyPipelineExecution(revision));
+    }
+
+    public MarkdownPipelineProgress getPipelineProgress(String documentId) {
+        MarkdownRevision revision = latestRevision(documentId);
+        MarkdownPipelineExecution execution = repository.findPipelineExecution(revision.revisionId())
+                .orElseGet(() -> legacyPipelineExecution(revision));
+        return new MarkdownPipelineProgress(execution, pipelinePort.latestRagProgress(revision));
+    }
+
+    public MarkdownPipelineEstimate estimatePipeline(String documentId, MarkdownResumeOptions request) {
+        MarkdownRevision revision = latestRevision(documentId);
+        if (revision.status() != MarkdownRevisionStatus.COMPLETED || !hasText(revision.markdownText())) {
+            throw new MarkdownPipelineEstimateUnavailableException(
+                    "Completed Markdown revision with text is required for pipeline estimate");
+        }
+        MarkdownPipelineOptions previous = readOptions(revision.optionsJson());
+        MarkdownPipelineOptions options = request == null ? previous : merge(previous, request);
+        int pageCount = pageCount(revision.revisionId());
+        int markdownLength = revision.markdownText().length();
+        int chunkCount = pipelinePort.estimateChunkCount(revision, options);
+        int embeddingBatchSize = ESTIMATE_DEFAULT_EMBEDDING_BATCH_SIZE;
+        int embeddingRequests = embeddingRequests(chunkCount, embeddingBatchSize);
+        RecommendedEstimate recommended = recommendedEstimate(revision, options, chunkCount, embeddingBatchSize);
+        List<MarkdownPipelineEstimate.Warning> warnings = estimateWarnings(markdownLength, pageCount, chunkCount);
+        return new MarkdownPipelineEstimate(
+                revision.documentId(),
+                revision.revisionId(),
+                revision.sourceFileName(),
+                revision.sourceFormat(),
+                markdownLength,
+                pageCount,
+                markdownLength,
+                chunkCount,
+                embeddingRequests,
+                embeddingBatchSize,
+                riskLevel(chunkCount),
+                recommended.toResponse(),
+                warnings);
+    }
+
+    public MarkdownPipelineEstimate estimatePipelineByAttachment(long attachmentId, MarkdownResumeOptions request) {
+        var document = repository.findDocumentBySourceAttachmentId(attachmentId);
+        if (document.isPresent() && document.get().currentRevisionId() != null) {
+            MarkdownRevision revision = repository.findRevision(document.get().currentRevisionId()).orElse(null);
+            if (revision != null && revision.status() == MarkdownRevisionStatus.COMPLETED && hasText(revision.markdownText())) {
+                return estimatePipeline(document.get().documentId(), request);
+            }
+        }
+        MarkdownSourcePort.MarkdownSourceDescriptor source = sourcePort.describe(attachmentId);
+        MarkdownPipelineOptions options = request == null ? MarkdownPipelineOptions.none()
+                : merge(new MarkdownPipelineOptions(true, true, false), request);
+        int markdownLengthEstimate = Math.toIntExact(Math.min(Integer.MAX_VALUE, Math.max(0L, source.size())));
+        int chunkCount = heuristicChunkCount(markdownLengthEstimate, options);
+        int embeddingBatchSize = ESTIMATE_DEFAULT_EMBEDDING_BATCH_SIZE;
+        int embeddingRequests = embeddingRequests(chunkCount, embeddingBatchSize);
+        RecommendedEstimate recommended = heuristicRecommendedEstimate(options, markdownLengthEstimate, chunkCount,
+                embeddingBatchSize);
+        List<MarkdownPipelineEstimate.Warning> warnings = estimateWarnings(markdownLengthEstimate, 0, chunkCount);
+        return new MarkdownPipelineEstimate(
+                document.map(MarkdownDocument::documentId).orElse(null),
+                null,
+                source.fileName(),
+                sourceFormat(source.fileName(), source.contentType()),
+                source.size(),
+                0,
+                markdownLengthEstimate,
+                chunkCount,
+                embeddingRequests,
+                embeddingBatchSize,
+                riskLevel(chunkCount),
+                recommended.toResponse(),
+                warnings);
     }
 
     public MarkdownResumeResult resume(String documentId, MarkdownPipelineStage requestedStage) {
@@ -639,6 +715,183 @@ public class MarkdownDocumentService {
                     revision.revisionId(), MarkdownPipelineExecutionStatus.FAILED, current.get(),
                     lastCompleted.get(), previous.attemptCount() + 1,
                     "PIPELINE_FAILED", sanitize(ex.getMessage()), started, now, now));
+        } catch (Error error) {
+            Instant now = clock.instant();
+            repository.savePipelineExecution(new MarkdownPipelineExecution(
+                    revision.revisionId(), MarkdownPipelineExecutionStatus.FAILED, current.get(),
+                    lastCompleted.get(), previous.attemptCount() + 1,
+                    "PIPELINE_ERROR", sanitize(error.getClass().getSimpleName() + ": " + error.getMessage()),
+                    started, now, now));
+            throw error;
+        }
+    }
+
+    private void recoverStalePipelineExecutions() {
+        Instant now = clock.instant();
+        repository.recoverStalePipelineExecutions(
+                now.minusSeconds(STALE_PIPELINE_RECOVERY_MINUTES * 60L),
+                now);
+    }
+
+    private int pageCount(String revisionId) {
+        return repository.findExtractParts(revisionId).stream()
+                .mapToInt(part -> Math.max(part.pageFrom(), part.pageTo()))
+                .max()
+                .orElseGet(() -> (int) repository.findLocators(revisionId).stream()
+                        .filter(locator -> "PAGE".equalsIgnoreCase(locator.locatorType()))
+                        .count());
+    }
+
+    private int embeddingRequests(int chunkCount, int batchSize) {
+        if (chunkCount <= 0) {
+            return 0;
+        }
+        int effectiveBatchSize = Math.max(1, batchSize);
+        return (int) Math.ceil((double) chunkCount / effectiveBatchSize);
+    }
+
+    private RecommendedEstimate recommendedEstimate(
+            MarkdownRevision revision,
+            MarkdownPipelineOptions current,
+            int currentChunkCount,
+            int embeddingBatchSize) {
+        if (currentChunkCount <= ESTIMATE_TARGET_CHUNKS) {
+            return new RecommendedEstimate(current, currentChunkCount, embeddingRequests(currentChunkCount, embeddingBatchSize));
+        }
+        int overlap = current.chunkOverlap() == null ? 150 : current.chunkOverlap();
+        String strategy = current.chunkingStrategy() == null ? "structure-based" : current.chunkingStrategy();
+        String unit = current.chunkUnit() == null ? "CHARACTER" : current.chunkUnit();
+        int[] candidates = {2000, 3000, 4000, 6000};
+        RecommendedEstimate best = new RecommendedEstimate(current, currentChunkCount,
+                embeddingRequests(currentChunkCount, embeddingBatchSize));
+        for (int maxSize : candidates) {
+            int candidateOverlap = Math.min(overlap, maxSize - 1);
+            MarkdownPipelineOptions candidate = new MarkdownPipelineOptions(
+                    current.runChunking(),
+                    current.runRagIndex(),
+                    current.runSkillExtraction(),
+                    strategy,
+                    maxSize,
+                    candidateOverlap,
+                    unit,
+                    current.embeddingProfileId(),
+                    current.embeddingProvider(),
+                    current.embeddingModel(),
+                    current.embeddingDimension(),
+                    current.useLlmKeywordExtraction(),
+                    current.skillExtractionMode(),
+                    current.generateSkillEmbeddings(),
+                    current.skillEmbeddingProvider(),
+                    current.skillEmbeddingModel(),
+                    current.skillEmbeddingDimension());
+            int chunks = pipelinePort.estimateChunkCount(revision, candidate);
+            best = new RecommendedEstimate(candidate, chunks, embeddingRequests(chunks, embeddingBatchSize));
+            if (chunks <= ESTIMATE_TARGET_CHUNKS) {
+                break;
+            }
+        }
+        return best;
+    }
+
+    private RecommendedEstimate heuristicRecommendedEstimate(
+            MarkdownPipelineOptions current,
+            int markdownLengthEstimate,
+            int currentChunkCount,
+            int embeddingBatchSize) {
+        if (currentChunkCount <= ESTIMATE_TARGET_CHUNKS) {
+            return new RecommendedEstimate(current, currentChunkCount, embeddingRequests(currentChunkCount, embeddingBatchSize));
+        }
+        int overlap = current.chunkOverlap() == null ? 150 : current.chunkOverlap();
+        String strategy = current.chunkingStrategy() == null ? "structure-based" : current.chunkingStrategy();
+        String unit = current.chunkUnit() == null ? "CHARACTER" : current.chunkUnit();
+        int[] candidates = {2000, 3000, 4000, 6000};
+        RecommendedEstimate best = new RecommendedEstimate(current, currentChunkCount,
+                embeddingRequests(currentChunkCount, embeddingBatchSize));
+        for (int maxSize : candidates) {
+            int candidateOverlap = Math.min(overlap, maxSize - 1);
+            MarkdownPipelineOptions candidate = new MarkdownPipelineOptions(
+                    current.runChunking(),
+                    current.runRagIndex(),
+                    current.runSkillExtraction(),
+                    strategy,
+                    maxSize,
+                    candidateOverlap,
+                    unit,
+                    current.embeddingProfileId(),
+                    current.embeddingProvider(),
+                    current.embeddingModel(),
+                    current.embeddingDimension(),
+                    current.useLlmKeywordExtraction(),
+                    current.skillExtractionMode(),
+                    current.generateSkillEmbeddings(),
+                    current.skillEmbeddingProvider(),
+                    current.skillEmbeddingModel(),
+                    current.skillEmbeddingDimension());
+            int chunks = heuristicChunkCount(markdownLengthEstimate, candidate);
+            best = new RecommendedEstimate(candidate, chunks, embeddingRequests(chunks, embeddingBatchSize));
+            if (chunks <= ESTIMATE_TARGET_CHUNKS) {
+                break;
+            }
+        }
+        return best;
+    }
+
+    private int heuristicChunkCount(int markdownLengthEstimate, MarkdownPipelineOptions options) {
+        if (markdownLengthEstimate <= 0) {
+            return 0;
+        }
+        int maxSize = options.chunkMaxSize() == null ? 1000 : options.chunkMaxSize();
+        int overlap = options.chunkOverlap() == null ? 0 : Math.min(options.chunkOverlap(), maxSize - 1);
+        int effectiveSize = Math.max(1, maxSize - overlap);
+        return Math.max(1, (int) Math.ceil((double) markdownLengthEstimate / effectiveSize));
+    }
+
+    private List<MarkdownPipelineEstimate.Warning> estimateWarnings(int markdownLength, int pageCount, int chunkCount) {
+        List<MarkdownPipelineEstimate.Warning> warnings = new ArrayList<>();
+        if (markdownLength >= 10 * 1024 * 1024) {
+            warnings.add(new MarkdownPipelineEstimate.Warning(
+                    "LARGE_MARKDOWN",
+                    "Markdown text is larger than 10MB. Use the recommended chunking options before indexing."));
+        }
+        if (pageCount >= 100) {
+            warnings.add(new MarkdownPipelineEstimate.Warning(
+                    "MANY_PAGES",
+                    "Document has 100 or more pages. Indexing may take a long time."));
+        }
+        if (chunkCount > ESTIMATE_TARGET_CHUNKS) {
+            warnings.add(new MarkdownPipelineEstimate.Warning(
+                    "MANY_CHUNKS",
+                    "Estimated chunk count is high. Recommended chunking options reduce embedding requests."));
+        }
+        return List.copyOf(warnings);
+    }
+
+    private String riskLevel(int chunkCount) {
+        if (chunkCount >= 5000) {
+            return "VERY_HIGH";
+        }
+        if (chunkCount >= 1500) {
+            return "HIGH";
+        }
+        if (chunkCount >= 500) {
+            return "MEDIUM";
+        }
+        return "LOW";
+    }
+
+    private record RecommendedEstimate(
+            MarkdownPipelineOptions options,
+            int estimatedChunkCount,
+            int estimatedEmbeddingRequests) {
+
+        MarkdownPipelineEstimate.RecommendedChunking toResponse() {
+            return new MarkdownPipelineEstimate.RecommendedChunking(
+                    options.chunkingStrategy(),
+                    options.chunkMaxSize(),
+                    options.chunkOverlap(),
+                    options.chunkUnit(),
+                    estimatedChunkCount,
+                    estimatedEmbeddingRequests);
         }
     }
 

--- a/studio-platform-markdown/src/main/java/studio/one/platform/markdown/application/MarkdownPipelineEstimate.java
+++ b/studio-platform-markdown/src/main/java/studio/one/platform/markdown/application/MarkdownPipelineEstimate.java
@@ -1,0 +1,31 @@
+package studio.one.platform.markdown.application;
+
+import java.util.List;
+
+public record MarkdownPipelineEstimate(
+        String documentId,
+        String revisionId,
+        String sourceFileName,
+        String sourceFormat,
+        long sourceSizeBytes,
+        int pageCount,
+        int markdownLength,
+        int estimatedChunkCount,
+        int estimatedEmbeddingRequests,
+        int embeddingBatchSize,
+        String riskLevel,
+        RecommendedChunking recommended,
+        List<Warning> warnings) {
+
+    public record RecommendedChunking(
+            String chunkingStrategy,
+            Integer chunkMaxSize,
+            Integer chunkOverlap,
+            String chunkUnit,
+            int estimatedChunkCount,
+            int estimatedEmbeddingRequests) {
+    }
+
+    public record Warning(String code, String message) {
+    }
+}

--- a/studio-platform-markdown/src/main/java/studio/one/platform/markdown/application/MarkdownPipelineEstimateUnavailableException.java
+++ b/studio-platform-markdown/src/main/java/studio/one/platform/markdown/application/MarkdownPipelineEstimateUnavailableException.java
@@ -1,0 +1,7 @@
+package studio.one.platform.markdown.application;
+
+public class MarkdownPipelineEstimateUnavailableException extends RuntimeException {
+    public MarkdownPipelineEstimateUnavailableException(String message) {
+        super(message);
+    }
+}

--- a/studio-platform-markdown/src/main/java/studio/one/platform/markdown/application/MarkdownPipelineProgress.java
+++ b/studio-platform-markdown/src/main/java/studio/one/platform/markdown/application/MarkdownPipelineProgress.java
@@ -1,0 +1,19 @@
+package studio.one.platform.markdown.application;
+
+import studio.one.platform.markdown.domain.MarkdownPipelineExecution;
+
+public record MarkdownPipelineProgress(
+        MarkdownPipelineExecution pipeline,
+        RagProgress rag) {
+
+    public record RagProgress(
+            String jobId,
+            String status,
+            String currentStep,
+            int chunkCount,
+            int embeddedCount,
+            int indexedCount,
+            int warningCount,
+            String errorMessage) {
+    }
+}

--- a/studio-platform-markdown/src/main/java/studio/one/platform/markdown/application/MarkdownSourceTooLargeException.java
+++ b/studio-platform-markdown/src/main/java/studio/one/platform/markdown/application/MarkdownSourceTooLargeException.java
@@ -1,0 +1,20 @@
+package studio.one.platform.markdown.application;
+
+public class MarkdownSourceTooLargeException extends RuntimeException {
+    private final long actualBytes;
+    private final long maxBytes;
+
+    public MarkdownSourceTooLargeException(long actualBytes, long maxBytes) {
+        super("Attachment exceeds markdown source size limit");
+        this.actualBytes = actualBytes;
+        this.maxBytes = maxBytes;
+    }
+
+    public long actualBytes() {
+        return actualBytes;
+    }
+
+    public long maxBytes() {
+        return maxBytes;
+    }
+}

--- a/studio-platform-markdown/src/main/java/studio/one/platform/markdown/application/port/MarkdownPipelinePort.java
+++ b/studio-platform-markdown/src/main/java/studio/one/platform/markdown/application/port/MarkdownPipelinePort.java
@@ -2,6 +2,7 @@ package studio.one.platform.markdown.application.port;
 
 import java.util.function.Consumer;
 
+import studio.one.platform.markdown.application.MarkdownPipelineProgress;
 import studio.one.platform.markdown.application.MarkdownPipelineOptions;
 import studio.one.platform.markdown.domain.MarkdownPipelineStage;
 import studio.one.platform.markdown.domain.MarkdownRevision;
@@ -19,6 +20,20 @@ public interface MarkdownPipelinePort {
             MarkdownPipelineStage fromStage, Consumer<MarkdownPipelineStage> stageCompleted) {
         process(revision, options);
         stageCompleted.accept(MarkdownPipelineStage.COMPLETED);
+    }
+
+    default int estimateChunkCount(MarkdownRevision revision, MarkdownPipelineOptions options) {
+        if (revision == null || revision.markdownText() == null || revision.markdownText().isBlank()) {
+            return 0;
+        }
+        int maxSize = options == null || options.chunkMaxSize() == null ? 1000 : options.chunkMaxSize();
+        int overlap = options == null || options.chunkOverlap() == null ? 0 : options.chunkOverlap();
+        int effectiveSize = Math.max(1, maxSize - Math.max(0, Math.min(overlap, maxSize - 1)));
+        return Math.max(1, (int) Math.ceil((double) revision.markdownText().length() / effectiveSize));
+    }
+
+    default MarkdownPipelineProgress.RagProgress latestRagProgress(MarkdownRevision revision) {
+        return null;
     }
 
     static MarkdownPipelinePort noop() {

--- a/studio-platform-markdown/src/main/java/studio/one/platform/markdown/application/port/MarkdownRepository.java
+++ b/studio-platform-markdown/src/main/java/studio/one/platform/markdown/application/port/MarkdownRepository.java
@@ -2,6 +2,7 @@ package studio.one.platform.markdown.application.port;
 
 import java.util.List;
 import java.util.Optional;
+import java.time.Instant;
 
 import studio.one.platform.markdown.domain.MarkdownDocument;
 import studio.one.platform.markdown.domain.MarkdownExtractPart;
@@ -27,6 +28,10 @@ public interface MarkdownRepository {
     Optional<MarkdownRevision> findRevisionByConvertJobId(String convertJobId);
 
     Optional<MarkdownPipelineExecution> findPipelineExecution(String revisionId);
+
+    default int recoverStalePipelineExecutions(Instant staleBefore, Instant now) {
+        return 0;
+    }
 
     Optional<MarkdownRevision> findActiveRevisionBySourceAttachmentId(long sourceAttachmentId);
 

--- a/studio-platform-markdown/src/main/java/studio/one/platform/markdown/application/port/MarkdownSourcePort.java
+++ b/studio-platform-markdown/src/main/java/studio/one/platform/markdown/application/port/MarkdownSourcePort.java
@@ -4,6 +4,12 @@ public interface MarkdownSourcePort {
 
     MarkdownSource load(long attachmentId);
 
+    default MarkdownSourceDescriptor describe(long attachmentId) {
+        MarkdownSource source = load(attachmentId);
+        return new MarkdownSourceDescriptor(source.attachmentId(), source.fileName(), source.contentType(),
+                source.objectType(), source.objectId(), source.content() == null ? 0L : source.content().length);
+    }
+
     record MarkdownSource(
             long attachmentId,
             String fileName,
@@ -11,5 +17,14 @@ public interface MarkdownSourcePort {
             String objectType,
             String objectId,
             byte[] content) {
+    }
+
+    record MarkdownSourceDescriptor(
+            long attachmentId,
+            String fileName,
+            String contentType,
+            String objectType,
+            String objectId,
+            long size) {
     }
 }

--- a/studio-platform-markdown/src/main/java/studio/one/platform/markdown/infrastructure/JdbcMarkdownRepository.java
+++ b/studio-platform-markdown/src/main/java/studio/one/platform/markdown/infrastructure/JdbcMarkdownRepository.java
@@ -172,6 +172,22 @@ public class JdbcMarkdownRepository implements MarkdownRepository {
     }
 
     @Override
+    public int recoverStalePipelineExecutions(Instant staleBefore, Instant now) {
+        return jdbc.update("""
+                UPDATE tb_ai_markdown_pipeline_execution
+                   SET status='FAILED',
+                       error_code='PIPELINE_STALE',
+                       error_message='Pipeline was marked stale during startup recovery',
+                       completed_at=:now,
+                       updated_at=:now
+                 WHERE status='RUNNING'
+                   AND updated_at < :staleBefore
+                """, new MapSqlParameterSource()
+                .addValue("staleBefore", timestamp(staleBefore))
+                .addValue("now", timestamp(now)));
+    }
+
+    @Override
     public Optional<MarkdownRevision> findActiveRevisionBySourceAttachmentId(long sourceAttachmentId) {
         return jdbc.query("""
                 SELECT * FROM tb_ai_markdown_revision

--- a/studio-platform-markdown/src/main/java/studio/one/platform/markdown/web/MarkdownDocumentController.java
+++ b/studio-platform-markdown/src/main/java/studio/one/platform/markdown/web/MarkdownDocumentController.java
@@ -26,9 +26,13 @@ import studio.one.platform.markdown.application.MarkdownDocumentService;
 import studio.one.platform.markdown.application.MarkdownDocumentNotFoundException;
 import studio.one.platform.markdown.application.MarkdownExtractionRequest;
 import studio.one.platform.markdown.application.MarkdownExtractionResult;
+import studio.one.platform.markdown.application.MarkdownPipelineEstimate;
+import studio.one.platform.markdown.application.MarkdownPipelineEstimateUnavailableException;
 import studio.one.platform.markdown.application.MarkdownPipelineOptions;
+import studio.one.platform.markdown.application.MarkdownPipelineProgress;
 import studio.one.platform.markdown.application.MarkdownResumeOptions;
 import studio.one.platform.markdown.application.MarkdownResumeResult;
+import studio.one.platform.markdown.application.MarkdownSourceTooLargeException;
 import studio.one.platform.markdown.domain.MarkdownDocument;
 import studio.one.platform.markdown.domain.MarkdownLocator;
 import studio.one.platform.markdown.domain.MarkdownPipelineExecution;
@@ -74,6 +78,26 @@ public class MarkdownDocumentController {
     @PreAuthorize("@endpointAuthz.can('features:markdown','read')")
     public ApiResponse<MarkdownPipelineExecution> pipeline(@PathVariable String id) {
         return ApiResponse.ok(service.getPipelineExecution(id));
+    }
+
+    @GetMapping("/{id}/pipeline/progress")
+    @PreAuthorize("@endpointAuthz.can('features:markdown','read')")
+    public ApiResponse<MarkdownPipelineProgress> pipelineProgress(@PathVariable String id) {
+        return ApiResponse.ok(service.getPipelineProgress(id));
+    }
+
+    @PostMapping("/{id}/pipeline/estimate")
+    @PreAuthorize("@endpointAuthz.can('features:markdown','read')")
+    public ApiResponse<MarkdownPipelineEstimate> pipelineEstimate(
+            @PathVariable String id, @RequestBody(required = false) MarkdownResumeRequest request) {
+        return ApiResponse.ok(service.estimatePipeline(id, resumeOptions(request)));
+    }
+
+    @PostMapping("/by-attachment/{attachmentId}/pipeline/estimate")
+    @PreAuthorize("@endpointAuthz.can('features:markdown','read')")
+    public ApiResponse<MarkdownPipelineEstimate> pipelineEstimateByAttachment(
+            @PathVariable long attachmentId, @RequestBody(required = false) MarkdownResumeRequest request) {
+        return ApiResponse.ok(service.estimatePipelineByAttachment(attachmentId, resumeOptions(request)));
     }
 
     @PostMapping("/{id}/resume")
@@ -142,6 +166,41 @@ public class MarkdownDocumentController {
                 .timestamp(OffsetDateTime.now())
                 .build();
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .body(problem);
+    }
+
+    @ExceptionHandler(MarkdownSourceTooLargeException.class)
+    public ResponseEntity<ProblemDetails> sourceTooLarge(
+            MarkdownSourceTooLargeException exception, HttpServletRequest request) {
+        ProblemDetails problem = ProblemDetails.builder()
+                .type("urn:error:markdown-source-too-large")
+                .title(HttpStatus.PAYLOAD_TOO_LARGE.getReasonPhrase())
+                .status(HttpStatus.PAYLOAD_TOO_LARGE.value())
+                .detail("Attachment exceeds markdown source size limit: actualBytes=%d, maxBytes=%d"
+                        .formatted(exception.actualBytes(), exception.maxBytes()))
+                .instance(request.getRequestURI())
+                .code("markdown.source.too-large")
+                .timestamp(OffsetDateTime.now())
+                .build();
+        return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE)
+                .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .body(problem);
+    }
+
+    @ExceptionHandler(MarkdownPipelineEstimateUnavailableException.class)
+    public ResponseEntity<ProblemDetails> estimateUnavailable(
+            MarkdownPipelineEstimateUnavailableException exception, HttpServletRequest request) {
+        ProblemDetails problem = ProblemDetails.builder()
+                .type("urn:error:markdown-pipeline-estimate-unavailable")
+                .title(HttpStatus.CONFLICT.getReasonPhrase())
+                .status(HttpStatus.CONFLICT.value())
+                .detail(exception.getMessage())
+                .instance(request.getRequestURI())
+                .code("markdown.pipeline.estimate-unavailable")
+                .timestamp(OffsetDateTime.now())
+                .build();
+        return ResponseEntity.status(HttpStatus.CONFLICT)
                 .contentType(MediaType.APPLICATION_PROBLEM_JSON)
                 .body(problem);
     }

--- a/studio-platform-markdown/src/main/resources/schema/markdown/mariadb/V1613__alter_markdown_locator_text_columns.sql
+++ b/studio-platform-markdown/src/main/resources/schema/markdown/mariadb/V1613__alter_markdown_locator_text_columns.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tb_ai_markdown_locator
+    MODIFY COLUMN title TEXT,
+    MODIFY COLUMN source_ref TEXT;

--- a/studio-platform-markdown/src/main/resources/schema/markdown/mysql/V1613__alter_markdown_locator_text_columns.sql
+++ b/studio-platform-markdown/src/main/resources/schema/markdown/mysql/V1613__alter_markdown_locator_text_columns.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tb_ai_markdown_locator
+    MODIFY COLUMN title TEXT,
+    MODIFY COLUMN source_ref TEXT;

--- a/studio-platform-markdown/src/main/resources/schema/markdown/postgres/V1613__alter_markdown_locator_text_columns.sql
+++ b/studio-platform-markdown/src/main/resources/schema/markdown/postgres/V1613__alter_markdown_locator_text_columns.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tb_ai_markdown_locator
+    ALTER COLUMN title TYPE TEXT,
+    ALTER COLUMN source_ref TYPE TEXT;


### PR DESCRIPTION
## Summary
- Markdown pipeline 진행률/estimate API와 stale pipeline 복구를 추가했습니다.
- 대형 RAG stage 저장 배치를 분리하고 모델 변경 재색인 시 기존 벡터 혼합을 방지했습니다.
- TEI embedding timeout 설정과 timeout 원인 메시지를 추가했습니다.
- Markdown locator title/source_ref를 TEXT로 변경하는 V1613 migration을 추가했습니다.

## Validation
- ./gradlew :starter:studio-platform-starter-ai:test :studio-platform-markdown:test :starter:studio-platform-starter-markdown:test
- git diff --check

## Notes
- .omx 로컬 상태 파일은 PR에 포함하지 않았습니다.
- 기존 V1610 migration은 checksum 안정성을 위해 수정하지 않고 V1613 migration으로 처리했습니다.
