### PR TITLE
[codex] 청킹 fallback 및 품질 metadata 보강

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- chunking metadata에 요청/실제 전략, fallback 상태, 품질 상태 key를 추가하고, structure-based full-strategy
+  fallback을 `recursive -> fixed-size` 순서로 기록하도록 보강했다. 기본 계약은 `recursive + character`로 유지한다.
+
+- 공통 chunking metadata 정책을 클라이언트가 표시할 수 있도록 요청/실제 전략, fallback, 품질 상태 표시 지침을
+  `docs/plans/client-chunking-metadata-policy-update-guide.md`에 추가했다.
+
+- 클라이언트가 청킹 품질 요약, 필터, provenance badge, strategy 분포, 재처리 추천을 구현할 수 있도록
+  `docs/plans/client-chunking-quality-ux-improvement-guide.md`를 추가했다.
+
 - chunking starter에 opt-in `knowledge-block` 전략을 추가했다. 기존 Blockify/IdeaBlock 생성 파이프라인을
   재사용하되 `knowledge-block-metadata-v1`, `knowledgeBlockFingerprint`, coverage/distillation alias를
   저장해 운영 RAG 정책과 PoC `blockify` 비교 결과를 분리할 수 있게 했다.

--- a/docs/plans/client-chunking-metadata-policy-update-guide.md
+++ b/docs/plans/client-chunking-metadata-policy-update-guide.md
@@ -1,0 +1,252 @@
+# 클라이언트 청킹 Metadata 정책 반영 가이드
+
+## 목적
+
+서버 청킹 결과 metadata에 요청 전략, 실제 전략, fallback 상태, 품질 상태가 공통으로 추가되었다.
+
+클라이언트는 기존 `strategy`, `chunkType`, `validationStatus` 표시를 유지하면서 새 metadata를 보조 진단 정보로 표시해야 한다. DB schema, API endpoint, request shape는 변경하지 않는다.
+
+## 적용 대상
+
+- 파일 상세의 RAG/Chunk 목록
+- Markdown pipeline 또는 RAG 색인 결과 상세
+- RAG Chat debug chunk 목록
+- 운영자용 chunk 진단 화면
+
+일반 사용자 답변 화면은 기존 `ragReferences` 표시를 유지한다. 새 metadata는 상세/개발자/운영 진단 화면에서 우선 사용한다.
+
+## 새 Metadata Key
+
+| Key | 값 예시 | 의미 |
+|---|---|---|
+| `requestedChunkingStrategy` | `structure-based`, `fixed-size`, `recursive`, `blockify` | 사용자가 요청했거나 상위 전략이 요청한 전략 |
+| `actualChunkingStrategy` | `structure-based`, `recursive`, `fixed-size`, `blockify` | 실제 chunk를 생성한 전략 |
+| `fallbackStatus` | `NOT_REQUIRED`, `APPLIED` | full-strategy fallback 적용 여부 |
+| `fallbackFrom` | `structure-based`, `recursive` | fallback 시작 전략 |
+| `fallbackTo` | `recursive`, `fixed-size` | fallback 대상 전략 |
+| `fallbackReason` | `plain-text-context`, `missing-structure`, `invalid-structure-chunks` | fallback 사유 |
+| `chunkQualityStatus` | `VALID`, `REVIEW_REQUIRED` | 색인된 chunk의 품질 검증 상태 |
+| `chunkQualityIssues` | `["MISSING_PROVENANCE"]` | 품질 이슈 목록 |
+
+`FAILED` chunk는 색인되지 않는다. 클라이언트는 chunk 목록에서 `FAILED` 상태를 기대하지 말고, 실패는 pipeline/job 오류 또는 진단 메시지에서 처리한다.
+
+## 표시 우선순위
+
+### Strategy 표시
+
+기존 `strategy`는 검색 filter 호환용 persisted strategy로 유지된다.
+
+UI에서 전략을 보여줄 때는 다음 순서를 사용한다.
+
+```ts
+const requested = metadata.requestedChunkingStrategy;
+const actual = metadata.actualChunkingStrategy ?? metadata.strategy;
+```
+
+표시 규칙:
+
+- `requested`가 없거나 `requested === actual`: `actual`
+- `requested !== actual`: `${requested} -> ${actual}`
+
+예:
+
+| Metadata | UI |
+|---|---|
+| `requested=structure-based`, `actual=structure-based` | `Structure-based` |
+| `requested=structure-based`, `actual=recursive` | `Structure-based -> Recursive` |
+| `requested=structure-based`, `actual=fixed-size` | `Structure-based -> Fixed` |
+| `requested=blockify`, `actual=structure-based` | `Blockify -> Structure-based` |
+
+### Fallback Badge
+
+`fallbackStatus=APPLIED`이면 fallback badge를 표시한다.
+
+권장 표시:
+
+```text
+Fallback: Structure-based -> Recursive
+Reason: plain-text-context
+```
+
+`fallbackStatus=NOT_REQUIRED`이거나 값이 없으면 fallback badge를 표시하지 않는다.
+
+Blockify 기존 fallback과 구분한다.
+
+- 공통 fallback: `fallbackStatus=APPLIED`
+- Blockify validation fallback: `validationStatus=FALLBACK`
+
+둘 다 있을 수 있으므로 UI에서는 별도 badge로 표시한다.
+
+```text
+Strategy Fallback
+Blockify Fallback
+```
+
+### Quality Badge
+
+`chunkQualityStatus` 기준으로 표시한다.
+
+| 값 | UI 상태 | 문구 |
+|---|---|---|
+| `VALID` | 정상 | `Valid` |
+| `REVIEW_REQUIRED` | 주의 | `Review required` |
+| 없음 | 중립 | 표시하지 않음 |
+
+`chunkQualityIssues`가 있으면 tooltip 또는 상세 영역에 그대로 표시한다.
+
+현재 서버가 내려줄 수 있는 공통 이슈:
+
+| Issue | UI 설명 |
+|---|---|
+| `MISSING_PROVENANCE` | 원문 위치 정보가 부족합니다. 검색은 가능하지만 원문 복원 품질 확인이 필요합니다. |
+| `EMPTY_CONTENT` | 본문이 비어 있습니다. 색인 대상에서는 제외되어야 합니다. |
+| `MAX_SIZE_EXCEEDED` | 최대 chunk 크기를 초과했습니다. fallback 또는 재청킹 확인이 필요합니다. |
+
+색인된 chunk에는 일반적으로 `EMPTY_CONTENT`, `MAX_SIZE_EXCEEDED`가 없어야 한다. 보이면 서버 오류 또는 legacy 데이터로 취급하고 운영 진단에 노출한다.
+
+## 화면별 반영 지시
+
+### 파일 상세 RAG/Chunk 탭
+
+chunk 목록 컬럼 또는 상세 panel에 다음 항목을 추가한다.
+
+| 항목 | 값 |
+|---|---|
+| 요청 전략 | `requestedChunkingStrategy` |
+| 실제 전략 | `actualChunkingStrategy ?? strategy` |
+| Fallback | `fallbackStatus`, `fallbackFrom`, `fallbackTo`, `fallbackReason` |
+| 품질 | `chunkQualityStatus`, `chunkQualityIssues` |
+| Provenance | 기존 `sourceRef`, `sourceRefs`, `page`, `slide`, `blockIds`, `startOffset`, `endOffset` |
+
+Provenance는 `startOffset/endOffset`만 요구하지 않는다. 다음 중 하나라도 있으면 원문 위치 정보가 있는 것으로 표시한다.
+
+- `sourceRef`
+- `sourceRefs`
+- `page`
+- `slide`
+- `blockIds`
+- `startOffset/endOffset`
+
+### Pipeline Progress 화면
+
+기존 progress API 응답 shape는 변경하지 않는다.
+
+공통 metadata 변경은 개별 chunk metadata에 저장되므로, progress aggregate에 새 필드가 없더라도 오류로 처리하지 않는다.
+
+권장:
+
+- `chunking.fallbackCount`는 기존 Blockify/IdeaBlock 집계로 유지
+- 공통 `fallbackStatus=APPLIED` 개수는 chunk 상세 조회가 있을 때만 별도 계산
+- progress 화면에서 공통 fallback 집계가 없으면 `상세 조회 필요`로 표시
+
+### RAG Chat Debug 화면
+
+debug chunk metadata가 있으면 다음을 추가 표시한다.
+
+```ts
+{
+  strategy: metadata.strategy,
+  requestedChunkingStrategy: metadata.requestedChunkingStrategy,
+  actualChunkingStrategy: metadata.actualChunkingStrategy,
+  fallbackStatus: metadata.fallbackStatus,
+  chunkQualityStatus: metadata.chunkQualityStatus
+}
+```
+
+일반 답변 화면에는 노출하지 않는다.
+
+## Request 옵션 안내
+
+기본값은 서버가 계속 `recursive + character`로 처리한다.
+
+클라이언트에서 별도 설정 UI가 있는 경우:
+
+| UI | 요청값 | 설명 |
+|---|---|---|
+| Recursive | `chunkingStrategy=recursive` | 기본 의미 경계 기반 분할 |
+| Structure-based | `chunkingStrategy=structure-based` | 구조화 입력 우선 전략 |
+| Fixed | `chunkingStrategy=fixed-size` | 균등 분할 및 최종 fallback 전략 |
+| Unit: Character | `chunkUnit=character` | 기본값 |
+| Unit: Token | `chunkUnit=token` | 명시 선택 시에만 사용 |
+
+Fixed는 token 전용이 아니다. `fixed-size + character`, `fixed-size + token` 모두 허용한다.
+
+## 예시
+
+### 정상 Structure-based Chunk
+
+```json
+{
+  "strategy": "structure-based",
+  "requestedChunkingStrategy": "structure-based",
+  "actualChunkingStrategy": "structure-based",
+  "fallbackStatus": "NOT_REQUIRED",
+  "chunkQualityStatus": "VALID",
+  "chunkQualityIssues": [],
+  "sourceRef": "page[1]/p[3]"
+}
+```
+
+표시:
+
+```text
+Structure-based
+Valid
+```
+
+### Structure-based에서 Recursive로 Fallback
+
+```json
+{
+  "strategy": "recursive",
+  "requestedChunkingStrategy": "structure-based",
+  "actualChunkingStrategy": "recursive",
+  "fallbackStatus": "APPLIED",
+  "fallbackFrom": "structure-based",
+  "fallbackTo": "recursive",
+  "fallbackReason": "missing-structure",
+  "chunkQualityStatus": "VALID",
+  "chunkQualityIssues": []
+}
+```
+
+표시:
+
+```text
+Structure-based -> Recursive
+Strategy Fallback
+Reason: missing-structure
+Valid
+```
+
+### Provenance 부족
+
+```json
+{
+  "strategy": "structure-based",
+  "requestedChunkingStrategy": "structure-based",
+  "actualChunkingStrategy": "structure-based",
+  "fallbackStatus": "NOT_REQUIRED",
+  "chunkQualityStatus": "REVIEW_REQUIRED",
+  "chunkQualityIssues": ["MISSING_PROVENANCE"]
+}
+```
+
+표시:
+
+```text
+Structure-based
+Review required
+Issue: MISSING_PROVENANCE
+```
+
+이 경우 fallback이 아니다. 클라이언트는 chunk를 숨기지 말고 주의 상태로 표시한다.
+
+## 완료 기준
+
+- chunk 상세에서 요청 전략과 실제 전략을 구분해 볼 수 있다.
+- `fallbackStatus=APPLIED`를 기존 `validationStatus=FALLBACK`과 별도로 표시한다.
+- `chunkQualityStatus=REVIEW_REQUIRED` chunk를 오류로 숨기지 않는다.
+- provenance 판단이 offset 전용으로 고정되지 않는다.
+- `fixed-size + token` 결과가 `recursive`로 잘못 표시되지 않는다.
+- 기존 `ragReferences`와 일반 RAG 답변 화면은 변경 없이 동작한다.

--- a/docs/plans/client-chunking-quality-ux-improvement-guide.md
+++ b/docs/plans/client-chunking-quality-ux-improvement-guide.md
@@ -1,0 +1,197 @@
+# 클라이언트 청킹 품질 UX 개선 지시문
+
+## 목적
+
+클라이언트는 공통 청킹 metadata를 이미 표시한다.
+
+이번 작업은 표시된 metadata를 운영자가 실제로 활용할 수 있도록 품질 요약, 필터, provenance badge, strategy 분포, 재처리 추천, RAG debug 표시를 개선한다.
+
+서버 API shape는 변경하지 않는다. 클라이언트는 기존 chunk 목록과 debug metadata에서 값을 파생한다.
+
+## 선행 문서
+
+먼저 다음 문서를 반영한 상태여야 한다.
+
+- `docs/plans/client-chunking-metadata-policy-update-guide.md`
+
+이 문서의 key 해석 규칙을 그대로 사용한다.
+
+## 1. 파일 상세: Chunk 품질 요약 카드
+
+파일 상세의 RAG/Chunk 탭 상단에 문서 단위 요약을 추가한다.
+
+### 집계 항목
+
+| 항목 | 계산식 |
+|---|---|
+| 전체 Chunk | `chunks.length` |
+| Valid | `chunkQualityStatus === "VALID"` |
+| Review Required | `chunkQualityStatus === "REVIEW_REQUIRED"` |
+| Strategy Fallback | `fallbackStatus === "APPLIED"` |
+| Missing Provenance | `chunkQualityIssues`에 `MISSING_PROVENANCE` 포함 |
+
+`chunkQualityStatus`가 없는 legacy chunk는 `Unknown`으로 집계한다.
+
+### UI 상태
+
+| 조건 | 상태 |
+|---|---|
+| `Review Required > 0` | 주의 |
+| `Strategy Fallback > 0` | 정보 |
+| `Missing Provenance > 0` | 주의 |
+| 전체가 `Valid` | 정상 |
+
+권장 문구:
+
+```text
+Chunk 품질: Valid 120 / Review 8 / Fallback 3 / Missing provenance 2
+```
+
+## 2. Chunk 목록 필터와 정렬
+
+Chunk 목록에 필터를 추가한다.
+
+### 필터
+
+| 필터 | 값 |
+|---|---|
+| Quality | `VALID`, `REVIEW_REQUIRED`, `UNKNOWN` |
+| Strategy | `actualChunkingStrategy ?? strategy` |
+| Strategy Flow | `requestedChunkingStrategy -> actualChunkingStrategy` |
+| Fallback | `APPLIED`, `NOT_REQUIRED`, `UNKNOWN` |
+| Issue | `MISSING_PROVENANCE`, `MAX_SIZE_EXCEEDED`, `EMPTY_CONTENT` |
+| Provenance | `HAS_PROVENANCE`, `NO_PROVENANCE` |
+
+### 정렬
+
+기본 정렬은 기존 chunk order를 유지한다.
+
+추가 정렬 옵션:
+
+- Review required 우선
+- Fallback 우선
+- Missing provenance 우선
+
+정렬을 바꿔도 사용자가 원래 순서로 돌아갈 수 있어야 한다.
+
+## 3. Provenance Badge
+
+각 chunk row 또는 상세 panel에 provenance badge를 표시한다.
+
+### Badge 판정
+
+| Badge | 조건 |
+|---|---|
+| `SourceRef` | `sourceRef` 있음 또는 `sourceRefs.length > 0` |
+| `Page` | `page` 있음 |
+| `Slide` | `slide` 있음 |
+| `Block` | `blockIds.length > 0` |
+| `Offset` | `startOffset`와 `endOffset` 있음 |
+| `No provenance` | 위 조건이 모두 없음 |
+
+`No provenance`는 `chunkQualityIssues`에 `MISSING_PROVENANCE`가 있으면 주의 색상으로 표시한다.
+
+offset만 provenance로 판단하지 않는다.
+
+## 4. Strategy/Fallback 분포
+
+문서 단위 strategy flow 분포를 표시한다.
+
+### Label 생성 규칙
+
+```ts
+const requested = metadata.requestedChunkingStrategy;
+const actual = metadata.actualChunkingStrategy ?? metadata.strategy ?? "unknown";
+const label = requested && requested !== actual ? `${requested} -> ${actual}` : actual;
+```
+
+### 표시 예시
+
+```text
+Structure-based: 120
+Structure-based -> Recursive: 8
+Structure-based -> Fixed-size: 1
+Blockify -> Structure-based: 12
+Unknown: 3
+```
+
+분포 항목 클릭 시 해당 strategy flow로 chunk 목록을 필터링한다.
+
+## 5. 재처리 추천 액션
+
+품질 요약 상태에 따라 안내 문구를 표시한다.
+
+자동으로 재처리를 실행하지 않는다. 기존 재색인, 재청킹, 재추출 버튼으로 연결한다.
+
+### 추천 규칙
+
+| 조건 | 권장 액션 | 문구 |
+|---|---|---|
+| `MISSING_PROVENANCE` 많음 | Markdown/OCR 재추출 | `원문 위치 정보가 부족합니다. Markdown 또는 OCR 재추출을 검토하세요.` |
+| `fallbackStatus=APPLIED` 많음 | `recursive` 또는 `fixed-size`로 재청킹 | `구조 기반 청킹이 일부 fallback되었습니다. recursive 또는 fixed-size 재청킹을 검토하세요.` |
+| `MAX_SIZE_EXCEEDED` 있음 | chunk max size 증가 후 재청킹 | `일부 chunk가 최대 크기를 초과했습니다. chunk 크기 설정을 늘려 재청킹하세요.` |
+| `REVIEW_REQUIRED` 많음 | 상세 검토 후 재청킹 | `검토가 필요한 chunk가 많습니다. issue 유형을 확인한 뒤 재청킹 설정을 조정하세요.` |
+
+“많음”의 기본 기준은 전체 chunk의 10% 이상이다. 클라이언트 설정으로 쉽게 조정할 수 있게 상수화한다.
+
+## 6. RAG Chat Debug Reference 보강
+
+RAG Chat debug chunk 목록에 다음 값을 표시한다.
+
+| 항목 | 값 |
+|---|---|
+| Strategy | `strategy` |
+| Requested | `requestedChunkingStrategy` |
+| Actual | `actualChunkingStrategy ?? strategy` |
+| Fallback | `fallbackStatus`, `fallbackReason` |
+| Quality | `chunkQualityStatus`, `chunkQualityIssues` |
+| Provenance | provenance badge |
+
+일반 답변 화면에는 노출하지 않는다.
+
+debug metadata가 없는 응답은 기존 표시를 유지하고 오류로 처리하지 않는다.
+
+## 7. Blockify 표시와의 관계
+
+기존 Blockify badge는 유지한다.
+
+공통 fallback과 Blockify validation fallback은 별도로 표시한다.
+
+| 유형 | 조건 | Badge |
+|---|---|---|
+| 공통 strategy fallback | `fallbackStatus === "APPLIED"` | `Strategy Fallback` |
+| Blockify validation fallback | `validationStatus === "FALLBACK"` | `Blockify Fallback` |
+| Blockify 검증 필요 | `validationStatus === "REVIEW_REQUIRED"` | `Blockify Review` |
+| 공통 품질 검토 필요 | `chunkQualityStatus === "REVIEW_REQUIRED"` | `Quality Review` |
+
+둘 이상의 badge가 동시에 표시될 수 있다.
+
+## 8. TypeScript 유틸 권장
+
+metadata 파생 로직은 화면 컴포넌트 안에 흩어놓지 말고 공통 유틸로 분리한다.
+
+권장 함수:
+
+```ts
+getActualChunkingStrategy(metadata)
+getRequestedChunkingStrategy(metadata)
+getStrategyFlowLabel(metadata)
+getFallbackBadge(metadata)
+getQualityBadge(metadata)
+getQualityIssues(metadata)
+getProvenanceBadges(metadata)
+hasProvenance(metadata)
+summarizeChunkQuality(chunks)
+recommendChunkingActions(summary)
+```
+
+## 완료 기준
+
+- 파일 상세에서 문서 단위 chunk 품질 요약을 볼 수 있다.
+- Quality, fallback, issue, provenance 기준으로 chunk를 필터링할 수 있다.
+- 각 chunk에서 provenance badge를 볼 수 있다.
+- Strategy flow 분포를 볼 수 있고 분포 항목으로 필터링할 수 있다.
+- 품질 상태에 따른 재처리 추천 문구가 표시된다.
+- RAG Chat debug chunk에서 fallback과 quality 상태를 확인할 수 있다.
+- 일반 RAG 답변 화면에는 debug metadata가 노출되지 않는다.
+- legacy chunk처럼 새 metadata가 없는 경우에도 화면이 깨지지 않는다.

--- a/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/autoconfigure/ChunkingAutoConfiguration.java
+++ b/starter/studio-platform-starter-chunking/src/main/java/studio/one/platform/chunking/autoconfigure/ChunkingAutoConfiguration.java
@@ -55,8 +55,10 @@ public class ChunkingAutoConfiguration {
     @ConditionalOnMissingBean
     public StructureBasedChunker structureBasedChunker(
             ChunkingProperties properties,
-            RecursiveChunker recursiveChunker) {
-        return new StructureBasedChunker(properties.getMaxSize(), properties.getOverlap(), recursiveChunker);
+            RecursiveChunker recursiveChunker,
+            FixedSizeChunker fixedSizeChunker) {
+        return new StructureBasedChunker(properties.getMaxSize(), properties.getOverlap(), recursiveChunker,
+                fixedSizeChunker);
     }
 
     @Bean

--- a/studio-platform-chunking-runtime/src/main/java/studio/one/platform/chunking/service/ChunkMetadataPolicy.java
+++ b/studio-platform-chunking-runtime/src/main/java/studio/one/platform/chunking/service/ChunkMetadataPolicy.java
@@ -1,0 +1,201 @@
+package studio.one.platform.chunking.service;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import studio.one.platform.chunking.core.Chunk;
+import studio.one.platform.chunking.core.ChunkMetadata;
+import studio.one.platform.chunking.core.ChunkUnit;
+import studio.one.platform.chunking.core.ChunkingContext;
+import studio.one.platform.chunking.core.ChunkingStrategyType;
+
+final class ChunkMetadataPolicy {
+
+    static final String FALLBACK_NOT_REQUIRED = "NOT_REQUIRED";
+    static final String FALLBACK_APPLIED = "APPLIED";
+    static final String QUALITY_VALID = "VALID";
+    static final String QUALITY_REVIEW_REQUIRED = "REVIEW_REQUIRED";
+
+    private static final String ISSUE_EMPTY_CONTENT = "EMPTY_CONTENT";
+    private static final String ISSUE_MAX_SIZE_EXCEEDED = "MAX_SIZE_EXCEEDED";
+    private static final String ISSUE_MISSING_PROVENANCE = "MISSING_PROVENANCE";
+
+    private ChunkMetadataPolicy() {
+    }
+
+    static List<Chunk> markCompleted(
+            ChunkingContext context,
+            List<Chunk> chunks,
+            ChunkingStrategyType requestedStrategy,
+            ChunkingStrategyType actualStrategy,
+            int maxSize,
+            int overlap) {
+        return enrich(context, chunks, requestedStrategy, actualStrategy, FALLBACK_NOT_REQUIRED, null, null, null,
+                maxSize, overlap);
+    }
+
+    static List<Chunk> markFallback(
+            ChunkingContext context,
+            List<Chunk> chunks,
+            ChunkingStrategyType requestedStrategy,
+            ChunkingStrategyType fallbackFrom,
+            ChunkingStrategyType fallbackTo,
+            String fallbackReason,
+            int maxSize,
+            int overlap) {
+        return enrich(context, chunks, requestedStrategy, fallbackTo, FALLBACK_APPLIED, fallbackFrom, fallbackTo,
+                fallbackReason, maxSize, overlap);
+    }
+
+    static boolean hasFatalIssues(List<Chunk> chunks, ChunkUnit unit, int maxSize) {
+        if (chunks == null || chunks.isEmpty()) {
+            return true;
+        }
+        return chunks.stream()
+                .map(chunk -> qualityIssues(chunk, unit, maxSize))
+                .anyMatch(issues -> issues.contains(ISSUE_EMPTY_CONTENT)
+                        || issues.contains(ISSUE_MAX_SIZE_EXCEEDED));
+    }
+
+    private static List<Chunk> enrich(
+            ChunkingContext context,
+            List<Chunk> chunks,
+            ChunkingStrategyType requestedStrategy,
+            ChunkingStrategyType actualStrategy,
+            String fallbackStatus,
+            ChunkingStrategyType fallbackFrom,
+            ChunkingStrategyType fallbackTo,
+            String fallbackReason,
+            int maxSize,
+            int overlap) {
+        if (chunks == null || chunks.isEmpty()) {
+            return List.of();
+        }
+        ChunkUnit unit = context.unit();
+        return chunks.stream()
+                .map(chunk -> enrichChunk(context, chunk, requestedStrategy, actualStrategy, fallbackStatus,
+                        fallbackFrom, fallbackTo, fallbackReason, unit, maxSize, overlap))
+                .toList();
+    }
+
+    private static Chunk enrichChunk(
+            ChunkingContext context,
+            Chunk chunk,
+            ChunkingStrategyType requestedStrategy,
+            ChunkingStrategyType actualStrategy,
+            String fallbackStatus,
+            ChunkingStrategyType fallbackFrom,
+            ChunkingStrategyType fallbackTo,
+            String fallbackReason,
+            ChunkUnit unit,
+            int maxSize,
+            int overlap) {
+        List<String> qualityIssues = qualityIssues(chunk, unit, maxSize);
+        Map<String, Object> attributes = new LinkedHashMap<>(context.metadata());
+        attributes.putAll(chunk.metadata().attributes());
+        attributes.put(ChunkMetadata.KEY_REQUESTED_CHUNKING_STRATEGY, value(requestedStrategy));
+        attributes.put(ChunkMetadata.KEY_ACTUAL_CHUNKING_STRATEGY, value(actualStrategy));
+        attributes.put(ChunkMetadata.KEY_FALLBACK_STATUS, fallbackStatus);
+        putIfPresent(attributes, ChunkMetadata.KEY_FALLBACK_FROM, value(fallbackFrom));
+        putIfPresent(attributes, ChunkMetadata.KEY_FALLBACK_TO, value(fallbackTo));
+        putIfPresent(attributes, ChunkMetadata.KEY_FALLBACK_REASON, fallbackReason);
+        attributes.put(ChunkMetadata.KEY_CHUNK_QUALITY_STATUS,
+                qualityIssues.isEmpty() ? QUALITY_VALID : QUALITY_REVIEW_REQUIRED);
+        attributes.put(ChunkMetadata.KEY_CHUNK_QUALITY_ISSUES, qualityIssues);
+        attributes.put(ChunkMetadata.KEY_CHUNK_UNIT, unit.value());
+        attributes.put(ChunkMetadata.KEY_MAX_SIZE, maxSize);
+        attributes.put(ChunkMetadata.KEY_OVERLAP, overlap);
+
+        ChunkMetadata metadata = rebuildMetadata(chunk.metadata(), attributes);
+        return Chunk.of(chunk.id(), chunk.content(), metadata);
+    }
+
+    private static List<String> qualityIssues(Chunk chunk, ChunkUnit unit, int maxSize) {
+        if (chunk == null) {
+            return List.of(ISSUE_EMPTY_CONTENT);
+        }
+        List<String> issues = new ArrayList<>();
+        Map<String, Object> metadata = chunk.metadata().toMap();
+        if (chunk.content() == null || chunk.content().isBlank()) {
+            issues.add(ISSUE_EMPTY_CONTENT);
+        }
+        if (maxSize > 0 && sizeOf(chunk, unit) > maxSize) {
+            issues.add(ISSUE_MAX_SIZE_EXCEEDED);
+        }
+        if (!hasProvenance(chunk.metadata(), metadata)) {
+            issues.add(ISSUE_MISSING_PROVENANCE);
+        }
+        return List.copyOf(issues);
+    }
+
+    private static int sizeOf(Chunk chunk, ChunkUnit unit) {
+        if (unit == ChunkUnit.TOKEN) {
+            Integer tokenCount = chunk.metadata().tokenCount();
+            return tokenCount == null ? ChunkSizing.estimateTokens(chunk.content()) : tokenCount;
+        }
+        return chunk.content() == null ? 0 : chunk.content().length();
+    }
+
+    private static boolean hasProvenance(ChunkMetadata metadata, Map<String, Object> metadataMap) {
+        if (metadata.startOffset() != null && metadata.endOffset() != null) {
+            return true;
+        }
+        if (!metadata.blockIds().isEmpty()) {
+            return true;
+        }
+        if (hasText(metadataMap.get(ChunkMetadata.KEY_SOURCE_REF))
+                || hasNonEmptyCollection(metadataMap.get(ChunkMetadata.KEY_SOURCE_REFS))
+                || metadataMap.containsKey(ChunkMetadata.KEY_PAGE)
+                || metadataMap.containsKey(ChunkMetadata.KEY_SLIDE)) {
+            return true;
+        }
+        return metadataMap.containsKey(ChunkMetadata.KEY_CHUNK_TOKEN_START)
+                && metadataMap.containsKey(ChunkMetadata.KEY_CHUNK_TOKEN_END);
+    }
+
+    private static boolean hasText(Object value) {
+        return value instanceof String text && !text.isBlank();
+    }
+
+    private static boolean hasNonEmptyCollection(Object value) {
+        return value instanceof Collection<?> collection && !collection.isEmpty();
+    }
+
+    private static void putIfPresent(Map<String, Object> attributes, String key, Object value) {
+        if (value == null) {
+            return;
+        }
+        if (value instanceof String text && text.isBlank()) {
+            return;
+        }
+        attributes.put(key, value);
+    }
+
+    private static String value(ChunkingStrategyType strategy) {
+        return strategy == null ? null : strategy.value();
+    }
+
+    private static ChunkMetadata rebuildMetadata(ChunkMetadata metadata, Map<String, Object> attributes) {
+        return ChunkMetadata.builder(metadata.strategy(), metadata.order())
+                .sourceDocumentId(metadata.sourceDocumentId())
+                .parentId(metadata.parentId())
+                .chunkType(metadata.chunkType())
+                .parentChunkId(metadata.parentChunkId())
+                .previousChunkId(metadata.previousChunkId())
+                .nextChunkId(metadata.nextChunkId())
+                .section(metadata.section())
+                .objectType(metadata.objectType())
+                .objectId(metadata.objectId())
+                .startOffset(metadata.startOffset())
+                .endOffset(metadata.endOffset())
+                .tokenCount(metadata.tokenCount())
+                .charCount(metadata.charCount())
+                .blockIds(metadata.blockIds())
+                .confidence(metadata.confidence())
+                .attributes(attributes)
+                .build();
+    }
+}

--- a/studio-platform-chunking-runtime/src/main/java/studio/one/platform/chunking/service/FixedSizeChunker.java
+++ b/studio-platform-chunking-runtime/src/main/java/studio/one/platform/chunking/service/FixedSizeChunker.java
@@ -60,7 +60,7 @@ public class FixedSizeChunker implements Chunker {
             start = Math.max(end - overlap, start + 1);
         }
 
-        return chunks;
+        return ChunkMetadataPolicy.markCompleted(context, chunks, strategy(), strategy(), maxSize, overlap);
     }
 
     private Chunk chunk(

--- a/studio-platform-chunking-runtime/src/main/java/studio/one/platform/chunking/service/RecursiveChunker.java
+++ b/studio-platform-chunking-runtime/src/main/java/studio/one/platform/chunking/service/RecursiveChunker.java
@@ -47,7 +47,8 @@ public class RecursiveChunker implements Chunker {
         int maxSize = effectiveMaxSize(context.maxSize());
         int overlap = effectiveOverlap(context.overlap(), maxSize);
         List<String> segments = splitRecursively(text, maxSize);
-        return pack(context, segments, maxSize, overlap);
+        List<Chunk> chunks = pack(context, segments, maxSize, overlap);
+        return ChunkMetadataPolicy.markCompleted(context, chunks, strategy(), strategy(), maxSize, overlap);
     }
 
     private List<Chunk> pack(ChunkingContext context, List<String> segments, int maxSize, int overlap) {

--- a/studio-platform-chunking-runtime/src/main/java/studio/one/platform/chunking/service/StructureBasedChunker.java
+++ b/studio-platform-chunking-runtime/src/main/java/studio/one/platform/chunking/service/StructureBasedChunker.java
@@ -24,9 +24,19 @@ public class StructureBasedChunker implements NormalizedDocumentChunker {
 
     private final int defaultOverlap;
 
-    private final Chunker fallbackChunker;
+    private final Chunker recursiveFallbackChunker;
+
+    private final Chunker fixedFallbackChunker;
 
     public StructureBasedChunker(int defaultMaxSize, int defaultOverlap, Chunker fallbackChunker) {
+        this(defaultMaxSize, defaultOverlap, fallbackChunker, new FixedSizeChunker(defaultMaxSize, defaultOverlap));
+    }
+
+    public StructureBasedChunker(
+            int defaultMaxSize,
+            int defaultOverlap,
+            Chunker recursiveFallbackChunker,
+            Chunker fixedFallbackChunker) {
         if (defaultMaxSize <= 0) {
             throw new IllegalArgumentException("defaultMaxSize must be positive");
         }
@@ -35,7 +45,10 @@ public class StructureBasedChunker implements NormalizedDocumentChunker {
         }
         this.defaultMaxSize = defaultMaxSize;
         this.defaultOverlap = Math.min(defaultOverlap, defaultMaxSize - 1);
-        this.fallbackChunker = fallbackChunker;
+        this.recursiveFallbackChunker = Objects.requireNonNull(recursiveFallbackChunker,
+                "recursiveFallbackChunker must not be null");
+        this.fixedFallbackChunker = Objects.requireNonNull(fixedFallbackChunker,
+                "fixedFallbackChunker must not be null");
     }
 
     @Override
@@ -48,17 +61,19 @@ public class StructureBasedChunker implements NormalizedDocumentChunker {
         if (context.text() == null || context.text().isBlank()) {
             return List.of();
         }
-        return fallbackChunker.chunk(context);
+        int maxSize = ChunkSizing.effectiveMaxSize(context.maxSize(), defaultMaxSize);
+        int overlap = ChunkSizing.effectiveOverlap(context.overlap(), defaultOverlap, maxSize);
+        return fallback(context, "plain-text-context", maxSize, overlap);
     }
 
     @Override
     public List<Chunk> chunk(NormalizedDocument document, ChunkingContext context) {
-        if (document.blocks().isEmpty()) {
-            return fallbackChunker.chunk(context);
-        }
-
         int maxSize = ChunkSizing.effectiveMaxSize(context.maxSize(), defaultMaxSize);
         int overlap = ChunkSizing.effectiveOverlap(context.overlap(), defaultOverlap, maxSize);
+        if (document.blocks().isEmpty()) {
+            return fallback(context, "missing-structure", maxSize, overlap);
+        }
+
         ChunkUnit unit = context.unit();
         List<Section> sections = splitSections(document.blocks());
         List<Chunk> chunks = new ArrayList<>();
@@ -68,7 +83,15 @@ public class StructureBasedChunker implements NormalizedDocumentChunker {
             ParentChunk parentChunk = createParentChunk(document, context, section, maxSize, overlap, unit);
             childOrder = appendChildChunks(document, context, section, parentChunk, maxSize, overlap, unit, chunks, childOrder);
         }
-        return linkNeighborsWithinParent(chunks);
+        List<Chunk> completed = ChunkMetadataPolicy.markCompleted(context, linkNeighborsWithinParent(chunks),
+                strategy(), strategy(), maxSize, overlap);
+        if (completed.isEmpty() && document.blocks().stream().allMatch(this::isHeading)) {
+            return List.of();
+        }
+        if (ChunkMetadataPolicy.hasFatalIssues(completed, unit, maxSize)) {
+            return fallback(context, "invalid-structure-chunks", maxSize, overlap);
+        }
+        return completed;
     }
 
     private ParentChunk createParentChunk(
@@ -171,7 +194,7 @@ public class StructureBasedChunker implements NormalizedDocumentChunker {
                 .unit(unit)
                 .metadata(context.metadata())
                 .build();
-        List<Chunk> splitChunks = fallbackChunker.chunk(splitContext);
+        List<Chunk> splitChunks = recursiveFallbackChunker.chunk(splitContext);
         List<NormalizedBlock> splitBlocks = new ArrayList<>(splitChunks.size());
         for (int index = 0; index < splitChunks.size(); index++) {
             Chunk splitChunk = splitChunks.get(index);
@@ -419,6 +442,49 @@ public class StructureBasedChunker implements NormalizedDocumentChunker {
             return null;
         }
         return values.stream().mapToDouble(Double::doubleValue).average().orElse(0.0d);
+    }
+
+    private List<Chunk> fallback(ChunkingContext context, String reason, int maxSize, int overlap) {
+        List<Chunk> recursiveChunks = tryChunk(recursiveFallbackChunker,
+                contextForStrategy(context, ChunkingStrategyType.RECURSIVE));
+        List<Chunk> recursiveFallback = ChunkMetadataPolicy.markFallback(context, recursiveChunks,
+                strategy(), strategy(), ChunkingStrategyType.RECURSIVE, reason, maxSize, overlap);
+        if (!ChunkMetadataPolicy.hasFatalIssues(recursiveFallback, context.unit(), maxSize)) {
+            return recursiveFallback;
+        }
+
+        List<Chunk> fixedChunks = tryChunk(fixedFallbackChunker,
+                contextForStrategy(context, ChunkingStrategyType.FIXED_SIZE));
+        List<Chunk> fixedFallback = ChunkMetadataPolicy.markFallback(context, fixedChunks,
+                strategy(), ChunkingStrategyType.RECURSIVE, ChunkingStrategyType.FIXED_SIZE,
+                reason + ":recursive-fallback-invalid", maxSize, overlap);
+        if (!ChunkMetadataPolicy.hasFatalIssues(fixedFallback, context.unit(), maxSize)) {
+            return fixedFallback;
+        }
+        return List.of();
+    }
+
+    private List<Chunk> tryChunk(Chunker chunker, ChunkingContext context) {
+        try {
+            return chunker.chunk(context);
+        } catch (RuntimeException ignored) {
+            return List.of();
+        }
+    }
+
+    private ChunkingContext contextForStrategy(ChunkingContext context, ChunkingStrategyType strategy) {
+        return ChunkingContext.builder(context.text())
+                .sourceDocumentId(context.sourceDocumentId())
+                .contentType(context.contentType())
+                .filename(context.filename())
+                .objectType(context.objectType())
+                .objectId(context.objectId())
+                .strategy(strategy)
+                .maxSize(context.maxSize())
+                .overlap(context.overlap())
+                .unit(context.unit())
+                .metadata(context.metadata())
+                .build();
     }
 
     private List<Chunk> linkNeighborsWithinParent(List<Chunk> chunks) {

--- a/studio-platform-chunking-runtime/src/main/java/studio/one/platform/chunking/service/TokenBasedChunker.java
+++ b/studio-platform-chunking-runtime/src/main/java/studio/one/platform/chunking/service/TokenBasedChunker.java
@@ -42,10 +42,14 @@ public class TokenBasedChunker {
         int maxSize = ChunkSizing.effectiveMaxSize(context.maxSize(), defaultMaxSize);
         int overlap = ChunkSizing.effectiveOverlap(context.overlap(), defaultOverlap, maxSize);
         ResolvedTokenizer resolvedTokenizer = tokenizerResolver.resolve(context.metadata());
+        ChunkingStrategyType actualStrategy = actualStrategy(context);
+        List<Chunk> chunks;
         if (resolvedTokenizer.fallbackUsed() && "approximate".equals(resolvedTokenizer.provider())) {
-            return approximateChunks(context, text, maxSize, overlap, resolvedTokenizer);
+            chunks = approximateChunks(context, text, maxSize, overlap, resolvedTokenizer);
+        } else {
+            chunks = tokenChunks(context, text, maxSize, overlap, resolvedTokenizer);
         }
-        return tokenChunks(context, text, maxSize, overlap, resolvedTokenizer);
+        return ChunkMetadataPolicy.markCompleted(context, chunks, actualStrategy, actualStrategy, maxSize, overlap);
     }
 
     private List<Chunk> tokenChunks(
@@ -133,7 +137,7 @@ public class TokenBasedChunker {
         attributes.put(ChunkMetadata.KEY_TOKENIZER_CONFIDENCE, resolvedTokenizer.confidence());
         attributes.put(ChunkMetadata.KEY_TOKENIZER_FALLBACK_USED, resolvedTokenizer.fallbackUsed());
         attributes.put(ChunkMetadata.KEY_TOKENIZER_WARNINGS, resolvedTokenizer.warnings());
-        ChunkMetadata metadata = ChunkMetadata.builder(ChunkingStrategyType.RECURSIVE, order)
+        ChunkMetadata metadata = ChunkMetadata.builder(actualStrategy(context), order)
                 .sourceDocumentId(context.sourceDocumentId())
                 .chunkType(ChunkType.CHILD)
                 .objectType(context.objectType())
@@ -168,6 +172,10 @@ public class TokenBasedChunker {
     private String chunkId(String sourceDocumentId, int order) {
         String prefix = sourceDocumentId == null || sourceDocumentId.isBlank() ? "document" : sourceDocumentId;
         return prefix + "-" + order;
+    }
+
+    private ChunkingStrategyType actualStrategy(ChunkingContext context) {
+        return context.strategy() == null ? ChunkingStrategyType.RECURSIVE : context.strategy();
     }
 
     private String normalize(String text) {

--- a/studio-platform-chunking-runtime/src/test/java/studio/one/platform/chunking/service/DefaultChunkingOrchestratorTest.java
+++ b/studio-platform-chunking-runtime/src/test/java/studio/one/platform/chunking/service/DefaultChunkingOrchestratorTest.java
@@ -11,11 +11,20 @@ import studio.one.platform.chunking.autoconfigure.ChunkingProperties;
 import studio.one.platform.chunking.core.ChunkingContext;
 import studio.one.platform.chunking.core.ChunkingStrategyType;
 import studio.one.platform.chunking.core.ChunkMetadata;
+import studio.one.platform.chunking.core.ChunkUnit;
 import studio.one.platform.chunking.core.NormalizedBlock;
 import studio.one.platform.chunking.core.NormalizedBlockType;
 import studio.one.platform.chunking.core.NormalizedDocument;
 
 class DefaultChunkingOrchestratorTest {
+
+    @Test
+    void defaultContractRemainsRecursiveCharacter() {
+        ChunkingProperties properties = new ChunkingProperties();
+
+        assertThat(properties.strategyType()).isEqualTo(ChunkingStrategyType.RECURSIVE);
+        assertThat(properties.unitType()).isEqualTo(ChunkUnit.CHARACTER);
+    }
 
     @Test
     void usesConfiguredStrategyWhenContextRequestsDefaults() {
@@ -288,5 +297,39 @@ class DefaultChunkingOrchestratorTest {
                 .containsEntry(ChunkMetadata.KEY_TOKENIZER_PROVIDER, "approximate")
                 .containsEntry(ChunkMetadata.KEY_TOKENIZER_FALLBACK_USED, true);
         assertThat(chunks.get(0).metadata().tokenCount()).isNotNull();
+    }
+
+    @Test
+    void tokenFixedSizePreservesFixedStrategyMetadata() {
+        ChunkingProperties properties = new ChunkingProperties();
+        properties.setUnit("token");
+        properties.setMaxSize(4);
+        properties.setOverlap(1);
+        TokenBasedChunker tokenBasedChunker = new TokenBasedChunker(
+                4,
+                1,
+                new DefaultTokenizerResolver(properties.getTokenizer(), List.of(new ApproximateTokenizer())));
+        DefaultChunkingOrchestrator orchestrator = new DefaultChunkingOrchestrator(
+                properties,
+                List.of(new FixedSizeChunker(10, 0), new RecursiveChunker(10, 0),
+                        new StructureBasedChunker(10, 0, new RecursiveChunker(10, 0))),
+                tokenBasedChunker);
+
+        var chunks = orchestrator.chunk(ChunkingContext.builder("한국어 English 1234567890 text")
+                .sourceDocumentId("doc")
+                .strategy(ChunkingStrategyType.FIXED_SIZE)
+                .unit(ChunkUnit.TOKEN)
+                .maxSize(4)
+                .overlap(1)
+                .metadata(java.util.Map.of("embeddingModel", "unknown-model"))
+                .build());
+
+        assertThat(chunks).isNotEmpty();
+        assertThat(chunks.get(0).metadata().strategy()).isEqualTo(ChunkingStrategyType.FIXED_SIZE);
+        assertThat(chunks.get(0).metadata().toMap())
+                .containsEntry(ChunkMetadata.KEY_CHUNK_UNIT, "token")
+                .containsEntry(ChunkMetadata.KEY_REQUESTED_CHUNKING_STRATEGY, "fixed-size")
+                .containsEntry(ChunkMetadata.KEY_ACTUAL_CHUNKING_STRATEGY, "fixed-size")
+                .containsEntry(ChunkMetadata.KEY_FALLBACK_STATUS, "NOT_REQUIRED");
     }
 }

--- a/studio-platform-chunking-runtime/src/test/java/studio/one/platform/chunking/service/FixedSizeChunkerTest.java
+++ b/studio-platform-chunking-runtime/src/test/java/studio/one/platform/chunking/service/FixedSizeChunkerTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import studio.one.platform.chunking.core.Chunk;
+import studio.one.platform.chunking.core.ChunkMetadata;
 import studio.one.platform.chunking.core.ChunkingContext;
 import studio.one.platform.chunking.core.ChunkingStrategyType;
 
@@ -23,6 +24,11 @@ class FixedSizeChunkerTest {
         assertThat(chunks).extracting(Chunk::content).containsExactly("abcde", "fghij", "kl");
         assertThat(chunks.get(0).metadata().strategy()).isEqualTo(ChunkingStrategyType.FIXED_SIZE);
         assertThat(chunks.get(0).metadata().order()).isZero();
+        assertThat(chunks.get(0).metadata().toMap())
+                .containsEntry(ChunkMetadata.KEY_REQUESTED_CHUNKING_STRATEGY, "fixed-size")
+                .containsEntry(ChunkMetadata.KEY_ACTUAL_CHUNKING_STRATEGY, "fixed-size")
+                .containsEntry(ChunkMetadata.KEY_FALLBACK_STATUS, "NOT_REQUIRED")
+                .containsEntry(ChunkMetadata.KEY_CHUNK_QUALITY_STATUS, "VALID");
     }
 
     @Test

--- a/studio-platform-chunking-runtime/src/test/java/studio/one/platform/chunking/service/StructureBasedChunkerTest.java
+++ b/studio-platform-chunking-runtime/src/test/java/studio/one/platform/chunking/service/StructureBasedChunkerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import studio.one.platform.chunking.core.Chunk;
 import studio.one.platform.chunking.core.ChunkMetadata;
 import studio.one.platform.chunking.core.ChunkUnit;
+import studio.one.platform.chunking.core.Chunker;
 import studio.one.platform.chunking.core.ChunkingContext;
 import studio.one.platform.chunking.core.ChunkingStrategyType;
 import studio.one.platform.chunking.core.NormalizedBlock;
@@ -173,6 +174,14 @@ class StructureBasedChunkerTest {
         assertThat(chunks).extracting(Chunk::content).containsExactly("alpha beta", "gamma");
         assertThat(chunks.get(0).metadata().strategy())
                 .isEqualTo(ChunkingStrategyType.RECURSIVE);
+        assertThat(chunks.get(0).metadata().toMap())
+                .containsEntry(ChunkMetadata.KEY_REQUESTED_CHUNKING_STRATEGY, "structure-based")
+                .containsEntry(ChunkMetadata.KEY_ACTUAL_CHUNKING_STRATEGY, "recursive")
+                .containsEntry(ChunkMetadata.KEY_FALLBACK_STATUS, "APPLIED")
+                .containsEntry(ChunkMetadata.KEY_FALLBACK_FROM, "structure-based")
+                .containsEntry(ChunkMetadata.KEY_FALLBACK_TO, "recursive")
+                .containsEntry(ChunkMetadata.KEY_FALLBACK_REASON, "plain-text-context")
+                .containsEntry(ChunkMetadata.KEY_CHUNK_QUALITY_STATUS, "VALID");
     }
 
     @Test
@@ -195,6 +204,77 @@ class StructureBasedChunkerTest {
                 .containsEntry(ChunkMetadata.KEY_BLOCK_IDS, List.of("page[1]"))
                 .containsEntry(ChunkMetadata.KEY_CONFIDENCE, 0.91d)
                 .containsEntry(ChunkMetadata.KEY_MAX_SIZE, 10);
+    }
+
+    @Test
+    void missingProvenanceMarksReviewRequiredWithoutFallback() {
+        StructureBasedChunker chunker = new StructureBasedChunker(120, 0, new RecursiveChunker(120, 0));
+        NormalizedDocument document = NormalizedDocument.builder("doc")
+                .blocks(List.of(NormalizedBlock.builder(NormalizedBlockType.PARAGRAPH, "Body without locator")
+                        .order(0)
+                        .build()))
+                .build();
+
+        Chunk chunk = chunker.chunk(document, context(document, 120, 0)).get(0);
+
+        assertThat(chunk.metadata().strategy()).isEqualTo(ChunkingStrategyType.STRUCTURE_BASED);
+        assertThat(chunk.metadata().toMap())
+                .containsEntry(ChunkMetadata.KEY_FALLBACK_STATUS, "NOT_REQUIRED")
+                .containsEntry(ChunkMetadata.KEY_CHUNK_QUALITY_STATUS, "REVIEW_REQUIRED")
+                .containsEntry(ChunkMetadata.KEY_CHUNK_QUALITY_ISSUES, List.of("MISSING_PROVENANCE"));
+    }
+
+    @Test
+    void oversizedStandaloneStructureChunkFallsBackToRecursive() {
+        StructureBasedChunker chunker = new StructureBasedChunker(10, 0, new RecursiveChunker(10, 0));
+        NormalizedDocument document = NormalizedDocument.builder("doc")
+                .blocks(List.of(block(NormalizedBlockType.TABLE,
+                        "alpha beta gamma", "table[1]", 0, 0.90d)))
+                .build();
+
+        List<Chunk> chunks = chunker.chunk(document, context(document, 10, 0));
+
+        assertThat(chunks).extracting(Chunk::content).containsExactly("alpha beta", "gamma");
+        assertThat(chunks.get(0).metadata().strategy()).isEqualTo(ChunkingStrategyType.RECURSIVE);
+        assertThat(chunks.get(0).metadata().toMap())
+                .containsEntry(ChunkMetadata.KEY_REQUESTED_CHUNKING_STRATEGY, "structure-based")
+                .containsEntry(ChunkMetadata.KEY_ACTUAL_CHUNKING_STRATEGY, "recursive")
+                .containsEntry(ChunkMetadata.KEY_FALLBACK_STATUS, "APPLIED")
+                .containsEntry(ChunkMetadata.KEY_FALLBACK_REASON, "invalid-structure-chunks");
+    }
+
+    @Test
+    void recursiveFallbackFailureUsesFixedFallback() {
+        Chunker failingRecursive = new Chunker() {
+            @Override
+            public ChunkingStrategyType strategy() {
+                return ChunkingStrategyType.RECURSIVE;
+            }
+
+            @Override
+            public List<Chunk> chunk(ChunkingContext context) {
+                throw new IllegalStateException("recursive unavailable");
+            }
+        };
+        StructureBasedChunker chunker = new StructureBasedChunker(5, 0, failingRecursive, new FixedSizeChunker(5, 0));
+
+        List<Chunk> chunks = chunker.chunk(ChunkingContext.builder("abcdefghi")
+                .sourceDocumentId("doc")
+                .strategy(ChunkingStrategyType.STRUCTURE_BASED)
+                .maxSize(5)
+                .overlap(0)
+                .build());
+
+        assertThat(chunks).extracting(Chunk::content).containsExactly("abcde", "fghi");
+        assertThat(chunks.get(0).metadata().strategy()).isEqualTo(ChunkingStrategyType.FIXED_SIZE);
+        assertThat(chunks.get(0).metadata().toMap())
+                .containsEntry(ChunkMetadata.KEY_REQUESTED_CHUNKING_STRATEGY, "structure-based")
+                .containsEntry(ChunkMetadata.KEY_ACTUAL_CHUNKING_STRATEGY, "fixed-size")
+                .containsEntry(ChunkMetadata.KEY_FALLBACK_STATUS, "APPLIED")
+                .containsEntry(ChunkMetadata.KEY_FALLBACK_FROM, "recursive")
+                .containsEntry(ChunkMetadata.KEY_FALLBACK_TO, "fixed-size")
+                .containsEntry(ChunkMetadata.KEY_FALLBACK_REASON,
+                        "plain-text-context:recursive-fallback-invalid");
     }
 
     private NormalizedBlock block(NormalizedBlockType type, String text, String sourceRef, int order, double confidence) {

--- a/studio-platform-chunking/README.md
+++ b/studio-platform-chunking/README.md
@@ -73,6 +73,9 @@ Chunk 생성은 여러 종류의 Chunking Processor를 통해 수행된다. Text
 | `page`, `slide`, `headingPath`, `sourceFormat` | 위치와 section context입니다. | 추가 key |
 | `confidence` | parser/OCR confidence가 있는 경우 보존합니다. | 추가 key |
 | `tokenEstimate`, `chunkUnit`, `maxSize`, `overlap` | size 정책과 검증 evidence입니다. | 추가 key |
+| `requestedChunkingStrategy`, `actualChunkingStrategy` | 요청 전략과 실제 생성 전략을 구분합니다. | 추가 key |
+| `fallbackStatus`, `fallbackFrom`, `fallbackTo`, `fallbackReason` | full-strategy fallback 적용 여부와 사유입니다. | 추가 key |
+| `chunkQualityStatus`, `chunkQualityIssues` | 색인 chunk의 품질 검증 결과입니다. 실패 chunk는 저장하지 않습니다. | 추가 key |
 
 `blockify` 전략은 starter 구현체가 제공하는 opt-in PoC 전략입니다.
 core 계약에서는 `ChunkingStrategyType.BLOCKIFY` 식별자와 metadata 전달만 정의하며, LLM 호출이나 생성 구현은 포함하지 않습니다.

--- a/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkMetadata.java
+++ b/studio-platform-chunking/src/main/java/studio/one/platform/chunking/core/ChunkMetadata.java
@@ -72,6 +72,14 @@ public record ChunkMetadata(
     public static final String KEY_TOKENIZER_CONFIDENCE = "tokenizerConfidence";
     public static final String KEY_TOKENIZER_FALLBACK_USED = "tokenizerFallbackUsed";
     public static final String KEY_TOKENIZER_WARNINGS = "tokenizerWarnings";
+    public static final String KEY_REQUESTED_CHUNKING_STRATEGY = "requestedChunkingStrategy";
+    public static final String KEY_ACTUAL_CHUNKING_STRATEGY = "actualChunkingStrategy";
+    public static final String KEY_FALLBACK_STATUS = "fallbackStatus";
+    public static final String KEY_FALLBACK_FROM = "fallbackFrom";
+    public static final String KEY_FALLBACK_TO = "fallbackTo";
+    public static final String KEY_FALLBACK_REASON = "fallbackReason";
+    public static final String KEY_CHUNK_QUALITY_STATUS = "chunkQualityStatus";
+    public static final String KEY_CHUNK_QUALITY_ISSUES = "chunkQualityIssues";
 
     public ChunkMetadata {
         if (order < 0) {


### PR DESCRIPTION
## Why

청킹 결과에서 요청 전략, 실제 전략, fallback, 품질 상태를 구분해 서버와 클라이언트 진단 품질을 높입니다.

## What

- Chunk metadata에 requested/actual strategy, fallback status, quality status key를 추가했습니다.
- Structure-based fallback 체인을 recursive -> fixed-size 순서로 보강했습니다.
- fixed-size + token 경로가 recursive로 기록되지 않도록 strategy metadata를 보존했습니다.
- provenance 누락은 fallback이 아니라 REVIEW_REQUIRED 품질 상태로 남기도록 했습니다.
- 클라이언트 표시/UX 개선 지시문 문서를 추가했습니다.

## Validation

- `git diff --check`: PASS
- `./gradlew :studio-platform-chunking:test :studio-platform-chunking-runtime:test :starter:studio-platform-starter-chunking:test`: PASS

## Notes

- DB schema와 API endpoint shape는 변경하지 않습니다.
- `.omx/*` 로컬 상태 변경은 PR 범위에서 제외했습니다.
