### PR TITLE
[ai-assisted] feat(rag): 문서 처리와 RAG 응답 품질 개선

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,66 @@
 
 ## Unreleased
 
+- 전체 문서 요약 컨텍스트와 Map-Reduce 결과에 문서 제목과 원본 파일명을 보존하고, 요약 답변이 해당
+  식별 정보로 시작하도록 개선했다. metadata에 없는 제목이나 파일명은 생성하지 않는다.
+
+- 대용량 RAG 문서의 구간별 요약을 최대 3개 제한 병렬 처리로 변경해 첫 전체 요약의 순차 대기 시간을
+  줄였다. RAG 응답 metadata와 10초 이상 소요된 서버 로그에는 검색, 중간 요약, 최종 생성, 전체 시간을
+  분리해 기록한다.
+
+- 대용량 문서 전체 요약은 구간별 근거 요약을 먼저 생성하고 내용 지문 기반 제한 캐시를 재사용한다.
+  구간 요약 실패 시 기존 전체 문서 컨텍스트로 복귀해 기존 API와 답변 경로를 유지한다.
+
+- 문서 요약·줄거리 요청에 사전 생성 summary metadata가 없을 때 object의 첫 chunk들만 요약하던 문제를
+  수정했다. 전체 object chunk를 순서대로 조회하고 `startOffset`/`endOffset` overlap을 제거해 하나의
+  전체 문서 context로 재구성한다. 안전 한도를 넘는 문서는 균등 coverage sample로 제한하고 응답 metadata에
+  `overviewCoverageStatus=PARTIAL`을 표시해 부분 근거를 전체 줄거리로 오인하지 않도록 했다.
+  마지막 user message만으로도 요약 의도를 감지하므로 클라이언트가 동일한 `ragQuery`를 중복 전송할 필요가
+  없으며, 서버 prompt가 원문에 없는 장소·진단을 단정하거나 극중 작품을 원본 전체와 혼동하지 않도록 한다.
+
+- RAG chat에 `INTERPRETIVE_ANALYSIS` query intent를 추가했다. MBTI·성격·인물 동기·상징 해석처럼 문서의
+  여러 근거를 종합해야 하는 질문은 semantic search를 유지하면서 최소 8개 근거 후보와 최대 `0.55`
+  score threshold를 사용한다. 모델에는 사실과 추론을 구분하고 대안 해석과 확신도를 제시하도록 안내하며,
+  응답 metadata에 `answerType=EVIDENCE_BASED_INFERENCE`와 실제 검색 조건을 additive로 노출한다.
+
+- RAG chat 자동 검색 전략이 일반 `recursive` chunk 문서까지 structure/idea-block hybrid filter로 보내
+  검색 결과를 0건으로 만드는 문제를 수정했다. object sample에 구조화/idea-block 신호가 없으면 기존
+  default semantic search를 사용하며, 저장된 embedding profile 정렬 동작은 유지한다.
+
+- 종료된 Gemini 1.5 Pro와 `text-embedding-004` 대신 실제 지원 모델인 `gemini-2.5-pro`와
+  `gemini-embedding-2`를 provider/profile로 선택할 수 있도록 Google provider별 명시적
+  `model-override`를 추가했다. 기존 `gemini-2.5-flash`, `gemini-embedding-001`, 기본 embedding profile은
+  유지한다. 임베딩 요청의 명시적 provider도 실제 provider별 port로 라우팅한다. chat 응답의 실제
+  provider/model/token usage를 기준으로 요청 수, token, 지연시간, 설정 기반
+  USD 추정 비용을 집계하고 `GET /api/ai/usage/models`에서 조회할 수 있게 했다. provider 정보 API는
+  비활성 channel의 상속 모델을 노출하지 않아 provider 이름과 실제 활성 모델이 일관되게 표시된다.
+
+- RAG prompt의 각 근거에 원본 파일명, 문서 제목, 페이지, 섹션, sourceRef provenance를 함께 전달하고,
+  `ragReferences`에도 `originalFileName`, `sourceFileName`, `title`, `sourceRef`, `citationLabel`을 additive로
+  노출해 답변의 `(근거 N)`을 실제 원문 위치와 연결할 수 있도록 개선했다. object-scoped 검색은 저장된
+  chunk의 `embeddingProfileId`와 질의 임베딩 profile을 자동 정렬해, 다른 profile을 전달했을 때 존재하지
+  않는 TEI endpoint를 호출하거나 색인과 다른 차원의 embedding을 사용하는 문제를 방지한다.
+
+- RAG chat이 저장된 chunk metadata에서 실제 청킹 전략을 감지해 불필요한 hybrid 검색과 질의 확장을
+  생략하도록 개선했다. 규칙 기반 query intent classifier를 추가해 구체 질문은 semantic retrieval로,
+  문서 요약·핵심 내용 요청은 `documentSummary`, `keyPoints`, `highlights` 등 사전 추출 metadata를
+  우선 사용하고 metadata가 없으면 기존 object chunk 요약으로 fallback한다. 분류 결과와 실제 retrieval
+  mode는 응답 metadata에 additive로 노출한다.
+
+- Fixed content embedding auto-configuration to pass the configured `ChunkSetStore` into the attachment structured RAG indexer, allowing prepared Markdown chunks to be indexed instead of failing with `ChunkSet store is not configured`.
+
+- Markdown 품질 게이트는 빈 Markdown 또는 정규화 block 부재만 치명 오류로 차단하고, 한글 자모·수식
+  손실 가능성·페이지 커버리지 같은 비치명 품질 이슈는 `ragIndexEligible=true`,
+  `qualityGateStatus=REVIEW_REQUIRED`로 보존해 검토 가능한 유효 chunk의 RAG 색인을 계속하도록 보완했다.
+
+- 재추출 요청에서 문서 프로필과 OCR/수식 보정 옵션이 모두 누락되면 최근 명시적 품질 설정을 계승해 대용량 문서의 비용 추산 경로에서 한글·수식 품질이 퇴행하지 않도록 보완했다.
+
+- 수학 PDF 보정 페이지 선정이 `x’`, `xry`, `52x'`처럼 지수·변수 경계가 손상된 OCR 패턴을 높은
+  우선순위로 판정하도록 보완했다. Gemini vision 응답의 LaTeX가 JSON에서 `\{`, `\frac` 형태로
+  잘못 escape되어도 복구한 뒤 수식 block으로 보존하며, 정규화·Markdown 품질 경고가 청킹 완료 시
+  `chunkQualityStatus=VALID`로 덮이지 않도록 원본 issue를 병합한다. 수학 질문 청크의 parent context가
+  질문 한 줄뿐이면 같은 페이지의 가까운 조건식까지 제한적으로 확장해 식과 질문의 분리를 복구한다.
+
 - Markdown/NormalizedDocument 청킹 결과를 영속 `ChunkSet`으로 저장하고 Markdown에서 시작된 RAG 색인은
   지정된 `chunkSetId`의 text/order/metadata만 임베딩하도록 분리했다. 임베딩 profile 변경 재색인도 같은
   ChunkSet을 재사용하며, ChunkSet이 없거나 scope·품질 상태가 유효하지 않으면 원문 재추출·재청킹 없이

--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -80,6 +80,7 @@ studio:
 | `POST` | `{basePath}/chat/cancel` | conversation cancel 상태 표시 | `services:ai_chat write` |
 | `POST` | `{basePath}/query-rewrite` | 검색 쿼리 리라이트 | `services:ai_chat read` |
 | `GET`  | `{basePath}/info/providers` | 프로바이더 및 벡터 스토어 상태 조회 | `services:ai_chat read` 또는 `services:ai_embedding read` |
+| `GET`  | `{basePath}/usage/models` | 실제 provider/model별 token 사용량과 추정 비용 조회 | `services:ai_chat read` |
 | `POST` | `{mgmtBasePath}/embedding` | 텍스트 임베딩 벡터 생성 | `services:ai_embedding write` |
 | `POST` | `{mgmtBasePath}/vectors` | 벡터 문서 업서트 | `services:ai_vector read` |
 | `POST` | `{mgmtBasePath}/vectors/search` | 벡터 유사도 검색 | `services:ai_vector read` |
@@ -482,6 +483,16 @@ Content-Type: application/json
 }
 ```
 
+provider가 token usage를 반환하고 `studio.ai.usage.pricing`에 실제 모델 단가가 설정된 경우 응답 metadata의
+`estimatedCost`와 `GET {basePath}/usage/models` 집계에 추정 비용이 포함된다. 단가는 `model` 또는
+`provider/model` key로 설정할 수 있고, provider/model 설정이 우선한다. 이 값은 API 응답 token 기준
+추정치이며 세금, 무료 tier, batch 할인, caching, grounding 등 별도 과금 항목을 포함하지 않는다.
+YAML에서 모델명에 `.`이 포함되면 Spring map key가 분해되지 않도록 `"[gemini-2.5-pro]"`처럼 대괄호로
+감싼 key를 사용한다.
+
+기본 `AiModelUsageStore`는 단일 인스턴스의 in-memory 집계다. 애플리케이션 재시작 시 초기화되며 장기 비용
+통계나 다중 인스턴스 합산이 필요하면 외부 저장소 기반 구현을 별도 Bean으로 등록한다.
+
 이 memory는 단일 앱 인스턴스의 in-memory cache다. 애플리케이션 재시작 시 사라지며, 다중 인스턴스 간 공유되지 않는다.
 운영에서 여러 인스턴스 간 대화 memory가 필요하면 `ChatMemoryStore`와 `ConversationRepositoryPort`를 외부 저장소 기반 구현으로 교체한다.
 
@@ -574,17 +585,12 @@ Content-Type: application/json
 {
   "chat": {
     "provider": "openai",
-    "systemPrompt": "제공된 파일 컨텍스트를 기반으로 답변하세요.",
     "messages": [
       {"role": "user", "content": "이 파일의 핵심 내용을 요약해줘"}
     ]
   },
-  "ragQuery": "핵심 내용 요약",
-  "topK": 3,
-  "minScore": 0.15,
   "objectType": "attachment",
-  "objectId": "123",
-  "embeddingProfileId": "retrieval-ko"
+  "objectId": "123"
 }
 ```
 
@@ -596,6 +602,26 @@ fallback 전략 선택은 서버 설정 `min-relevance-score` 기준으로 결�
 이 값은 attachment 전용 ID가 아니라 색인 시 저장된 chunk metadata의 object scope와 같은 의미다. 예를 들어 RAG job이
 `objectType=2001`, `objectId=6`으로 생성됐다면 RAG Chat에도 같은 값을 전달해야 한다. `ragQuery`가 없고
 객체 범위만 있으면 저장된 chunk를 순서대로 가져와 컨텍스트로 사용한다.
+단, 마지막 user message가 문서 요약·줄거리·핵심 내용 의도로 분류되면 `ragQuery`를 중복 전송하지 않아도
+서버가 overview 경로를 사용한다. 이 경우 `topK`, `minScore`, `embeddingProfileId`는 semantic retrieval
+선택값이 아니므로 클라이언트에서 생략하는 것을 권장한다.
+
+클라이언트는 질문 유형별 `systemPrompt`를 조립하지 않는다. 서버가 질문을 `CONTENT_QA`,
+`DOCUMENT_SUMMARY`, `KEY_POINTS`, `INTERPRETIVE_ANALYSIS`로 분류하고 검색 방식과 답변 정책을 결정한다.
+`systemPrompt` 필드는 기존 호환성과 일반적인 출력 형식 지시를 위해 유지하지만, 해석형 질문의 근거 기반
+추론 정책은 서버가 마지막에 적용한다. MBTI·성격·인물 동기·상징 해석 질문은 최소 8개 후보와 최대
+`0.55` cutoff를 사용하며, 응답 metadata의 `ragQueryIntent`, `answerType`, `ragRetrievalTopK`,
+`ragRetrievalMinScore`로 실제 적용값을 확인할 수 있다.
+
+전체 문서 context가 80,000자를 넘으면 서버는 원문 순서대로 구간 요약을 만든 뒤 최종 답변에 사용한다.
+구간 요약은 object, provider, model, 원문 내용 지문 기준의 제한 캐시를 사용하므로 같은 내용의 반복 요약은
+재사용된다. 응답 metadata의 `overviewReduction=MAP_REDUCE`, `overviewReductionSegmentCount`,
+`overviewReductionCacheHit`로 적용 여부를 확인할 수 있다. 구간 요약이 실패하면 기존 전체 문서 context로
+자동 복귀한다.
+대용량 문서의 구간 요약은 외부 provider 부하를 제한하기 위해 최대 3개까지만 병렬 처리한다. 모든 RAG chat
+응답은 `metadata.ragTiming`에 `retrievalMs`, `overviewReductionMs`, `generationMs`, `totalMs`를 제공한다.
+전체 문서 요약 답변은 metadata에 존재하는 문서 제목과 원본 파일명을 첫 문장에 표시한다. 둘 중 없는 값은
+추측하지 않는다.
 
 RAG context는 이슈 #202부터 설정된 chunk 수와 문자 수를 넘지 않도록 제한된다.
 문자 수 한도는 context header를 포함해 계산하며, 큰 chunk는 `max-chunk-chars` 기준으로 deterministic excerpt preview로
@@ -627,16 +653,21 @@ packed content는 서버 `allow-client-debug=true`와 요청 `debug=true`가 모
         "chunkOrder": 0,
         "score": 0.91,
         "page": 3,
-        "pageNumber": 3
+        "pageNumber": 3,
+        "sourceRef": "page[3]"
       }
-    ]
+    ],
+    "ragQueryIntent": "INTERPRETIVE_ANALYSIS",
+    "answerType": "EVIDENCE_BASED_INFERENCE",
+    "ragRetrievalTopK": 8,
+    "ragRetrievalMinScore": 0.55
   }
 }
 ```
 
-`sourceName`은 `sourceName`, `title`, `filename`, `fileName`, `name` metadata 순서로 선택한다.
+`sourceName`은 원본 파일명 metadata를 우선하고, 없으면 문서 제목을 사용한다.
 위치 정보는 metadata에 있으면 `page`/`pageNumber`, `slide`/`slideNumber`, `section`, `heading`으로 함께 내려간다.
-raw metadata map과 `sourceRef`는 응답하지 않는다.
+`sourceRef`는 provenance 표시를 위해 응답하며 raw metadata map은 응답하지 않는다.
 
 ```yaml
 studio:

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiModelUsageProperties.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiModelUsageProperties.java
@@ -1,0 +1,93 @@
+package studio.one.platform.ai.autoconfigure;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "studio.ai.usage")
+public class AiModelUsageProperties {
+
+    private boolean enabled = true;
+    private String currency = "USD";
+    private final Map<String, ModelPricing> pricing = new LinkedHashMap<>();
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public Map<String, ModelPricing> getPricing() {
+        return pricing;
+    }
+
+    public static class ModelPricing {
+        private BigDecimal inputPerMillionTokens;
+        private BigDecimal outputPerMillionTokens;
+        private Integer highContextThresholdTokens;
+        private BigDecimal highContextInputPerMillionTokens;
+        private BigDecimal highContextOutputPerMillionTokens;
+
+        public BigDecimal getInputPerMillionTokens() {
+            return inputPerMillionTokens;
+        }
+
+        public void setInputPerMillionTokens(BigDecimal value) {
+            this.inputPerMillionTokens = nonNegative(value, "inputPerMillionTokens");
+        }
+
+        public BigDecimal getOutputPerMillionTokens() {
+            return outputPerMillionTokens;
+        }
+
+        public void setOutputPerMillionTokens(BigDecimal value) {
+            this.outputPerMillionTokens = nonNegative(value, "outputPerMillionTokens");
+        }
+
+        public Integer getHighContextThresholdTokens() {
+            return highContextThresholdTokens;
+        }
+
+        public void setHighContextThresholdTokens(Integer value) {
+            if (value != null && value <= 0) {
+                throw new IllegalArgumentException("highContextThresholdTokens must be greater than 0");
+            }
+            this.highContextThresholdTokens = value;
+        }
+
+        public BigDecimal getHighContextInputPerMillionTokens() {
+            return highContextInputPerMillionTokens;
+        }
+
+        public void setHighContextInputPerMillionTokens(BigDecimal value) {
+            this.highContextInputPerMillionTokens = nonNegative(value, "highContextInputPerMillionTokens");
+        }
+
+        public BigDecimal getHighContextOutputPerMillionTokens() {
+            return highContextOutputPerMillionTokens;
+        }
+
+        public void setHighContextOutputPerMillionTokens(BigDecimal value) {
+            this.highContextOutputPerMillionTokens = nonNegative(value, "highContextOutputPerMillionTokens");
+        }
+
+        private static BigDecimal nonNegative(BigDecimal value, String name) {
+            if (value != null && value.signum() < 0) {
+                throw new IllegalArgumentException(name + " must not be negative");
+            }
+            return value;
+        }
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/autoconfigure/AiWebAutoConfiguration.java
@@ -56,9 +56,12 @@ import studio.one.platform.ai.service.visualization.VectorProjectionService;
 import studio.one.platform.ai.service.visualization.VectorSearchVisualizationService;
 import studio.one.platform.ai.web.controller.AiWebExceptionHandler;
 import studio.one.platform.ai.web.controller.AiInfoController;
+import studio.one.platform.ai.web.controller.AiModelUsageController;
+import studio.one.platform.ai.web.controller.AiModelUsageStore;
 import studio.one.platform.ai.web.controller.ChatController;
 import studio.one.platform.ai.web.controller.EmbeddingController;
 import studio.one.platform.ai.web.controller.InMemoryRagRetrievalEvaluationStore;
+import studio.one.platform.ai.web.controller.InMemoryAiModelUsageStore;
 import studio.one.platform.ai.web.controller.InMemoryRagRetrievalEvaluationJobStore;
 import studio.one.platform.ai.web.controller.InMemoryRagRetrievalEvaluationQuestionSetStore;
 import studio.one.platform.ai.web.controller.JdbcRagRetrievalEvaluationStore;
@@ -114,6 +117,7 @@ import studio.one.platform.chunking.core.ChunkingOrchestrator;
 @EnableConfigurationProperties({
         AiWebRagProperties.class,
         AiWebChatProperties.class,
+        AiModelUsageProperties.class,
         RagPipelineProperties.class,
         VectorProjectionProperties.class
 })
@@ -170,7 +174,8 @@ public class AiWebAutoConfiguration {
             ObjectMapper objectMapper,
             RagPipelineProperties ragPipelineProperties,
             RagRetrievalPolicyStore ragRetrievalPolicyStore,
-            RagRetrievalPolicyUsageStore ragRetrievalPolicyUsageStore) {
+            RagRetrievalPolicyUsageStore ragRetrievalPolicyUsageStore,
+            AiModelUsageStore modelUsageStore) {
         return new ChatController(providerRegistry, ragPipelineService, ragChatRetrievalService,
                 ragContextBuilder,
                 ragProperties.getDiagnostics().isAllowClientDebug(),
@@ -182,7 +187,19 @@ public class AiWebAutoConfiguration {
                 ragProperties.getContext().getExpansion().getMaxCandidates(),
                 ragPipelineOptions(ragPipelineProperties),
                 ragRetrievalPolicyStore,
-                ragRetrievalPolicyUsageStore);
+                ragRetrievalPolicyUsageStore,
+                modelUsageStore);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    AiModelUsageStore aiModelUsageStore(AiModelUsageProperties properties) {
+        return new InMemoryAiModelUsageStore(properties);
+    }
+
+    @Bean
+    AiModelUsageController aiModelUsageController(AiModelUsageStore usageStore) {
+        return new AiModelUsageController(usageStore);
     }
 
     @Bean

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/AiInfoController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/AiInfoController.java
@@ -85,14 +85,17 @@ public class AiInfoController {
         };
         ProviderChannel chat = new ProviderChannel(
                 provider.getChat().isEnabled(),
-                chatModel(provider));
+                provider.getChat().isEnabled() ? chatModel(provider) : null);
         ProviderChannel embedding = new ProviderChannel(
                 provider.getEmbedding().isEnabled(),
-                embeddingModel(provider));
+                provider.getEmbedding().isEnabled() ? embeddingModel(provider) : null);
         return new ProviderInfo(name, provider.getType(), chat, embedding, baseUrl);
     }
 
     private String chatModel(AiAdapterProperties.Provider provider) {
+        if (provider.getChat().isModelOverride() && provider.getChat().getModel() != null) {
+            return provider.getChat().getModel();
+        }
         return switch (provider.getType()) {
             case OPENAI -> firstNonBlank(
                     environment.getProperty("spring.ai.openai.chat.options.model"),
@@ -108,6 +111,9 @@ public class AiInfoController {
     }
 
     private String embeddingModel(AiAdapterProperties.Provider provider) {
+        if (provider.getEmbedding().isModelOverride() && provider.getEmbedding().getModel() != null) {
+            return provider.getEmbedding().getModel();
+        }
         return switch (provider.getType()) {
             case OPENAI -> firstNonBlank(
                     environment.getProperty("spring.ai.openai.embedding.options.model"),

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/AiModelUsageController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/AiModelUsageController.java
@@ -1,0 +1,32 @@
+package studio.one.platform.ai.web.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import studio.one.platform.constant.PropertyKeys;
+import studio.one.platform.web.dto.ApiResponse;
+
+@RestController
+@RequestMapping("${" + PropertyKeys.AI.Endpoints.BASE_PATH + ":/api/ai}/usage")
+public class AiModelUsageController {
+
+    private final AiModelUsageStore usageStore;
+
+    public AiModelUsageController(AiModelUsageStore usageStore) {
+        this.usageStore = usageStore;
+    }
+
+    @GetMapping("/models")
+    @PreAuthorize("@endpointAuthz.can('services:ai_chat','read')")
+    public ResponseEntity<ApiResponse<List<AiModelUsageStore.ModelUsageSummary>>> models(
+            @RequestParam(required = false) String provider,
+            @RequestParam(required = false) String model) {
+        return ResponseEntity.ok(ApiResponse.ok(usageStore.summaries(provider, model)));
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/AiModelUsageStore.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/AiModelUsageStore.java
@@ -1,0 +1,67 @@
+package studio.one.platform.ai.web.controller;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import studio.one.platform.ai.core.chat.ChatResponseMetadata;
+
+public interface AiModelUsageStore {
+
+    UsageEstimate record(ChatResponseMetadata metadata, String fallbackModel);
+
+    List<ModelUsageSummary> summaries(String provider, String model);
+
+    static AiModelUsageStore noop() {
+        return new AiModelUsageStore() {
+            @Override
+            public UsageEstimate record(ChatResponseMetadata metadata, String fallbackModel) {
+                return UsageEstimate.unavailable();
+            }
+
+            @Override
+            public List<ModelUsageSummary> summaries(String provider, String model) {
+                return List.of();
+            }
+        };
+    }
+
+    record UsageEstimate(
+            String currency,
+            BigDecimal estimatedCost,
+            boolean pricingConfigured,
+            String pricingKey) {
+
+        static UsageEstimate unavailable() {
+            return new UsageEstimate("USD", null, false, null);
+        }
+
+        public Map<String, Object> toMetadata() {
+            if (!pricingConfigured || estimatedCost == null) {
+                return Map.of("pricingConfigured", false);
+            }
+            return Map.of(
+                    "currency", currency,
+                    "estimatedCost", estimatedCost,
+                    "pricingConfigured", true,
+                    "pricingKey", pricingKey);
+        }
+    }
+
+    record ModelUsageSummary(
+            String provider,
+            String model,
+            long requestCount,
+            long pricedRequestCount,
+            long inputTokens,
+            long outputTokens,
+            long totalTokens,
+            long totalLatencyMs,
+            double averageLatencyMs,
+            String currency,
+            BigDecimal estimatedCost,
+            Instant firstSeenAt,
+            Instant lastSeenAt) {
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/ChatController.java
@@ -110,6 +110,30 @@ public class ChatController {
     private static final int MAX_CONTEXT_EXPANSION_CANDIDATES = 500;
     private static final String RAG_NO_CONTEXT_MESSAGE = "제공된 RAG 문서에서 확인할 수 없습니다.";
     private static final String RAG_SKIP_REASON_NO_RESULTS = "NO_RAG_RESULTS";
+    private static final int INTERPRETIVE_MIN_TOP_K = 8;
+    private static final double INTERPRETIVE_MAX_MIN_SCORE = 0.55d;
+    private static final int MAX_OVERVIEW_SOURCE_CHUNKS = 2_000;
+    private static final int MAX_WHOLE_DOCUMENT_CONTEXT_CHARS = 300_000;
+    private static final int MAP_REDUCE_OVERVIEW_THRESHOLD_CHARS = 80_000;
+    private static final int MAP_REDUCE_SEGMENT_CHARS = 40_000;
+    private static final String INTERPRETIVE_ANALYSIS_PROMPT = """
+            이 질문은 문서 근거를 종합하는 해석형 질문입니다.
+            문서에 결론이나 분류명이 직접 명시되지 않아도 행동, 대화, 감정 표현과 사건을 근거로 합리적으로 추론하세요.
+            답변에서는 문서에서 확인되는 사실과 추론을 구분하고, 주요 결론, 핵심 근거, 가능한 대안 해석, 확신도(낮음/중간/높음)를 제시하세요.
+            문서에 분류명이 없다는 이유만으로 답변을 거부하지 말고, 관련 근거 자체가 없을 때만 확인할 수 없다고 답하세요.
+            """;
+    private static final String DOCUMENT_SUMMARY_PROMPT = """
+            이 질문은 원본 문서 전체의 요약 또는 줄거리를 요구합니다.
+            문서 제목 metadata가 있으면 답변 첫 문장을 '[문서 제목] (파일: [원본 파일명])의 줄거리는 다음과 같습니다.' 형식으로 시작하세요.
+            제목만 있으면 제목만, 파일명만 있으면 파일명만 자연스럽게 언급하고, 둘 다 없으면 일반적인 도입 문장으로 시작하세요. 제목이나 파일명을 추측하지 마세요.
+            문서의 시작, 주요 전개, 결말을 균형 있게 포함하고 일부 장면이나 문서 안에서 언급되는 영화, 책, 이야기를 원본 전체의 줄거리로 오인하지 마세요.
+            원문에 명시되지 않은 장소, 진단, 관계를 추가하거나 원문보다 강하게 단정하지 마세요. 예를 들어 요양 또는 치료 시설을 근거 없이 병원으로 바꾸지 마세요.
+            전체 근거가 제공되지 않은 경우에는 부분 요약임을 명시하세요.
+            """;
+    private static final List<String> DOCUMENT_SUMMARY_METADATA_KEYS = List.of(
+            "documentSummary", "abstract", "executiveSummary");
+    private static final List<String> KEY_POINTS_METADATA_KEYS = List.of(
+            "keyPoints", "keyContent", "highlights", "documentOutline", "outline");
 
     private final AiProviderRegistry providerRegistry;
     private final RagPipelineService ragPipelineService;
@@ -125,6 +149,10 @@ public class ChatController {
     private final ObjectMapper objectMapper;
     private final RagRetrievalPolicyStore ragRetrievalPolicyStore;
     private final RagRetrievalPolicyUsageStore ragRetrievalPolicyUsageStore;
+    private final AiModelUsageStore modelUsageStore;
+    private final RagQueryIntentClassifier ragQueryIntentClassifier = RagQueryIntentClassifier.rules();
+    private final RagDocumentOverviewAssembler documentOverviewAssembler = new RagDocumentOverviewAssembler();
+    private final RagDocumentMapReduceOverview documentMapReduceOverview = new RagDocumentMapReduceOverview();
 
     public ChatController(AiProviderRegistry providerRegistry, RagPipelineService ragPipelineService) {
         this(providerRegistry, ragPipelineService, RagContextBuilder.defaults());
@@ -255,6 +283,28 @@ public class ChatController {
             RagPipelineOptions ragPipelineOptions,
             RagRetrievalPolicyStore ragRetrievalPolicyStore,
             RagRetrievalPolicyUsageStore ragRetrievalPolicyUsageStore) {
+        this(providerRegistry, ragPipelineService, ragChatRetrievalService, ragContextBuilder, allowClientDebug,
+                chatMemoryStore, chatMemoryEnabled, conversationChatService, objectMapper,
+                ragContextCandidateMultiplier, ragContextMaxCandidates, ragPipelineOptions,
+                ragRetrievalPolicyStore, ragRetrievalPolicyUsageStore, AiModelUsageStore.noop());
+    }
+
+    public ChatController(
+            AiProviderRegistry providerRegistry,
+            RagPipelineService ragPipelineService,
+            RagChatRetrievalService ragChatRetrievalService,
+            RagContextBuilder ragContextBuilder,
+            boolean allowClientDebug,
+            ChatMemoryStore chatMemoryStore,
+            boolean chatMemoryEnabled,
+            ConversationChatService conversationChatService,
+            ObjectMapper objectMapper,
+            int ragContextCandidateMultiplier,
+            int ragContextMaxCandidates,
+            RagPipelineOptions ragPipelineOptions,
+            RagRetrievalPolicyStore ragRetrievalPolicyStore,
+            RagRetrievalPolicyUsageStore ragRetrievalPolicyUsageStore,
+            AiModelUsageStore modelUsageStore) {
         this.providerRegistry = Objects.requireNonNull(providerRegistry, "providerRegistry");
         this.ragPipelineService = Objects.requireNonNull(ragPipelineService, "ragPipelineService");
         this.ragChatRetrievalService = Objects.requireNonNull(ragChatRetrievalService, "ragChatRetrievalService");
@@ -275,6 +325,7 @@ public class ChatController {
         this.ragPipelineOptions = ragPipelineOptions == null ? RagPipelineOptions.defaults() : ragPipelineOptions;
         this.ragRetrievalPolicyStore = ragRetrievalPolicyStore;
         this.ragRetrievalPolicyUsageStore = ragRetrievalPolicyUsageStore;
+        this.modelUsageStore = modelUsageStore == null ? AiModelUsageStore.noop() : modelUsageStore;
     }
 
     public ChatController(
@@ -434,10 +485,15 @@ public class ChatController {
     private ResponseEntity<ApiResponse<ChatResponseDto>> chatWithRagInternal(
             ChatRagRequestDto request,
             Principal principal) {
+        long requestStartedNanos = System.nanoTime();
         ChatRequestDto chat = request.chat();
         ObjectScope objectScope = resolveObjectScope(request.objectType(), request.objectId());
         RagRetrievalPolicyDto appliedPolicy = resolveRetrievalPolicy(request, objectScope);
         request = applyRetrievalPolicy(request, appliedPolicy);
+        String ragQuery = request.ragQuery();
+        RagQueryIntentClassifier.Classification queryIntent = ragQueryIntentClassifier.classify(
+                ragQuery == null || ragQuery.isBlank() ? lastUserMessage(chat) : ragQuery);
+        request = applyIntentRetrievalPolicy(request, queryIntent);
         int ragTopK = effectiveTopK(request);
         int resultTopK = effectiveResultTopK(request, ragTopK);
         double minScore = effectiveMinScore(request);
@@ -445,26 +501,58 @@ public class ChatController {
         String objectId = objectScope.objectId();
 
         List<RagSearchResult> ragResults;
-        String ragQuery = request.ragQuery();
         boolean hasFilter = objectScope.hasFilter();
+        String retrievalMode = "SEMANTIC_SEARCH";
         RagChatRetrievalService.RetrievalDebug retrievalDebug = RagChatRetrievalService.RetrievalDebug.disabled();
         long retrievalStartedNanos = System.nanoTime();
 
         boolean objectCandidateResults = false;
         boolean skipFinalResultLimit = false;
-        if (ragQuery == null || ragQuery.isBlank()) {
+        RagDocumentOverviewAssembler.Assembly documentOverview = null;
+        boolean implicitOverviewRequest = (ragQuery == null || ragQuery.isBlank())
+                && request.ragTopK() == null
+                && request.topK() == null
+                && request.retrievalStrategy() == null
+                && request.retrievalOptions() == null;
+        boolean overviewRequested = hasFilter
+                && usesOverviewRetrieval(queryIntent.intent())
+                && ((ragQuery != null && !ragQuery.isBlank()) || implicitOverviewRequest);
+        if (overviewRequested) {
+            List<RagSearchResult> objectResults = ragPipelineService.listByObject(
+                    objectType,
+                    objectId,
+                    contextExpansionCandidateLimit(Math.max(ragTopK, resultTopK)));
+            OverviewSelection overview = metadataOverviewResults(objectResults, queryIntent);
+            if (overview.metadataUsed()) {
+                ragResults = overview.results();
+            } else {
+                ObjectChunks completeChunks = completeOverviewChunks(
+                        objectType, objectId, overview.results());
+                OverviewSelection completeOverview = metadataOverviewResults(
+                        completeChunks.results(), queryIntent);
+                if (completeOverview.metadataUsed()) {
+                    overview = completeOverview;
+                    ragResults = completeOverview.results();
+                } else {
+                    ragResults = completeChunks.results();
+                    documentOverview = documentOverviewAssembler.assemble(
+                            ragResults,
+                            MAX_WHOLE_DOCUMENT_CONTEXT_CHARS,
+                            completeChunks.complete());
+                }
+            }
+            objectCandidateResults = true;
+            skipFinalResultLimit = true;
+            retrievalMode = overview.metadataUsed()
+                    ? "METADATA_OVERVIEW"
+                    : documentOverview.fullCoverage() ? "WHOLE_DOCUMENT_CONTEXT" : "DOCUMENT_COVERAGE_SAMPLES";
+        } else if (ragQuery == null || ragQuery.isBlank()) {
             if (!hasFilter) {
                 throw new IllegalArgumentException("ragQuery가 없으면 objectType 또는 objectId를 제공해야 합니다");
             }
             ragResults = ragPipelineService.listByObject(objectType, objectId, ragTopK);
             objectCandidateResults = true;
-        } else if (hasFilter && isWholeDocumentSummaryQuery(ragQuery, chat)) {
-            ragResults = ragPipelineService.listByObject(
-                    objectType,
-                    objectId,
-                    contextExpansionCandidateLimit(Math.max(ragTopK, resultTopK)));
-            objectCandidateResults = true;
-            skipFinalResultLimit = true;
+            retrievalMode = "DOCUMENT_CHUNKS";
         } else {
             String resolvedQuery = resolveRagQuery(request);
             RagChatRetrievalService.RetrievalResult retrieval = ragChatRetrievalService.retrieve(
@@ -491,6 +579,7 @@ public class ChatController {
             extraMetadata.put("ragReferences", List.of());
             extraMetadata.put("ragSkippedChat", true);
             extraMetadata.put("ragSkipReason", RAG_SKIP_REASON_NO_RESULTS);
+            putQueryIntentMetadata(extraMetadata, queryIntent, retrievalMode, ragTopK, minScore);
             if (exposeDiagnostics && retrievalDebug.enabled()) {
                 extraMetadata.put("retrieval", retrievalDebug.toMetadata());
             }
@@ -512,11 +601,27 @@ public class ChatController {
                 objectId,
                 resultTopK,
                 objectCandidateResults);
-        RagContextBuilder.BuildResult contextResult = ragContextBuilder.buildWithDiagnostics(ragResults, expansionCandidates);
+        RagContextBuilder.BuildResult contextResult = documentOverview == null
+                ? ragContextBuilder.buildWithDiagnostics(ragResults, expansionCandidates)
+                : new RagContextBuilder.BuildResult(
+                        documentOverview.context(),
+                        null,
+                        documentOverview.references());
         String context = contextResult.context();
+        long overviewReductionStartedNanos = System.nanoTime();
+        RagDocumentMapReduceOverview.Reduction overviewReduction = reduceLargeDocumentOverview(
+                chat,
+                objectType,
+                objectId,
+                queryIntent,
+                context);
+        long overviewReductionElapsedMs = elapsedMillis(overviewReductionStartedNanos);
+        context = overviewReduction.context();
 
         List<ChatMessageDto> augmentedMessages = new ArrayList<>();
-        augmentedMessages.add(new ChatMessageDto("system", combineSystemPrompts(context, chat.systemPrompt())));
+        augmentedMessages.add(new ChatMessageDto(
+                "system",
+                combineRagSystemPrompts(context, chat.systemPrompt(), queryIntent)));
         ChatMemoryContext memory = resolveMemory(chat, principal);
         augmentedMessages.addAll(toDtoMessages(memory.history()));
         augmentedMessages.addAll(chat.messages());
@@ -533,7 +638,9 @@ public class ChatController {
                 chat.stopSequences(),
                 chat.memory());
 
+        long generationStartedNanos = System.nanoTime();
         ChatResponse response = executeChat(chatPort(chat.provider()), toDomainChatRequest(augmented));
+        long generationElapsedMs = elapsedMillis(generationStartedNanos);
         int memoryMessageCount = appendMemory(memory, chat.messages(), response);
         appendConversation(principal, memory, chat.messages().stream().map(this::toDomainMessage).toList(), response);
         Map<String, Object> extraMetadata = memoryMetadata(memory, memoryMessageCount);
@@ -543,6 +650,29 @@ public class ChatController {
         }
         if (exposeDiagnostics && retrievalDebug.enabled()) {
             extraMetadata.put("retrieval", retrievalDebug.toMetadata());
+        }
+        putQueryIntentMetadata(extraMetadata, queryIntent, retrievalMode, ragTopK, minScore);
+        if (documentOverview != null) {
+            extraMetadata.put("overviewSourceChunkCount", documentOverview.sourceChunkCount());
+            extraMetadata.put("overviewCoverageStatus", documentOverview.fullCoverage() ? "FULL" : "PARTIAL");
+        }
+        if (overviewReduction.applied()) {
+            extraMetadata.put("overviewReduction", "MAP_REDUCE");
+            extraMetadata.put("overviewReductionSegmentCount", overviewReduction.segmentCount());
+            extraMetadata.put("overviewReductionCacheHit", overviewReduction.cacheHit());
+        }
+        long totalElapsedMs = elapsedMillis(requestStartedNanos);
+        extraMetadata.put("ragTiming", Map.of(
+                "retrievalMs", retrievalElapsedMs,
+                "overviewReductionMs", overviewReductionElapsedMs,
+                "generationMs", generationElapsedMs,
+                "totalMs", totalElapsedMs));
+        if (totalElapsedMs >= 10_000L) {
+            log.info("Slow RAG chat: intent={}, mode={}, results={}, retrievalMs={}, overviewReductionMs={}, "
+                            + "generationMs={}, totalMs={}, overviewCacheHit={}",
+                    queryIntent.intent(), retrievalMode, ragResults.size(), retrievalElapsedMs,
+                    overviewReductionElapsedMs, generationElapsedMs, totalElapsedMs,
+                    overviewReduction.cacheHit());
         }
         putRetrievalPolicyMetadata(extraMetadata, appliedPolicy);
         return ResponseEntity.ok(ApiResponse.ok(toDto(
@@ -697,10 +827,62 @@ public class ChatController {
 
     private ChatResponse executeChat(ChatPort port, ChatRequest request) {
         try {
-            return port.chat(request);
+            ChatResponse response = port.chat(request);
+            AiModelUsageStore.UsageEstimate estimate = modelUsageStore.record(
+                    response.typedMetadata(), response.model());
+            Map<String, Object> metadata = new LinkedHashMap<>(response.metadata());
+            metadata.put("estimatedCost", estimate.toMetadata());
+            return new ChatResponse(response.messages(), response.model(), metadata);
         } catch (IllegalArgumentException ex) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
         }
+    }
+
+    private long elapsedMillis(long startedNanos) {
+        return Math.max(0L, (System.nanoTime() - startedNanos) / 1_000_000L);
+    }
+
+    private RagDocumentMapReduceOverview.Reduction reduceLargeDocumentOverview(
+            ChatRequestDto chat,
+            String objectType,
+            String objectId,
+            RagQueryIntentClassifier.Classification classification,
+            String context) {
+        if (!usesOverviewRetrieval(classification.intent())) {
+            return RagDocumentMapReduceOverview.Reduction.notApplied(context);
+        }
+        try {
+            ChatPort port = chatPort(chat.provider());
+            return documentMapReduceOverview.reduce(
+                    objectType,
+                    objectId,
+                    chat.provider(),
+                    chat.model(),
+                    context,
+                    MAP_REDUCE_OVERVIEW_THRESHOLD_CHARS,
+                    MAP_REDUCE_SEGMENT_CHARS,
+                    prompt -> segmentSummary(port, chat, prompt));
+        } catch (RuntimeException ex) {
+            log.warn("Large document map-reduce overview failed; using the original context: {}", ex.getMessage());
+            return RagDocumentMapReduceOverview.Reduction.notApplied(context);
+        }
+    }
+
+    private String segmentSummary(ChatPort port, ChatRequestDto chat, String prompt) {
+        ChatRequest.Builder request = ChatRequest.builder()
+                .messages(List.of(ChatMessage.user(prompt)))
+                .temperature(0.1d)
+                .maxOutputTokens(1_200);
+        if (chat.model() != null) {
+            request.model(chat.model());
+        }
+        ChatResponse response = executeChat(port, request.build());
+        return response.messages().stream()
+                .filter(message -> message.role() == ChatMessageRole.ASSISTANT)
+                .map(ChatMessage::content)
+                .filter(content -> content != null && !content.isBlank())
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("No assistant segment summary was returned"));
     }
 
     private java.util.stream.Stream<ChatStreamEvent> openStream(ChatPort port, ChatRequest request) {
@@ -766,6 +948,46 @@ public class ChatController {
                 request.debug(),
                 effectiveStrategy,
                 effectiveOptions);
+    }
+
+    private ChatRagRequestDto applyIntentRetrievalPolicy(
+            ChatRagRequestDto request,
+            RagQueryIntentClassifier.Classification classification) {
+        if (classification.intent() != RagQueryIntentClassifier.Intent.INTERPRETIVE_ANALYSIS) {
+            return request;
+        }
+        int topK = Math.max(effectiveTopK(request), INTERPRETIVE_MIN_TOP_K);
+        double minScore = Math.min(effectiveMinScore(request), INTERPRETIVE_MAX_MIN_SCORE);
+        ChatRagRetrievalOptionsDto options = request.retrievalOptions();
+        ChatRagRetrievalOptionsDto adjustedOptions = new ChatRagRetrievalOptionsDto(
+                atLeast(options == null ? null : options.structureTopK(), INTERPRETIVE_MIN_TOP_K),
+                atLeast(options == null ? null : options.ideaBlockTopK(), INTERPRETIVE_MIN_TOP_K),
+                atLeast(options == null ? null : options.finalTopK(), INTERPRETIVE_MIN_TOP_K),
+                options == null || options.minScore() == null
+                        ? minScore
+                        : Math.min(options.minScore(), minScore),
+                options == null ? null : options.dedupe(),
+                options == null ? null : options.includeDebugChunks(),
+                options == null ? null : options.distilledScoreBoost(),
+                options == null ? null : options.queryExpansionEnabled());
+        return new ChatRagRequestDto(
+                request.chat(),
+                request.ragQuery(),
+                request.ragTopK(),
+                request.objectType(),
+                request.objectId(),
+                request.embeddingProfileId(),
+                request.embeddingProvider(),
+                request.embeddingModel(),
+                topK,
+                minScore,
+                request.debug(),
+                request.retrievalStrategy(),
+                adjustedOptions);
+    }
+
+    private Integer atLeast(Integer value, int minimum) {
+        return value == null ? minimum : Math.max(value, minimum);
     }
 
     private void putRetrievalPolicyMetadata(Map<String, Object> metadata, RagRetrievalPolicyDto policy) {
@@ -849,6 +1071,20 @@ public class ChatController {
         return first + "\n\n" + second;
     }
 
+    private String combineRagSystemPrompts(
+            String context,
+            String clientPrompt,
+            RagQueryIntentClassifier.Classification classification) {
+        String prompt = combineSystemPrompts(context, clientPrompt);
+        if (classification.intent() == RagQueryIntentClassifier.Intent.INTERPRETIVE_ANALYSIS) {
+            return combineSystemPrompts(prompt, INTERPRETIVE_ANALYSIS_PROMPT);
+        }
+        if (usesOverviewRetrieval(classification.intent())) {
+            return combineSystemPrompts(prompt, DOCUMENT_SUMMARY_PROMPT);
+        }
+        return prompt;
+    }
+
     private List<ChatMessage> toDomainMessages(ChatRequestDto request) {
         return toDomainMessages(request, List.of());
     }
@@ -922,8 +1158,15 @@ public class ChatController {
             documentId = result.documentId();
         }
         put(reference, "documentId", documentId);
-        String sourceName = firstText(metadata, "sourceName", "title", "filename", "fileName", "name");
+        String originalFileName = firstText(metadata,
+                "sourceFileName", "filename", "fileName", "name", "sourceName");
+        String title = firstText(metadata, "documentTitle", "title");
+        String sourceName = originalFileName == null ? title : originalFileName;
         put(reference, "sourceName", sourceName == null ? documentId : sourceName);
+        put(reference, "originalFileName", originalFileName);
+        put(reference, "sourceFileName", originalFileName);
+        put(reference, "title", title);
+        put(reference, "citationLabel", "근거 " + index);
         String chunkId = firstText(metadata, VectorRecord.KEY_CHUNK_ID, "chunkId");
         put(reference, "chunkId", chunkId == null ? documentId : chunkId);
         put(reference, "chunkOrder", firstInteger(metadata, "chunkOrder", VectorRecord.KEY_CHUNK_INDEX));
@@ -943,6 +1186,7 @@ public class ChatController {
         }
         put(reference, "section", firstText(metadata, "section", VectorRecord.KEY_HEADING_PATH, "headingPath"));
         put(reference, "heading", firstText(metadata, "heading", VectorRecord.KEY_HEADING_PATH, "headingPath"));
+        put(reference, "sourceRef", firstText(metadata, "sourceRef"));
         return Map.copyOf(reference);
     }
 
@@ -956,12 +1200,12 @@ public class ChatController {
         for (String key : keys) {
             Object value = metadata.get(key);
             if (value instanceof String text && !text.isBlank()) {
-                return text.trim();
+                return java.text.Normalizer.normalize(text.trim(), java.text.Normalizer.Form.NFC);
             }
             if (value != null && !(value instanceof String)) {
                 String text = value.toString();
                 if (!text.isBlank()) {
-                    return text.trim();
+                    return java.text.Normalizer.normalize(text.trim(), java.text.Normalizer.Form.NFC);
                 }
             }
         }
@@ -1045,30 +1289,147 @@ public class ChatController {
         throw new IllegalArgumentException("RAG query is empty");
     }
 
-    private boolean isWholeDocumentSummaryQuery(String ragQuery, ChatRequestDto chat) {
-        String query = normalizeText(ragQuery);
-        if (query == null && chat != null && chat.messages() != null) {
-            for (int i = chat.messages().size() - 1; i >= 0; i--) {
-                ChatMessageDto message = chat.messages().get(i);
-                if ("user".equalsIgnoreCase(message.role())) {
-                    query = normalizeText(message.content());
-                    break;
+    private String lastUserMessage(ChatRequestDto chat) {
+        if (chat == null || chat.messages() == null) {
+            return null;
+        }
+        for (int i = chat.messages().size() - 1; i >= 0; i--) {
+            ChatMessageDto message = chat.messages().get(i);
+            if ("user".equalsIgnoreCase(message.role())) {
+                return message.content();
+            }
+        }
+        return null;
+    }
+
+    private OverviewSelection metadataOverviewResults(
+            List<RagSearchResult> objectResults,
+            RagQueryIntentClassifier.Classification classification) {
+        if (objectResults == null || objectResults.isEmpty()) {
+            return new OverviewSelection(List.of(), false);
+        }
+        List<String> keys = new ArrayList<>();
+        if (classification.intent() == RagQueryIntentClassifier.Intent.KEY_POINTS) {
+            keys.addAll(KEY_POINTS_METADATA_KEYS);
+            keys.addAll(DOCUMENT_SUMMARY_METADATA_KEYS);
+        } else {
+            keys.addAll(DOCUMENT_SUMMARY_METADATA_KEYS);
+            keys.addAll(KEY_POINTS_METADATA_KEYS);
+        }
+        for (RagSearchResult result : objectResults) {
+            for (String key : keys) {
+                String content = metadataText(metadataValue(result.metadata(), key));
+                if (content != null) {
+                    Map<String, Object> metadata = new LinkedHashMap<>(result.metadata());
+                    metadata.put("overviewMetadataKey", key);
+                    metadata.put("overviewMetadataUsed", true);
+                    return new OverviewSelection(
+                            List.of(new RagSearchResult(
+                                    result.documentId() + ":" + key,
+                                    content,
+                                    metadata,
+                                    1.0d)),
+                            true);
                 }
             }
         }
-        if (query == null) {
-            return false;
+        return new OverviewSelection(objectResults, false);
+    }
+
+    private ObjectChunks completeOverviewChunks(
+            String objectType,
+            String objectId,
+            List<RagSearchResult> initialResults) {
+        List<RagSearchResult> initial = initialResults == null ? List.of() : initialResults;
+        long total = ragPipelineService.countByObject(objectType, objectId);
+        if (total <= initial.size() || total <= 0L) {
+            return new ObjectChunks(initial, true);
         }
-        String normalized = query.toLowerCase(Locale.ROOT);
-        return normalized.contains("줄거리")
-                || normalized.contains("전체 내용")
-                || normalized.contains("전체내용")
-                || normalized.contains("문서 요약")
-                || normalized.contains("요약해")
-                || normalized.contains("요약해줘")
-                || normalized.contains("요약하여")
-                || normalized.contains("plot summary")
-                || normalized.contains("synopsis");
+        int requested = (int) Math.min(total, MAX_OVERVIEW_SOURCE_CHUNKS);
+        int pageSize = Math.max(1, Math.min(ragPipelineOptions.maxListLimit(), requested));
+        List<RagSearchResult> all = new ArrayList<>(requested);
+        for (int offset = 0; offset < requested; offset += pageSize) {
+            int size = Math.min(pageSize, requested - offset);
+            List<RagSearchResult> page = ragPipelineService.listByObject(objectType, objectId, offset, size);
+            if (page == null || page.isEmpty()) {
+                break;
+            }
+            all.addAll(page);
+            if (page.size() < size) {
+                break;
+            }
+        }
+        if (all.isEmpty()) {
+            return new ObjectChunks(initial, false);
+        }
+        return new ObjectChunks(List.copyOf(all), all.size() >= total);
+    }
+
+    private boolean usesOverviewRetrieval(RagQueryIntentClassifier.Intent intent) {
+        return intent == RagQueryIntentClassifier.Intent.DOCUMENT_SUMMARY
+                || intent == RagQueryIntentClassifier.Intent.KEY_POINTS;
+    }
+
+    private Object metadataValue(Map<String, Object> metadata, String key) {
+        Object direct = metadata.get(key);
+        if (direct != null) {
+            return direct;
+        }
+        for (String containerKey : List.of("documentMetadata", "documentOverview", "overview")) {
+            Object container = metadata.get(containerKey);
+            if (container instanceof Map<?, ?> values && values.get(key) != null) {
+                return values.get(key);
+            }
+        }
+        return null;
+    }
+
+    private String metadataText(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof String text) {
+            return normalizeText(text);
+        }
+        if (value instanceof Iterable<?> values) {
+            List<String> lines = new ArrayList<>();
+            for (Object item : values) {
+                String text = normalizeText(Objects.toString(item, null));
+                if (text != null) {
+                    lines.add("- " + text);
+                }
+            }
+            return lines.isEmpty() ? null : String.join("\n", lines);
+        }
+        try {
+            return normalizeText(objectMapper.writeValueAsString(value));
+        } catch (IOException ex) {
+            return normalizeText(Objects.toString(value, null));
+        }
+    }
+
+    private void putQueryIntentMetadata(
+            Map<String, Object> metadata,
+            RagQueryIntentClassifier.Classification classification,
+            String retrievalMode,
+            int retrievalTopK,
+            double retrievalMinScore) {
+        metadata.put("ragQueryIntent", classification.intent().name());
+        metadata.put("ragQueryIntentConfidence", classification.confidence());
+        metadata.put("ragQueryIntentReason", classification.reason());
+        metadata.put("ragRetrievalMode", retrievalMode);
+        metadata.put("ragRetrievalTopK", retrievalTopK);
+        metadata.put("ragRetrievalMinScore", retrievalMinScore);
+        if (classification.intent() == RagQueryIntentClassifier.Intent.INTERPRETIVE_ANALYSIS) {
+            metadata.put("answerType", "EVIDENCE_BASED_INFERENCE");
+            metadata.put("ragInferenceEnabled", true);
+        }
+    }
+
+    private record OverviewSelection(List<RagSearchResult> results, boolean metadataUsed) {
+    }
+
+    private record ObjectChunks(List<RagSearchResult> results, boolean complete) {
     }
 
     private List<RagSearchResult> contextExpansionCandidates(
@@ -1211,6 +1572,9 @@ public class ChatController {
                     last == null ? Map.of() : last.metadata().toMap());
             appendMemory(memory, toDtoMessages(requestMessages), response);
             appendConversation(principal, memory, requestMessages, response);
+        }
+        if (!streamFailed && last != null) {
+            modelUsageStore.record(last.metadata(), last.model());
         }
     }
 

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/InMemoryAiModelUsageStore.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/InMemoryAiModelUsageStore.java
@@ -1,0 +1,168 @@
+package studio.one.platform.ai.web.controller;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import studio.one.platform.ai.autoconfigure.AiModelUsageProperties;
+import studio.one.platform.ai.core.chat.ChatResponseMetadata;
+import studio.one.platform.ai.core.chat.TokenUsage;
+
+public final class InMemoryAiModelUsageStore implements AiModelUsageStore {
+
+    private static final BigDecimal ONE_MILLION = BigDecimal.valueOf(1_000_000L);
+
+    private final AiModelUsageProperties properties;
+    private final Map<ModelKey, MutableUsage> usage = new LinkedHashMap<>();
+
+    public InMemoryAiModelUsageStore(AiModelUsageProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public synchronized UsageEstimate record(ChatResponseMetadata metadata, String fallbackModel) {
+        if (!properties.isEnabled() || metadata == null) {
+            return UsageEstimate.unavailable();
+        }
+        String provider = normalize(metadata.provider(), "unknown");
+        String model = normalize(metadata.resolvedModel(), normalize(fallbackModel, "unknown"));
+        TokenUsage tokens = metadata.tokenUsage();
+        long inputTokens = value(tokens.inputTokens());
+        long outputTokens = value(tokens.outputTokens());
+        long totalTokens = value(tokens.totalTokens());
+        boolean tokenUsageAvailable = !tokens.toMap().isEmpty();
+        PricingMatch pricing = pricing(provider, model);
+        BigDecimal cost = tokenUsageAvailable && pricing != null
+                ? estimate(pricing.pricing(), inputTokens, outputTokens)
+                : null;
+
+        Instant now = Instant.now();
+        MutableUsage aggregate = usage.computeIfAbsent(new ModelKey(provider, model), ignored -> new MutableUsage(now));
+        aggregate.record(inputTokens, outputTokens, totalTokens, metadata.latencyMs(), cost, now);
+        return pricing == null || cost == null
+                ? new UsageEstimate(currency(), null, false, null)
+                : new UsageEstimate(currency(), cost, true, pricing.key());
+    }
+
+    @Override
+    public synchronized List<ModelUsageSummary> summaries(String provider, String model) {
+        String providerFilter = normalize(provider, null);
+        String modelFilter = normalize(model, null);
+        List<ModelUsageSummary> results = new ArrayList<>();
+        usage.forEach((key, value) -> {
+            if (matches(key.provider(), providerFilter) && matches(key.model(), modelFilter)) {
+                results.add(value.snapshot(key, currency()));
+            }
+        });
+        results.sort(Comparator.comparing(ModelUsageSummary::estimatedCost).reversed()
+                .thenComparing(ModelUsageSummary::model));
+        return List.copyOf(results);
+    }
+
+    private PricingMatch pricing(String provider, String model) {
+        String qualifiedKey = provider + "/" + model;
+        AiModelUsageProperties.ModelPricing qualified = findPricing(qualifiedKey);
+        if (qualified != null) {
+            return new PricingMatch(qualifiedKey, qualified);
+        }
+        AiModelUsageProperties.ModelPricing modelPricing = findPricing(model);
+        return modelPricing == null ? null : new PricingMatch(model, modelPricing);
+    }
+
+    private AiModelUsageProperties.ModelPricing findPricing(String key) {
+        AiModelUsageProperties.ModelPricing direct = properties.getPricing().get(key);
+        if (direct != null) {
+            return direct;
+        }
+        return properties.getPricing().entrySet().stream()
+                .filter(entry -> entry.getKey().equalsIgnoreCase(key))
+                .map(Map.Entry::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private BigDecimal estimate(AiModelUsageProperties.ModelPricing pricing, long inputTokens, long outputTokens) {
+        boolean highContext = pricing.getHighContextThresholdTokens() != null
+                && inputTokens > pricing.getHighContextThresholdTokens();
+        BigDecimal inputRate = highContext && pricing.getHighContextInputPerMillionTokens() != null
+                ? pricing.getHighContextInputPerMillionTokens()
+                : pricing.getInputPerMillionTokens();
+        BigDecimal outputRate = highContext && pricing.getHighContextOutputPerMillionTokens() != null
+                ? pricing.getHighContextOutputPerMillionTokens()
+                : pricing.getOutputPerMillionTokens();
+        if (inputRate == null || outputRate == null) {
+            return null;
+        }
+        BigDecimal inputCost = BigDecimal.valueOf(inputTokens).multiply(inputRate).divide(ONE_MILLION, 12,
+                RoundingMode.HALF_UP);
+        BigDecimal outputCost = BigDecimal.valueOf(outputTokens).multiply(outputRate).divide(ONE_MILLION, 12,
+                RoundingMode.HALF_UP);
+        return inputCost.add(outputCost).setScale(12, RoundingMode.HALF_UP);
+    }
+
+    private String currency() {
+        return normalize(properties.getCurrency(), "USD").toUpperCase(Locale.ROOT);
+    }
+
+    private boolean matches(String value, String filter) {
+        return filter == null || value.equalsIgnoreCase(filter);
+    }
+
+    private static long value(Integer value) {
+        return value == null ? 0L : value.longValue();
+    }
+
+    private static String normalize(String value, String fallback) {
+        return value == null || value.isBlank() ? fallback : value.trim();
+    }
+
+    private record ModelKey(String provider, String model) {
+    }
+
+    private record PricingMatch(String key, AiModelUsageProperties.ModelPricing pricing) {
+    }
+
+    private static final class MutableUsage {
+        private long requestCount;
+        private long pricedRequestCount;
+        private long inputTokens;
+        private long outputTokens;
+        private long totalTokens;
+        private long totalLatencyMs;
+        private BigDecimal estimatedCost = BigDecimal.ZERO;
+        private final Instant firstSeenAt;
+        private Instant lastSeenAt;
+
+        private MutableUsage(Instant firstSeenAt) {
+            this.firstSeenAt = firstSeenAt;
+            this.lastSeenAt = firstSeenAt;
+        }
+
+        private void record(long input, long output, long total, Long latencyMs, BigDecimal cost, Instant now) {
+            requestCount++;
+            inputTokens += input;
+            outputTokens += output;
+            totalTokens += total;
+            totalLatencyMs += latencyMs == null ? 0L : Math.max(0L, latencyMs);
+            if (cost != null) {
+                pricedRequestCount++;
+                estimatedCost = estimatedCost.add(cost);
+            }
+            lastSeenAt = now;
+        }
+
+        private ModelUsageSummary snapshot(ModelKey key, String currency) {
+            double averageLatency = requestCount == 0 ? 0.0d : (double) totalLatencyMs / requestCount;
+            return new ModelUsageSummary(
+                    key.provider(), key.model(), requestCount, pricedRequestCount,
+                    inputTokens, outputTokens, totalTokens, totalLatencyMs, averageLatency,
+                    currency, estimatedCost.setScale(12, RoundingMode.HALF_UP), firstSeenAt, lastSeenAt);
+        }
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagChatRetrievalService.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagChatRetrievalService.java
@@ -35,6 +35,7 @@ public class RagChatRetrievalService {
     private static final String VALUE_STRUCTURE_BASED = "structure-based";
     private static final String VALUE_BLOCKIFY = "blockify";
     private static final String VALUE_IDEA_BLOCK = "ideaBlock";
+    private static final int STRATEGY_SAMPLE_LIMIT = 32;
 
     private final RagPipelineService ragPipelineService;
     private final AiWebRagProperties.RetrievalProperties properties;
@@ -62,7 +63,9 @@ public class RagChatRetrievalService {
         RetrievalPlan plan = RetrievalPlan.from(request, properties, defaultTopK, defaultMinScore);
         MetadataFilter baseFilter = baseFilter(objectType, objectId);
         Strategy requestedStrategy = Strategy.from(plan.requestedStrategy());
-        Strategy resolvedStrategy = requestedStrategy == Strategy.AUTO ? Strategy.HYBRID : requestedStrategy;
+        RetrievalResolution resolution = resolveStrategy(request, requestedStrategy, objectType, objectId);
+        Strategy resolvedStrategy = resolution.strategy();
+        request = alignEmbeddingProfile(request, resolution.embeddingProfileId());
         if (resolvedStrategy == Strategy.DEFAULT) {
             List<RagSearchResult> results = search(request, resolvedQuery, defaultTopK, baseFilter,
                     defaultMinScore, requestedTopK, requestedMinScore(request));
@@ -95,6 +98,78 @@ public class RagChatRetrievalService {
                                 ? null : request.retrievalOptions().includeDebugChunks()))
                 : RetrievalDebug.disabled();
         return new RetrievalResult(merged, debug);
+    }
+
+    private RetrievalResolution resolveStrategy(
+            ChatRagRequestDto request,
+            Strategy requestedStrategy,
+            String objectType,
+            String objectId) {
+        boolean adaptive = requestedStrategy == Strategy.AUTO
+                || request.retrievalStrategy() == null
+                || request.retrievalStrategy().isBlank();
+        if (objectType == null || objectId == null) {
+            return new RetrievalResolution(
+                    requestedStrategy == Strategy.AUTO ? Strategy.HYBRID : requestedStrategy,
+                    null);
+        }
+        List<RagSearchResult> samples = ragPipelineService.listByObject(objectType, objectId, STRATEGY_SAMPLE_LIMIT);
+        boolean structure = false;
+        boolean ideaBlock = false;
+        String indexedEmbeddingProfileId = null;
+        boolean mixedEmbeddingProfiles = false;
+        List<RagSearchResult> availableSamples = samples == null ? List.of() : samples;
+        for (RagSearchResult sample : availableSamples) {
+            Map<String, Object> metadata = sample.metadata() == null ? Map.of() : sample.metadata();
+            String strategy = firstText(metadata, KEY_ACTUAL_CHUNKING_STRATEGY, ChunkMetadata.KEY_STRATEGY, "strategy");
+            String chunkType = firstText(metadata, ChunkMetadata.KEY_CHUNK_TYPE, "chunkType");
+            structure |= VALUE_STRUCTURE_BASED.equalsIgnoreCase(strategy);
+            ideaBlock |= VALUE_BLOCKIFY.equalsIgnoreCase(strategy) || VALUE_IDEA_BLOCK.equalsIgnoreCase(chunkType);
+            String profileId = firstText(metadata, "embeddingProfileId");
+            if (profileId != null && indexedEmbeddingProfileId == null) {
+                indexedEmbeddingProfileId = profileId;
+            } else if (profileId != null && !profileId.equalsIgnoreCase(indexedEmbeddingProfileId)) {
+                mixedEmbeddingProfiles = true;
+            }
+        }
+        String effectiveProfileId = mixedEmbeddingProfiles ? null : indexedEmbeddingProfileId;
+        if (!adaptive) {
+            return new RetrievalResolution(requestedStrategy, effectiveProfileId);
+        }
+        if (structure && !ideaBlock) {
+            return new RetrievalResolution(Strategy.STRUCTURE, effectiveProfileId);
+        }
+        if (ideaBlock && !structure) {
+            return new RetrievalResolution(Strategy.IDEA_BLOCK, effectiveProfileId);
+        }
+        if (!structure && !ideaBlock && !availableSamples.isEmpty()) {
+            return new RetrievalResolution(Strategy.DEFAULT, effectiveProfileId);
+        }
+        return new RetrievalResolution(Strategy.HYBRID, effectiveProfileId);
+    }
+
+    private ChatRagRequestDto alignEmbeddingProfile(ChatRagRequestDto request, String indexedProfileId) {
+        if (indexedProfileId == null || indexedProfileId.isBlank()
+                || indexedProfileId.equalsIgnoreCase(Objects.toString(request.embeddingProfileId(), ""))) {
+            return request;
+        }
+        return new ChatRagRequestDto(
+                request.chat(),
+                request.ragQuery(),
+                request.ragTopK(),
+                request.objectType(),
+                request.objectId(),
+                indexedProfileId,
+                null,
+                null,
+                request.topK(),
+                request.minScore(),
+                request.debug(),
+                request.retrievalStrategy(),
+                request.retrievalOptions());
+    }
+
+    private record RetrievalResolution(Strategy strategy, String embeddingProfileId) {
     }
 
     private List<LegResult> ideaBlockLegs(

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagContextBuilder.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagContextBuilder.java
@@ -238,7 +238,7 @@ public class RagContextBuilder {
             return Optional.empty();
         }
         int overhead = formatChunk(index,
-                new RagSearchResult(result.documentId(), "", result.metadata(), result.score()), false)
+                new RagSearchResult(result.documentId(), "", result.metadata(), result.score()))
                 .length();
         int contentBudget = remainingChars - overhead;
         if (contentBudget <= 0) {
@@ -250,7 +250,7 @@ public class RagContextBuilder {
                 packedContent,
                 result.metadata(),
                 result.score());
-        String packedText = formatChunk(index, packedResult, false);
+        String packedText = formatChunk(index, packedResult);
         if (packedText.length() > remainingChars) {
             return Optional.empty();
         }
@@ -258,14 +258,63 @@ public class RagContextBuilder {
     }
 
     private String formatChunk(int index, RagSearchResult result) {
-        return formatChunk(index, result, true);
-    }
-
-    private String formatChunk(int index, RagSearchResult result, boolean includeMetadata) {
         StringBuilder sb = new StringBuilder();
         sb.append("[").append(index).append("]");
-        sb.append("\n").append(result.content()).append("\n\n");
+        int headerLength = sb.length();
+        appendSourceMetadata(sb, result.metadata());
+        sb.append(sb.length() > headerLength ? "\n내용:\n" : "\n")
+                .append(result.content())
+                .append("\n\n");
         return sb.toString();
+    }
+
+    private void appendSourceMetadata(StringBuilder target, Map<String, Object> metadata) {
+        Map<String, Object> values = metadata == null ? Map.of() : metadata;
+        appendMetadataLine(target, "원본 파일", firstText(values,
+                "sourceFileName", "filename", "fileName", "name", "sourceName"));
+        appendMetadataLine(target, "문서 제목", firstText(values, "documentTitle", "title"));
+        Integer page = firstInteger(values, ChunkMetadata.KEY_PAGE, "pageNumber", "pageFrom");
+        if (page != null) {
+            appendMetadataLine(target, "페이지", page.toString());
+        }
+        appendMetadataLine(target, "섹션", firstText(values,
+                ChunkMetadata.KEY_SECTION, ChunkMetadata.KEY_HEADING_PATH, "heading"));
+        appendMetadataLine(target, "원문 위치", firstText(values,
+                ChunkMetadata.KEY_SOURCE_REF, "sourceRef"));
+    }
+
+    private void appendMetadataLine(StringBuilder target, String label, String value) {
+        String normalized = singleLine(value);
+        if (normalized != null) {
+            target.append("\n").append(label).append(": ").append(normalized);
+        }
+    }
+
+    private Integer firstInteger(Map<String, Object> metadata, String... keys) {
+        for (String key : keys) {
+            Object value = metadata.get(key);
+            if (value instanceof Number number) {
+                return number.intValue();
+            }
+            if (value != null) {
+                try {
+                    return Integer.valueOf(value.toString().trim());
+                } catch (NumberFormatException ignored) {
+                    // Try the next provenance key.
+                }
+            }
+        }
+        return null;
+    }
+
+    private String singleLine(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String normalized = java.text.Normalizer.normalize(value, java.text.Normalizer.Form.NFC)
+                .replaceAll("\\s+", " ")
+                .trim();
+        return normalized.length() <= 300 ? normalized : normalized.substring(0, 300);
     }
 
     private String excerpt(String content, int limit) {
@@ -414,7 +463,7 @@ public class RagContextBuilder {
 
     private String firstText(Map<String, Object> metadata, String... keys) {
         for (String key : keys) {
-            String value = text(metadata.get(key));
+            String value = singleLine(Objects.toString(metadata.get(key), null));
             if (hasText(value)) {
                 return value;
             }

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagDocumentMapReduceOverview.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagDocumentMapReduceOverview.java
@@ -1,0 +1,192 @@
+package studio.one.platform.ai.web.controller;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.function.Function;
+
+/**
+ * Reduces large ordered document contexts before the final overview answer.
+ */
+final class RagDocumentMapReduceOverview {
+
+    private static final int MAX_CACHE_ENTRIES = 64;
+    private static final int MAX_PARALLEL_SEGMENTS = 3;
+    private static final String REDUCED_HEADER_PREFIX = """
+            다음은 원본 문서를 처음부터 끝까지 나눈 구간별 요약입니다.
+            각 구간 요약은 원본 순서대로 배치되어 있습니다. 문서 안에서 언급되는 영화, 책, 이야기를 원본 문서 전체와 혼동하지 마세요.
+            """;
+
+    private final Map<String, String> cache = new LinkedHashMap<>(16, 0.75f, true) {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<String, String> eldest) {
+            return size() > MAX_CACHE_ENTRIES;
+        }
+    };
+
+    Reduction reduce(
+            String objectType,
+            String objectId,
+            String provider,
+            String model,
+            String context,
+            int thresholdChars,
+            int segmentChars,
+            Function<String, String> segmentSummarizer) {
+        Objects.requireNonNull(segmentSummarizer, "segmentSummarizer");
+        String source = Objects.toString(context, "");
+        if (source.length() <= thresholdChars) {
+            return Reduction.notApplied(source);
+        }
+
+        List<String> segments = split(source, segmentChars);
+        String cacheKey = fingerprint(objectType, objectId, provider, model, source);
+        synchronized (cache) {
+            String cached = cache.get(cacheKey);
+            if (cached != null) {
+                return new Reduction(cached, true, true, segments.size());
+            }
+        }
+
+        List<String> summaries = summarizeSegments(segments, segmentSummarizer);
+        StringBuilder reduced = new StringBuilder(reducedHeader(source));
+        for (int index = 0; index < segments.size(); index++) {
+            reduced.append("\n[구간 ")
+                    .append(index + 1)
+                    .append('/')
+                    .append(segments.size())
+                    .append("]\n")
+                    .append(summaries.get(index))
+                    .append('\n');
+        }
+        String result = reduced.toString();
+        synchronized (cache) {
+            cache.put(cacheKey, result);
+        }
+        return new Reduction(result, true, false, segments.size());
+    }
+
+    private String reducedHeader(String source) {
+        StringBuilder header = new StringBuilder(REDUCED_HEADER_PREFIX);
+        appendIdentityLine(header, source, "문서 제목:");
+        appendIdentityLine(header, source, "원본 파일:");
+        header.append("[1]\n");
+        return header.toString();
+    }
+
+    private void appendIdentityLine(StringBuilder target, String source, String prefix) {
+        for (String line : source.lines().limit(12).toList()) {
+            String normalized = line.strip();
+            if (normalized.startsWith(prefix) && normalized.length() > prefix.length()) {
+                target.append(normalized).append('\n');
+                return;
+            }
+        }
+    }
+
+    private List<String> summarizeSegments(
+            List<String> segments,
+            Function<String, String> segmentSummarizer) {
+        int parallelism = Math.min(MAX_PARALLEL_SEGMENTS, segments.size());
+        ExecutorService executor = Executors.newFixedThreadPool(parallelism);
+        try {
+            List<Future<String>> futures = new ArrayList<>(segments.size());
+            for (int index = 0; index < segments.size(); index++) {
+                int segmentIndex = index;
+                futures.add(executor.submit(() -> validatedSummary(segmentSummarizer.apply(
+                        mapPrompt(segments.get(segmentIndex), segmentIndex, segments.size())))));
+            }
+            List<String> summaries = new ArrayList<>(segments.size());
+            for (Future<String> future : futures) {
+                summaries.add(future.get());
+            }
+            return List.copyOf(summaries);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Document segment summary was interrupted", ex);
+        } catch (ExecutionException ex) {
+            Throwable cause = ex.getCause();
+            if (cause instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            throw new IllegalStateException("Document segment summary failed", cause);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private String validatedSummary(String value) {
+        String summary = Objects.toString(value, "").strip();
+        if (summary.isBlank()) {
+            throw new IllegalStateException("Document segment summary was blank");
+        }
+        return summary;
+    }
+
+    private List<String> split(String context, int maxChars) {
+        int limit = Math.max(1_000, maxChars);
+        List<String> segments = new ArrayList<>();
+        int start = 0;
+        while (start < context.length()) {
+            int end = Math.min(context.length(), start + limit);
+            if (end < context.length()) {
+                int paragraphBoundary = context.lastIndexOf('\n', end);
+                if (paragraphBoundary > start + limit / 2) {
+                    end = paragraphBoundary;
+                }
+            }
+            segments.add(context.substring(start, end).strip());
+            start = end;
+            while (start < context.length() && Character.isWhitespace(context.charAt(start))) {
+                start++;
+            }
+        }
+        return List.copyOf(segments);
+    }
+
+    private String mapPrompt(String segment, int index, int total) {
+        return """
+                아래 내용은 하나의 원본 문서 중 %d/%d 구간입니다.
+                이 구간의 핵심 주장, 개념, 절차 또는 사건과 인물의 변화, 다음 구간 이해에 필요한 연결 정보만 원문 근거대로 요약하세요.
+                문서 속 인물이 언급하거나 감상하는 영화, 책, 꿈, 회상은 원본 문서의 주 줄거리와 구분해서 표시하세요.
+                원문에 없는 장소, 진단, 관계, 동기를 추가하지 마세요. 1,200자 이내의 한국어로 작성하세요.
+
+                %s
+                """.formatted(index + 1, total, segment);
+    }
+
+    private String fingerprint(String objectType, String objectId, String provider, String model, String context) {
+        String value = String.join("\u0000",
+                Objects.toString(objectType, ""),
+                Objects.toString(objectId, ""),
+                Objects.toString(provider, ""),
+                Objects.toString(model, ""),
+                context);
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder encoded = new StringBuilder(digest.length * 2);
+            for (byte item : digest) {
+                encoded.append(String.format("%02x", item));
+            }
+            return encoded.toString();
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("SHA-256 is not available", ex);
+        }
+    }
+
+    record Reduction(String context, boolean applied, boolean cacheHit, int segmentCount) {
+
+        static Reduction notApplied(String context) {
+            return new Reduction(context, false, false, 0);
+        }
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagDocumentOverviewAssembler.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagDocumentOverviewAssembler.java
@@ -1,0 +1,171 @@
+package studio.one.platform.ai.web.controller;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import studio.one.platform.ai.core.rag.RagSearchResult;
+import studio.one.platform.chunking.core.ChunkMetadata;
+
+/**
+ * Reconstructs ordered object chunks for whole-document overview questions.
+ */
+final class RagDocumentOverviewAssembler {
+
+    private static final String HEADER_PREFIX = """
+            다음은 하나의 원본 문서를 처음부터 끝까지 순서대로 재구성한 내용입니다.
+            문서 안에서 언급되는 영화, 책, 이야기의 줄거리를 원본 문서 전체의 줄거리와 혼동하지 마세요.
+            """;
+
+    Assembly assemble(List<RagSearchResult> results, int maxChars, boolean allChunksLoaded) {
+        List<RagSearchResult> ordered = ordered(results);
+        if (ordered.isEmpty()) {
+            return new Assembly("", List.of(), 0, false);
+        }
+        Map<String, Object> firstMetadata = ordered.get(0).metadata();
+        String header = header(firstMetadata);
+        String reconstructed = reconstruct(ordered);
+        boolean fullCoverage = allChunksLoaded && header.length() + reconstructed.length() <= maxChars;
+        String body = fullCoverage
+                ? reconstructed
+                : representativeCoverage(ordered, Math.max(0, maxChars - header.length()));
+        String context = header + body;
+        Map<String, Object> metadata = new LinkedHashMap<>(firstMetadata == null ? Map.of() : firstMetadata);
+        int firstOrder = order(ordered.get(0), 0);
+        int lastOrder = order(ordered.get(ordered.size() - 1), ordered.size() - 1);
+        String overviewDocumentId = ordered.get(0).documentId() + ":whole-document";
+        metadata.put("overviewArtifactType", "WHOLE_DOCUMENT_CONTEXT");
+        metadata.put("overviewCoverageStatus", fullCoverage ? "FULL" : "PARTIAL");
+        metadata.put("overviewSourceChunkCount", ordered.size());
+        metadata.put(RagContextBuilder.KEY_CHUNK_ID, overviewDocumentId);
+        metadata.put(ChunkMetadata.KEY_SOURCE_REF, "chunks[" + firstOrder + ".." + lastOrder + "]");
+        RagSearchResult reference = new RagSearchResult(
+                overviewDocumentId,
+                "전체 문서 범위",
+                Map.copyOf(metadata),
+                1.0d);
+        return new Assembly(context, List.of(reference), ordered.size(), fullCoverage);
+    }
+
+    private String header(Map<String, Object> metadata) {
+        StringBuilder header = new StringBuilder(HEADER_PREFIX);
+        appendIdentity(header, "문서 제목", firstText(metadata, "documentTitle", "title"));
+        appendIdentity(header, "원본 파일", firstText(metadata,
+                "originalFileName", "sourceFileName", "filename", "fileName", "sourceName", "name"));
+        header.append("[1]\n");
+        return header.toString();
+    }
+
+    private void appendIdentity(StringBuilder target, String label, String value) {
+        if (value != null) {
+            target.append(label).append(": ").append(value).append('\n');
+        }
+    }
+
+    private String firstText(Map<String, Object> metadata, String... keys) {
+        Map<String, Object> values = metadata == null ? Map.of() : metadata;
+        for (String key : keys) {
+            Object value = values.get(key);
+            if (value != null && !value.toString().isBlank()) {
+                String normalized = value.toString().replaceAll("\\s+", " ").trim();
+                return normalized.length() <= 300 ? normalized : normalized.substring(0, 300);
+            }
+        }
+        return null;
+    }
+
+    private List<RagSearchResult> ordered(List<RagSearchResult> results) {
+        if (results == null || results.isEmpty()) {
+            return List.of();
+        }
+        List<RagSearchResult> ordered = new ArrayList<>(results);
+        ordered.sort(Comparator.comparingInt(result -> order(result, Integer.MAX_VALUE)));
+        return ordered;
+    }
+
+    private String reconstruct(List<RagSearchResult> ordered) {
+        StringBuilder text = new StringBuilder();
+        Integer previousEnd = null;
+        for (RagSearchResult result : ordered) {
+            String content = Objects.toString(result.content(), "");
+            Integer start = integer(result.metadata(), ChunkMetadata.KEY_START_OFFSET, "startOffset");
+            Integer end = integer(result.metadata(), ChunkMetadata.KEY_END_OFFSET, "endOffset");
+            int overlap = previousEnd != null && start != null ? Math.max(0, previousEnd - start) : 0;
+            if (overlap < content.length()) {
+                append(text, content.substring(overlap));
+            }
+            if (end != null) {
+                previousEnd = previousEnd == null ? end : Math.max(previousEnd, end);
+            }
+        }
+        return text.toString();
+    }
+
+    private String representativeCoverage(List<RagSearchResult> ordered, int budget) {
+        if (budget <= 0) {
+            return "";
+        }
+        int sampleCount = Math.min(ordered.size(), 48);
+        int excerptSize = Math.max(80, budget / Math.max(1, sampleCount) - 40);
+        StringBuilder text = new StringBuilder(Math.min(budget, 16_384));
+        for (int index = 0; index < sampleCount && text.length() < budget; index++) {
+            int sourceIndex = sampleCount == 1
+                    ? 0
+                    : (int) Math.round((double) index * (ordered.size() - 1) / (sampleCount - 1));
+            RagSearchResult result = ordered.get(sourceIndex);
+            String content = Objects.toString(result.content(), "").strip();
+            if (content.length() > excerptSize) {
+                content = content.substring(0, excerptSize);
+            }
+            String excerpt = "\n[chunk " + order(result, sourceIndex) + "] " + content;
+            if (text.length() + excerpt.length() > budget) {
+                excerpt = excerpt.substring(0, Math.max(0, budget - text.length()));
+            }
+            text.append(excerpt);
+        }
+        return text.toString();
+    }
+
+    private void append(StringBuilder target, String content) {
+        if (content == null || content.isBlank()) {
+            return;
+        }
+        if (!target.isEmpty() && !Character.isWhitespace(target.charAt(target.length() - 1))) {
+            target.append('\n');
+        }
+        target.append(content.strip());
+    }
+
+    private int order(RagSearchResult result, int fallback) {
+        Integer value = integer(result.metadata(), ChunkMetadata.KEY_CHUNK_ORDER, "chunkOrder", "chunkIndex");
+        return value == null ? fallback : value;
+    }
+
+    private Integer integer(Map<String, Object> metadata, String... keys) {
+        Map<String, Object> values = metadata == null ? Map.of() : metadata;
+        for (String key : keys) {
+            Object value = values.get(key);
+            if (value instanceof Number number) {
+                return number.intValue();
+            }
+            if (value != null) {
+                try {
+                    return Integer.valueOf(value.toString().trim());
+                } catch (NumberFormatException ignored) {
+                    // Try the next key.
+                }
+            }
+        }
+        return null;
+    }
+
+    record Assembly(
+            String context,
+            List<RagSearchResult> references,
+            int sourceChunkCount,
+            boolean fullCoverage) {
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagQueryIntentClassifier.java
+++ b/starter/studio-platform-starter-ai-web/src/main/java/studio/one/platform/ai/web/controller/RagQueryIntentClassifier.java
@@ -1,0 +1,61 @@
+package studio.one.platform.ai.web.controller;
+
+import java.util.Locale;
+
+/**
+ * Classifies an object-scoped RAG query without adding another model call.
+ */
+public interface RagQueryIntentClassifier {
+
+    Classification classify(String query);
+
+    static RagQueryIntentClassifier rules() {
+        return new RuleBasedRagQueryIntentClassifier();
+    }
+
+    enum Intent {
+        CONTENT_QA,
+        DOCUMENT_SUMMARY,
+        KEY_POINTS,
+        INTERPRETIVE_ANALYSIS
+    }
+
+    record Classification(Intent intent, double confidence, String reason) {
+    }
+}
+
+final class RuleBasedRagQueryIntentClassifier implements RagQueryIntentClassifier {
+
+    @Override
+    public Classification classify(String query) {
+        String normalized = query == null ? "" : query.strip().toLowerCase(Locale.ROOT);
+        if (containsAny(normalized,
+                "핵심 내용", "핵심내용", "핵심 요점", "핵심요점", "주요 내용", "주요내용",
+                "중요 내용", "중요내용", "목차", "key point", "key points", "highlights", "main ideas")) {
+            return new Classification(Intent.KEY_POINTS, 0.95d, "KEY_POINT_PHRASE");
+        }
+        if (containsAny(normalized,
+                "줄거리", "전체 내용", "전체내용", "문서 요약", "요약해", "요약하여",
+                "요약해줘", "요약해 주세요", "plot summary", "summarize", "synopsis", "give me an overview")) {
+            return new Classification(Intent.DOCUMENT_SUMMARY, 0.95d, "SUMMARY_PHRASE");
+        }
+        if (containsAny(normalized,
+                "mbti", "성격 유형", "성격유형", "어떤 성격", "주인공의 성격", "인물의 성격",
+                "성격은", "성격을 분석", "성격 분석", "인물 분석", "인물을 분석", "동기를 분석",
+                "상징을 분석", "의미를 해석", "추정해",
+                "personality type", "character analysis", "analyze the character", "interpret the character",
+                "character motivation", "symbolism")) {
+            return new Classification(Intent.INTERPRETIVE_ANALYSIS, 0.92d, "INTERPRETIVE_PHRASE");
+        }
+        return new Classification(Intent.CONTENT_QA, 0.80d, "DEFAULT_CONTENT_QA");
+    }
+
+    private boolean containsAny(String value, String... candidates) {
+        for (String candidate : candidates) {
+            if (value.contains(candidate)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/starter/studio-platform-starter-ai-web/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -59,6 +59,43 @@
       "type": "java.lang.Double",
       "defaultValue": 0.2,
       "description": "질문 세트 평가 결과를 운영 retrieval policy로 적용하기 위한 최소 MRR입니다. 미만이면 apply-recommendation 요청을 거부합니다."
+    },
+    {
+      "name": "studio.ai.usage.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "모델별 chat token 사용량과 추정 비용의 in-memory 집계를 활성화합니다."
+    },
+    {
+      "name": "studio.ai.usage.currency",
+      "type": "java.lang.String",
+      "defaultValue": "USD",
+      "description": "설정된 모델 단가와 추정 비용에 사용하는 통화 코드입니다."
+    },
+    {
+      "name": "studio.ai.usage.pricing.*.input-per-million-tokens",
+      "type": "java.math.BigDecimal",
+      "description": "모델별 입력 100만 token 단가입니다. provider/model 또는 model을 key로 사용할 수 있습니다."
+    },
+    {
+      "name": "studio.ai.usage.pricing.*.output-per-million-tokens",
+      "type": "java.math.BigDecimal",
+      "description": "모델별 출력 100만 token 단가입니다."
+    },
+    {
+      "name": "studio.ai.usage.pricing.*.high-context-threshold-tokens",
+      "type": "java.lang.Integer",
+      "description": "고용량 context 단가를 적용할 입력 token 임계값입니다."
+    },
+    {
+      "name": "studio.ai.usage.pricing.*.high-context-input-per-million-tokens",
+      "type": "java.math.BigDecimal",
+      "description": "고용량 context의 입력 100만 token 단가입니다."
+    },
+    {
+      "name": "studio.ai.usage.pricing.*.high-context-output-per-million-tokens",
+      "type": "java.math.BigDecimal",
+      "description": "고용량 context의 출력 100만 token 단가입니다."
     }
   ]
 }

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/AiModelUsagePropertiesTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/AiModelUsagePropertiesTest.java
@@ -1,0 +1,29 @@
+package studio.one.platform.ai.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+class AiModelUsagePropertiesTest {
+
+    @Test
+    void preservesDotsInBracketedModelPricingKeys() {
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().addFirst(new MapPropertySource("test", Map.of(
+                "studio.ai.usage.pricing[gemini-2.5-pro].input-per-million-tokens", "1.25",
+                "studio.ai.usage.pricing[gemini-2.5-pro].output-per-million-tokens", "10.00")));
+
+        AiModelUsageProperties properties = Binder.get(environment)
+                .bind("studio.ai.usage", AiModelUsageProperties.class)
+                .orElseThrow(() -> new AssertionError("usage properties were not bound"));
+
+        assertThat(properties.getPricing()).containsKey("gemini-2.5-pro");
+        assertThat(properties.getPricing().get("gemini-2.5-pro").getInputPerMillionTokens())
+                .isEqualByComparingTo("1.25");
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/autoconfigure/config/OpenAiProviderAutoConfigurationTest.java
@@ -110,7 +110,7 @@ class OpenAiProviderAutoConfigurationTest {
             assertThat(registry.availableChatPorts()).containsOnlyKeys("openai");
             assertThat(registry.availableEmbeddingPorts()).containsOnlyKeys("openai");
             assertThat(context.getBean(ChatPort.class)).isSameAs(registry.chatPort("openai"));
-            assertThat(context.getBean(EmbeddingPort.class)).isSameAs(registry.embeddingPort("openai"));
+            assertThat(context.getBean(EmbeddingPort.class)).isNotSameAs(registry.embeddingPort("openai"));
         });
     }
 

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/AiInfoControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/AiInfoControllerTest.java
@@ -55,6 +55,44 @@ class AiInfoControllerTest {
     }
 
     @Test
+    void exposesActualModelForExplicitGoogleProviderOverrides() {
+        AiAdapterProperties properties = new AiAdapterProperties();
+        properties.setDefaultChatProvider("google-pro");
+        properties.setDefaultEmbeddingProvider("google-embedding-2");
+
+        AiAdapterProperties.Provider pro = new AiAdapterProperties.Provider();
+        pro.setType(AiAdapterProperties.ProviderType.GOOGLE_AI_GEMINI);
+        pro.getChat().setEnabled(true);
+        pro.getChat().setModel("gemini-2.5-pro");
+        pro.getChat().setModelOverride(true);
+        properties.getProviders().put("google-pro", pro);
+
+        AiAdapterProperties.Provider embedding = new AiAdapterProperties.Provider();
+        embedding.setType(AiAdapterProperties.ProviderType.GOOGLE_AI_GEMINI);
+        embedding.getEmbedding().setEnabled(true);
+        embedding.getEmbedding().setModel("gemini-embedding-2");
+        embedding.getEmbedding().setModelOverride(true);
+        properties.getProviders().put("google-embedding-2", embedding);
+
+        AiInfoController controller = new AiInfoController(
+                properties,
+                new AiWebChatProperties(),
+                new MockEnvironment()
+                        .withProperty("spring.ai.google.genai.chat.options.model", "gemini-2.5-flash")
+                        .withProperty("spring.ai.google.genai.embedding.text.options.model", "gemini-embedding-001"),
+                null);
+
+        ApiResponse<AiInfoController.AiInfoResponse> body = controller.providers().getBody();
+
+        AiInfoController.ProviderInfo proInfo = body.getData().providers().get(0);
+        assertThat(proInfo.chat().model()).isEqualTo("gemini-2.5-pro");
+        assertThat(proInfo.embedding().model()).isNull();
+        AiInfoController.ProviderInfo embeddingInfo = body.getData().providers().get(1);
+        assertThat(embeddingInfo.chat().model()).isNull();
+        assertThat(embeddingInfo.embedding().model()).isEqualTo("gemini-embedding-2");
+    }
+
+    @Test
     void exposesOpenAiBaseUrlOnlyFromSpringAiCanonicalProperty() {
         AiAdapterProperties properties = new AiAdapterProperties();
         properties.setDefaultProvider("openai");

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/ChatControllerTest.java
@@ -630,6 +630,8 @@ class ChatControllerTest {
                         "file text",
                         Map.of(
                                 "sourceName", "sample.pdf",
+                                "sourceFileName", "original-sample.pdf",
+                                "title", "Sample Document",
                                 RagContextBuilder.KEY_CHUNK_ID, "chunk-1",
                                 ChunkMetadata.KEY_CHUNK_ORDER, 7,
                                 "page", 3,
@@ -659,13 +661,18 @@ class ChatControllerTest {
         assertThat(references.get(0))
                 .containsEntry("index", 1)
                 .containsEntry("documentId", "doc-1")
-                .containsEntry("sourceName", "sample.pdf")
+                .containsEntry("sourceName", "original-sample.pdf")
+                .containsEntry("originalFileName", "original-sample.pdf")
+                .containsEntry("sourceFileName", "original-sample.pdf")
+                .containsEntry("title", "Sample Document")
+                .containsEntry("citationLabel", "근거 1")
                 .containsEntry("chunkId", "chunk-1")
                 .containsEntry("chunkOrder", 7)
                 .containsEntry("score", 0.9d)
                 .containsEntry("page", 3)
-                .containsEntry("pageNumber", 3);
-        assertThat(references.get(0)).doesNotContainKeys("content", "metadata", "sourceRef");
+                .containsEntry("pageNumber", 3)
+                .containsEntry("sourceRef", "page[3]");
+        assertThat(references.get(0)).doesNotContainKeys("content", "metadata");
     }
 
     @Test
@@ -1030,7 +1037,178 @@ class ChatControllerTest {
         verify(defaultChatPort).chat(chatCaptor.capture());
         assertThat(chatCaptor.getValue().messages().get(0).content())
                 .contains("first plot fragment")
-                .contains("second plot fragment");
+                .contains("second plot fragment")
+                .contains("요양 또는 치료 시설을 근거 없이 병원으로 바꾸지 마세요")
+                .contains("영화, 책, 이야기를 원본 전체의 줄거리로 오인하지 마세요");
+    }
+
+    @Test
+    void ragChatDetectsSummaryIntentFromTheLastUserMessageWithoutDuplicatedRagQuery() {
+        ArgumentCaptor<ChatRequest> chatCaptor = ArgumentCaptor.forClass(ChatRequest.class);
+        when(ragPipelineService.listByObject("attachment", "3", 12))
+                .thenReturn(List.of(
+                        new RagSearchResult("chunk-1", "beginning", chunkMetadata("chunk-1"), 1.0d),
+                        new RagSearchResult("chunk-2", "ending", chunkMetadata("chunk-2"), 1.0d)));
+
+        ChatResponseDto response = controller.chatWithRag(new ChatRagRequestDto(
+                new ChatRequestDto(
+                        null,
+                        null,
+                        List.of(new ChatMessageDto("user", "줄거리를 요약해줘")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null),
+                null,
+                null,
+                "attachment",
+                "3")).getBody().getData();
+
+        verify(defaultChatPort).chat(chatCaptor.capture());
+        assertThat(chatCaptor.getValue().messages().get(0).content())
+                .contains("beginning", "ending", "원본 문서 전체의 요약 또는 줄거리");
+        assertThat(response.metadata())
+                .containsEntry("ragQueryIntent", "DOCUMENT_SUMMARY")
+                .containsEntry("ragRetrievalMode", "WHOLE_DOCUMENT_CONTEXT")
+                .containsEntry("overviewCoverageStatus", "FULL");
+    }
+
+    @Test
+    void ragChatReducesLargeWholeDocumentContextBeforeTheFinalAnswer() {
+        String content = "beginning\n" + "a".repeat(40_500) + "\nending\n" + "b".repeat(40_500);
+        when(ragPipelineService.listByObject("attachment", "3", 12))
+                .thenReturn(List.of(new RagSearchResult(
+                        "chunk-1",
+                        content,
+                        Map.of(
+                                "chunkId", "chunk-1",
+                                "chunkOrder", 0,
+                                "startOffset", 0,
+                                "endOffset", content.length()),
+                        1.0d)));
+
+        ChatResponseDto response = controller.chatWithRag(new ChatRagRequestDto(
+                new ChatRequestDto(
+                        null,
+                        null,
+                        List.of(new ChatMessageDto("user", "줄거리를 요약해줘")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null),
+                null,
+                null,
+                "attachment",
+                "3")).getBody().getData();
+
+        verify(defaultChatPort, times(4)).chat(any(ChatRequest.class));
+        assertThat(response.metadata())
+                .containsEntry("overviewReduction", "MAP_REDUCE")
+                .containsEntry("overviewReductionSegmentCount", 3)
+                .containsEntry("overviewReductionCacheHit", false);
+        assertThat((Map<String, Object>) response.metadata().get("ragTiming"))
+                .containsKeys("retrievalMs", "overviewReductionMs", "generationMs", "totalMs");
+    }
+
+    @Test
+    void ragChatUsesPreExtractedKeyPointsWithoutSemanticSearch() {
+        ArgumentCaptor<ChatRequest> chatCaptor = ArgumentCaptor.forClass(ChatRequest.class);
+        when(ragPipelineService.listByObject("attachment", "6", 20))
+                .thenReturn(List.of(new RagSearchResult(
+                        "chunk-1",
+                        "raw document body",
+                        Map.of("keyPoints", List.of("다항식의 연산", "인수분해의 기초")),
+                        1.0d)));
+
+        ChatResponseDto response = controller.chatWithRag(new ChatRagRequestDto(
+                new ChatRequestDto(
+                        null,
+                        null,
+                        List.of(new ChatMessageDto("user", "이 문서의 핵심 내용을 요약해줘")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null),
+                "이 문서의 핵심 내용을 요약해줘",
+                5,
+                "attachment",
+                "6")).getBody().getData();
+
+        verify(ragPipelineService, times(0)).search(any(RagSearchRequest.class));
+        verify(defaultChatPort).chat(chatCaptor.capture());
+        assertThat(chatCaptor.getValue().messages().get(0).content())
+                .contains("다항식의 연산", "인수분해의 기초")
+                .doesNotContain("raw document body");
+        assertThat(response.metadata())
+                .containsEntry("ragQueryIntent", "KEY_POINTS")
+                .containsEntry("ragRetrievalMode", "METADATA_OVERVIEW");
+    }
+
+    @Test
+    void ragChatUsesBroaderEvidenceSearchAndServerPromptForInterpretiveQuestions() {
+        ArgumentCaptor<RagSearchRequest> ragCaptor = ArgumentCaptor.forClass(RagSearchRequest.class);
+        ArgumentCaptor<ChatRequest> chatCaptor = ArgumentCaptor.forClass(ChatRequest.class);
+        when(ragPipelineService.listByObject("attachment", "3", 32))
+                .thenReturn(List.of(new RagSearchResult(
+                        "chunk-1",
+                        "홀든은 타인의 위선을 비판하면서도 동생 피비를 보호하려 한다.",
+                        chunkMetadata("chunk-1"),
+                        1.0d)));
+        when(ragPipelineService.search(any(RagSearchRequest.class)))
+                .thenReturn(List.of(new RagSearchResult(
+                        "chunk-1",
+                        "홀든은 타인의 위선을 비판하면서도 동생 피비를 보호하려 한다.",
+                        chunkMetadata("chunk-1"),
+                        0.67d)));
+
+        ChatResponseDto response = controller.chatWithRag(new ChatRagRequestDto(
+                new ChatRequestDto(
+                        null,
+                        "문서에 명시된 내용만 답변하세요.",
+                        List.of(new ChatMessageDto("user", "주인공의 MBTI 성격 유형을 문서 근거로 추정해줘")),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null),
+                "주인공의 MBTI 성격 유형을 문서 근거로 추정해줘",
+                2,
+                "attachment",
+                "3",
+                null,
+                null,
+                null,
+                2,
+                0.7d,
+                null,
+                null,
+                new ChatRagRetrievalOptionsDto(2, 2, 2, 0.7d, true, false, null, true)))
+                .getBody().getData();
+
+        verify(ragPipelineService).search(ragCaptor.capture());
+        assertThat(ragCaptor.getValue().topK()).isEqualTo(8);
+        assertThat(ragCaptor.getValue().requestedTopK()).isEqualTo(8);
+        assertThat(ragCaptor.getValue().minScore()).isEqualTo(0.55d);
+        assertThat(ragCaptor.getValue().requestedMinScore()).isEqualTo(0.55d);
+        verify(defaultChatPort).chat(chatCaptor.capture());
+        assertThat(chatCaptor.getValue().messages().get(0).content())
+                .contains("문서에 명시된 내용만 답변하세요.")
+                .contains("문서에 분류명이 없다는 이유만으로 답변을 거부하지 말고")
+                .contains("가능한 대안 해석", "확신도");
+        assertThat(response.metadata())
+                .containsEntry("ragQueryIntent", "INTERPRETIVE_ANALYSIS")
+                .containsEntry("ragRetrievalMode", "SEMANTIC_SEARCH")
+                .containsEntry("ragRetrievalTopK", 8)
+                .containsEntry("ragRetrievalMinScore", 0.55d)
+                .containsEntry("answerType", "EVIDENCE_BASED_INFERENCE")
+                .containsEntry("ragInferenceEnabled", true);
     }
 
     @Test

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/InMemoryAiModelUsageStoreTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/InMemoryAiModelUsageStoreTest.java
@@ -1,0 +1,69 @@
+package studio.one.platform.ai.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.ai.autoconfigure.AiModelUsageProperties;
+import studio.one.platform.ai.core.chat.ChatResponseMetadata;
+
+class InMemoryAiModelUsageStoreTest {
+
+    @Test
+    void aggregatesTokenUsageAndEstimatesConfiguredModelCost() {
+        AiModelUsageProperties properties = new AiModelUsageProperties();
+        AiModelUsageProperties.ModelPricing pricing = new AiModelUsageProperties.ModelPricing();
+        pricing.setInputPerMillionTokens(new BigDecimal("1.25"));
+        pricing.setOutputPerMillionTokens(new BigDecimal("10.00"));
+        properties.getPricing().put("gemini-2.5-pro", pricing);
+        InMemoryAiModelUsageStore store = new InMemoryAiModelUsageStore(properties);
+
+        AiModelUsageStore.UsageEstimate estimate = store.record(ChatResponseMetadata.from(Map.of(
+                "provider", "GOOGLE_AI_GEMINI",
+                "resolvedModel", "gemini-2.5-pro",
+                "latencyMs", 1500L,
+                "tokenUsage", Map.of(
+                        "inputTokens", 1000,
+                        "outputTokens", 500,
+                        "totalTokens", 1500))), null);
+
+        assertThat(estimate.pricingConfigured()).isTrue();
+        assertThat(estimate.estimatedCost()).isEqualByComparingTo("0.006250000000");
+        assertThat(store.summaries(null, null)).singleElement().satisfies(summary -> {
+            assertThat(summary.model()).isEqualTo("gemini-2.5-pro");
+            assertThat(summary.requestCount()).isEqualTo(1);
+            assertThat(summary.inputTokens()).isEqualTo(1000);
+            assertThat(summary.outputTokens()).isEqualTo(500);
+            assertThat(summary.estimatedCost()).isEqualByComparingTo("0.006250000000");
+        });
+    }
+
+    @Test
+    void appliesHighContextPricingAndKeepsUnpricedRequestsVisible() {
+        AiModelUsageProperties properties = new AiModelUsageProperties();
+        AiModelUsageProperties.ModelPricing pricing = new AiModelUsageProperties.ModelPricing();
+        pricing.setInputPerMillionTokens(new BigDecimal("1.25"));
+        pricing.setOutputPerMillionTokens(new BigDecimal("10.00"));
+        pricing.setHighContextThresholdTokens(200_000);
+        pricing.setHighContextInputPerMillionTokens(new BigDecimal("2.50"));
+        pricing.setHighContextOutputPerMillionTokens(new BigDecimal("15.00"));
+        properties.getPricing().put("gemini-2.5-pro", pricing);
+        InMemoryAiModelUsageStore store = new InMemoryAiModelUsageStore(properties);
+
+        store.record(ChatResponseMetadata.from(Map.of(
+                "provider", "GOOGLE_AI_GEMINI",
+                "resolvedModel", "gemini-2.5-pro",
+                "tokenUsage", Map.of("inputTokens", 300_000, "outputTokens", 10_000, "totalTokens", 310_000))), null);
+        AiModelUsageStore.UsageEstimate unpriced = store.record(ChatResponseMetadata.from(Map.of(
+                "provider", "LOCAL",
+                "resolvedModel", "local-model")), null);
+
+        assertThat(store.summaries(null, "gemini-2.5-pro").get(0).estimatedCost())
+                .isEqualByComparingTo("0.900000000000");
+        assertThat(unpriced.pricingConfigured()).isFalse();
+        assertThat(store.summaries("LOCAL", null).get(0).pricedRequestCount()).isZero();
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagChatRetrievalServiceTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagChatRetrievalServiceTest.java
@@ -72,6 +72,67 @@ class RagChatRetrievalServiceTest {
     }
 
     @Test
+    void omittedStrategyUsesOnlyStructureLegForStructureOnlyObject() {
+        when(ragPipelineService.listByObject("attachment", "1", 32))
+                .thenReturn(List.of(result("doc-1", "chunk-1", 1.0d, Map.of(
+                        ChunkMetadata.KEY_STRATEGY, "structure-based",
+                        "actualChunkingStrategy", "structure-based"))));
+        when(ragPipelineService.search(any(RagSearchRequest.class)))
+                .thenReturn(List.of(result("doc-1", "chunk-1", 0.9d)));
+
+        RagChatRetrievalService.RetrievalResult result = service.retrieve(
+                request(null, null), "query", "attachment", "1", 5, 0.6d, 5, true);
+
+        verify(ragPipelineService).search(any(RagSearchRequest.class));
+        assertThat(result.debug().toMetadata()).containsEntry("resolvedStrategy", "structure");
+    }
+
+    @Test
+    void omittedStrategyUsesDefaultSearchForRecursiveObject() {
+        when(ragPipelineService.listByObject("attachment", "1", 32))
+                .thenReturn(List.of(result("doc-1", "chunk-1", 1.0d, Map.of(
+                        ChunkMetadata.KEY_STRATEGY, "recursive",
+                        "actualChunkingStrategy", "recursive"))));
+        when(ragPipelineService.search(any(RagSearchRequest.class)))
+                .thenReturn(List.of(result("doc-1", "chunk-1", 0.65d)));
+
+        RagChatRetrievalService.RetrievalResult result = service.retrieve(
+                request(null, null), "query", "attachment", "1", 5, 0.55d, 5, true);
+
+        assertThat(result.results()).hasSize(1);
+        assertThat(result.debug().enabled()).isFalse();
+        ArgumentCaptor<RagSearchRequest> captor = ArgumentCaptor.forClass(RagSearchRequest.class);
+        verify(ragPipelineService).search(captor.capture());
+        assertThat(captor.getValue().metadataFilter().equalsCriteria())
+                .doesNotContainKeys(ChunkMetadata.KEY_STRATEGY, "actualChunkingStrategy");
+    }
+
+    @Test
+    void objectScopedSearchUsesTheProfileStoredWithIndexedChunks() {
+        ChatRagRequestDto base = request("structure", null);
+        ChatRagRequestDto mismatchedProfileRequest = new ChatRagRequestDto(
+                base.chat(), base.ragQuery(), base.ragTopK(), base.objectType(), base.objectId(),
+                "retrieval-ko-kure", null, null, base.topK(), base.minScore(), base.debug(),
+                base.retrievalStrategy(), base.retrievalOptions());
+        when(ragPipelineService.listByObject("attachment", "1", 32))
+                .thenReturn(List.of(result("doc-1", "chunk-1", 1.0d, Map.of(
+                        ChunkMetadata.KEY_STRATEGY, "structure-based",
+                        "embeddingProfileId", "gemini-768"))));
+        when(ragPipelineService.search(any(RagSearchRequest.class)))
+                .thenReturn(List.of(result("doc-1", "chunk-1", 0.9d)));
+
+        service.retrieve(mismatchedProfileRequest, "query", "attachment", "1", 5, 0.6d, 5, true);
+
+        ArgumentCaptor<RagSearchRequest> captor = ArgumentCaptor.forClass(RagSearchRequest.class);
+        verify(ragPipelineService).search(captor.capture());
+        assertThat(captor.getValue().embeddingProfileId()).isEqualTo("gemini-768");
+        assertThat(captor.getValue().embeddingProvider()).isNull();
+        assertThat(captor.getValue().embeddingModel()).isNull();
+        assertThat(captor.getValue().metadataFilter().equalsCriteria())
+                .containsEntry(ChunkMetadata.KEY_STRATEGY, "structure-based");
+    }
+
+    @Test
     void structureStrategyAddsStructureBasedFilter() {
         when(ragPipelineService.search(any(RagSearchRequest.class)))
                 .thenReturn(List.of(result("doc-1", "chunk-1", 0.9d)));

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagContextBuilderTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagContextBuilderTest.java
@@ -28,6 +28,31 @@ class RagContextBuilderTest {
     }
 
     @Test
+    void includesSourceFileTitleAndProvenanceInPromptContext() {
+        RagContextBuilder builder = new RagContextBuilder(8, 12_000, true);
+
+        String context = builder.build(List.of(new RagSearchResult(
+                "doc-1",
+                "다항식 문제 본문",
+                Map.of(
+                        "sourceFileName", "math-textbook.pdf",
+                        "title", "고등 수학",
+                        "page", 42,
+                        "section", "다항식의 연산",
+                        "sourceRef", "page[42]/block[7]"),
+                0.9d)));
+
+        assertThat(context)
+                .contains("[1]")
+                .contains("원본 파일: math-textbook.pdf")
+                .contains("문서 제목: 고등 수학")
+                .contains("페이지: 42")
+                .contains("섹션: 다항식의 연산")
+                .contains("원문 위치: page[42]/block[7]")
+                .contains("내용:\n다항식 문제 본문");
+    }
+
+    @Test
     void expandsChunkContextWhenObjectScopedMetadataIsAvailable() {
         RagContextBuilder builder = new RagContextBuilder(8, 12_000, true, TestWindowChunkContextExpander.asList());
 

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagDocumentMapReduceOverviewTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagDocumentMapReduceOverviewTest.java
@@ -1,0 +1,56 @@
+package studio.one.platform.ai.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+class RagDocumentMapReduceOverviewTest {
+
+    private final RagDocumentMapReduceOverview overview = new RagDocumentMapReduceOverview();
+
+    @Test
+    void reducesLargeDocumentsInOrderAndReusesTheContentFingerprint() {
+        AtomicInteger calls = new AtomicInteger();
+        String context = "문서 제목: Sample Book\n원본 파일: book.epub\nfirst section\n"
+                + "a".repeat(1_100) + "\nlast section\n" + "b".repeat(1_100);
+
+        RagDocumentMapReduceOverview.Reduction first = overview.reduce(
+                "attachment", "3", "gemini", "flash", context, 1_000, 1_000,
+                prompt -> "summary-" + calls.incrementAndGet());
+        RagDocumentMapReduceOverview.Reduction second = overview.reduce(
+                "attachment", "3", "gemini", "flash", context, 1_000, 1_000,
+                prompt -> "unused");
+
+        assertThat(first.applied()).isTrue();
+        assertThat(first.cacheHit()).isFalse();
+        assertThat(first.segmentCount()).isGreaterThan(1);
+        assertThat(first.context()).contains("summary-1", "summary-2");
+        assertThat(first.context()).contains("문서 제목: Sample Book", "원본 파일: book.epub");
+        assertThat(second.context()).isEqualTo(first.context());
+        assertThat(second.cacheHit()).isTrue();
+        assertThat(calls).hasValue(first.segmentCount());
+    }
+
+    @Test
+    void doesNotReduceSmallDocuments() {
+        RagDocumentMapReduceOverview.Reduction reduction = overview.reduce(
+                "attachment", "3", "gemini", "flash", "short", 100, 1_000,
+                prompt -> "not called");
+
+        assertThat(reduction.applied()).isFalse();
+        assertThat(reduction.context()).isEqualTo("short");
+    }
+
+    @Test
+    void changedContentDoesNotReuseTheCachedSummary() {
+        AtomicInteger calls = new AtomicInteger();
+        overview.reduce("attachment", "3", "gemini", "flash", "a".repeat(1_200), 1_000, 1_000,
+                prompt -> "summary-" + calls.incrementAndGet());
+        overview.reduce("attachment", "3", "gemini", "flash", "b".repeat(1_200), 1_000, 1_000,
+                prompt -> "summary-" + calls.incrementAndGet());
+
+        assertThat(calls).hasValue(4);
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagDocumentOverviewAssemblerTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagDocumentOverviewAssemblerTest.java
@@ -1,0 +1,57 @@
+package studio.one.platform.ai.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import studio.one.platform.ai.core.rag.RagSearchResult;
+
+class RagDocumentOverviewAssemblerTest {
+
+    private final RagDocumentOverviewAssembler assembler = new RagDocumentOverviewAssembler();
+
+    @Test
+    void reconstructsAllOrderedChunksAndRemovesConfiguredOverlap() {
+        RagDocumentOverviewAssembler.Assembly assembly = assembler.assemble(List.of(
+                result(2, 10, 16, "dthree"),
+                result(0, 0, 5, "first"),
+                result(1, 4, 11, "tsecond")), 10_000, true);
+
+        assertThat(assembly.context())
+                .contains("문서 제목: Sample Book")
+                .contains("원본 파일: book.epub")
+                .contains("first")
+                .contains("second")
+                .contains("three")
+                .doesNotContain("tsecond");
+        assertThat(assembly.fullCoverage()).isTrue();
+        assertThat(assembly.sourceChunkCount()).isEqualTo(3);
+        assertThat(assembly.references()).singleElement().satisfies(reference -> assertThat(reference.metadata())
+                .containsEntry("overviewCoverageStatus", "FULL")
+                .containsEntry("chunkId", "doc-1:whole-document")
+                .containsEntry("sourceRef", "chunks[0..2]"));
+    }
+
+    @Test
+    void marksCoveragePartialWhenTheWholeDocumentExceedsTheLimit() {
+        RagDocumentOverviewAssembler.Assembly assembly = assembler.assemble(List.of(
+                result(0, 0, 200, "a".repeat(200)),
+                result(1, 200, 400, "b".repeat(200))), 400, true);
+
+        assertThat(assembly.fullCoverage()).isFalse();
+        assertThat(assembly.context()).contains("chunk 0", "chunk 1");
+        assertThat(assembly.context().length()).isLessThanOrEqualTo(400);
+    }
+
+    private RagSearchResult result(int order, int start, int end, String content) {
+        return new RagSearchResult("doc-1", content, Map.of(
+                "chunkOrder", order,
+                "startOffset", start,
+                "endOffset", end,
+                "documentTitle", "Sample Book",
+                "sourceFileName", "book.epub"), 1.0d);
+    }
+}

--- a/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagQueryIntentClassifierTest.java
+++ b/starter/studio-platform-starter-ai-web/src/test/java/studio/one/platform/ai/web/controller/RagQueryIntentClassifierTest.java
@@ -1,0 +1,38 @@
+package studio.one.platform.ai.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class RagQueryIntentClassifierTest {
+
+    private final RagQueryIntentClassifier classifier = RagQueryIntentClassifier.rules();
+
+    @Test
+    void classifiesDocumentSummaryQueries() {
+        assertThat(classifier.classify("이 문서를 요약해줘").intent())
+                .isEqualTo(RagQueryIntentClassifier.Intent.DOCUMENT_SUMMARY);
+    }
+
+    @Test
+    void classifiesKeyPointQueriesBeforeGenericSummaryPhrases() {
+        assertThat(classifier.classify("핵심 내용을 요약해줘").intent())
+                .isEqualTo(RagQueryIntentClassifier.Intent.KEY_POINTS);
+    }
+
+    @Test
+    void treatsSpecificQuestionsAsContentQa() {
+        assertThat(classifier.classify("A-3B를 구하시오").intent())
+                .isEqualTo(RagQueryIntentClassifier.Intent.CONTENT_QA);
+    }
+
+    @Test
+    void classifiesEvidenceBasedCharacterInterpretationQueries() {
+        assertThat(classifier.classify("주인공의 MBTI 성격 유형을 문서 근거로 추정해줘").intent())
+                .isEqualTo(RagQueryIntentClassifier.Intent.INTERPRETIVE_ANALYSIS);
+        assertThat(classifier.classify("주인공의 성격은 어떤가?").intent())
+                .isEqualTo(RagQueryIntentClassifier.Intent.INTERPRETIVE_ANALYSIS);
+        assertThat(classifier.classify("Analyze the character motivation").intent())
+                .isEqualTo(RagQueryIntentClassifier.Intent.INTERPRETIVE_ANALYSIS);
+    }
+}

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/AiSecretPresenceGuard.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/AiSecretPresenceGuard.java
@@ -75,13 +75,13 @@ public class AiSecretPresenceGuard {
 
     private void validateSpringAiProviderMultiplicity() {
         if (hasUnique(chatModelProvider)) {
-            rejectMultipleEnabledProviders(
+            rejectMultipleSharedModelProviders(
                     AiAdapterProperties.ProviderType.GOOGLE_AI_GEMINI,
                     true,
                     "Exactly one enabled GOOGLE_AI_GEMINI chat provider is supported when a Spring AI ChatModel bean is used");
         }
         if (hasUnique(embeddingModelProvider)) {
-            rejectMultipleEnabledProviders(
+            rejectMultipleSharedModelProviders(
                     AiAdapterProperties.ProviderType.GOOGLE_AI_GEMINI,
                     false,
                     "Exactly one enabled GOOGLE_AI_GEMINI embedding provider is supported when a Spring AI EmbeddingModel bean is used");
@@ -89,6 +89,22 @@ public class AiSecretPresenceGuard {
                     AiAdapterProperties.ProviderType.OLLAMA,
                     false,
                     "Exactly one enabled OLLAMA embedding provider is supported when a Spring AI EmbeddingModel bean is used");
+        }
+    }
+
+    private void rejectMultipleSharedModelProviders(
+            AiAdapterProperties.ProviderType type,
+            boolean chat,
+            String message) {
+        long count = properties.getProviders().values().stream()
+                .filter(provider -> provider != null
+                        && provider.isEnabled()
+                        && provider.getType() == type
+                        && (chat ? provider.getChat().isEnabled() : provider.getEmbedding().isEnabled())
+                        && !(chat ? provider.getChat().isModelOverride() : provider.getEmbedding().isModelOverride()))
+                .count();
+        if (count > 1) {
+            throw new IllegalStateException(message);
         }
     }
 
@@ -152,12 +168,14 @@ public class AiSecretPresenceGuard {
                             provider.getApiKey(),
                             log),
                     "spring.ai.google.genai.embedding.api-key must be configured for GOOGLE_AI_GEMINI embedding provider");
-            requireText(AiConfigurationMigration.springOrLegacyProviderValue(
-                            environment,
-                            "spring.ai.google.genai.embedding.text.options.model",
-                            "studio.ai.providers." + providerId + ".embedding.model",
-                            provider.getEmbedding().getModel(),
-                            log),
+            requireText(provider.getEmbedding().isModelOverride()
+                            ? provider.getEmbedding().getModel()
+                            : AiConfigurationMigration.springOrLegacyProviderValue(
+                                    environment,
+                                    "spring.ai.google.genai.embedding.text.options.model",
+                                    "studio.ai.providers." + providerId + ".embedding.model",
+                                    provider.getEmbedding().getModel(),
+                                    log),
                     "spring.ai.google.genai.embedding.text.options.model must be configured for GOOGLE_AI_GEMINI embedding provider");
         }
         if (provider.getChat().isEnabled()) {
@@ -168,12 +186,14 @@ public class AiSecretPresenceGuard {
                             provider.getApiKey(),
                             log),
                     "spring.ai.google.genai.chat.api-key must be configured for GOOGLE_AI_GEMINI chat provider");
-            requireText(AiConfigurationMigration.springOrLegacyProviderValue(
-                            environment,
-                            "spring.ai.google.genai.chat.options.model",
-                            "studio.ai.providers." + providerId + ".chat.model",
-                            provider.getChat().getModel(),
-                            log),
+            requireText(provider.getChat().isModelOverride()
+                            ? provider.getChat().getModel()
+                            : AiConfigurationMigration.springOrLegacyProviderValue(
+                                    environment,
+                                    "spring.ai.google.genai.chat.options.model",
+                                    "studio.ai.providers." + providerId + ".chat.model",
+                                    provider.getChat().getModel(),
+                                    log),
                     "spring.ai.google.genai.chat.options.model must be configured for GOOGLE_AI_GEMINI chat provider");
         }
     }

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/AiAdapterProperties.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/AiAdapterProperties.java
@@ -64,6 +64,7 @@ public class AiAdapterProperties {
     public static final class Channel {
         private boolean enabled = false;
         private String model;
+        private boolean modelOverride = false;
         private Integer dimension;
         private Duration requestTimeout;
     }

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/AiProviderRegistryConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/AiProviderRegistryConfiguration.java
@@ -85,7 +85,7 @@ public class AiProviderRegistryConfiguration {
                 LogUtils.green(EmbeddingPort.class, true),
                 LogUtils.red(State.CREATED.toString())));
 
-        return registry.embeddingPort(null);
+        return request -> registry.embeddingPort(request.provider()).embed(request);
     }
 
     private static <T> void requirePort(Map<String, T> ports, String provider, String propertyName, Class<?> portType) {

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/DefaultAiEmbeddingOptionCatalog.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/DefaultAiEmbeddingOptionCatalog.java
@@ -102,6 +102,10 @@ public final class DefaultAiEmbeddingOptionCatalog implements AiEmbeddingOptionC
     }
 
     private String embeddingModel(String providerId, AiAdapterProperties.Provider provider) {
+        if (provider != null && provider.getEmbedding().isModelOverride()
+                && normalize(provider.getEmbedding().getModel()) != null) {
+            return normalize(provider.getEmbedding().getModel());
+        }
         return switch (providerType(provider) == null ? "" : providerType(provider)) {
             case "OPENAI" -> firstText(
                     property("spring.ai.openai.embedding.options.model"),

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/GoogleGenAiChatPortFactoryConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/GoogleGenAiChatPortFactoryConfiguration.java
@@ -47,12 +47,14 @@ public class GoogleGenAiChatPortFactoryConfiguration {
                                AiAdapterProperties.Provider provider,
                                Environment env,
                                ObjectProvider<org.springframework.ai.chat.model.ChatModel> chatModelProvider) {
-            String model = AiConfigurationMigration.springOrLegacyProviderValue(
-                    env,
-                    "spring.ai.google.genai.chat.options.model",
-                    "studio.ai.providers." + providerId + ".chat.model",
-                    provider.getChat().getModel(),
-                    log);
+            String model = provider.getChat().isModelOverride()
+                    ? provider.getChat().getModel()
+                    : AiConfigurationMigration.springOrLegacyProviderValue(
+                            env,
+                            "spring.ai.google.genai.chat.options.model",
+                            "studio.ai.providers." + providerId + ".chat.model",
+                            provider.getChat().getModel(),
+                            log);
             String apiKey = requireText(
                     AiConfigurationMigration.springOrLegacyProviderValue(
                             env,

--- a/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/GoogleGenAiEmbeddingPortFactoryConfiguration.java
+++ b/starter/studio-platform-starter-ai/src/main/java/studio/one/platform/ai/autoconfigure/config/GoogleGenAiEmbeddingPortFactoryConfiguration.java
@@ -49,12 +49,14 @@ public class GoogleGenAiEmbeddingPortFactoryConfiguration {
                                     AiAdapterProperties.Provider provider,
                                     Environment env,
                                     ObjectProvider<org.springframework.ai.embedding.EmbeddingModel> embeddingModelProvider) {
-            String model = AiConfigurationMigration.springOrLegacyProviderValue(
-                    env,
-                    "spring.ai.google.genai.embedding.text.options.model",
-                    "studio.ai.providers." + providerId + ".embedding.model",
-                    provider.getEmbedding().getModel(),
-                    log);
+            String model = provider.getEmbedding().isModelOverride()
+                    ? provider.getEmbedding().getModel()
+                    : AiConfigurationMigration.springOrLegacyProviderValue(
+                            env,
+                            "spring.ai.google.genai.embedding.text.options.model",
+                            "studio.ai.providers." + providerId + ".embedding.model",
+                            provider.getEmbedding().getModel(),
+                            log);
             String apiKey = requireText(
                     AiConfigurationMigration.springOrLegacyProviderValue(
                             env,
@@ -65,9 +67,10 @@ public class GoogleGenAiEmbeddingPortFactoryConfiguration {
                     "spring.ai.google.genai.embedding.api-key must be configured for GOOGLE_AI_GEMINI embedding provider");
             model = requireText(model,
                     "spring.ai.google.genai.embedding.text.options.model must be configured for GOOGLE_AI_GEMINI embedding provider");
-            Integer dimensions = env.getProperty(
-                    "spring.ai.google.genai.embedding.text.options.dimensions",
-                    Integer.class);
+            Integer dimensions = provider.getEmbedding().isModelOverride()
+                    && provider.getEmbedding().getDimension() != null
+                            ? provider.getEmbedding().getDimension()
+                            : env.getProperty("spring.ai.google.genai.embedding.text.options.dimensions", Integer.class);
 
             org.springframework.ai.google.genai.GoogleGenAiEmbeddingConnectionDetails connectionDetails =
                     org.springframework.ai.google.genai.GoogleGenAiEmbeddingConnectionDetails.builder()

--- a/starter/studio-platform-starter-ai/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/starter/studio-platform-starter-ai/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -73,6 +73,18 @@
       "description": "Embedding vector dimension metadata exposed through AI embedding option discovery."
     },
     {
+      "name": "studio.ai.providers.*.chat.model-override",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Use this provider's chat model instead of the shared spring.ai.google.genai.chat.options.model. Intended for multiple Google model providers."
+    },
+    {
+      "name": "studio.ai.providers.*.embedding.model-override",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Use this provider's embedding model and dimension instead of the shared Spring AI Google embedding options."
+    },
+    {
       "name": "studio.ai.providers.*.embedding.request-timeout",
       "type": "java.time.Duration",
       "defaultValue": "2m",

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/AiSecretPresenceGuardTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/AiSecretPresenceGuardTest.java
@@ -337,6 +337,48 @@ class AiSecretPresenceGuardTest {
     }
 
     @Test
+    void validateAllowsGoogleProvidersWithExplicitModelOverrides() {
+        AiAdapterProperties properties = new AiAdapterProperties();
+        properties.getRouting().setDefaultChatProvider("google-primary");
+        properties.getRouting().setDefaultEmbeddingProvider("google-primary");
+        Provider primary = googleProvider(true, true);
+        Provider pro = googleProvider(true, false);
+        pro.getChat().setModelOverride(true);
+        pro.getChat().setModel("gemini-2.5-pro");
+        Provider embedding2 = googleProvider(false, true);
+        embedding2.getEmbedding().setModelOverride(true);
+        embedding2.getEmbedding().setModel("gemini-embedding-2");
+        properties.getProviders().put("google-primary", primary);
+        properties.getProviders().put("google-pro", pro);
+        properties.getProviders().put("google-embedding-2", embedding2);
+
+        MockEnvironment environment = new MockEnvironment()
+                .withProperty("spring.ai.google.genai.chat.api-key", "test-key")
+                .withProperty("spring.ai.google.genai.chat.options.model", "gemini-2.5-flash")
+                .withProperty("spring.ai.google.genai.embedding.api-key", "test-key")
+                .withProperty("spring.ai.google.genai.embedding.text.options.model", "gemini-embedding-001");
+        StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
+        beanFactory.addBean("googleChatModel", org.mockito.Mockito.mock(ChatModel.class));
+        beanFactory.addBean("googleEmbeddingModel", org.mockito.Mockito.mock(EmbeddingModel.class));
+
+        assertDoesNotThrow(() -> guard(properties, environment, beanFactory).validate());
+    }
+
+    @Test
+    void validateRejectsBlankExplicitGoogleModelOverride() {
+        AiAdapterProperties properties = new AiAdapterProperties();
+        properties.setDefaultProvider("google");
+        Provider provider = googleProvider(true, false);
+        provider.getChat().setModelOverride(true);
+        properties.getProviders().put("google", provider);
+        MockEnvironment environment = new MockEnvironment()
+                .withProperty("spring.ai.google.genai.chat.api-key", "test-key")
+                .withProperty("spring.ai.google.genai.chat.options.model", "gemini-2.5-flash");
+
+        assertThrows(IllegalStateException.class, () -> guard(properties, environment).validate());
+    }
+
+    @Test
     void validateRejectsMultipleOllamaEmbeddingProvidersWhenUsingSingleSpringAiEmbeddingModel() {
         AiAdapterProperties properties = new AiAdapterProperties();
         properties.getRouting().setDefaultChatProvider("ollama-primary");

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/adapter/SpringAiEmbeddingAdapterTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/adapter/SpringAiEmbeddingAdapterTest.java
@@ -39,7 +39,7 @@ class SpringAiEmbeddingAdapterTest {
     @Test
     void rejectsRequestModelThatDoesNotMatchConfiguredModel() {
         EmbeddingModel model = mock(EmbeddingModel.class);
-        SpringAiEmbeddingAdapter adapter = new SpringAiEmbeddingAdapter(model, "text-embedding-004");
+        SpringAiEmbeddingAdapter adapter = new SpringAiEmbeddingAdapter(model, "gemini-embedding-001");
 
         assertThatThrownBy(() -> adapter.embed(new EmbeddingRequest(
                 List.of("text"),

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/AiProviderRegistryConfigurationTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/AiProviderRegistryConfigurationTest.java
@@ -3,6 +3,7 @@ package studio.one.platform.ai.autoconfigure.config;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,9 @@ import org.springframework.core.env.Environment;
 
 import studio.one.platform.ai.core.chat.ChatPort;
 import studio.one.platform.ai.core.embedding.EmbeddingPort;
+import studio.one.platform.ai.core.embedding.EmbeddingRequest;
+import studio.one.platform.ai.core.embedding.EmbeddingResponse;
+import studio.one.platform.ai.core.embedding.EmbeddingVector;
 import studio.one.platform.ai.core.registry.AiProviderRegistry;
 
 /**
@@ -122,6 +126,33 @@ class AiProviderRegistryConfigurationTest {
         assertThat(registry.defaultEmbeddingProvider()).isEqualTo("ollama");
         assertThat(registry.chatPort(null)).isSameAs(mockChatPort);
         assertThat(registry.embeddingPort(null)).isSameAs(mockEmbeddingPort);
+    }
+
+    @Test
+    void defaultEmbeddingPortRoutesExplicitProviderAndPreservesDefaultFallback() {
+        StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
+        AiProviderRegistryConfiguration configuration =
+                new AiProviderRegistryConfiguration(beanFactory.getBeanProvider(
+                        studio.one.platform.service.I18n.class));
+        EmbeddingPort defaultProvider = org.mockito.Mockito.mock(EmbeddingPort.class);
+        EmbeddingPort alternateProvider = org.mockito.Mockito.mock(EmbeddingPort.class);
+        EmbeddingResponse defaultResponse = new EmbeddingResponse(
+                List.of(new EmbeddingVector("default", List.of(1.0d))));
+        EmbeddingResponse alternateResponse = new EmbeddingResponse(
+                List.of(new EmbeddingVector("alternate", List.of(2.0d))));
+        EmbeddingRequest defaultRequest = new EmbeddingRequest(List.of("default"));
+        EmbeddingRequest alternateRequest = new EmbeddingRequest(
+                List.of("alternate"), "alternate", null, null, null);
+        org.mockito.Mockito.when(defaultProvider.embed(defaultRequest)).thenReturn(defaultResponse);
+        org.mockito.Mockito.when(alternateProvider.embed(alternateRequest)).thenReturn(alternateResponse);
+
+        AiProviderRegistry registry = new AiProviderRegistry(
+                "default", "default", "default",
+                Map.of(), Map.of("default", defaultProvider, "alternate", alternateProvider));
+        EmbeddingPort routingPort = configuration.defaultEmbeddingPort(registry);
+
+        assertThat(routingPort.embed(defaultRequest)).isSameAs(defaultResponse);
+        assertThat(routingPort.embed(alternateRequest)).isSameAs(alternateResponse);
     }
 
     @Test

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/DefaultAiEmbeddingOptionCatalogTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/DefaultAiEmbeddingOptionCatalogTest.java
@@ -52,7 +52,7 @@ class DefaultAiEmbeddingOptionCatalogTest {
         AiAdapterProperties.Provider provider = new AiAdapterProperties.Provider();
         provider.setType(AiAdapterProperties.ProviderType.GOOGLE_AI_GEMINI);
         provider.getEmbedding().setEnabled(true);
-        provider.getEmbedding().setModel("text-embedding-004");
+        provider.getEmbedding().setModel("gemini-embedding-2");
         provider.getEmbedding().setDimension(768);
         properties.getProviders().put("google", provider);
 
@@ -60,7 +60,7 @@ class DefaultAiEmbeddingOptionCatalogTest {
         ragProperties.setDefaultEmbeddingProfile("retrieval-ko");
         RagEmbeddingProperties.ProfileProperties profile = new RagEmbeddingProperties.ProfileProperties();
         profile.setProvider("google");
-        profile.setModel("text-embedding-004");
+        profile.setModel("gemini-embedding-2");
         profile.setDimension(768);
         profile.setSupportedInputTypes(java.util.List.of("text", "ocr-text"));
         profile.setMetadata(Map.of("locale", "ko"));
@@ -82,7 +82,7 @@ class DefaultAiEmbeddingOptionCatalogTest {
                 .satisfies(option -> {
                     assertThat(option.profileId()).isEqualTo("retrieval-ko");
                     assertThat(option.provider()).isEqualTo("google");
-                    assertThat(option.model()).isEqualTo("text-embedding-004");
+                    assertThat(option.model()).isEqualTo("gemini-embedding-2");
                     assertThat(option.dimension()).isEqualTo(768);
                     assertThat(option.supportedInputTypes()).containsExactly("TEXT", "OCR_TEXT");
                     assertThat(option.defaultProfile()).isTrue();
@@ -119,5 +119,34 @@ class DefaultAiEmbeddingOptionCatalogTest {
                 .singleElement()
                 .extracting(AiEmbeddingOption::model)
                 .isEqualTo("text-embedding-3-small");
+    }
+
+    @Test
+    void explicitProviderOverrideIsExposedInsteadOfSharedGoogleModel() {
+        AiAdapterProperties properties = new AiAdapterProperties();
+        AiAdapterProperties.Provider provider = new AiAdapterProperties.Provider();
+        provider.setType(AiAdapterProperties.ProviderType.GOOGLE_AI_GEMINI);
+        provider.getEmbedding().setEnabled(true);
+        provider.getEmbedding().setModel("gemini-embedding-2");
+        provider.getEmbedding().setModelOverride(true);
+        provider.getEmbedding().setDimension(768);
+        properties.getProviders().put("google-embedding-2", provider);
+
+        AiProviderRegistry registry = new AiProviderRegistry(
+                "google-embedding-2",
+                Map.of("google-embedding-2", org.mockito.Mockito.mock(studio.one.platform.ai.core.chat.ChatPort.class)),
+                Map.of("google-embedding-2", org.mockito.Mockito.mock(EmbeddingPort.class)));
+
+        DefaultAiEmbeddingOptionCatalog catalog = new DefaultAiEmbeddingOptionCatalog(
+                registry,
+                properties,
+                new RagEmbeddingProperties(),
+                new MockEnvironment()
+                        .withProperty("spring.ai.google.genai.embedding.text.options.model", "gemini-embedding-001"));
+
+        assertThat(catalog.options()).singleElement().satisfies(option -> {
+            assertThat(option.model()).isEqualTo("gemini-embedding-2");
+            assertThat(option.dimension()).isEqualTo(768);
+        });
     }
 }

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/GoogleSpringAiChatRegistrationTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/GoogleSpringAiChatRegistrationTest.java
@@ -153,4 +153,37 @@ class GoogleSpringAiChatRegistrationTest {
         Method modelMethod = defaultOptions.getClass().getMethod("getModel");
         assertThat(modelMethod.invoke(defaultOptions)).isEqualTo("gemini-2.5-flash");
     }
+
+    @Test
+    void explicitModelOverrideCreatesAProviderWithItsOwnGoogleModel() throws Exception {
+        AiAdapterProperties properties = new AiAdapterProperties();
+        properties.setDefaultProvider("google-pro");
+
+        AiAdapterProperties.Provider provider = new AiAdapterProperties.Provider();
+        provider.setType(AiAdapterProperties.ProviderType.GOOGLE_AI_GEMINI);
+        provider.getChat().setEnabled(true);
+        provider.getChat().setModel("gemini-2.5-pro");
+        provider.getChat().setModelOverride(true);
+        properties.getProviders().put("google-pro", provider);
+
+        Map<String, ChatPort> chatPorts = new ProviderChatConfiguration().chatPorts(
+                properties,
+                new MockEnvironment()
+                        .withProperty("spring.ai.google.genai.chat.api-key", "spring-key")
+                        .withProperty("spring.ai.google.genai.chat.options.model", "gemini-2.5-flash"),
+                new StaticListableBeanFactory().getBeanProvider(org.springframework.ai.chat.model.ChatModel.class),
+                List.of(new GoogleGenAiChatPortFactoryConfiguration().googleGenAiChatPortFactory()));
+
+        GoogleSpringAiChatAdapter adapter = (GoogleSpringAiChatAdapter) chatPorts.get("google-pro");
+        Field chatModelField = studio.one.platform.ai.autoconfigure.adapter.SpringAiChatAdapter.class
+                .getDeclaredField("chatModel");
+        chatModelField.setAccessible(true);
+        Object chatModel = chatModelField.get(adapter);
+        Field defaultOptionsField = chatModel.getClass().getDeclaredField("defaultOptions");
+        defaultOptionsField.setAccessible(true);
+        Object defaultOptions = defaultOptionsField.get(chatModel);
+
+        assertThat(defaultOptions.getClass().getMethod("getModel").invoke(defaultOptions))
+                .isEqualTo("gemini-2.5-pro");
+    }
 }

--- a/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/GoogleSpringAiEmbeddingRegistrationTest.java
+++ b/starter/studio-platform-starter-ai/src/test/java/studio/one/platform/ai/autoconfigure/config/GoogleSpringAiEmbeddingRegistrationTest.java
@@ -118,4 +118,40 @@ class GoogleSpringAiEmbeddingRegistrationTest {
         assertThat(String.valueOf(taskType)).isEqualTo("RETRIEVAL_QUERY");
         assertThat(dimensions).isEqualTo(768);
     }
+
+    @Test
+    void explicitModelOverrideCreatesAProviderWithItsOwnEmbeddingModel() throws Exception {
+        AiAdapterProperties properties = new AiAdapterProperties();
+        properties.setDefaultProvider("google-embedding-2");
+
+        AiAdapterProperties.Provider provider = new AiAdapterProperties.Provider();
+        provider.setType(AiAdapterProperties.ProviderType.GOOGLE_AI_GEMINI);
+        provider.getEmbedding().setEnabled(true);
+        provider.getEmbedding().setModel("gemini-embedding-2");
+        provider.getEmbedding().setModelOverride(true);
+        provider.getEmbedding().setDimension(768);
+        properties.getProviders().put("google-embedding-2", provider);
+
+        EmbeddingPort port = new ProviderEmbeddingConfiguration().embeddingPorts(
+                properties,
+                new MockEnvironment()
+                        .withProperty("spring.ai.google.genai.embedding.api-key", "spring-key")
+                        .withProperty("spring.ai.google.genai.embedding.text.options.model", "gemini-embedding-001")
+                        .withProperty("spring.ai.google.genai.embedding.text.options.dimensions", "3072"),
+                new StaticListableBeanFactory().getBeanProvider(org.springframework.ai.embedding.EmbeddingModel.class),
+                List.of(new GoogleGenAiEmbeddingPortFactoryConfiguration().googleGenAiEmbeddingPortFactory()))
+                .get("google-embedding-2");
+
+        java.lang.reflect.Field configuredModelField = SpringAiEmbeddingAdapter.class.getDeclaredField("configuredModel");
+        configuredModelField.setAccessible(true);
+        assertThat(configuredModelField.get(port)).isEqualTo("gemini-embedding-2");
+
+        java.lang.reflect.Field modelField = SpringAiEmbeddingAdapter.class.getDeclaredField("embeddingModel");
+        modelField.setAccessible(true);
+        Object model = modelField.get(port);
+        java.lang.reflect.Field optionsField = model.getClass().getDeclaredField("defaultOptions");
+        optionsField.setAccessible(true);
+        Object options = optionsField.get(model);
+        assertThat(options.getClass().getMethod("getDimensions").invoke(options)).isEqualTo(768);
+    }
 }

--- a/starter/studio-platform-starter-markdown/src/main/java/studio/one/platform/markdown/autoconfigure/RenderedMarkdownPostProcessor.java
+++ b/starter/studio-platform-starter-markdown/src/main/java/studio/one/platform/markdown/autoconfigure/RenderedMarkdownPostProcessor.java
@@ -72,10 +72,16 @@ final class RenderedMarkdownPostProcessor {
         metadata.put("markdownQualityStatus", qualityIssues.isEmpty() ? "VALID" : "REVIEW_REQUIRED");
         double score = qualityScore(qualityIssues, number(metrics.get("renderedMarkdownShortLineRatio")),
                 number(metrics.get("renderedMarkdownJamoLineRatio")), document, markdown);
-        boolean ragIndexEligible = score >= TARGET_QUALITY_SCORE && qualityIssues.stream().noneMatch(this::blockingIssue);
+        boolean fatalQualityFailure = qualityIssues.stream().anyMatch(this::fatalIssue)
+                || markdown == null
+                || markdown.isBlank()
+                || document.blocks().isEmpty();
+        boolean ragIndexEligible = !fatalQualityFailure;
         metadata.put("markdownQualityScore", score);
         metadata.put("ragIndexEligible", ragIndexEligible);
-        metadata.put("qualityGateStatus", ragIndexEligible ? "PASSED" : "BLOCKED");
+        metadata.put("qualityGateStatus", fatalQualityFailure
+                ? "BLOCKED"
+                : score >= TARGET_QUALITY_SCORE && qualityIssues.isEmpty() ? "PASSED" : "REVIEW_REQUIRED");
         return NormalizedDocument.builder(document.sourceDocumentId())
                 .plainText(document.plainText())
                 .sourceFormat(document.sourceFormat())
@@ -563,14 +569,9 @@ final class RenderedMarkdownPostProcessor {
         return retention >= 0.20d ? 0.0d : Math.min(0.30d, (0.20d - retention) * 1.5d);
     }
 
-    private boolean blockingIssue(String issue) {
+    private boolean fatalIssue(String issue) {
         return "MARKDOWN_BLANK".equals(issue)
-                || "NO_NORMALIZED_BLOCKS".equals(issue)
-                || "KOREAN_JAMO_REVIEW_REQUIRED".equals(issue)
-                || "KOREAN_TEXT_GARBLING".equals(issue)
-                || "KOREAN_TEXT_OCR_INCOMPLETE".equals(issue)
-                || "MATH_RENDERING_LOSS".equals(issue)
-                || "CONTENT_PAGE_COVERAGE_INCOMPLETE".equals(issue);
+                || "NO_NORMALIZED_BLOCKS".equals(issue);
     }
 
     private double number(Object value) {

--- a/starter/studio-platform-starter-markdown/src/test/java/studio/one/platform/markdown/autoconfigure/MarkdownNormalizationComponentsTest.java
+++ b/starter/studio-platform-starter-markdown/src/test/java/studio/one/platform/markdown/autoconfigure/MarkdownNormalizationComponentsTest.java
@@ -1100,7 +1100,7 @@ class MarkdownNormalizationComponentsTest {
     }
 
     @Test
-    void blocksRagIndexWhenKoreanJamoAndMathRenderingLossAreSevere() {
+    void keepsRagIndexEligibleForReviewableKoreanAndMathQualityIssues() {
         List<NormalizedBlock> blocks = new java.util.ArrayList<>();
         for (int index = 0; index < 24; index++) {
             blocks.add(NormalizedBlock.builder(NormalizedBlockType.PARAGRAPH, "x^2+" + index + "=0")
@@ -1127,13 +1127,13 @@ class MarkdownNormalizationComponentsTest {
         assertThat(issues).contains("KOREAN_JAMO_REVIEW_REQUIRED", "PYMUPDF_FALLBACK_USED",
                 "MATH_RENDERING_LOSS", "CONTENT_PAGE_COVERAGE_INCOMPLETE");
         assertThat(assessed.metadata())
-                .containsEntry("ragIndexEligible", false)
-                .containsEntry("qualityGateStatus", "BLOCKED");
+                .containsEntry("ragIndexEligible", true)
+                .containsEntry("qualityGateStatus", "REVIEW_REQUIRED");
         assertThat((Double) assessed.metadata().get("markdownQualityScore")).isLessThan(0.85d);
     }
 
     @Test
-    void blocksRagIndexWhenKoreanDocumentWasTransliteratedToLatin() {
+    void keepsRagIndexEligibleWhenKoreanGarblingRequiresReview() {
         String garbled = "CrefAlo ChStAJo Cerio HUH GES latin replacement text ".repeat(12);
         NormalizedDocument document = NormalizedDocument.builder("doc-korean-garbling")
                 .filename("미래엔_고등수학.pdf")
@@ -1150,6 +1150,24 @@ class MarkdownNormalizationComponentsTest {
                 .withRenderedQuality(document, garbled, issues);
 
         assertThat(issues).contains("KOREAN_TEXT_GARBLING");
+        assertThat(assessed.metadata())
+                .containsEntry("ragIndexEligible", true)
+                .containsEntry("qualityGateStatus", "REVIEW_REQUIRED");
+    }
+
+    @Test
+    void blocksRagIndexOnlyWhenRenderedMarkdownIsEmpty() {
+        NormalizedDocument document = NormalizedDocument.builder("doc-empty")
+                .blocks(List.of(NormalizedBlock.builder(NormalizedBlockType.PARAGRAPH, "원문")
+                        .page(1)
+                        .sourceRef("page[1]/block[0]")
+                        .order(0)
+                        .build()))
+                .build();
+
+        NormalizedDocument assessed = new RenderedMarkdownPostProcessor()
+                .withRenderedQuality(document, "", List.of("MARKDOWN_BLANK"));
+
         assertThat(assessed.metadata())
                 .containsEntry("ragIndexEligible", false)
                 .containsEntry("qualityGateStatus", "BLOCKED");

--- a/starter/studio-platform-textract-starter/src/main/java/studio/one/platform/textract/autoconfigure/GeminiMathVisionCorrectionClient.java
+++ b/starter/studio-platform-textract-starter/src/main/java/studio/one/platform/textract/autoconfigure/GeminiMathVisionCorrectionClient.java
@@ -160,7 +160,7 @@ class GeminiMathVisionCorrectionClient implements MathVisionCorrectionClient {
         }
         String json = stripFence(modelText);
         try {
-            Map<String, Object> parsed = objectMapper.readValue(json, MAP_TYPE);
+            Map<String, Object> parsed = objectMapper.readValue(repairLatexJsonEscapes(json), MAP_TYPE);
             Object formulas = parsed.get("formulas");
             if (formulas instanceof List<?> list) {
                 List<String> lines = new ArrayList<>();
@@ -180,10 +180,74 @@ class GeminiMathVisionCorrectionClient implements MathVisionCorrectionClient {
                 }
                 return String.join("\n\n", lines);
             }
-        } catch (RuntimeException ignored) {
+        } catch (IOException | RuntimeException ignored) {
             // Fall through and parse line-by-line.
         }
         return modelText;
+    }
+
+    private String repairLatexJsonEscapes(String json) {
+        if (json == null || json.indexOf('\\') < 0) {
+            return json;
+        }
+        StringBuilder repaired = new StringBuilder(json.length() + 16);
+        for (int index = 0; index < json.length(); index++) {
+            char current = json.charAt(index);
+            if (current != '\\' || index + 1 >= json.length()) {
+                repaired.append(current);
+                continue;
+            }
+            char next = json.charAt(index + 1);
+            if (next == 'u' && hasUnicodeEscape(json, index + 2)) {
+                repaired.append(current);
+                continue;
+            }
+            if (next == '\\') {
+                repaired.append(current).append(next);
+                index++;
+                continue;
+            }
+            if (next == '"' || next == '/') {
+                repaired.append(current);
+                continue;
+            }
+            if ((next == 'b' || next == 'f' || next == 'n' || next == 'r' || next == 't')
+                    && !startsLatexCommand(json, index + 1)) {
+                repaired.append(current);
+                continue;
+            }
+            repaired.append("\\\\");
+        }
+        return repaired.toString();
+    }
+
+    private boolean hasUnicodeEscape(String value, int start) {
+        if (start + 4 > value.length()) {
+            return false;
+        }
+        for (int index = start; index < start + 4; index++) {
+            if (Character.digit(value.charAt(index), 16) < 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean startsLatexCommand(String value, int commandStart) {
+        int end = commandStart;
+        while (end < value.length() && Character.isLetter(value.charAt(end))) {
+            end++;
+        }
+        String command = value.substring(commandStart, end);
+        return command.equals("begin")
+                || command.equals("beta")
+                || command.equals("frac")
+                || command.equals("nabla")
+                || command.equals("neq")
+                || command.equals("nu")
+                || command.equals("right")
+                || command.equals("text")
+                || command.equals("times");
     }
 
     private int resolvePage(Object value, List<Integer> pages, int fallbackIndex) {

--- a/starter/studio-platform-textract-starter/src/test/java/studio/one/platform/textract/autoconfigure/GeminiMathVisionCorrectionClientTest.java
+++ b/starter/studio-platform-textract-starter/src/test/java/studio/one/platform/textract/autoconfigure/GeminiMathVisionCorrectionClientTest.java
@@ -7,6 +7,7 @@ import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpServer;
@@ -19,6 +20,45 @@ import studio.one.platform.textract.infrastructure.extractor.pdf.PdfExtractionOp
 import studio.one.platform.textract.infrastructure.extractor.pdf.PdfExtractionRequest;
 
 class GeminiMathVisionCorrectionClientTest {
+
+    @Test
+    void repairsUnescapedLatexCommandsInJsonFormulaResponses() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        String modelText = "{\"formulas\":["
+                + "{\"page\":8,\"latex\":\"$\\{x\\}+\\frac{1}{2}$\"},"
+                + "{\"page\":8,\"latex\":\"$\\\\sqrt{x}$\"}]}";
+        byte[] response = objectMapper.writeValueAsBytes(Map.of(
+                "candidates", List.of(Map.of(
+                        "content", Map.of("parts", List.of(Map.of("text", modelText)))))));
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", exchange -> {
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+        });
+        server.start();
+        try {
+            GeminiMathVisionCorrectionClient client = new GeminiMathVisionCorrectionClient(
+                    "http://127.0.0.1:" + server.getAddress().getPort(),
+                    "test-key", "gemini-test", Duration.ofSeconds(5), 1024, objectMapper);
+            PdfDocumentAnalysis analysis = new PdfDocumentAnalysis(
+                    8, 2, 0.0d, 1.0d, 0.0d, true, 0.0d, 1.0d, 1.0d, PdfDocumentKind.MATH_LIKE);
+            PdfExtractionRequest request = new PdfExtractionRequest(
+                    "pdf".getBytes(StandardCharsets.UTF_8),
+                    "application/pdf",
+                    "math.pdf",
+                    PdfExtractionOptions.defaults().withMathVisionCorrection(true));
+
+            ParsedFile result = client.correct(request, analysis, List.of(8));
+
+            assertThat(result.blocks()).extracting(block -> block.text())
+                    .containsExactly("$\\{x\\}+\\frac{1}{2}$", "$\\sqrt{x}$");
+            assertThat(result.blocks()).extracting(block -> block.page()).containsExactly(8, 8);
+        } finally {
+            server.stop(0);
+        }
+    }
 
     @Test
     void parsesStringArrayFormulaResponses() throws Exception {

--- a/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/autoconfigure/ContentEmbeddingPipelineAutoConfiguration.java
+++ b/studio-application-modules/content-embedding-pipeline/src/main/java/studio/one/application/web/autoconfigure/ContentEmbeddingPipelineAutoConfiguration.java
@@ -19,6 +19,7 @@ import studio.one.application.web.service.AttachmentRagIndexService;
 import studio.one.application.web.service.AttachmentStructuredRagIndexer;
 import studio.one.platform.ai.service.pipeline.RagPipelineService;
 import studio.one.platform.ai.service.pipeline.RagChunkStageStore;
+import studio.one.platform.chunking.artifact.ChunkSetStore;
 import studio.one.platform.textract.application.usecase.FileContentExtractionService;
 
 @AutoConfiguration
@@ -82,6 +83,7 @@ class ContentEmbeddingPipelineStructuredRagAutoConfiguration {
                     embeddingProfileResolverProvider,
             ObjectProvider<studio.one.platform.ai.core.vector.VectorStorePort> vectorStoreProvider,
             ObjectProvider<RagChunkStageStore> chunkStageStoreProvider,
+            ObjectProvider<ChunkSetStore> chunkSetStoreProvider,
             @Value("${studio.ai.rag.indexing.embedding-batch-size:10}") int indexEmbeddingBatchSize,
             @Value("${studio.ai.rag.indexing.upsert-batch-size:10}") int indexUpsertBatchSize) {
         return new studio.one.application.web.service.DefaultAttachmentStructuredRagIndexer(
@@ -91,6 +93,7 @@ class ContentEmbeddingPipelineStructuredRagAutoConfiguration {
                 embeddingProfileResolverProvider,
                 vectorStoreProvider,
                 chunkStageStoreProvider,
+                chunkSetStoreProvider,
                 indexEmbeddingBatchSize,
                 indexUpsertBatchSize);
     }

--- a/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/autoconfigure/ContentEmbeddingPipelineAutoConfigurationTest.java
+++ b/studio-application-modules/content-embedding-pipeline/src/test/java/studio/one/application/web/autoconfigure/ContentEmbeddingPipelineAutoConfigurationTest.java
@@ -4,9 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import studio.one.application.attachment.application.usecase.AttachmentService;
 import studio.one.application.web.controller.AttachmentEmbeddingPipelineController;
@@ -15,6 +17,7 @@ import studio.one.application.web.service.AttachmentRagIndexJobSourceNameResolve
 import studio.one.application.web.service.AttachmentRagIndexService;
 import studio.one.application.web.service.AttachmentStructuredRagIndexer;
 import studio.one.application.web.service.DefaultAttachmentStructuredRagIndexer;
+import studio.one.platform.chunking.artifact.ChunkSetStore;
 
 class ContentEmbeddingPipelineAutoConfigurationTest {
 
@@ -31,6 +34,24 @@ class ContentEmbeddingPipelineAutoConfigurationTest {
                     assertThat(context).hasSingleBean(AttachmentRagIndexJobSourceExecutor.class);
                     assertThat(context).hasSingleBean(AttachmentRagIndexJobSourceNameResolver.class);
                     assertThat(context).hasSingleBean(AttachmentEmbeddingPipelineController.class);
+                });
+    }
+
+    @Test
+    void suppliesChunkSetStoreToStructuredRagIndexer() {
+        ChunkSetStore chunkSetStore = mock(ChunkSetStore.class);
+
+        contextRunner
+                .withBean(AttachmentService.class, () -> mock(AttachmentService.class))
+                .withBean(ChunkSetStore.class, () -> chunkSetStore)
+                .run(context -> {
+                    DefaultAttachmentStructuredRagIndexer indexer =
+                            context.getBean(DefaultAttachmentStructuredRagIndexer.class);
+                    ObjectProvider<?> provider = (ObjectProvider<?>) ReflectionTestUtils.getField(
+                            indexer, "chunkSetStoreProvider");
+
+                    assertThat(provider).isNotNull();
+                    assertThat(provider.getIfAvailable()).isSameAs(chunkSetStore);
                 });
     }
 

--- a/studio-platform-chunking-runtime/src/main/java/studio/one/platform/chunking/service/ChunkMetadataPolicy.java
+++ b/studio-platform-chunking-runtime/src/main/java/studio/one/platform/chunking/service/ChunkMetadataPolicy.java
@@ -22,6 +22,8 @@ final class ChunkMetadataPolicy {
     private static final String ISSUE_EMPTY_CONTENT = "EMPTY_CONTENT";
     private static final String ISSUE_MAX_SIZE_EXCEEDED = "MAX_SIZE_EXCEEDED";
     private static final String ISSUE_MISSING_PROVENANCE = "MISSING_PROVENANCE";
+    private static final String ISSUE_NORMALIZATION_REVIEW_REQUIRED = "NORMALIZATION_REVIEW_REQUIRED";
+    private static final String ISSUE_MARKDOWN_REVIEW_REQUIRED = "MARKDOWN_QUALITY_REVIEW_REQUIRED";
 
     private ChunkMetadataPolicy() {
     }
@@ -93,7 +95,8 @@ final class ChunkMetadataPolicy {
             ChunkUnit unit,
             int maxSize,
             int overlap) {
-        List<String> qualityIssues = qualityIssues(chunk, unit, maxSize);
+        List<String> qualityIssues = new ArrayList<>(qualityIssues(chunk, unit, maxSize));
+        mergeSourceQualityIssues(qualityIssues, context.metadata());
         Map<String, Object> attributes = new LinkedHashMap<>(context.metadata());
         attributes.putAll(chunk.metadata().attributes());
         attributes.put(ChunkMetadata.KEY_REQUESTED_CHUNKING_STRATEGY, value(requestedStrategy));
@@ -104,13 +107,49 @@ final class ChunkMetadataPolicy {
         putIfPresent(attributes, ChunkMetadata.KEY_FALLBACK_REASON, fallbackReason);
         attributes.put(ChunkMetadata.KEY_CHUNK_QUALITY_STATUS,
                 qualityIssues.isEmpty() ? QUALITY_VALID : QUALITY_REVIEW_REQUIRED);
-        attributes.put(ChunkMetadata.KEY_CHUNK_QUALITY_ISSUES, qualityIssues);
+        attributes.put(ChunkMetadata.KEY_CHUNK_QUALITY_ISSUES, List.copyOf(qualityIssues));
         attributes.put(ChunkMetadata.KEY_CHUNK_UNIT, unit.value());
         attributes.put(ChunkMetadata.KEY_MAX_SIZE, maxSize);
         attributes.put(ChunkMetadata.KEY_OVERLAP, overlap);
 
         ChunkMetadata metadata = rebuildMetadata(chunk.metadata(), attributes);
         return Chunk.of(chunk.id(), chunk.content(), metadata);
+    }
+
+    private static void mergeSourceQualityIssues(List<String> issues, Map<String, Object> metadata) {
+        if (metadata == null || metadata.isEmpty()) {
+            return;
+        }
+        int beforeNormalization = issues.size();
+        addIssueValues(issues, metadata.get("normalizationIssues"));
+        if (reviewRequired(metadata.get("normalizationStatus")) && issues.size() == beforeNormalization) {
+            addIssue(issues, ISSUE_NORMALIZATION_REVIEW_REQUIRED);
+        }
+        int beforeMarkdown = issues.size();
+        addIssueValues(issues, metadata.get("markdownQualityIssues"));
+        if (reviewRequired(metadata.get("markdownQualityStatus")) && issues.size() == beforeMarkdown) {
+            addIssue(issues, ISSUE_MARKDOWN_REVIEW_REQUIRED);
+        }
+        addIssueValues(issues, metadata.get(ChunkMetadata.KEY_CHUNK_QUALITY_ISSUES));
+    }
+
+    private static void addIssueValues(List<String> issues, Object value) {
+        if (value instanceof Collection<?> values) {
+            values.forEach(item -> addIssue(issues, item == null ? null : item.toString()));
+            return;
+        }
+        addIssue(issues, value == null ? null : value.toString());
+    }
+
+    private static void addIssue(List<String> issues, String issue) {
+        if (issue == null || issue.isBlank() || issues.contains(issue.trim())) {
+            return;
+        }
+        issues.add(issue.trim());
+    }
+
+    private static boolean reviewRequired(Object value) {
+        return value != null && "REVIEW_REQUIRED".equalsIgnoreCase(value.toString().trim());
     }
 
     private static List<String> qualityIssues(Chunk chunk, ChunkUnit unit, int maxSize) {

--- a/studio-platform-chunking-runtime/src/main/java/studio/one/platform/chunking/service/ParentChildChunkContextExpander.java
+++ b/studio-platform-chunking-runtime/src/main/java/studio/one/platform/chunking/service/ParentChildChunkContextExpander.java
@@ -1,7 +1,10 @@
 package studio.one.platform.chunking.service;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import studio.one.platform.chunking.core.Chunk;
 import studio.one.platform.chunking.core.ChunkContextExpander;
@@ -11,6 +14,8 @@ import studio.one.platform.chunking.core.ChunkContextExpansionStrategy;
 import studio.one.platform.chunking.core.ChunkMetadata;
 
 public class ParentChildChunkContextExpander implements ChunkContextExpander {
+
+    private static final int MAX_PROBLEM_CONTEXT_CHUNKS = 6;
 
     @Override
     public ChunkContextExpansionStrategy strategy() {
@@ -32,10 +37,83 @@ public class ParentChildChunkContextExpander implements ChunkContextExpander {
         String parentContent = request.includeParentContent()
                 ? ChunkContextExpansionSupport.parentContent(seed)
                 : "";
-        if (!parentContent.isBlank()) {
+        if (!parentContent.isBlank() && !sameContent(parentContent, seed.content())) {
             return new ChunkContextExpansion(seed, contextChunks, parentContent, strategy(), metadata);
         }
+        List<Chunk> problemContext = problemContext(seed, request.availableChunks());
+        if (!problemContext.isEmpty()) {
+            Map<String, Object> problemMetadata = new java.util.LinkedHashMap<>(metadata);
+            problemMetadata.put("problemContextFallback", true);
+            problemMetadata.put("problemContextChunkCount", problemContext.size());
+            return ChunkContextExpansion.of(seed, problemContext, strategy(), problemMetadata);
+        }
         return ChunkContextExpansion.of(seed, contextChunks, strategy(), metadata);
+    }
+
+    private List<Chunk> problemContext(Chunk seed, List<Chunk> availableChunks) {
+        if (!questionLike(seed.content())) {
+            return List.of();
+        }
+        Integer page = page(seed);
+        if (page == null) {
+            return List.of();
+        }
+        List<Chunk> pageChunks = new ArrayList<>(ChunkContextExpansionSupport.withSeed(seed, availableChunks).stream()
+                .filter(chunk -> Objects.equals(page, page(chunk)))
+                .filter(chunk -> chunk.metadata().order() <= seed.metadata().order())
+                .sorted(Comparator.comparingInt(chunk -> chunk.metadata().order()))
+                .toList());
+        int seedIndex = pageChunks.indexOf(seed);
+        if (seedIndex <= 0) {
+            return List.of();
+        }
+        int lowerBound = Math.max(0, seedIndex - MAX_PROBLEM_CONTEXT_CHUNKS + 1);
+        int anchor = -1;
+        for (int index = seedIndex - 1; index >= lowerBound; index--) {
+            if (conditionLike(pageChunks.get(index).content())) {
+                anchor = index;
+                break;
+            }
+        }
+        return anchor < 0 ? List.of() : List.copyOf(pageChunks.subList(anchor, seedIndex + 1));
+    }
+
+    private boolean questionLike(String content) {
+        if (content == null || content.isBlank()) {
+            return false;
+        }
+        String value = content.replaceAll("\\s+", "");
+        return value.contains("구하시오")
+                || value.contains("구하세요")
+                || value.contains("계산하시오")
+                || value.matches("(?i).*(find|calculate|solve).*");
+    }
+
+    private boolean conditionLike(String content) {
+        if (content == null || !content.contains("=")) {
+            return false;
+        }
+        long operators = content.chars().filter(ch -> ch == '+' || ch == '-' || ch == '^' || ch == '=').count();
+        return operators >= 2;
+    }
+
+    private Integer page(Chunk chunk) {
+        Object value = chunk.metadata().toMap().get(ChunkMetadata.KEY_PAGE);
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        if (value instanceof String text && !text.isBlank()) {
+            try {
+                return Integer.parseInt(text.trim());
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private boolean sameContent(String left, String right) {
+        return left == null ? right == null : left.strip().equals(right == null ? "" : right.strip());
     }
 
 }

--- a/studio-platform-chunking-runtime/src/test/java/studio/one/platform/chunking/service/ChunkContextExpanderTest.java
+++ b/studio-platform-chunking-runtime/src/test/java/studio/one/platform/chunking/service/ChunkContextExpanderTest.java
@@ -113,6 +113,34 @@ class ChunkContextExpanderTest {
     }
 
     @Test
+    void parentChildExpansionRecoversNearbyMathConditionForOrphanQuestion() {
+        Chunk condition = chunk("doc-37",
+                "$A+B=5x^2+xy-2y^2$\n$A-B=x^2+3xy-6y^2$",
+                37, "parent-table", null, null, "Problems", ChunkType.TABLE,
+                Map.of(ChunkMetadata.KEY_PAGE, 8));
+        Chunk explanation = chunk("doc-42", "두 식을 연립하여 계산한다.",
+                42, "parent-help", null, null, "Problems", ChunkType.CHILD,
+                Map.of(ChunkMetadata.KEY_PAGE, 8));
+        Chunk seed = chunk("doc-43", "일 때, A-3B를 구하시오.",
+                43, "parent-question", null, null, "Problems", ChunkType.CHILD,
+                Map.of(
+                        ChunkMetadata.KEY_PAGE, 8,
+                        ChunkMetadata.KEY_PARENT_CHUNK_CONTENT, "일 때, A-3B를 구하시오."));
+
+        ChunkContextExpansion expansion = new ParentChildChunkContextExpander().expand(
+                ChunkContextExpansionRequest.builder(seed)
+                        .availableChunks(List.of(seed, explanation, condition))
+                        .includeParentContent(true)
+                        .build());
+
+        assertThat(expansion.contextChunks()).containsExactly(condition, explanation, seed);
+        assertThat(expansion.content()).contains("A+B=5x^2", "A-3B를 구하시오");
+        assertThat(expansion.metadata())
+                .containsEntry("problemContextFallback", true)
+                .containsEntry("problemContextChunkCount", 3);
+    }
+
+    @Test
     void headingExpansionUsesSameSectionCandidates() {
         Chunk seed = chunk("doc-1", "seed", 1, "parent-a", null, null, "Install", ChunkType.CHILD, Map.of());
         Chunk sameHeading = chunk("doc-2", "same", 2, "parent-a", null, null, "Install", ChunkType.CHILD, Map.of());

--- a/studio-platform-chunking-runtime/src/test/java/studio/one/platform/chunking/service/StructureBasedChunkerTest.java
+++ b/studio-platform-chunking-runtime/src/test/java/studio/one/platform/chunking/service/StructureBasedChunkerTest.java
@@ -277,6 +277,27 @@ class StructureBasedChunkerTest {
     }
 
     @Test
+    void sourceQualityWarningsRemainVisibleOnCompletedChunks() {
+        StructureBasedChunker chunker = new StructureBasedChunker(120, 0, new RecursiveChunker(120, 0));
+        NormalizedDocument document = NormalizedDocument.builder("doc")
+                .metadata(Map.of(
+                        "normalizationStatus", "REVIEW_REQUIRED",
+                        "normalizationIssues", List.of("LOW_QUALITY_MATH"),
+                        "markdownQualityStatus", "REVIEW_REQUIRED",
+                        "markdownQualityIssues", List.of("MATH_VISION_CORRECTION_FAILED")))
+                .blocks(List.of(block(NormalizedBlockType.PARAGRAPH,
+                        "$A+B=52x'$", "page[8]/block[0]", 0, 0.60d)))
+                .build();
+
+        Chunk chunk = chunker.chunk(document, context(document, 120, 0)).get(0);
+
+        assertThat(chunk.metadata().toMap())
+                .containsEntry(ChunkMetadata.KEY_CHUNK_QUALITY_STATUS, "REVIEW_REQUIRED")
+                .containsEntry(ChunkMetadata.KEY_CHUNK_QUALITY_ISSUES,
+                        List.of("LOW_QUALITY_MATH", "MATH_VISION_CORRECTION_FAILED"));
+    }
+
+    @Test
     void oversizedStandaloneStructureChunkIsSplitWithoutFullStrategyFallback() {
         StructureBasedChunker chunker = new StructureBasedChunker(10, 0, new RecursiveChunker(10, 0));
         NormalizedDocument document = NormalizedDocument.builder("doc")

--- a/studio-platform-markdown/src/main/java/studio/one/platform/markdown/application/MarkdownDocumentService.java
+++ b/studio-platform-markdown/src/main/java/studio/one/platform/markdown/application/MarkdownDocumentService.java
@@ -965,14 +965,51 @@ public class MarkdownDocumentService {
     }
 
     public MarkdownExtractionResult reextract(String documentId, MarkdownPipelineOptions options, String requestedBy) {
+        return reextract(documentId, options, false, requestedBy);
+    }
+
+    public MarkdownExtractionResult reextract(String documentId, MarkdownPipelineOptions options,
+            boolean inheritOmittedExtractionQualityOptions, String requestedBy) {
         MarkdownDocument document = requireDocument(documentId);
-        return create(new MarkdownExtractionRequest(document.sourceAttachmentId(), options, true, requestedBy));
+        MarkdownPipelineOptions effectiveOptions = inheritOmittedExtractionQualityOptions
+                ? inheritExtractionQualityOptions(documentId, options)
+                : options;
+        return create(new MarkdownExtractionRequest(
+                document.sourceAttachmentId(), effectiveOptions, true, requestedBy));
     }
 
     public MarkdownExtractionResult reextract(String documentId, boolean runChunking, boolean runRagIndex,
             boolean runSkillExtraction, String requestedBy) {
         return reextract(documentId,
                 new MarkdownPipelineOptions(runChunking, runRagIndex, runSkillExtraction), requestedBy);
+    }
+
+    private MarkdownPipelineOptions inheritExtractionQualityOptions(
+            String documentId, MarkdownPipelineOptions requested) {
+        return repository.findRevisions(documentId).stream()
+                .map(revision -> readOptions(revision.optionsJson()))
+                .filter(this::hasExplicitExtractionQualityOptions)
+                .findFirst()
+                .map(previous -> new MarkdownPipelineOptions(
+                        requested.runChunking(), requested.runRagIndex(), requested.runSkillExtraction(),
+                        requested.chunkingStrategy(), requested.chunkMaxSize(), requested.chunkOverlap(),
+                        requested.chunkUnit(), requested.blockifyLlmProvider(), requested.blockifyLlmModel(),
+                        requested.blockifyPiiMaskingEnabled(), requested.embeddingProfileId(),
+                        requested.embeddingProvider(), requested.embeddingModel(), requested.embeddingDimension(),
+                        requested.useLlmKeywordExtraction(), requested.skillExtractionMode(),
+                        requested.generateSkillEmbeddings(), requested.skillEmbeddingProvider(),
+                        requested.skillEmbeddingModel(), requested.skillEmbeddingDimension(),
+                        previous.ocrRequired(), previous.ocrLanguage(), previous.ocrMode(),
+                        previous.mathVisionCorrection(), previous.requestedDocumentProfile(), null, null))
+                .orElse(requested);
+    }
+
+    private boolean hasExplicitExtractionQualityOptions(MarkdownPipelineOptions options) {
+        return options.requestedDocumentProfile() != null
+                || options.ocrRequired() != null
+                || options.ocrLanguage() != null
+                || options.ocrMode() != null
+                || Boolean.TRUE.equals(options.mathVisionCorrection());
     }
 
     public MarkdownRevision cancel(String documentId) {

--- a/studio-platform-markdown/src/main/java/studio/one/platform/markdown/web/MarkdownDocumentController.java
+++ b/studio-platform-markdown/src/main/java/studio/one/platform/markdown/web/MarkdownDocumentController.java
@@ -296,7 +296,8 @@ public class MarkdownDocumentController {
     public ResponseEntity<ApiResponse<MarkdownExtractionResult>> reextract(
             @PathVariable String id, @RequestBody MarkdownReextractRequest request, Authentication authentication) {
         String actor = authentication == null ? null : authentication.getName();
-        return ResponseEntity.accepted().body(ApiResponse.ok(service.reextract(id, options(request), actor)));
+        return ResponseEntity.accepted().body(ApiResponse.ok(service.reextract(
+                id, options(request), extractionQualityOptionsOmitted(request), actor)));
     }
 
     @DeleteMapping("/{id}/extraction")
@@ -444,6 +445,14 @@ public class MarkdownDocumentController {
                 request.skillEmbeddingModel(), request.skillEmbeddingDimension(), request.ocrRequired(),
                 request.ocrLanguage(), request.ocrMode(), request.mathVisionCorrection(),
                 request.documentProfile(), null, null);
+    }
+
+    private boolean extractionQualityOptionsOmitted(MarkdownReextractRequest request) {
+        return request.documentProfile() == null
+                && request.ocrRequired() == null
+                && request.ocrLanguage() == null
+                && request.ocrMode() == null
+                && request.mathVisionCorrection() == null;
     }
 
     private MarkdownResumeOptions resumeOptions(MarkdownResumeRequest request) {

--- a/studio-platform-markdown/src/test/java/studio/one/platform/markdown/MarkdownDocumentServiceTest.java
+++ b/studio-platform-markdown/src/test/java/studio/one/platform/markdown/MarkdownDocumentServiceTest.java
@@ -79,6 +79,35 @@ class MarkdownDocumentServiceTest {
     }
 
     @Test
+    void reextractInheritsLastExplicitQualityOptionsWhenClientOmitsThem() throws Exception {
+        InMemoryRepository repository = new InMemoryRepository();
+        SourcePort sources = new SourcePort();
+        sources.add(1L, "math-textbook.pdf", "application/pdf", "%PDF-test");
+        MarkdownDocumentService service = service(repository, sources,
+                (source, revisionId) -> new MarkdownNativeExtractorPort.NativeExtraction(
+                        "# Math", "textract-1", List.of(), List.of()), MarkdownPipelinePort.noop());
+        MarkdownPipelineOptions qualityOptions = new MarkdownPipelineOptions(
+                false, false, false,
+                null, null, null, null,
+                null, null, null,
+                null, null, null, null,
+                false, null, false,
+                null, null, null,
+                true, "kor+eng", "FORCE", true);
+
+        var initial = service.create(new MarkdownExtractionRequest(1L, qualityOptions, true, "tester"));
+        var reextracted = service.reextract(
+                initial.document().documentId(), new MarkdownPipelineOptions(false, false, false), true, "tester");
+        Map<String, Object> stored = new ObjectMapper().readValue(
+                reextracted.revision().optionsJson(), new TypeReference<>() {});
+
+        assertEquals(Boolean.TRUE, stored.get("ocrRequired"));
+        assertEquals("kor+eng", stored.get("ocrLanguage"));
+        assertEquals("FORCE", stored.get("ocrMode"));
+        assertEquals(Boolean.TRUE, stored.get("mathVisionCorrection"));
+    }
+
+    @Test
     void rewritesLogicalImageReferencesAndCachesPdfPagePreview() throws Exception {
         InMemoryRepository repository = new InMemoryRepository();
         SourcePort sources = new SourcePort();

--- a/studio-platform-textract/src/main/java/studio/one/platform/textract/infrastructure/extractor/pdf/PdfExtractionEngineSelector.java
+++ b/studio-platform-textract/src/main/java/studio/one/platform/textract/infrastructure/extractor/pdf/PdfExtractionEngineSelector.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -22,6 +23,13 @@ import studio.one.platform.textract.domain.model.ParsedBlock;
 import studio.one.platform.textract.domain.model.ParsedFile;
 
 public class PdfExtractionEngineSelector {
+
+    private static final Pattern MALFORMED_PRIME_EXPONENT = Pattern.compile(
+            "(?i).*(?<![a-z])(?:[xyzabc][’'](?:\\d+)?|\\d{2,}[xyzabc][’'])(?![a-z]).*");
+    private static final Pattern OCR_DIGIT_PRIME_EXPONENT = Pattern.compile(
+            "(?i)\\d{2,}[xyzabc][’'](?![a-z])");
+    private static final Pattern OCR_JOINED_MATH_VARIABLES = Pattern.compile(
+            "(?i).*(?<![a-z])(?:[xyzabc][rv][xyzabc]|[xyzabc]{2,}r[xyzabc])(?![a-z]).*");
 
     public static final String KEY_EXTRACTION_ENGINE = "pdfExtractionEngine";
     public static final String KEY_FALLBACK_FROM = "pdfExtractionFallbackFrom";
@@ -733,25 +741,45 @@ public class PdfExtractionEngineSelector {
             return List.of();
         }
         Map<Integer, Integer> scores = new LinkedHashMap<>();
+        Set<Integer> malformedEquationPages = new LinkedHashSet<>();
         for (ParsedBlock block : baseline.blocks()) {
             if (block == null || block.page() == null || block.text() == null) {
                 continue;
             }
             String text = block.text().strip();
-            if (text.isBlank() || !mathLikeText(text)) {
+            boolean severeMalformedEquation = severeMalformedEquationText(text);
+            if (text.isBlank() || (!mathLikeText(text) && !severeMalformedEquation)) {
                 continue;
             }
-            if (lowQualityMathText(text)) {
+            if (lowQualityMathText(text) || severeMalformedEquation) {
                 scores.merge(block.page(), lowQualityMathScore(text), Integer::sum);
+                if (severeMalformedEquation) {
+                    malformedEquationPages.add(block.page());
+                }
             }
         }
-        return scores.entrySet().stream()
+        List<Integer> ranked = scores.entrySet().stream()
                 .sorted((left, right) -> {
                     int byScore = Integer.compare(right.getValue(), left.getValue());
                     return byScore != 0 ? byScore : Integer.compare(left.getKey(), right.getKey());
                 })
                 .map(Map.Entry::getKey)
                 .toList();
+        if (malformedEquationPages.isEmpty()) {
+            return ranked;
+        }
+        LinkedHashSet<Integer> prioritized = new LinkedHashSet<>();
+        malformedEquationPages.stream()
+                .sorted()
+                .limit(Math.min(2, malformedEquationPages.size()))
+                .forEach(prioritized::add);
+        prioritized.addAll(ranked);
+        return List.copyOf(prioritized);
+    }
+
+    private boolean severeMalformedEquationText(String text) {
+        String value = text == null ? "" : text;
+        return OCR_DIGIT_PRIME_EXPONENT.matcher(value).find();
     }
 
     private int lowQualityMathScore(String text) {
@@ -761,6 +789,9 @@ public class PdfExtractionEngineSelector {
         score += value.contains("@$") ? 2 : 0;
         score += value.contains("\"$") || value.contains("$\"") ? 2 : 0;
         score += value.chars().filter(ch -> ch == '$').count() % 2 == 0 ? 0 : 3;
+        score += MALFORMED_PRIME_EXPONENT.matcher(value).matches() ? 10 : 0;
+        score += OCR_DIGIT_PRIME_EXPONENT.matcher(value).find() ? 50 : 0;
+        score += OCR_JOINED_MATH_VARIABLES.matcher(value).matches() ? 8 : 0;
         return score;
     }
 
@@ -974,7 +1005,9 @@ public class PdfExtractionEngineSelector {
                 || value.contains("\"$")
                 || value.contains("$\"")
                 || dollars % 2 != 0
-                || value.matches(".*(?:\\bOO\\b|\\bSS\\b|\\bSAS\\b|[?°]).*");
+                || value.matches(".*(?:\\bOO\\b|\\bSS\\b|\\bSAS\\b|[?°]).*")
+                || MALFORMED_PRIME_EXPONENT.matcher(value).matches()
+                || OCR_JOINED_MATH_VARIABLES.matcher(value).matches();
     }
 
     private List<List<Integer>> pageBatches(List<Integer> pages, int batchSize) {

--- a/studio-platform-textract/src/test/java/studio/one/platform/textract/infrastructure/extractor/pdf/PdfExtractionEngineSelectorTest.java
+++ b/studio-platform-textract/src/test/java/studio/one/platform/textract/infrastructure/extractor/pdf/PdfExtractionEngineSelectorTest.java
@@ -874,6 +874,74 @@ class PdfExtractionEngineSelectorTest {
     }
 
     @Test
+    void hybridMathRoutePrioritizesMalformedPrimeAndJoinedVariablePages() {
+        PdfDocumentAnalysis analysis = new PdfDocumentAnalysis(
+                44, 5, 0.0d, 1.0d, 0.0d, true, 0.0d, 1.0d, 1.0d, PdfDocumentKind.MATH_LIKE);
+        PdfExtractionEngine baseline = new PdfExtractionEngine() {
+            @Override
+            public PdfExtractionEngineType type() {
+                return PdfExtractionEngineType.PYMUPDF4LLM;
+            }
+
+            @Override
+            public boolean supports(PdfExtractionRequest request) {
+                return true;
+            }
+
+            @Override
+            public ParsedFile extract(PdfExtractionRequest request) {
+                List<studio.one.platform.textract.domain.model.ParsedBlock> blocks = new ArrayList<>(List.of(
+                        studio.one.platform.textract.domain.model.ParsedBlock.text(
+                                "page[2]/block[0]", studio.one.platform.textract.domain.model.BlockType.PARAGRAPH,
+                                "$xㅡ2+1$", 2, 0, Map.of("sourceRef", "page[2]/block[0]")),
+                        studio.one.platform.textract.domain.model.ParsedBlock.text(
+                                "page[7]/block[0]", studio.one.platform.textract.domain.model.BlockType.PARAGRAPH,
+                                "$xㅡ3+1$", 7, 1, Map.of("sourceRef", "page[7]/block[0]")),
+                        studio.one.platform.textract.domain.model.ParsedBlock.text(
+                                "page[8]/block[0]", studio.one.platform.textract.domain.model.BlockType.TABLE,
+                                "문제 006\n|A+B=52x' +2y-2y|\n|A-B=x’+3xry-6y|", 8, 2,
+                                Map.of("sourceRef", "page[8]/block[0]"))));
+                for (int page = 10; page <= 20; page++) {
+                    blocks.add(studio.one.platform.textract.domain.model.ParsedBlock.text(
+                            "page[" + page + "]/block[0]",
+                            studio.one.platform.textract.domain.model.BlockType.PARAGRAPH,
+                            "$x????????????+1$", page, page,
+                            Map.of("sourceRef", "page[" + page + "]/block[0]")));
+                }
+                return new ParsedFile(DocumentFormat.PDF, "math", blocks,
+                        Map.of(PdfExtractionEngineSelector.KEY_EXTRACTION_ENGINE, "pymupdf4llm"),
+                        List.of(), List.of(), List.of(), List.of(), true);
+            }
+        };
+        List<Integer> receivedPages = new ArrayList<>();
+        MathVisionCorrectionClient visionClient = new MathVisionCorrectionClient() {
+            @Override
+            public boolean available() {
+                return true;
+            }
+
+            @Override
+            public String provider() {
+                return "gemini";
+            }
+
+            @Override
+            public ParsedFile correct(PdfExtractionRequest request, PdfDocumentAnalysis analysis, List<Integer> pages) {
+                receivedPages.addAll(pages);
+                return ParsedFile.textOnly(DocumentFormat.PDF, "$x^{2}+1$", request.filename());
+            }
+        };
+        PdfExtractionEngineSelector selector = selectorWithAnalysis(analysis, List.of(mathEngine("$x^2$", "pix2text")),
+                true, 4, List.of(visionClient), true, pdfBox("fallback"), baseline);
+
+        selector.extract(request(PdfExtractionOptions.defaults()
+                .withOcrMode("FORCE")
+                .withMathVisionCorrection(true)));
+
+        assertThat(receivedPages).hasSize(2).first().isEqualTo(8);
+    }
+
+    @Test
     void hybridMathRouteSkipsVisionCorrectionWhenRequestDoesNotOptIn() {
         PdfDocumentAnalysis analysis = new PdfDocumentAnalysis(
                 12, 5, 0.0d, 1.0d, 0.0d, true, 0.0d, 1.0d, 1.0d, PdfDocumentKind.MATH_LIKE);


### PR DESCRIPTION
## Why

- 수학 PDF의 Markdown 품질과 page/sourceRef/bbox provenance 보존을 강화할 필요가 있었습니다.
- 문서 종류에 따른 RAG 검색 실패, 전체 문서 요약의 일부 장면 오인, 해석형 질문의 근거 부족과 긴 응답 시간을 개선합니다.
- Google chat/embedding provider와 실제 모델 이름을 일치시키고 모델별 사용량 및 추정 비용을 확인할 수 있게 합니다.

## What

- PDF/Markdown 정규화, 수식 보정, OCR 노이즈 억제와 품질 metadata 처리를 보완했습니다.
- 청킹 provenance와 parent context 확장을 보강하고 준비된 ChunkSet 기반 RAG 색인 연결을 수정했습니다.
- RAG query intent 분류, 검색 전략 자동 선택, 해석형 질문 정책과 전체 문서 Map-Reduce 요약을 추가했습니다.
- 대용량 구간 요약을 최대 3개 제한 병렬 처리하고 `ragTiming` 단계별 시간을 제공합니다.
- 전체 문서 요약은 metadata의 문서 제목과 원본 파일명으로 시작하며 없는 값은 추측하지 않습니다.
- Google chat/embedding 모델 설정과 secret 검증을 정리하고 모델별 token/비용 통계 API를 추가했습니다.

## Related Issues

- 별도 Issue 없이 사용자 요청에 따라 장기간 누적 개선을 수행한 예외 작업입니다.

## Validation

- Command: `./gradlew :studio-platform-markdown:test :studio-platform-textract:test :studio-platform-chunking-runtime:test :starter:studio-platform-starter-markdown:test :starter:studio-platform-textract-starter:test :starter:studio-platform-starter-ai:test :starter:studio-platform-starter-ai-web:test :studio-application-modules:content-embedding-pipeline:test --no-daemon`
- Result: 성공 (`BUILD SUCCESSFUL`, 85 actionable tasks)
- Command: `git diff --cached --check`
- Result: 성공
- Runtime: 로컬 API 서버 재기동 후 `8080` listen 확인

## Risk / Rollback

- Risk: 대용량 전체 문서의 첫 요약은 복수 provider 호출로 비용과 지연이 증가할 수 있으며, 모델별 비용은 설정 기반 추정값입니다.
- Risk: 문서 품질 및 RAG metadata가 additive로 늘어나므로 클라이언트는 알 수 없는 필드를 허용해야 합니다.
- Rollback: commit `8b228e73`을 revert하면 기존 Markdown/RAG 처리 경로로 복귀합니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: 변경 모듈 테스트, diff 검사, 로컬 서버 기동을 직접 확인했습니다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [ ] CI / repository verification passed
- [x] human review completed before merge
- [x] no unrelated changes included