### PR TITLE
[ai-assisted] fix(markdown): native fallback 중복 예약 방지

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Pandoc 제출 실패와 비동기 실패 callback이 동시에 native fallback을 요청해 동일 revision의 추출 작업이
+  중복 예약되던 경쟁 조건을 제거했다. 먼저 예약된 fallback은 계속 실행하고 후속 요청은 현재 revision을
+  반환하므로 `Markdown task is already running` 오류로 생성 API가 실패하지 않는다.
+
 - 임베딩 선택 옵션에 Google 공식 모델명을 포함한 canonical `embeddingModelId`, 사용자 표시명,
   `embeddingSpaceId`, legacy alias를 추가한다. 기존 `embeddingProfileId` 요청은 호환 alias로 유지하고,
   동일 모델·차원의 기존 PostgreSQL 벡터 metadata는 재임베딩 없이 canonical 식별자로 이관한다.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 - Pandoc 제출 실패와 비동기 실패 callback이 동시에 native fallback을 요청해 동일 revision의 추출 작업이
   중복 예약되던 경쟁 조건을 제거했다. 먼저 예약된 fallback은 계속 실행하고 후속 요청은 현재 revision을
-  반환하므로 `Markdown task is already running` 오류로 생성 API가 실패하지 않는다.
+  반환하므로 `Markdown task is already running` 오류로 생성 API가 실패하지 않는다. 실패 callback이
+  native fallback으로 전환한 뒤 늦게 반환된 Pandoc submit 응답이 revision을 다시 PANDOC 상태로 덮어쓰지
+  않도록 현재 상태를 재확인한다.
 
 - 임베딩 선택 옵션에 Google 공식 모델명을 포함한 canonical `embeddingModelId`, 사용자 표시명,
   `embeddingSpaceId`, legacy alias를 추가한다. 기존 `embeddingProfileId` 요청은 호환 alias로 유지하고,

--- a/studio-platform-markdown/src/main/java/studio/one/platform/markdown/application/MarkdownDocumentService.java
+++ b/studio-platform-markdown/src/main/java/studio/one/platform/markdown/application/MarkdownDocumentService.java
@@ -1176,11 +1176,26 @@ public class MarkdownDocumentService {
 
     private MarkdownExtractionResult fallbackToNative(MarkdownDocument document, MarkdownRevision revision,
             String errorCode, String errorMessage) {
-        MarkdownRevision nativeRevision = switchToNativeFallback(revision, errorCode, errorMessage);
-        String scheduledRevisionId = nativeRevision.revisionId();
-        scheduleNative(scheduledRevisionId);
-        MarkdownRevision current = repository.findRevision(scheduledRevisionId).orElse(nativeRevision);
-        return new MarkdownExtractionResult(requireDocument(document.documentId()), current, false);
+        String revisionId = revision.revisionId();
+        String taskKey = extractionTaskKey(revisionId);
+        if (!activeTasks.add(taskKey)) {
+            MarkdownRevision current = repository.findRevision(revisionId).orElse(revision);
+            return new MarkdownExtractionResult(requireDocument(document.documentId()), current, false);
+        }
+        try {
+            MarkdownRevision current = repository.findRevision(revisionId).orElse(revision);
+            if (current.status().terminal()) {
+                activeTasks.remove(taskKey);
+                return new MarkdownExtractionResult(requireDocument(document.documentId()), current, false);
+            }
+            MarkdownRevision nativeRevision = switchToNativeFallback(current, errorCode, errorMessage);
+            executeReservedTask(taskKey, () -> processNative(revisionId));
+            current = repository.findRevision(revisionId).orElse(nativeRevision);
+            return new MarkdownExtractionResult(requireDocument(document.documentId()), current, false);
+        } catch (RuntimeException ex) {
+            activeTasks.remove(taskKey);
+            throw ex;
+        }
     }
 
     private MarkdownRevision switchToNativeFallback(MarkdownRevision revision, String errorCode, String errorMessage) {
@@ -1200,7 +1215,11 @@ public class MarkdownDocumentService {
     }
 
     private void scheduleNative(String revisionId) {
-        scheduleTask("extraction:" + revisionId, () -> processNative(revisionId));
+        scheduleTask(extractionTaskKey(revisionId), () -> processNative(revisionId));
+    }
+
+    private String extractionTaskKey(String revisionId) {
+        return "extraction:" + revisionId;
     }
 
     private void prepareAndSchedulePipeline(MarkdownRevision revision) {
@@ -1237,6 +1256,10 @@ public class MarkdownDocumentService {
         if (!activeTasks.add(taskKey)) {
             throw new IllegalStateException("Markdown task is already running: " + taskKey);
         }
+        executeReservedTask(taskKey, task);
+    }
+
+    private void executeReservedTask(String taskKey, Runnable task) {
         try {
             taskExecutor.executeAfterCommit(() -> {
                 try {

--- a/studio-platform-markdown/src/main/java/studio/one/platform/markdown/application/MarkdownDocumentService.java
+++ b/studio-platform-markdown/src/main/java/studio/one/platform/markdown/application/MarkdownDocumentService.java
@@ -206,7 +206,11 @@ public class MarkdownDocumentService {
                 }
                 return fallbackToNative(document, revision, "PANDOC_SUBMIT_FAILED", ex.getMessage());
             }
-            revision = withConversionJob(revision, submission.jobId());
+            MarkdownRevision current = repository.findRevision(revision.revisionId()).orElse(revision);
+            if (current.status().terminal() || !"PANDOC".equalsIgnoreCase(current.extractorType())) {
+                return new MarkdownExtractionResult(requireDocument(document.documentId()), current, false);
+            }
+            revision = withConversionJob(current, submission.jobId());
             if ("FAILED".equalsIgnoreCase(submission.status())) {
                 if (fallbackToNativeOnPandocFailure) {
                     return fallbackToNative(document, revision, submission.errorCode(), submission.errorMessage());

--- a/studio-platform-markdown/src/test/java/studio/one/platform/markdown/MarkdownDocumentServiceTest.java
+++ b/studio-platform-markdown/src/test/java/studio/one/platform/markdown/MarkdownDocumentServiceTest.java
@@ -282,6 +282,45 @@ class MarkdownDocumentServiceTest {
     }
 
     @Test
+    void doesNotOverwriteNativeFallbackWhenCallbackCompletesBeforePandocSubmissionReturns() {
+        InMemoryRepository repository = new InMemoryRepository();
+        SourcePort sources = new SourcePort();
+        sources.add(1L, "sample.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "docx");
+        DeferredTaskExecutor tasks = new DeferredTaskExecutor();
+        MarkdownDocumentService[] serviceRef = new MarkdownDocumentService[1];
+        MarkdownConversionPort conversion = new MarkdownConversionPort() {
+            @Override
+            public ConversionSubmission submit(String jobId, long sourceAttachmentId, String sourceFormat,
+                    String requestedBy) {
+                serviceRef[0].onConversionFailed(jobId, sourceAttachmentId, "PANDOC_FAILED", "Pandoc failed");
+                return new ConversionSubmission(jobId, "RUNNING", null, null);
+            }
+
+            @Override
+            public void cancel(String jobId) {
+            }
+        };
+        serviceRef[0] = service(repository, sources,
+                (source, revisionId) -> new MarkdownNativeExtractorPort.NativeExtraction(
+                        "# Native", "textract-docx", List.of(), List.of()),
+                conversion, MarkdownPipelinePort.noop(), tasks, Set.of("docx", "html"), true);
+
+        var created = serviceRef[0].create(
+                new MarkdownExtractionRequest(1L, false, false, false, false, "tester"));
+
+        assertEquals(MarkdownRevisionStatus.RUNNING, created.revision().status());
+        assertEquals("TEXTRACT", created.revision().extractorType());
+        assertEquals(1, tasks.tasks.size());
+
+        tasks.runNext();
+
+        MarkdownRevision revision = serviceRef[0].getRevisions(created.document().documentId()).get(0);
+        assertEquals(MarkdownRevisionStatus.COMPLETED, revision.status());
+        assertEquals("TEXTRACT", revision.extractorType());
+    }
+
+    @Test
     void exposesRunningRevisionBeforeNativeExtractionCompletes() {
         InMemoryRepository repository = new InMemoryRepository();
         SourcePort sources = new SourcePort();

--- a/studio-platform-markdown/src/test/java/studio/one/platform/markdown/MarkdownDocumentServiceTest.java
+++ b/studio-platform-markdown/src/test/java/studio/one/platform/markdown/MarkdownDocumentServiceTest.java
@@ -243,6 +243,45 @@ class MarkdownDocumentServiceTest {
     }
 
     @Test
+    void keepsPandocFailureFallbackIdempotentWhenCallbackWinsSubmissionRace() {
+        InMemoryRepository repository = new InMemoryRepository();
+        SourcePort sources = new SourcePort();
+        sources.add(1L, "sample.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "docx");
+        DeferredTaskExecutor tasks = new DeferredTaskExecutor();
+        MarkdownDocumentService[] serviceRef = new MarkdownDocumentService[1];
+        MarkdownConversionPort conversion = new MarkdownConversionPort() {
+            @Override
+            public ConversionSubmission submit(String jobId, long sourceAttachmentId, String sourceFormat,
+                    String requestedBy) {
+                serviceRef[0].onConversionFailed(jobId, sourceAttachmentId, "PANDOC_TIMEOUT", "Pandoc timed out");
+                throw new IllegalStateException("Pandoc submission timed out");
+            }
+
+            @Override
+            public void cancel(String jobId) {
+            }
+        };
+        serviceRef[0] = service(repository, sources,
+                (source, revisionId) -> new MarkdownNativeExtractorPort.NativeExtraction(
+                        "# Native", "textract-docx", List.of(), List.of()),
+                conversion, MarkdownPipelinePort.noop(), tasks, Set.of("docx", "html"), true);
+
+        var created = serviceRef[0].create(
+                new MarkdownExtractionRequest(1L, false, false, false, false, "tester"));
+
+        assertEquals(MarkdownRevisionStatus.RUNNING, created.revision().status());
+        assertEquals("TEXTRACT", created.revision().extractorType());
+        assertEquals(1, tasks.tasks.size());
+
+        tasks.runNext();
+
+        MarkdownRevision revision = serviceRef[0].getRevisions(created.document().documentId()).get(0);
+        assertEquals(MarkdownRevisionStatus.COMPLETED, revision.status());
+        assertEquals("# Native", revision.markdownText());
+    }
+
+    @Test
     void exposesRunningRevisionBeforeNativeExtractionCompletes() {
         InMemoryRepository repository = new InMemoryRepository();
         SourcePort sources = new SourcePort();


### PR DESCRIPTION
## Why

Pandoc 제출 실패와 비동기 실패 callback이 경합하면 동일 Markdown revision의 native fallback 추출이 두 번 예약되었습니다. 이 경우 두 번째 예약이 `Markdown task is already running` 예외를 발생시켜 생성 API가 HTTP 500으로 종료되었습니다.

별도 Issue 없이 운영 중 확인된 재추출 실패를 긴급 수정합니다.

## What

- native fallback이 추출 작업 키를 먼저 원자적으로 선점하도록 변경했습니다.
- 동일 revision의 후속 fallback 요청은 중복 실행하지 않고 현재 revision을 반환하도록 멱등 처리했습니다.
- 일반 native 추출과 pipeline의 기존 중복 실행 방어는 유지했습니다.
- callback이 먼저 fallback을 예약한 뒤 Pandoc submit이 예외를 발생시키는 경쟁 조건 회귀 테스트를 추가했습니다.
- `CHANGELOG.md`에 변경 내용을 기록했습니다.

## Impact

Pandoc worker 장애나 submit timeout이 발생해도 native fallback이 이미 예약되어 있다면 API가 500으로 실패하지 않고 기존 추출 작업을 계속 사용합니다. API와 DB schema 변경은 없습니다.

## Validation

- `java -cp /Users/donghyuck.son/git/studio-api/gradle/wrapper/gradle-wrapper.jar org.gradle.wrapper.GradleWrapperMain :studio-platform-markdown:test --tests studio.one.platform.markdown.MarkdownDocumentServiceTest --no-daemon`
  - `BUILD SUCCESSFUL`
- `git diff --check`
  - 통과

## Checklist

- [x] 변경 범위를 Markdown fallback 경쟁 조건으로 제한했습니다.
- [x] 회귀 테스트를 추가했습니다.
- [x] 기존 API 및 DB schema를 유지했습니다.
- [x] AI-assisted 변경 및 검증 결과를 기록했습니다.
