### PR TITLE
[ai-assisted] chore(release): 2.1.0 release candidate 준비

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- `2.1.0-rc.1` release candidate로 artifact version을 갱신했다. 이 candidate는 Java 17,
+  Gradle 8.14.5, Spring Boot 3.5.16, Spring AI 1.1.8 호환 기준선을 보존하며, 개발 실행
+  서버의 ApplicationContext·DB migration·chat/embedding·RAG sync/SSE·Redis fail-open
+  검증을 통과한 뒤에만 `v2.1.0`으로 승격한다.
+
 - Redis가 설치되지 않은 실행 서버에서도 RAG answer-cache 자동 구성을 안전하게 건너뛰도록 Redis 전용 구성을 클래스패스 조건부 중첩 구성으로 격리했습니다.
 
 - Spring Boot 3.5.16, Spring AI 1.1.8, Gradle 8.14.5로 패치 기준선을 갱신하고 Spring AI BOM을

--- a/docs/dev/redis-rag-cache-rollout.md
+++ b/docs/dev/redis-rag-cache-rollout.md
@@ -56,7 +56,7 @@ studio:
 
 | Server | Candidate artifact | Cache mode | Context | Chat | Embedding | RAG sync | RAG SSE | Redis fail-open | Owner |
 |---|---|---|---|---|---|---|---|---|---|
-| 개발 서버 | 미입력 | `none` → `redis` | 미검증 | 미검증 | 미검증 | 미검증 | 미검증 | 미검증 | 미입력 |
+| 개발 서버 | `2.1.0-rc.1` | `none` → `redis` | 미검증 | 미검증 | 미검증 | 미검증 | 미검증 | 미검증 | 미입력 |
 
 이 repository에는 실행 가능한 server instance와 해당 `application.yml`이 포함되어 있지 않다.
 따라서 위 matrix가 소비 서버에서 채워지기 전에는 candidate artifact를 정식 승격하지 않는다.

--- a/docs/dev/spring-boot-4-spring-ai-2-spike.md
+++ b/docs/dev/spring-boot-4-spring-ai-2-spike.md
@@ -88,3 +88,17 @@ test starter 전환이 필요하다. 테스트를 제외해 제품 전환을 승
 
 그전까지 제품 기준선은 Boot 3.5.16/Spring AI 1.1.8을 유지하며, exact cache는 이
 기준선의 Spring Data Redis로 구현한다.
+
+## 2.1 호환 기준선 보존
+
+Boot 4/Jackson 3 전환 전에 `2.1.0-rc.1` candidate를 아래 순서로 검증한다.
+
+1. repository 전체 main/test build와 PostgreSQL/MySQL/MariaDB migration contract를 확인한다.
+2. 개발 실행 서버를 Spring Boot 3.5.16과 `2.1.0-rc.1` artifact에 맞춘다.
+3. ApplicationContext, chat, embedding, RAG sync/SSE를 확인한다.
+4. exact cache의 MISS/HIT, revision 변경 miss, Redis fail-open을 확인한다.
+5. 동일 소스를 `2.1.0`으로 승격해 `2.x`에 병합한 뒤 annotated tag `v2.1.0`을 생성한다.
+
+`2.x`는 Boot 3 호환 유지보수 브랜치로 남긴다. Boot 4.1, Spring AI 2.0,
+Jackson 3 전환은 `v2.1.0`에서 분기한 별도 `3.x` 또는 `upgrade/boot4-ai2`
+브랜치에서 수행하며 `2.x`에 병합하지 않는다.

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ buildApplicationGroup=studio.one.api
 buildModulesGroup=studio.one.modules
 buildStarterGroup=studio.one.starter
 buildApplicationName=studio-one
-buildApplicationVersion=2.0.0
+buildApplicationVersion=2.1.0-rc.1
 sourceCompatibility=17
 targetCompatibility=17
 #libraries


### PR DESCRIPTION
## Why

Spring Boot 4/Jackson 3 major 전환 전에 현재 Java 17, Spring Boot 3.5.16, Spring AI 1.1.8 호환 기준선을 재현 가능한 artifact와 rollback 지점으로 보존해야 합니다. 실행 서버 검증 없이 바로 `v2.1.0` 태그를 생성하지 않도록 release candidate gate를 명시합니다.

## What

- `buildApplicationVersion`을 `2.1.0-rc.1`로 갱신했습니다.
- CHANGELOG에 release candidate 기준선과 최종 승격 조건을 기록했습니다.
- 실행 서버의 ApplicationContext, DB migration, chat/embedding, RAG sync/SSE 검증 절차를 추가했습니다.
- Redis exact cache의 MISS/HIT, revision 변경 miss, fail-open 검증을 `v2.1.0` 선행 조건으로 지정했습니다.
- `2.x`는 Boot 3 유지보수 브랜치로 보존하고 Boot 4/Jackson 3 전환은 별도 `3.x` 계열에서 진행하도록 경계를 명시했습니다.

## Related Issues

- 별도 Issue 없음: 사용자의 2.1 호환 기준선 보존 및 다음 major 작업 준비 요청에 따라 진행했습니다.

## Validation

- Command: `git diff --check`
- Result: passed
- Command: 기준선 정적 확인
- Result: Gradle 8.14.5, Spring Boot 3.5.16, Spring AI 1.1.8 유지 확인
- Command: `./gradlew properties --no-daemon`
- Result: sandbox의 Gradle wrapper lock 권한 제한으로 task 시작 전에 중단됨
- 원격 CI와 실행 서버 compatibility matrix는 이 PR의 필수 후속 gate입니다.

## Risk / Rollback

- Risk: RC artifact를 사용하는 소비 서버가 아직 `studioOneVersion=2.0.0`, Spring Boot 3.5.9에 머물러 있어 설정 정렬 전에는 검증 결과가 대표성을 갖지 못합니다.
- Rollback: 이 커밋을 revert해 artifact version을 `2.0.0`으로 복구합니다. 최종 `v2.1.0` tag는 아직 생성하지 않습니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: 원격 `2.x` 원본과 변경 파일을 직접 비교하고 version·release gate·diff를 확인했습니다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [ ] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included