### PR TITLE
AI/RAG 아키텍처와 근거 흐름 문서화

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 3.0.0-rc.1
 
+- AI/RAG 전체 모듈 경계, 색인, 근거·인용, SSE, 운영 진단을 연결하는 문서 진입점을 추가했다.
+  누락돼 있던 document-metadata와 chunking-runtime README를 보완하고 루트·AI starter·Markdown
+  문서에서 동일한 기준 문서로 탐색할 수 있도록 정리했다.
+
 - `3.x` 첫 release candidate를 Java 17, Gradle 8.14.5, Spring Boot 4.1.0,
   Spring AI 2.0.0, MyBatis Spring Boot Starter 4.0.1, Boot 관리형 Jackson 3으로
   전환했다. Boot 4의 분리된 WebMVC·AspectJ·Flyway starter를 적용하고 classic/Jackson 2

--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ studio-application-modules/      # 애플리케이션 기능 모듈 (attachment,
 studio-platform/                 # 코어 플랫폼 라이브러리
 studio-platform-objecttype/      # objectType 레지스트리/정책/런타임 검증 구현
 studio-platform-ai/              # AI/RAG 공통 계약과 포트
+studio-platform-ai-model-catalog/ # AI 모델 capability 카탈로그
 studio-platform-chunking/        # RAG indexing용 chunking 계약
+studio-platform-chunking-runtime/ # 청킹 전략과 context expansion 구현
+studio-platform-document-metadata/ # 문서 의미 유형과 metadata schema 계약
+studio-platform-markdown/        # Markdown document/revision/pipeline 계약
 studio-platform-thumbnail/       # image/PDF 썸네일 생성 SPI
 studio-platform-autoconfigure/   # 공통 자동 구성
 studio-platform-data/            # 데이터 액세스 공통
@@ -76,10 +80,54 @@ studio-platform-workspace-default/ # Workspace JPA 기본 구현
 - `studio-platform-security`, `studio-platform-security-acl`: 인증/인가, JWT, ACL
 - `studio-platform-user`, `studio-platform-user-default`: 사용자 계약과 기본 구현
 - `studio-platform-data`, `studio-platform-data-mybatis`, `studio-platform-objecttype`, `studio-platform-realtime`, `studio-platform-workspace`: 데이터, MyBatis convention, objectType, 실시간 기능, workspace 공통
-- `studio-platform-ai`, `studio-platform-chunking`, `studio-platform-thumbnail`, `studio-platform-storage`, `studio-platform-identity`: AI/RAG 계약, chunking 계약, 썸네일 생성, 저장소, 식별 공통
+- `studio-platform-ai`, `studio-platform-ai-model-catalog`: AI/RAG 공통 계약과 모델 capability 카탈로그
+- `studio-platform-chunking`, `studio-platform-chunking-runtime`: chunking 계약과 전략/context expansion 구현
+- `studio-platform-document-metadata`, `studio-platform-markdown`: 문서 의미 metadata와 Markdown revision/pipeline 계약
+- `studio-platform-thumbnail`, `studio-platform-storage`, `studio-platform-identity`: 썸네일 생성, 저장소, 식별 공통
 - `studio-application-modules/*`: attachment, avatar, embedding pipeline, template, mail
 
 세부 설정, 엔드포인트, 확장 포인트는 각 모듈 README를 참고한다.
+
+## AI/RAG 한눈에 보기
+
+Studio One의 RAG는 파일이나 도메인 원문을 검색 가능한 작은 근거 단위로 색인하고, 사용자의 질문과
+관련된 원문 구간만 LLM에 전달해 답변과 인용을 함께 만드는 기능이다. 단순한 vector 검색을 넘어
+문서 revision, 의미 metadata, 청킹 provenance, embedding identity, object 권한과 citation 검증을
+하나의 흐름으로 연결한다.
+
+![Studio One AI/RAG 전체 흐름](docs/ai-rag/images/ai-rag-overview.svg)
+
+그림의 위쪽은 문서 색인 경로다. Attachment나 Markdown 원문을 정규화하고 문서 metadata를 추출한 뒤,
+검색에 적합한 chunk로 분할한다. 각 chunk는 선택한 embedding deployment로 vector화되며 원문 위치,
+revision과 object scope를 함께 저장한다.
+
+아래쪽은 근거 기반 답변 경로다. 요청 권한과 질의 의도를 확인하고 같은 object scope에서 관련 chunk를
+검색한다. 실제 prompt와 화면의 근거 목록은 하나의 `PackedEvidenceSet`에서 만들어진다. 생성된 답변은
+citation 번호와 원문 span 검증을 통과해야 canonical 답변으로 확정되며, SSE 화면도 마지막
+`complete.canonicalContent`를 최종 결과로 사용한다.
+
+### 구성요소
+
+| 구성요소 | 쉬운 설명 | 주요 모듈 |
+|---|---|---|
+| 원문 연결 | Attachment, Markdown, 도메인 데이터를 RAG 입력으로 연결 | `content-embedding-pipeline`, `studio-platform-markdown` |
+| 문서 metadata | 책·논문·보고서 유형과 제목·저자·발간일의 근거를 관리 | `studio-platform-document-metadata`, starter-markdown |
+| 청킹 | 긴 문서를 검색 가능한 단위로 나누고 원문 위치와 문맥 관계를 보존 | `studio-platform-chunking`, `studio-platform-chunking-runtime` |
+| 모델 카탈로그 | 채팅·임베딩 모델의 capability와 workload를 공통 관리 | `studio-platform-ai-model-catalog` |
+| 임베딩·검색 | chunk를 vector로 저장하고 질문과 관련된 근거를 검색 | `studio-platform-ai`, `studio-platform-starter-ai` |
+| 근거 패킹 | 검색 결과를 prompt 한도에 맞추고 번호순 evidence와 span을 생성 | `studio-platform-starter-ai-web` |
+| 답변·인용 | sync/SSE 답변의 citation을 검증하고 canonical 결과를 확정 | `studio-platform-starter-ai-web` |
+| 운영 cache | 검증된 exact answer만 재사용하고 Redis 장애 시 provider로 우회 | `studio-platform-starter-ai-web` |
+
+구현하거나 문제를 진단할 때는 [AI/RAG 아키텍처 가이드](docs/ai-rag/README.md)에서 모듈 책임과
+색인·근거 답변의 상세 계약을 먼저 확인한다.
+
+| 목적 | 문서 |
+|---|---|
+| 전체 모듈 지도와 최소 조합 | [AI/RAG 아키텍처](docs/ai-rag/README.md) |
+| 추출·metadata·청킹·embedding·vector 저장 | [RAG 색인](docs/ai-rag/indexing.md) |
+| retrieval·evidence·citation·SSE | [근거 기반 RAG Chat](docs/ai-rag/grounded-chat.md) |
+| 기동·진단·cache·장애 대응 | [AI/RAG 운영](docs/ai-rag/operations.md) |
 
 ## 스타터
 각 기능은 대응되는 스타터를 추가하면 자동 구성된다. 요약은 `starter/README.md` 참고.
@@ -194,9 +242,13 @@ application modules
 | `:studio-platform` | - |
 | `:studio-platform-autoconfigure` | `implementation :studio-platform` |
 | `:studio-platform-ai` | `implementation :studio-platform` |
+| `:studio-platform-ai-model-catalog` | `api :studio-platform-ai` |
 | `:studio-platform-chunking` | - |
+| `:studio-platform-chunking-runtime` | `api :studio-platform-chunking`, `compileOnly :studio-platform-ai`, `compileOnly :studio-platform-textract` |
 | `:studio-platform-data` | `api :studio-platform-textract`, `implementation :studio-platform` |
+| `:studio-platform-document-metadata` | - |
 | `:studio-platform-identity` | - |
+| `:studio-platform-markdown` | `api :studio-platform`, `api :studio-platform-document-metadata`, `compileOnly :studio-platform-document-convert` |
 | `:studio-platform-objecttype` | `compileOnly :studio-platform`, `compileOnly :studio-platform-data` |
 | `:studio-platform-realtime` | `compileOnly :studio-platform`, `compileOnly :studio-platform-security` |
 | `:studio-platform-security` | `compileOnly :studio-platform`, `compileOnly :studio-platform-identity`, `compileOnly :studio-platform-user`, `compileOnly :studio-platform-user-default`, `compileOnly :studio-platform-data` |
@@ -421,6 +473,7 @@ studio:
 - 사용자 계약: `studio-platform-user/README.md`
 - 사용자 기본 구현: `studio-platform-user-default/README.md`
 - 3.x 업그레이드 기준선: `docs/dev/3x-upgrade-baseline.md`
+- AI/RAG 아키텍처: `docs/ai-rag/README.md`
 - RAG cache 운영 절차: `docs/dev/redis-rag-cache-rollout.md`
 - 변경 이력: `CHANGELOG.md`
 - 보안 운영 규칙: `SECURITY.md`

--- a/docs/ai-rag/README.md
+++ b/docs/ai-rag/README.md
@@ -1,0 +1,156 @@
+# AI/RAG 아키텍처 가이드
+
+Studio One의 AI/RAG 기능을 처음 구성하거나 변경할 때 사용하는 문서 진입점이다.
+이 문서는 모듈 경계와 전체 실행 흐름을 설명한다. 세부 설정값과 전체 HTTP 계약은 각 스타터
+README를 기준으로 하며, 같은 설정을 이 문서에 중복 정의하지 않는다.
+
+## 먼저 읽을 문서
+
+| 목적 | 문서 |
+|---|---|
+| 문서 색인 흐름과 재색인 기준 | [RAG 색인](indexing.md) |
+| 근거 기반 답변·인용·SSE 계약 | [근거 기반 RAG Chat](grounded-chat.md) |
+| 기동·진단·캐시·장애 대응 | [운영 및 문제 해결](operations.md) |
+| AI 공통 타입과 metadata key | [studio-platform-ai](../../studio-platform-ai/README.md) |
+| Provider·벡터·RAG runtime 설정 | [studio-platform-starter-ai](../../starter/studio-platform-starter-ai/README.md) |
+| HTTP API와 권한 | [studio-platform-starter-ai-web](../../starter/studio-platform-starter-ai-web/README.md) |
+| 청킹 전략과 설정 | [studio-platform-starter-chunking](../../starter/studio-platform-starter-chunking/README.md) |
+
+## 모듈 책임 지도
+
+| 영역 | 소유 모듈 | 담당하는 것 | 담당하지 않는 것 |
+|---|---|---|---|
+| AI 공통 계약 | `studio-platform-ai` | Chat, embedding, vector, RAG, job, metadata key 계약 | Spring AI adapter, HTTP controller |
+| 모델 정의 | `studio-platform-ai-model-catalog` | 모델 capability와 workload 카탈로그 | 운영 deployment와 secret |
+| 모델 배포 | `studio-platform-starter-ai` | `ModelDeploymentRegistry`, provider adapter, 기본 포트 선택 | 서버별 API key 관리 |
+| RAG runtime | `studio-platform-starter-ai` | `DefaultRagPipelineService`, pgvector adapter, job service | 파일 추출, HTTP 노출 |
+| AI/RAG HTTP | `studio-platform-starter-ai-web` | Chat/RAG API, 검색 orchestration, 근거 패킹, 인용 검증, SSE, answer cache | 문서 파싱, 청킹 구현 |
+| 청킹 계약 | `studio-platform-chunking` | chunk, normalized document, provenance, context expansion 계약 | 전략 구현과 Spring 설정 |
+| 청킹 구현 | `studio-platform-chunking-runtime` | recursive, fixed, token, structure, blockify, context expander | REST API, vector 저장 |
+| 청킹 자동 구성 | `studio-platform-starter-chunking` | runtime Bean과 `studio.chunking.*` 설정 | 문서 추출, embedding |
+| 문서 메타데이터 | `studio-platform-document-metadata` | 의미 유형, schema, artifact, provenance, projection allowlist | 저장소, LLM 호출, HTTP |
+| Markdown 계약 | `studio-platform-markdown` | 문서/revision/pipeline/resource 저장 계약과 API | 추출기·AI runtime 구현 |
+| Markdown runtime | `studio-platform-starter-markdown` | native metadata, 조건부 LLM enrichment, backfill, RAG 연결 | Provider 모델 카탈로그 |
+| 첨부 연동 | `content-embedding-pipeline` | Attachment 추출, 구조화 색인, attachment job executor | 범용 AI/RAG 계약 |
+
+## 전체 구조
+
+```mermaid
+flowchart LR
+    S["Attachment / Markdown / Domain source"]
+    X["Textract / Document Convert"]
+    M["Document metadata enrichment"]
+    C["ChunkingOrchestrator"]
+    E["EmbeddingPort"]
+    V["VectorStorePort"]
+    Q["RAG Chat request"]
+    R["RagChatRetrievalService"]
+    P["RagContextBuilder / PackedEvidenceSet"]
+    L["ChatPort"]
+    F["RagAnswerFinalizer"]
+    A["Canonical answer + references"]
+
+    S --> X --> M --> C --> E --> V
+    Q --> R --> V
+    R --> P --> L --> F --> A
+```
+
+색인과 답변은 같은 metadata와 object scope를 공유하지만 별도 실행 흐름이다.
+문서 처리 프로필과 의미 유형은 metadata·질의 라우팅에 사용하며, 의미 유형만으로 청킹 전략을
+자동 변경하지 않는다.
+
+## 색인 흐름
+
+1. source adapter가 원문을 정규화하고 `objectType`, `objectId`, revision과 locator를 보존한다.
+2. Markdown 경로는 `METADATA_ENRICHMENT`에서 native·구조 기반 metadata를 먼저 생성한다.
+3. `ChunkingOrchestrator`가 설정된 전략과 단위로 chunk를 생성한다.
+4. `EmbeddingPort`가 deployment에 맞는 embedding을 생성한다.
+5. `VectorStorePort`가 embedding identity, object scope, chunk provenance를 저장한다.
+6. 재색인은 같은 object scope의 오래된 chunk가 남지 않도록 replace/delete 후 저장한다.
+
+세부 동작과 structured/fallback 경계는 [RAG 색인](indexing.md)을 따른다.
+
+## 근거 기반 답변 흐름
+
+1. `ChatController`가 권한과 object scope를 확인한다.
+2. 질의 의도를 분류하고 metadata 조회 또는 semantic retrieval 경로를 선택한다.
+3. `RagChatRetrievalService`가 검색 결과와 주변 문맥을 수집한다.
+4. `RagContextBuilder`가 prompt 한도 안에서 근거를 패킹한다.
+5. `PackedEvidenceSet`이 prompt context, 번호순 evidence, source span과 fingerprint의 단일 원본이 된다.
+6. Provider draft를 `RagCitationValidator`와 `RagAnswerFinalizer`가 검증한다.
+7. sync 응답과 SSE `complete`는 같은 canonical content와 reference를 반환한다.
+
+packed evidence가 없거나 citation이 구조적으로 유효하지 않으면 근거 부족 응답을 반환하며,
+검증되지 않은 draft를 대화 메모리나 exact-answer cache에 저장하지 않는다.
+
+## 최소 조합
+
+### 일반 채팅
+
+```kotlin
+implementation(project(":starter:studio-platform-starter-ai"))
+implementation(project(":starter:studio-platform-starter-ai-web"))
+implementation("org.springframework.ai:spring-ai-starter-model-openai")
+```
+
+Chat deployment와 provider 설정만 필요하다. 벡터 저장소가 없으면 RAG·vector 기능은 사용할 수 없다.
+
+### 범용 RAG
+
+```kotlin
+implementation(project(":starter:studio-platform-starter-ai"))
+implementation(project(":starter:studio-platform-starter-ai-web"))
+implementation(project(":starter:studio-platform-starter-chunking"))
+implementation("org.springframework.ai:spring-ai-starter-model-openai")
+```
+
+PostgreSQL/pgvector와 `JdbcTemplate`을 준비하고 CHAT과 EMBEDDING deployment를 각각 등록한다.
+
+### 첨부파일 RAG
+
+```kotlin
+implementation(project(":starter:studio-application-starter-attachment"))
+implementation(project(":studio-application-modules:content-embedding-pipeline"))
+implementation(project(":starter:studio-platform-textract-starter"))
+implementation(project(":starter:studio-platform-starter-chunking"))
+implementation(project(":starter:studio-platform-starter-ai-web"))
+```
+
+파일 추출과 attachment object 권한이 추가로 필요하다.
+
+### Markdown 지식 파이프라인
+
+```kotlin
+implementation(project(":starter:studio-platform-starter-markdown"))
+implementation(project(":starter:studio-platform-starter-chunking"))
+implementation(project(":starter:studio-platform-starter-ai-web"))
+```
+
+`studio-platform-starter-markdown`은 revision, metadata enrichment, ChunkSet/RAG 후속 실행을 연결한다.
+실제 변환·추출·provider 의존성은 사용하는 포맷과 모델에 맞게 소비 서버가 추가한다.
+
+## 설정 소유권
+
+| Namespace | 소유 영역 |
+|---|---|
+| `spring.ai.*` | Provider SDK 연결과 모델별 native option |
+| `studio.ai.providers.*` | Studio provider 등록과 channel 활성화 |
+| `studio.ai.deployments.*` | 논리 deployment와 모델 카탈로그 연결 |
+| `studio.ai.routing.*` | 기본 chat/embedding provider 호환 설정 |
+| `studio.ai.rag.*` | RAG pipeline, retrieval, job, answer cache |
+| `studio.ai.endpoints.*` | 사용자·관리 HTTP API |
+| `studio.chunking.*` | 청킹 전략, 크기, tokenizer, blockify |
+| `studio.markdown.*` | Markdown 변환, metadata enrichment와 후속 pipeline |
+
+서버에는 논리 deployment ID와 secret reference를 두고 모델 capability는 공통 모델 카탈로그에서 관리한다.
+Provider base URL, credential, 내부 topology는 사용자 응답이나 운영 로그에 노출하지 않는다.
+
+## 변경 시 확인할 계약
+
+- 인덱싱과 검색은 동일한 embedding deployment, dimension, input type을 사용한다.
+- `objectType`/`objectId`는 API, vector metadata, 권한 router에서 같은 의미를 가진다.
+- prompt context와 API reference는 같은 `PackedEvidenceSet`에서 생성한다.
+- exact excerpt는 인덱싱된 정규화 chunk의 연속 부분 문자열이어야 한다.
+- SSE draft는 확정 답변이 아니며 `complete.canonicalContent`가 최종 계약이다.
+- cache hit도 현재 검색 결과로 reference와 citation을 다시 검증한다.
+- metadata prompt fact에는 source-verified field만 사용한다.

--- a/docs/ai-rag/grounded-chat.md
+++ b/docs/ai-rag/grounded-chat.md
@@ -1,0 +1,117 @@
+# 근거 기반 RAG Chat
+
+RAG Chat의 목표는 검색 결과를 단순히 prompt에 붙이는 것이 아니라, 답변과 API reference가 동일한
+원문 구간을 가리키도록 보장하는 것이다.
+
+## 실행 흐름
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Chat as ChatController
+    participant Retrieval as RagChatRetrievalService
+    participant Vector as VectorStorePort
+    participant Pack as RagContextBuilder
+    participant Model as ChatPort
+    participant Final as RagAnswerFinalizer
+
+    Client->>Chat: RAG request
+    Chat->>Chat: authorization and intent
+    Chat->>Retrieval: retrieve object-scoped evidence
+    Retrieval->>Vector: semantic/object search
+    Vector-->>Retrieval: chunks and scores
+    Retrieval->>Pack: results and expanded context
+    Pack-->>Chat: PackedEvidenceSet
+    Chat->>Model: prompt context
+    Model-->>Chat: draft answer
+    Chat->>Final: draft and PackedEvidenceSet
+    Final-->>Client: canonical content and references
+```
+
+## `PackedEvidenceSet`
+
+`PackedEvidenceSet`은 응답 단위의 단일 근거 원본이다.
+
+- `promptContext`: 실제 모델에 전달하는 context
+- `evidence[]`: 1부터 시작하는 citation 순서
+- `sourceSpans[]`: exact text와 locator
+- `diagnostics`: 패킹 결과와 제외 사유
+- `contextFingerprint`: cache와 응답 일관성 확인값
+
+각 evidence는 안정적인 `evidenceId`, document/revision/chunk ID, score, evidence kind,
+support status와 source span을 가진다. reference는 이 집합에서만 생성한다.
+
+`exactText`는 원본 binary byte 구간이 아니라 인덱싱된 정규화 chunk 안의 연속 부분 문자열이다.
+source span이 packed content에 존재하지 않으면 reference span으로 채택하지 않는다.
+
+## 질의 경로
+
+| 질의 | 기본 경로 |
+|---|---|
+| 제목·저자·소속·발간일·ISBN·DOI | source-verified document metadata |
+| 특정 사실·문장 | object-scoped semantic retrieval |
+| 전체 요약·줄거리 | overview 또는 map-reduce |
+| 해석·비교 | 복수 근거 retrieval 후 evidence-based inference |
+
+자동 감지한 문서 의미 유형만으로 검색 결과를 배제하지 않는다. 사용자가 명시한 필터 또는 object scope가
+있을 때만 hard filter를 적용한다.
+
+## 인용 검증과 canonical 응답
+
+`RagCitationValidator`는 답변의 citation 번호가 packed evidence 범위 안에 있는지 확인한다.
+유효한 번호라는 사실은 의미적 사실 검증과 같지 않다.
+
+| 상태 | 의미 |
+|---|---|
+| `INDEX_VALID` | citation 번호와 packed evidence 구조가 유효함 |
+| `MISSING_CITATION` | 근거가 있지만 답변에 citation이 없음 |
+| `OUT_OF_RANGE` | packed evidence 범위 밖 citation이 있음 |
+| `NO_PACKED_EVIDENCE` | 모델에 전달할 근거가 없음 |
+
+근거가 없거나 구조적으로 유효하지 않은 답변은 `RagAnswerFinalizer`가 안전한 근거 부족 응답으로 교체한다.
+기본 경로는 두 번째 LLM repair를 호출하지 않는다.
+
+`supportStatus=SOURCE_VERIFIED`는 원문 span의 provenance를 뜻한다. citation 번호가 유효하다는 이유만으로
+모델이 작성한 모든 문장을 `SOURCE_VERIFIED`로 승격하지 않는다.
+
+## Sync와 SSE
+
+동기 API와 SSE는 같은 retrieval, `PackedEvidenceSet`, finalizer를 사용한다.
+
+- SSE `delta`는 draft이며 citation 링크를 확정하지 않는다.
+- `complete.canonicalContent`가 최종 표시·저장 대상이다.
+- `complete.metadata.ragReferences`는 canonical content에 대응하는 검증된 reference다.
+- 대화 메모리에는 draft가 아니라 canonical content만 저장한다.
+
+클라이언트는 스트리밍이 완료되면 누적 draft를 `canonicalContent`로 교체해야 한다.
+
+## Answer cache
+
+exact-answer cache는 authorization과 현재 retrieval/packing 이후에 조회한다.
+key에는 principal, object scope, 질문/대화, deployment, retrieval 설정과 evidence fingerprint가 포함된다.
+
+cache hit도 현재 `PackedEvidenceSet`으로 citation을 재검증하고 reference를 다시 만든다.
+cached payload에는 credential, 원문 전체, locator/reference 전체를 저장하지 않는다.
+
+## Reference 표시 권장
+
+클라이언트는 citation 번호만 표시하지 말고 다음 값을 함께 보여준다.
+
+- 문서 제목 또는 원본 파일명
+- exact excerpt
+- page, slide, section, sourceRef
+- score
+- support status
+- truncated 여부
+
+raw vector metadata map이나 내부 provider topology는 사용자에게 노출하지 않는다.
+
+## 관련 API
+
+- `POST /api/ai/chat/rag`
+- `POST /api/ai/chat/rag/stream`
+- `GET /api/mgmt/ai/rag/objects/{objectType}/{objectId}/chunks`
+- `GET /api/mgmt/ai/rag/objects/{objectType}/{objectId}/metadata`
+
+전체 endpoint와 권한은
+[AI Web README](../../starter/studio-platform-starter-ai-web/README.md#3-rest-엔드포인트)를 따른다.

--- a/docs/ai-rag/images/ai-rag-overview.svg
+++ b/docs/ai-rag/images/ai-rag-overview.svg
@@ -1,0 +1,140 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720" role="img" aria-labelledby="title desc">
+  <title id="title">Studio One AI/RAG 전체 흐름</title>
+  <desc id="desc">문서 색인과 근거 기반 답변이 공통 벡터 저장소와 원문 근거를 통해 연결되는 구조</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f7f7ff"/>
+      <stop offset="1" stop-color="#eef8ff"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="5" stdDeviation="7" flood-color="#1f2937" flood-opacity="0.12"/>
+    </filter>
+    <marker id="arrowPurple" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#7157d9"/>
+    </marker>
+    <marker id="arrowBlue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#2680c2"/>
+    </marker>
+    <style>
+      .title { font: 700 34px Pretendard, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif; fill: #172033; }
+      .subtitle { font: 400 17px Pretendard, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif; fill: #566176; }
+      .lane { font: 700 20px Pretendard, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif; }
+      .box-title { font: 700 17px Pretendard, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif; fill: #172033; }
+      .box-copy { font: 400 13px Pretendard, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif; fill: #556176; }
+      .module { font: 600 11px ui-monospace, SFMono-Regular, Menlo, monospace; fill: #7157d9; }
+      .legend { font: 500 13px Pretendard, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif; fill: #4b5565; }
+      .arrow-label { font: 600 12px Pretendard, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif; fill: #566176; }
+    </style>
+  </defs>
+
+  <rect width="1280" height="720" rx="28" fill="url(#background)"/>
+  <text x="64" y="62" class="title">Studio One AI/RAG 한눈에 보기</text>
+  <text x="64" y="94" class="subtitle">색인된 원문 구간과 최종 답변의 인용이 같은 evidence를 가리키도록 구성합니다.</text>
+
+  <rect x="48" y="130" width="1184" height="222" rx="24" fill="#ffffff" stroke="#dfd9ff" filter="url(#shadow)"/>
+  <text x="72" y="168" class="lane" fill="#7157d9">① 문서 색인</text>
+
+  <g transform="translate(72 194)">
+    <rect width="174" height="112" rx="16" fill="#f5f2ff" stroke="#cfc4ff"/>
+    <text x="87" y="31" text-anchor="middle" class="box-title">원문 입력</text>
+    <text x="87" y="56" text-anchor="middle" class="box-copy">Attachment · Markdown</text>
+    <text x="87" y="78" text-anchor="middle" class="box-copy">도메인 객체</text>
+    <text x="87" y="99" text-anchor="middle" class="module">source adapters</text>
+  </g>
+  <path d="M 252 250 L 291 250" stroke="#7157d9" stroke-width="3" marker-end="url(#arrowPurple)"/>
+
+  <g transform="translate(298 194)">
+    <rect width="190" height="112" rx="16" fill="#f5f2ff" stroke="#cfc4ff"/>
+    <text x="95" y="31" text-anchor="middle" class="box-title">정규화 · 메타데이터</text>
+    <text x="95" y="56" text-anchor="middle" class="box-copy">revision · locator · provenance</text>
+    <text x="95" y="78" text-anchor="middle" class="box-copy">문서 의미 유형과 schema</text>
+    <text x="95" y="99" text-anchor="middle" class="module">markdown / document-metadata</text>
+  </g>
+  <path d="M 494 250 L 533 250" stroke="#7157d9" stroke-width="3" marker-end="url(#arrowPurple)"/>
+
+  <g transform="translate(540 194)">
+    <rect width="174" height="112" rx="16" fill="#f5f2ff" stroke="#cfc4ff"/>
+    <text x="87" y="31" text-anchor="middle" class="box-title">청킹</text>
+    <text x="87" y="56" text-anchor="middle" class="box-copy">recursive · structure</text>
+    <text x="87" y="78" text-anchor="middle" class="box-copy">parent · neighbor · span</text>
+    <text x="87" y="99" text-anchor="middle" class="module">chunking-runtime</text>
+  </g>
+  <path d="M 720 250 L 759 250" stroke="#7157d9" stroke-width="3" marker-end="url(#arrowPurple)"/>
+
+  <g transform="translate(766 194)">
+    <rect width="174" height="112" rx="16" fill="#f5f2ff" stroke="#cfc4ff"/>
+    <text x="87" y="31" text-anchor="middle" class="box-title">임베딩</text>
+    <text x="87" y="56" text-anchor="middle" class="box-copy">deployment · dimension</text>
+    <text x="87" y="78" text-anchor="middle" class="box-copy">embedding space</text>
+    <text x="87" y="99" text-anchor="middle" class="module">EmbeddingPort</text>
+  </g>
+  <path d="M 946 250 L 985 250" stroke="#7157d9" stroke-width="3" marker-end="url(#arrowPurple)"/>
+
+  <g transform="translate(992 194)">
+    <rect width="174" height="112" rx="16" fill="#eeeaff" stroke="#ab98ff"/>
+    <text x="87" y="31" text-anchor="middle" class="box-title">Vector Store</text>
+    <text x="87" y="56" text-anchor="middle" class="box-copy">chunk · embedding</text>
+    <text x="87" y="78" text-anchor="middle" class="box-copy">object scope · source span</text>
+    <text x="87" y="99" text-anchor="middle" class="module">VectorStorePort</text>
+  </g>
+
+  <rect x="48" y="382" width="1184" height="222" rx="24" fill="#ffffff" stroke="#cce8f8" filter="url(#shadow)"/>
+  <text x="72" y="420" class="lane" fill="#2680c2">② 근거 기반 답변</text>
+
+  <g transform="translate(72 446)">
+    <rect width="174" height="112" rx="16" fill="#eef8ff" stroke="#b8def4"/>
+    <text x="87" y="31" text-anchor="middle" class="box-title">질문 · 권한 범위</text>
+    <text x="87" y="56" text-anchor="middle" class="box-copy">principal · objectType</text>
+    <text x="87" y="78" text-anchor="middle" class="box-copy">질의 의도 분류</text>
+    <text x="87" y="99" text-anchor="middle" class="module">ChatController</text>
+  </g>
+  <path d="M 252 502 L 291 502" stroke="#2680c2" stroke-width="3" marker-end="url(#arrowBlue)"/>
+
+  <g transform="translate(298 446)">
+    <rect width="190" height="112" rx="16" fill="#eef8ff" stroke="#b8def4"/>
+    <text x="95" y="31" text-anchor="middle" class="box-title">검색 · 문맥 확장</text>
+    <text x="95" y="56" text-anchor="middle" class="box-copy">semantic · metadata</text>
+    <text x="95" y="78" text-anchor="middle" class="box-copy">previous · parent · next</text>
+    <text x="95" y="99" text-anchor="middle" class="module">RagChatRetrievalService</text>
+  </g>
+  <path d="M 494 502 L 533 502" stroke="#2680c2" stroke-width="3" marker-end="url(#arrowBlue)"/>
+
+  <g transform="translate(540 446)">
+    <rect width="174" height="112" rx="16" fill="#eef8ff" stroke="#b8def4"/>
+    <text x="87" y="31" text-anchor="middle" class="box-title">근거 패킹</text>
+    <text x="87" y="56" text-anchor="middle" class="box-copy">prompt · evidence · span</text>
+    <text x="87" y="78" text-anchor="middle" class="box-copy">context fingerprint</text>
+    <text x="87" y="99" text-anchor="middle" class="module">PackedEvidenceSet</text>
+  </g>
+  <path d="M 720 502 L 759 502" stroke="#2680c2" stroke-width="3" marker-end="url(#arrowBlue)"/>
+
+  <g transform="translate(766 446)">
+    <rect width="174" height="112" rx="16" fill="#eef8ff" stroke="#b8def4"/>
+    <text x="87" y="31" text-anchor="middle" class="box-title">답변 생성</text>
+    <text x="87" y="56" text-anchor="middle" class="box-copy">근거 context + 질문</text>
+    <text x="87" y="78" text-anchor="middle" class="box-copy">sync 또는 SSE draft</text>
+    <text x="87" y="99" text-anchor="middle" class="module">ChatPort</text>
+  </g>
+  <path d="M 946 502 L 985 502" stroke="#2680c2" stroke-width="3" marker-end="url(#arrowBlue)"/>
+
+  <g transform="translate(992 446)">
+    <rect width="174" height="112" rx="16" fill="#e5f5ff" stroke="#75bce7"/>
+    <text x="87" y="31" text-anchor="middle" class="box-title">인용 검증 · 확정</text>
+    <text x="87" y="56" text-anchor="middle" class="box-copy">canonical content</text>
+    <text x="87" y="78" text-anchor="middle" class="box-copy">exact excerpt · reference</text>
+    <text x="87" y="99" text-anchor="middle" class="module">RagAnswerFinalizer</text>
+  </g>
+
+  <path d="M 1079 306 L 1079 352 Q 1079 366 1065 366 L 413 366 Q 393 366 393 382 L 393 440"
+        fill="none" stroke="#708399" stroke-width="2.5" stroke-dasharray="7 6" marker-end="url(#arrowBlue)"/>
+  <rect x="677" y="353" width="162" height="26" rx="13" fill="#ffffff" stroke="#c9d4df"/>
+  <text x="758" y="371" text-anchor="middle" class="arrow-label">같은 object scope 검색</text>
+
+  <g transform="translate(64 648)">
+    <circle cx="9" cy="9" r="8" fill="#7157d9"/>
+    <text x="25" y="14" class="legend">색인 경로</text>
+    <circle cx="128" cy="9" r="8" fill="#2680c2"/>
+    <text x="144" y="14" class="legend">답변 경로</text>
+    <text x="261" y="14" class="legend">핵심 원칙: prompt context와 사용자 reference는 동일한 PackedEvidenceSet에서 생성</text>
+  </g>
+</svg>

--- a/docs/ai-rag/indexing.md
+++ b/docs/ai-rag/indexing.md
@@ -1,0 +1,129 @@
+# RAG 색인
+
+이 문서는 원문이 검색 가능한 chunk와 vector record로 변환되는 흐름, 경로별 차이와 재색인 기준을
+설명한다. 청킹 전략별 세부 설정은
+[starter-chunking README](../../starter/studio-platform-starter-chunking/README.md)를 기준으로 한다.
+
+## 공통 색인 단계
+
+```mermaid
+flowchart LR
+    S["Source"]
+    N["Normalized text / document"]
+    M["Metadata artifact"]
+    C["Chunks"]
+    E["Embeddings"]
+    V["Vector records"]
+
+    S --> N --> M --> C --> E --> V
+```
+
+| 단계 | 주요 계약 | 필수 보존값 |
+|---|---|---|
+| 정규화 | `NormalizedDocument`, Markdown revision | source/revision, locator, block |
+| 메타데이터 | `DocumentMetadataArtifact` | semantic type, provenance, evidence |
+| 청킹 | `ChunkingOrchestrator` | chunk ID/order, parent/neighbor, source span |
+| 임베딩 | `EmbeddingPort` | deployment, model, dimension, input type |
+| 저장 | `VectorStorePort`, `VectorRecord` | object scope, content hash, embedding identity |
+
+`DefaultRagPipelineService`는 범용 text 색인을 제공한다. attachment와 Markdown은 source 고유의
+정규화·revision 정보를 보존하기 위해 별도 adapter를 사용하고, 최종 embedding/vector 계약은 동일하게 맞춘다.
+
+## 범용 text 색인
+
+`RagPipelineService.index(...)`는 text 정제, chunking, embedding, vector 저장을 순서대로 수행한다.
+`ChunkingOrchestrator`가 있으면 이를 우선하고 없으면 legacy `TextChunker`를 사용한다.
+
+새로운 소비 모듈은 다음 값을 명시해야 한다.
+
+- 안정적인 `documentId`
+- 권한과 검색 범위를 나타내는 `objectType`, `objectId`
+- 사용할 embedding deployment 또는 profile
+- 원문 변경을 식별할 revision/content hash
+- UI 근거 표시에 필요한 `sourceRef`, page/section/block locator
+
+## 첨부파일 색인
+
+`content-embedding-pipeline`의 `AttachmentRagIndexService`가 attachment source를 실행한다.
+
+1. `AttachmentService`가 파일 stream과 source 정보를 제공한다.
+2. `FileContentExtractionService`가 text 또는 구조화 문서를 생성한다.
+3. `TextractNormalizedDocumentAdapter`, `ChunkingOrchestrator`, `EmbeddingPort`,
+   `VectorStorePort`가 모두 있으면 구조화 색인을 사용한다.
+4. 선택 Bean이 부족하면 `RagPipelineService.index(...)` text 경로로 fallback한다.
+5. 대용량 문서는 chunk를 batch upsert해 전체 embedding 목록을 메모리에 보관하지 않는다.
+
+구조화 경로와 fallback 경로는 요청의 embedding 선택과 object scope를 동일하게 전달해야 한다.
+상세 API는
+[Content Embedding Pipeline](../../studio-application-modules/content-embedding-pipeline/README.md)을
+참고한다.
+
+## Markdown 색인
+
+Markdown pipeline의 명시적 순서는 다음과 같다.
+
+1. `METADATA_ENRICHMENT`
+2. `CHUNKING`
+3. `RAG_INDEX`
+4. 선택적 `SKILL_EXTRACTION`
+
+metadata enrichment는 native/구조 기반 값을 우선한다. `AUTO` 모드에서는 신뢰도가 낮거나 필드가
+부족한 경우에만 structured-output CHAT deployment를 호출한다. metadata 실패 정책은
+`OFF | AUTO | REQUIRED`로 구분한다.
+
+현재 revision의 normalized snapshot을 기준으로 처리하며, metadata artifact는 revision별 typed resource로
+저장한다. 전체 artifact를 각 chunk에 반복 저장하지 않고 vector에는 projection allowlist만 저장한다.
+
+## 청킹 선택
+
+기본 청킹 계약은 다음과 같다.
+
+```yaml
+studio:
+  chunking:
+    strategy: recursive
+    unit: character
+    max-size: 800
+    overlap: 100
+```
+
+문서 처리 프로필, 문서 의미 유형, Blockify 문서 유형은 서로 다른 값이다.
+
+- 처리 프로필: extraction/chunking 요청 preset
+- 의미 유형: metadata schema와 metadata 질의 라우팅
+- Blockify 유형: block 생성 prompt/profile 선택
+
+의미 유형을 자동 감지했다는 이유만으로 청킹 전략을 변경하거나 검색 결과를 hard filter하지 않는다.
+
+## Embedding identity
+
+색인과 검색에서 아래 값이 일치해야 한다.
+
+- embedding deployment ID
+- provider와 model reference
+- dimension
+- embedding purpose/input type
+- embedding space 또는 profile ID
+
+명시한 deployment를 찾지 못했을 때 다른 모델로 조용히 대체하지 않는다. 기존 record에 model identity가
+불완전한 경우 `unknown`을 새로 추정해 쓰거나 자동 재임베딩하지 않는다.
+
+## 재색인과 metadata backfill
+
+| 작업 | Chunk 변경 | Embedding 변경 | 사용 시점 |
+|---|---:|---:|---|
+| metadata backfill | 아니오 | 아니오 | 기존 revision에 metadata artifact/projection 보강 |
+| RAG reindex | 예 | 예 | 원문·청킹·embedding deployment 변경 |
+| metadata-only vector patch | 아니오 | 아니오 | 기존 index의 compact metadata 갱신 |
+
+backfill은 normalized snapshot이 있는 현재 완료 revision만 대상으로 한다. revision 또는 content hash가
+바뀌면 건너뛰며, index가 없던 문서에 새 index를 만들지 않는다.
+
+## 색인 완료 확인
+
+- RAG job이 `COMPLETED` 또는 허용된 warning 상태인지 확인한다.
+- chunk 수와 vector 수가 기대 범위인지 확인한다.
+- 첫 chunk와 마지막 chunk의 locator/sourceRef를 확인한다.
+- vector metadata에 object scope와 canonical embedding identity가 있는지 확인한다.
+- 같은 object를 다시 색인한 뒤 stale chunk가 검색되지 않는지 확인한다.
+- attachment/Markdown 상세 조회가 현재 revision을 가리키는지 확인한다.

--- a/docs/ai-rag/operations.md
+++ b/docs/ai-rag/operations.md
@@ -1,0 +1,109 @@
+# AI/RAG 운영 및 문제 해결
+
+이 문서는 개발·운영 인스턴스에서 AI/RAG 준비 상태, 품질 문제와 cache 장애를 확인하는 순서를 제공한다.
+원문, 질문, credential, 개인정보를 로그에 남기지 않는다.
+
+## 기동 전 확인
+
+1. 모든 Studio artifact가 같은 3.x 버전인지 확인한다.
+2. CHAT과 EMBEDDING 논리 deployment가 `ModelDeploymentRegistry`에 등록됐는지 확인한다.
+3. embedding deployment의 model, dimension, input type이 기존 index와 같은지 확인한다.
+4. PostgreSQL에 pgvector와 AI schema migration이 적용됐는지 확인한다.
+5. `studio.features.ai.enabled`와 필요한 endpoint 설정을 확인한다.
+6. attachment/Markdown을 사용하면 textract, chunking, source adapter Bean을 확인한다.
+
+Provider API key는 환경변수나 secret store로 공급한다. repository, Actuator 응답, 예외 detail에
+credential 또는 provider topology를 노출하지 않는다.
+
+## 단계별 진단
+
+### 1. Provider와 deployment
+
+`GET /api/ai/info/providers`에서 활성 provider와 기본 deployment를 확인한다.
+
+- deployment ID가 `unknown`이면 요청·저장 계약을 먼저 확인한다.
+- 모델 capability와 workload가 맞지 않으면 catalog/deployment 설정을 수정한다.
+- embedding 선택을 찾을 수 없을 때 default로 조용히 대체되는지 확인한다.
+
+### 2. 색인
+
+RAG job API에서 현재 단계와 로그를 확인한다.
+
+- `CHUNKING`: normalized source와 청킹 설정 확인
+- `EMBEDDING`: provider quota, deployment, dimension 확인
+- `INDEXING`: DB schema, vector column dimension, object scope 확인
+- `COMPLETED`: chunk/vector count와 warning 확인
+
+원문 chunk를 확인할 때는 vector search 대신 chunk inspection API를 사용하면 query embedding provider를
+호출하지 않는다.
+
+### 3. Retrieval
+
+- 요청의 `objectType`/`objectId`가 색인 metadata와 같은지 확인한다.
+- 질의에 사용한 embedding deployment가 index의 embedding identity와 같은지 확인한다.
+- `topK`, `minScore`, retrieval diagnostics와 실제 결과 수를 함께 확인한다.
+- minScore를 임의의 고정값으로 올리지 말고 평가 세트로 조정한다.
+- overview 질의와 특정 사실 질의를 구분한다.
+
+### 4. Evidence packing과 답변
+
+- 검색 결과가 있어도 `PackedEvidenceSet.evidence`가 비어 있는지 확인한다.
+- context 문자/chunk 제한으로 gold evidence가 제외됐는지 확인한다.
+- reference의 `exactText`가 해당 normalized chunk에 실제로 포함되는지 확인한다.
+- `citationValidationStatus`가 `INDEX_VALID`인지 확인한다.
+- SSE 화면이 draft가 아니라 `complete.canonicalContent`를 표시하는지 확인한다.
+
+## 대표 증상
+
+| 증상 | 우선 확인 | 일반적인 원인 |
+|---|---|---|
+| 근거 부족 응답 | packed evidence 수, object scope | 검색 결과 없음, 패킹 한도, 권한 범위 |
+| 관련 문서를 찾지 못함 | embedding identity, topK/minScore | 다른 embedding space, 과도한 cutoff |
+| 근거 excerpt가 비어 있음 | source span, normalized chunk | legacy metadata, 잘못된 locator |
+| 인용 번호가 링크되지 않음 | final validation, SSE complete | draft 표시, invalid citation |
+| 재색인 후 옛 내용 검색 | replace/delete 결과 | stale object chunk |
+| embedding model이 unknown | deployment ID와 저장 metadata | legacy 요청 key, 불완전한 모델 설정 |
+| 파일 상세가 느림 | metadata 조회 query | vector 목록을 상세 API에서 함께 조회 |
+| Redis 중단 시 RAG 실패 | fail-open 설정과 로그 | cache 예외가 provider 경로로 전파됨 |
+
+## Exact-answer cache
+
+기본값은 `none`이다. Redis 승격은 다음 순서를 따른다.
+
+1. cache `none`에서 sync/SSE canonical parity를 확인한다.
+2. Redis ACL/TLS와 namespace를 확인한다.
+3. 같은 principal/object/evidence 요청에서 `MISS → HIT`를 확인한다.
+4. revision 또는 evidence 변경 후 `MISS`인지 확인한다.
+5. Redis를 중단해도 provider 경로가 정상 응답하는지 확인한다.
+
+상세 절차는 [Redis RAG cache rollout](../dev/redis-rag-cache-rollout.md)을 따른다.
+
+## 품질 평가 최소 조건
+
+- 같은 source revision과 normalized snapshot
+- 같은 chunking 설정
+- 같은 embedding deployment와 dimension
+- 같은 topK/minScore
+- 같은 chat model과 prompt version
+- 정답 근거가 표시된 평가 질문
+
+최소한 retrieval recall, evidence packing 유지율, citation support precision, citation coverage,
+답변 불가 질의 abstention을 함께 측정한다. 모델 또는 embedding이 다른 결과는 순수 청킹 A/B로 해석하지 않는다.
+
+## 로그 기준
+
+허용:
+
+- request/job/document/revision ID
+- hash와 길이
+- 단계, duration, count
+- provider/model의 논리 ID
+- error code와 error type
+
+금지:
+
+- 원문과 질문 전문
+- exact excerpt와 sourceRef
+- API key, token, password
+- 이메일, 전화번호, 결제·정부 식별자
+- provider base URL과 내부 topology

--- a/starter/studio-platform-starter-ai-web/README.md
+++ b/starter/studio-platform-starter-ai-web/README.md
@@ -9,6 +9,16 @@ orchestration, vector persistence 구현을 추가하지 않는다.
 RAG chunking 실행은 `starter:studio-platform-starter-ai`의 `RagPipelineService`와 선택적
 `starter:studio-platform-starter-chunking`에 위임한다.
 
+## 문서 지도
+
+이 README는 전체 HTTP endpoint와 세부 설정의 기준 문서다. 실행 흐름을 먼저 이해하려면 다음 문서를
+사용한다.
+
+- 전체 모듈 경계: [AI/RAG 아키텍처](../../docs/ai-rag/README.md)
+- 추출부터 vector 저장까지: [RAG 색인](../../docs/ai-rag/indexing.md)
+- `PackedEvidenceSet`, citation, canonical SSE: [근거 기반 RAG Chat](../../docs/ai-rag/grounded-chat.md)
+- 장애 진단과 exact-answer cache: [AI/RAG 운영](../../docs/ai-rag/operations.md)
+
 ## 1) 의존성 추가
 
 AI 코어 스타터와 웹 스타터를 함께 선언한다. 프로바이더 라이브러리도 소비 앱에서 직접 선언해야 한다.
@@ -21,7 +31,7 @@ dependencies {
     implementation(project(":starter:studio-platform-starter-ai-web"))
 
     // REST 엔드포인트 활성화에 필요
-    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-webmvc")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")
 

--- a/starter/studio-platform-starter-ai/README.md
+++ b/starter/studio-platform-starter-ai/README.md
@@ -13,6 +13,14 @@ MyBatis가 없거나 애플리케이션의 custom `mybatis.mapper-locations` 설
 `starter:studio-platform-starter-chunking`이 있으면 `RagPipelineService`는 `ChunkingOrchestrator`를 우선 사용하고,
 없으면 기존 `TextChunker` fallback을 사용한다.
 
+## 문서 지도
+
+- 전체 모듈 경계: [AI/RAG 아키텍처](../../docs/ai-rag/README.md)
+- 색인·재색인: [RAG 색인](../../docs/ai-rag/indexing.md)
+- 근거·인용·SSE: [근거 기반 RAG Chat](../../docs/ai-rag/grounded-chat.md)
+- 기동·진단·cache: [AI/RAG 운영](../../docs/ai-rag/operations.md)
+- HTTP endpoint와 권한: [AI Web Starter](../studio-platform-starter-ai-web/README.md)
+
 > **중요** Spring AI BOM은 `gradle.properties`의 `springAiVersion`으로 중앙 관리되며
 > `api(platform())` 으로 노출되므로, 소비 앱에서 별도로 BOM을 선언하지 않아도
 > Spring AI 의존성 버전이 자동 관리된다.

--- a/studio-application-modules/content-embedding-pipeline/README.md
+++ b/studio-application-modules/content-embedding-pipeline/README.md
@@ -3,6 +3,9 @@
 첨부파일 텍스트를 추출하고 임베딩을 생성해 벡터 스토어 업서트 또는 RAG 인덱싱을 수행하는 모듈이다.
 `studio-application-modules:attachment-service`와 함께 사용하며, AI 플랫폼 포트(`studio-platform-ai`)에 의존한다.
 
+첨부 경로가 공통 RAG 계약과 연결되는 전체 구조는
+[AI/RAG 아키텍처 가이드](../../docs/ai-rag/README.md)를 참고한다.
+
 ## 사용 요약
 
 - attachment 모듈과 함께 사용한다.

--- a/studio-platform-ai-model-catalog/README.md
+++ b/studio-platform-ai-model-catalog/README.md
@@ -4,6 +4,9 @@
 Catalog 등록은 모델을 실제 runtime에 활성화하지 않는다. 애플리케이션의 provider 연결과 adapter
 capability 검증을 통과한 deployment만 사용할 수 있다.
 
+모델 카탈로그가 deployment와 RAG에 연결되는 위치는
+[AI/RAG 아키텍처 가이드](../docs/ai-rag/README.md)를 참고한다.
+
 ## Catalog tier
 
 - `MIGRATION_READY`: 현재 애플리케이션 설정을 그대로 옮길 수 있는 모델

--- a/studio-platform-ai/README.md
+++ b/studio-platform-ai/README.md
@@ -5,6 +5,9 @@ AI 공통 계약 계층이다. 챗 완성, 임베딩 생성, 벡터 스토어 �
 Spring AI 기반 런타임 구현체와 RAG pipeline 구현은 `studio-platform-starter-ai`가 담당한다.
 RAG indexing용 chunking 계약과 구현은 `studio-platform-chunking`과 `studio-platform-starter-chunking`을 사용한다.
 
+전체 모듈 경계와 색인·근거 답변 흐름은
+[AI/RAG 아키텍처 가이드](../docs/ai-rag/README.md)를 먼저 참고한다.
+
 ## 요약
 포트/어댑터 원칙에 따라 AI 공급자(OpenAI, Ollama, Google AI Gemini 등)를 추상화한다. 애플리케이션 코드는 이 모듈의 포트 인터페이스에만 의존하고, 실제 공급자는 스타터가 빈으로 등록한다.
 

--- a/studio-platform-chunking-runtime/README.md
+++ b/studio-platform-chunking-runtime/README.md
@@ -1,0 +1,107 @@
+# Studio Platform Chunking Runtime
+
+`studio-platform-chunking`의 계약을 구현하는 청킹 runtime 모듈이다. recursive, fixed, token,
+structure-based, blockify 전략과 tokenizer, 정규화 adapter, context expander를 제공한다.
+Spring Bean 조립은 `studio-platform-starter-chunking`이 담당한다.
+
+전체 RAG 흐름은 [AI/RAG 아키텍처 가이드](../docs/ai-rag/README.md)를 먼저 참고한다.
+
+## 책임 범위
+
+이 모듈이 담당하는 것:
+
+- `DefaultChunkingOrchestrator`
+- character/token 기반 chunk 구현
+- normalized document 기반 구조 청킹
+- Blockify 생성·검증·PII masking adapter
+- parent/neighbor/table/heading context expansion
+- textract 결과를 normalized document로 변환
+
+이 모듈이 담당하지 않는 것:
+
+- 파일 추출
+- embedding과 vector 저장
+- RAG retrieval와 답변 생성
+- HTTP API
+- 문서 의미 metadata schema
+
+## 구현 전략
+
+| 구현 | 입력 | 목적 |
+|---|---|---|
+| `RecursiveChunker` | text | separator 계층을 사용하는 기본 character 청킹 |
+| `FixedSizeChunker` | text | 명시적인 고정 길이 청킹 |
+| `TokenBasedChunker` | text | tokenizer 기준 size/overlap |
+| `StructureBasedChunker` | `NormalizedDocument` | heading/table/list 등 문서 구조 보존 |
+| `BlockifyChunker` | `NormalizedDocument` | 검색·질의에 적합한 지식 block 생성 |
+| `KnowledgeBlockChunker` | `NormalizedDocument` | Blockify 기반 knowledge block |
+
+기본 runtime 설정은 `recursive`, `character`, `max-size=800`, `overlap=100`이다.
+Blockify는 별도 opt-in이며 기본 활성화되지 않는다.
+
+## Orchestrator
+
+`DefaultChunkingOrchestrator`는 요청 strategy/unit과 `ChunkingProperties`를 해석해 적절한 구현을 선택한다.
+호출자는 concrete chunker 대신 `ChunkingOrchestrator` 계약에 의존한다.
+
+구조화 입력이 필요한 전략에 text만 전달했거나 구조화 전략을 실행할 수 없는 경우의 fallback은
+[Starter Chunking README](../starter/studio-platform-starter-chunking/README.md)에 정의된 현재 정책을 따른다.
+새 fallback 체인을 암묵적으로 추가하지 않는다.
+
+## Tokenizer
+
+| 타입 | 역할 |
+|---|---|
+| `DefaultTokenizerResolver` | provider/model과 설정 mapping으로 tokenizer 선택 |
+| `TiktokenTokenizerAdapter` | 지원 encoding/model의 token 계산 |
+| `ApproximateTokenizer` | 설정된 fallback 정책에 따른 근사 계산 |
+
+알 수 없는 model을 무조건 특정 tokenizer로 추정하지 않는다.
+`studio.chunking.tokenizer.fail-on-unknown-model`과 fallback 설정에 따라 처리한다.
+
+## Blockify
+
+Blockify runtime은 다음 구성요소를 분리한다.
+
+- `BlockifyDocumentTypeClassifier`: Blockify 전용 문서 유형 감지
+- `BlockifyProfileResolver`: 유형별 prompt/profile 선택
+- `HeuristicBlockifyGenerator`: provider 호출 없는 기본 generator
+- `LlmBlockifyGenerator`: 등록된 chat adapter를 사용하는 generator
+- `PiiMaskingBlockifyGenerator`: 외부 생성 전 PII masking wrapper
+- `BlockifyTypedFieldValidator`: 결과 field와 source evidence 검증
+
+Blockify 문서 유형은 `DocumentSemanticType`과 같지 않다. Blockify 결과는 source evidence를 보존해야
+하며 생성된 텍스트가 원문 근거를 대체하지 않는다.
+
+## Context expansion
+
+| 구현 | 확장 범위 |
+|---|---|
+| `WindowChunkContextExpander` | 이전/다음 chunk |
+| `ParentChildChunkContextExpander` | parent/child |
+| `TableChunkContextExpander` | 같은 table 또는 주변 table context |
+| `HeadingChunkContextExpander` | heading path 기반 context |
+
+expander는 검색 후보를 보강하지만 최종 prompt 한도를 우회하지 않는다. `RagContextBuilder`가 확장 결과를
+다시 패킹하고 실제 포함된 span만 `PackedEvidenceSet`에 남긴다.
+
+## 사용
+
+일반 소비 애플리케이션은 runtime 모듈을 직접 추가하기보다 starter를 사용한다.
+
+```kotlin
+implementation(project(":starter:studio-platform-starter-chunking"))
+```
+
+직접 조립이 필요한 라이브러리 테스트나 커스텀 runtime에서만 다음 의존성을 사용한다.
+
+```kotlin
+implementation(project(":studio-platform-chunking-runtime"))
+```
+
+## 관련 문서
+
+- [Chunking 계약](../studio-platform-chunking/README.md)
+- [Chunking 자동 구성과 전략 설정](../starter/studio-platform-starter-chunking/README.md)
+- [RAG 색인](../docs/ai-rag/indexing.md)
+- [근거 기반 RAG Chat](../docs/ai-rag/grounded-chat.md)

--- a/studio-platform-chunking/README.md
+++ b/studio-platform-chunking/README.md
@@ -1,24 +1,13 @@
 # Studio Platform Chunking
 ![image](./img/image_chunking.png)
 
-텍스트 및 문서 데이터를 의미 단위(Chunk)로 분할하고, 메타데이터를 부여하여 저장·검색·임베딩·RAG(Retrieval-Augmented Generation) 파이프라인에서 효율적으로 활용할 수 있도록 지원하는 Chunk 생성 플랫폼 모듈이다. 이 모듈은 단순 문자열 분할을 넘어 문서 구조와 의미를 고려한 Semantic Chunking 및 Layout-aware Chunking을 지원하며, AI 기반 검색과 문맥(Context) 유지 성능 향상을 목표로 설계되었다.
+`studio-platform-chunking`은 AI/RAG 색인을 위한 provider-neutral 청킹 계약 모듈이다.
+텍스트와 정규화 문서 입력, chunk 결과, provenance metadata, parent/child 관계와 검색 후 context
+expansion 확장점을 정의한다. 전략 구현은 `studio-platform-chunking-runtime`, Spring 자동 구성은
+`studio-platform-starter-chunking`이 담당한다.
 
-외부 시스템 또는 상위 서비스는 REST API를 통해 Chunking 작업을 요청하며, API Entry 계층의 ChunkingController는 요청 검증, 인증/인가, Rate Limiting 등을 수행한 후 Chunking Application Service로 작업을 전달한다. Chunking Application Service는 작업 생성, 상태 관리, 정책 처리, 예외 처리 등을 담당하며, 전체 Chunk 생성 프로세스를 제어한다.
-
-이후 Chunking Orchestrator는 입력 문서와 텍스트를 분석하여 적절한 Chunking 전략을 결정한다. 문서 유형, 텍스트 길이, 문맥 구조 등을 기반으로 Chunking Pipeline을 선택하며, Chunking Pipeline Manager는 실제 Chunk 생성 흐름과 단계별 Processor 실행을 조합·제어한다.
-
-Chunk 생성은 여러 종류의 Chunking Processor를 통해 수행된다. Text Splitter는 고정 길이, 문장 기반, Token 기반, Recursive Splitter 등의 일반적인 텍스트 분할 전략을 제공한다. Semantic Splitter는 임베딩 기반 의미 분석을 활용하여 문맥 및 주제 단위로 텍스트를 분할하며, Layout Splitter는 제목·본문·표·이미지·코드 블록 등 문서 레이아웃 구조를 고려한 Chunk 분리를 지원한다. 또한 Overlap / Merge Processor는 Chunk 간 문맥 유지와 검색 정확도 향상을 위해 Overlap 영역 생성 및 노이즈 제거를 수행한다.
-
-생성된 Chunk는 Metadata Enricher를 통해 문서명, 페이지, 섹션, 레이아웃 정보, 키워드, 태그, 관계 정보 등 다양한 메타데이터가 부여된다. 이후 Chunk Result Assembler는 Chunk 리스트를 조립하고 품질·길이 검증을 수행하여 최종 결과를 구성한다.
-
-완성된 Chunk는 Chunk Storage Service를 통해 저장되며, 원본 문서는 File Storage(S3/Object Storage)에 저장되고, Chunk 및 메타데이터는 Database(RDS)에 관리된다. 또한 Search Index(OpenSearch)에는 검색용 색인이 생성되어 빠른 검색과 RAG 기반 Context Retrieval을 지원한다. 필요 시 AI/Embedding Platform과 연동하여 벡터 생성 및 Vector Store 적재가 수행된다.
-
-대용량 문서 또는 장시간 Chunking 작업은 Message Queue(SQS 등)와 Background Worker를 기반으로 비동기 처리되며, 실패 작업은 Dead Letter Queue(DLQ)로 이동하여 안정적인 운영과 재처리를 지원한다. 작업 완료 후에는 Event Publisher를 통해 Chunk 생성 완료 이벤트가 발행되어 상위 AI/RAG 시스템과 연계된다.
-
-최종적으로 studio-platform-chunking 모듈은 단순 텍스트 분할 기능을 넘어, AI 기반 검색, Semantic Retrieval, Hybrid Search, Context-aware RAG, Skill Extraction 등의 상위 AI 기능을 지원하기 위한 핵심 전처리 플랫폼 역할을 수행하며, 향후 Layout-aware RAG, 멀티모달 Chunking, Skill 기반 Chunk Tagging, 학습 콘텐츠 Semantic 분석 등으로 확장 가능한 구조를 목표로 한다.
-
-`studio-platform-chunking`은 AI/RAG 색인을 위한 provider-neutral chunking 계약 모듈입니다.
-
+청킹이 metadata·embedding·retrieval과 연결되는 전체 흐름은
+[AI/RAG 아키텍처 가이드](../docs/ai-rag/README.md)를 참고한다.
 
 ## 책임 범위
 

--- a/studio-platform-document-metadata/README.md
+++ b/studio-platform-document-metadata/README.md
@@ -1,0 +1,120 @@
+# Studio Platform Document Metadata
+
+문서 의미 유형과 유형별 metadata schema, provenance, evidence, projection 정책을 제공하는 순수 Java
+계약 모듈이다. Spring, AI SDK, 문서 파서, 저장소 구현에 의존하지 않는다.
+
+전체 AI/RAG 구조는 [AI/RAG 아키텍처 가이드](../docs/ai-rag/README.md)를 먼저 참고한다.
+
+## 책임 범위
+
+이 모듈이 담당하는 것:
+
+- 문서 의미 유형과 사용자 선택값 분리
+- 유형별 metadata field schema와 UI 설명
+- revision 단위 metadata artifact
+- field confidence, provenance와 source evidence
+- vector/prompt/API projection allowlist
+
+이 모듈이 담당하지 않는 것:
+
+- EPUB/PDF/OOXML/HTML native metadata 추출
+- LLM 호출과 JSON Schema 응답 처리
+- artifact DB 저장과 backfill job
+- HTTP controller
+- 청킹 전략 선택과 embedding
+
+위 runtime 기능은 `studio-platform-starter-markdown`과 `studio-platform-markdown`이 연결한다.
+
+## 핵심 타입
+
+| 타입 | 역할 |
+|---|---|
+| `DocumentSemanticType` | 감지·확정된 문서 의미 유형 |
+| `DocumentSemanticTypeSelection` | 요청 선택값. `AUTO`는 저장 유형이 아님 |
+| `DocumentMetadataSchemaRegistry` | 유형별 field 정의 조회 |
+| `BuiltInDocumentMetadataSchemaRegistry` | 기본 schema registry |
+| `DocumentMetadataArtifact` | revision별 metadata 결과와 version/fingerprint |
+| `DocumentMetadataField` | raw/normalized value, confidence, provenance, evidence |
+| `DocumentMetadataEvidence` | 정규화 원문 기준 locator와 offset |
+| `DocumentMetadataProjectionPolicy` | vector와 prompt에 노출할 field allowlist |
+| `MetadataEnrichmentMode` | `OFF`, `AUTO`, `REQUIRED` 실행 정책 |
+
+## 의미 유형
+
+지원 유형:
+
+- `GENERAL`
+- `BOOK`
+- `ACADEMIC_PAPER`
+- `THESIS`
+- `REPORT`
+- `POLICY`
+- `MANUAL`
+- `PRESENTATION`
+- `UNKNOWN`
+
+요청에서는 `DocumentSemanticTypeSelection.AUTO`를 사용할 수 있지만 감지 결과로 `AUTO`를 저장하지 않는다.
+처리 프로필, 의미 유형, Blockify 유형은 별도 계약이며 이 모듈은 처리 프로필이나 청킹 전략을 결정하지 않는다.
+
+## Artifact
+
+`DocumentMetadataArtifact`는 다음 식별·품질 값을 보존한다.
+
+- artifact ID와 revision ID
+- schema/extractor version
+- content fingerprint
+- requested/detected/effective classification
+- `COMPLETE | PARTIAL | WARNING` 품질
+- 등록 field와 warning
+
+field map의 key는 `DocumentMetadataField.fieldId`와 같아야 한다. 등록되지 않은 임의 field를 외부
+metadata에서 그대로 저장하지 않는다.
+
+## Provenance와 evidence
+
+| Provenance | 의미 |
+|---|---|
+| `USER_PROVIDED` | 사용자가 명시한 값 |
+| `NATIVE_STRUCTURED` | OPF/XMP/OOXML/meta 같은 native 속성 |
+| `STRUCTURAL_HEURISTIC` | 제목·표지·문서 구조 규칙으로 추출 |
+| `SOURCE_VERIFIED` | 제안값이 정규화 원문에서 확인됨 |
+| `INFERRED` | 원문 exact evidence로 확정되지 않은 추론 |
+
+RAG prompt의 확정 사실에는 source-verified field만 사용한다. inferred 값은 UI 검토 대상으로 표시할 수
+있지만 근거가 확인된 사실로 승격하지 않는다.
+
+## Projection 정책
+
+전체 artifact를 chunk/vector마다 반복 저장하지 않는다.
+
+vector compact metadata:
+
+- `docMetadataId`
+- `docSemanticType`
+- `docTitle`
+- `docAuthors` 최대 5개
+- `docPublicationYear`
+- `docOrganization`
+
+`DocumentMetadataProjectionPolicy.promptFacts(...)`는 source-verified field만 반환한다.
+projection 정책을 변경할 때는 vector payload 크기, 개인정보, 기존 index 호환성을 함께 검토한다.
+
+## 사용
+
+```kotlin
+dependencies {
+    implementation(project(":studio-platform-document-metadata"))
+}
+```
+
+```java
+DocumentMetadataSchema schema = registry.require(DocumentSemanticType.BOOK);
+Map<String, Object> compact = projectionPolicy.compact(artifact);
+Map<String, DocumentMetadataField> promptFacts = projectionPolicy.promptFacts(artifact);
+```
+
+## 관련 문서
+
+- [RAG 색인](../docs/ai-rag/indexing.md)
+- [Studio Platform Markdown](../studio-platform-markdown/README.md)
+- [Studio Platform Starter Markdown](../starter/studio-platform-starter-markdown/README.md)

--- a/studio-platform-markdown/README.md
+++ b/studio-platform-markdown/README.md
@@ -2,6 +2,9 @@
 
 Attachment를 안정적인 Markdown 지식 원본으로 변환하고 Revision 이력을 관리한다.
 
+전체 AI/RAG 흐름은 [AI/RAG 아키텍처 가이드](../docs/ai-rag/README.md), 문서 metadata 계약은
+[studio-platform-document-metadata](../studio-platform-document-metadata/README.md)를 참고한다.
+
 ## 처리 방식
 
 - DOCX/HTML은 `studio-platform-document-convert` application port를 통해 Pandoc 변환 Job을 생성한다.
@@ -12,6 +15,8 @@ Attachment를 안정적인 Markdown 지식 원본으로 변환하고 Revision �
 - 성공한 Revision만 `MarkdownDocument.currentRevisionId`로 승격한다.
 - 동일 원본 hash, extractor/version, options 조합의 완료 Revision은 재사용한다.
 - 후속 Chunking/RAG/Skill 실패는 완료된 Markdown Revision 상태를 되돌리지 않는다.
+- 명시적인 후속 단계 순서는 `METADATA_ENRICHMENT -> CHUNKING -> RAG_INDEX -> SKILL_EXTRACTION`이다.
+- metadata enrichment는 native·구조 기반 값을 우선하고 설정된 모드에 따라 조건부 LLM 보강을 사용한다.
 - Markdown RAG 색인은 `RagIndexJobService`를 통해 실행하며 기존 RAG Job 이력과 로그에
   `sourceType=markdown-revision`으로 기록한다.
 
@@ -24,6 +29,8 @@ Attachment를 안정적인 Markdown 지식 원본으로 변환하고 Revision �
 - `GET /api/markdown-documents/{id}/pipeline`
 - `GET /api/markdown-documents/{id}/locators`
 - `GET /api/markdown-documents/{id}/resources`
+- `GET /api/markdown-documents/{id}/metadata?revisionId=...`
+- `GET /api/document-metadata/schemas`
 - `POST /api/markdown-documents/{id}/reextract`
 - `POST /api/markdown-documents/{id}/resume`
 - `POST /api/markdown-documents/{id}/rag/reindex`
@@ -38,7 +45,8 @@ Attachment를 안정적인 Markdown 지식 원본으로 변환하고 Revision �
 }
 ```
 
-지원 단계는 `CHUNKING`, `RAG_INDEX`, `SKILL_EXTRACTION`이다. 추출 단계가 완료되지 않았으면
+지원 단계는 `METADATA_ENRICHMENT`, `CHUNKING`, `RAG_INDEX`, `SKILL_EXTRACTION`이다.
+추출 단계가 완료되지 않았으면
 `resume`은 native 추출을 다시 실행하며, 실패한 Pandoc 추출은 새 Revision과 변환 Job으로 재시작한다.
 
 embedding 모델만 변경해 다시 색인하려면 `rag/reindex`를 사용한다.
@@ -57,6 +65,9 @@ embedding 모델만 변경해 다시 색인하려면 `rag/reindex`를 사용한�
 Markdown 생성, 재추출, resume, RAG reindex 요청은 다음 선택 항목을 지원한다.
 
 - `useLlmKeywordExtraction`: RAG 색인 중 LLM keyword extraction 사용 여부
+- `documentSemanticType`: `AUTO`, `GENERAL`, `BOOK`, `ACADEMIC_PAPER`, `THESIS`, `REPORT`,
+  `POLICY`, `MANUAL`, `PRESENTATION`
+- `metadataEnrichmentMode`: `OFF`, `AUTO`, `REQUIRED`
 - `skillExtractionMode`: Skill 후보 추출 방식(`regex`, `llm`). 생략하면 서버의
   `studio.skillgraph.extraction.mode` 설정을 사용한다.
 - `generateSkillEmbeddings`: Skill 후보 추출 완료 후 후보 embedding 생성 여부
@@ -69,6 +80,24 @@ Skill 추출 LLM이 아니라 추출된 후보의 후속 embedding에만 사용�
 `pipeline`은 신규 Revision에 대해 요청 단계가 없더라도 최종 `COMPLETED` 실행 정보를 저장하고
 항상 non-null 응답을 반환한다. 실행 이력이 없던 기존 완료 Revision은 상태를 추측하지 않고
 `UNKNOWN`, `errorCode=PIPELINE_HISTORY_UNAVAILABLE`로 반환한다.
+
+## 문서 metadata와 backfill
+
+metadata artifact는 revision별 `DOCUMENT_METADATA` resource로 한 번 저장한다. vector에는 전체 artifact가
+아니라 `docMetadataId`, 의미 유형, 제목, 제한된 저자, 발간 연도와 조직만 projection한다.
+RAG metadata 질의에는 source-verified field만 사용한다.
+
+기존 완료 revision은 관리 API로 metadata-only backfill할 수 있다.
+
+- `POST /api/mgmt/markdown/metadata-backfill-jobs`
+- `GET /api/mgmt/markdown/metadata-backfill-jobs`
+- `GET /api/mgmt/markdown/metadata-backfill-jobs/{jobId}`
+- `GET /api/mgmt/markdown/metadata-backfill-jobs/{jobId}/items`
+- `POST /api/mgmt/markdown/metadata-backfill-jobs/{jobId}/retry`
+- `POST /api/mgmt/markdown/metadata-backfill-jobs/{jobId}/cancel`
+
+backfill은 normalized snapshot이 있는 현재 완료 revision만 처리하며 새 revision, chunk 또는 embedding을
+자동 생성하지 않는다. 변경 작업은 Markdown manage와 AI RAG write 권한을 모두 요구한다.
 
 ## 응답 규약
 


### PR DESCRIPTION
## Why

- 루트 README의 AI/RAG 안내가 모듈 이름을 나열하는 수준이라 처음 접하는 개발자가 색인과 근거 기반 답변의 전체 흐름을 이해하기 어려웠습니다.
- AI/RAG 계약, 문서 metadata, chunking, embedding, citation, SSE와 운영 cache의 책임 경계를 한곳에서 탐색할 수 있는 문서 진입점이 필요했습니다.

## What

- 루트 `README.md`에 AI/RAG 개요, 전체 흐름 SVG, 구성요소별 담당 모듈 표를 추가했습니다.
- `docs/ai-rag/`에 아키텍처, 색인, 근거 기반 Chat, 운영 및 문제 해결 문서를 추가했습니다.
- 누락돼 있던 `studio-platform-document-metadata`와 `studio-platform-chunking-runtime` README를 추가했습니다.
- AI starter, AI web starter, 모델 카탈로그, Markdown, chunking, embedding pipeline 문서에서 공통 AI/RAG 가이드로 이동할 수 있도록 링크를 정리했습니다.
- 실제 코드의 `PackedEvidenceSet`, citation validation, metadata enrichment, backfill 및 SSE canonical 응답 계약과 문서 표현을 대조했습니다.
- `CHANGELOG.md`에 문서 개선 내역을 기록했습니다.

## Related Issues

- 별도 Issue 없음: 사용자의 AI/RAG 문서 개선 직접 요청에 따라 진행했습니다.

## Validation

- Command: `./gradlew :studio-platform-document-metadata:test :studio-platform-chunking-runtime:test :studio-platform-markdown:test --no-daemon`
- Result: `BUILD SUCCESSFUL`
- Command: `./gradlew :starter:studio-platform-starter-ai-web:test --tests studio.one.platform.ai.web.controller.RagCitationValidatorTest --no-daemon`
- Result: `BUILD SUCCESSFUL`
- Command: `xmllint --noout docs/ai-rag/images/ai-rag-overview.svg`
- Result: 통과
- Command: Markdown 내부 링크 검사
- Result: 15개 파일, 57개 내부 링크 통과
- Command: `git diff --cached --check`
- Result: 통과

## Risk / Rollback

- Risk: 문서의 모듈 책임이나 설정 설명이 이후 구현 변경과 불일치할 수 있습니다. 런타임 동작 변경은 없습니다.
- Rollback: 이 PR의 단일 문서 커밋을 revert하면 기존 문서 상태로 복원됩니다.

## AI / Subagent Usage

- AI-assisted: Yes
- Subagent used: No
- Delegated scope: N/A
- Main author validation: 실제 Java 계약, README, 설정과 API 경로를 대조하고 관련 테스트 및 링크 검사를 수행했습니다.

## Checklist

- [x] commit message follows policy
- [x] issue template used or exception recorded
- [x] `AI-Assisted` value is correct
- [x] validation recorded
- [x] subagent usage recorded when used
- [ ] CI / repository verification passed
- [ ] human review completed before merge
- [x] no unrelated changes included